### PR TITLE
Fix separators appearing in newDesign + Add "n more..." string

### DIFF
--- a/src/ui/Facet/BreadcrumbValuesList.ts
+++ b/src/ui/Facet/BreadcrumbValuesList.ts
@@ -3,6 +3,7 @@ import {DeviceUtils} from '../../utils/DeviceUtils';
 import {Facet} from './Facet';
 import {IBreadcrumbValueElementKlass} from './BreadcrumbValueElement';
 import {Assert} from '../../misc/Assert';
+import {l} from '../../strings/Strings';
 import {$$} from '../../utils/Dom';
 
 declare var Globalize;
@@ -60,7 +61,7 @@ export class BreadcrumbValueList {
     var elem = $$('div', {
       className: 'coveo-facet-breadcrumb-value'
     })
-    if (!DeviceUtils.isMobileDevice()) {
+    if (!DeviceUtils.isMobileDevice() && !this.facet.searchInterface.isNewDesign()) {
       let sep = $$('span', {
         className: 'coveo-separator'
       });
@@ -71,7 +72,7 @@ export class BreadcrumbValueList {
       let multi = $$('span', {
         className: 'coveo-facet-breadcrumb-multi-count'
       })
-      multi.text(Globalize.format(numberOfSelected, 'n0'));
+      multi.text(l('NMore', Globalize.format(numberOfSelected, 'n0')));
       elem.el.appendChild(multi.el);
 
       let multiIcon = $$('div', {
@@ -83,7 +84,7 @@ export class BreadcrumbValueList {
       let multiExcluded = $$('span', {
         className: 'coveo-facet-breadcrumb-multi-count'
       })
-      multiExcluded.text(Globalize.format(numberOfExcluded, 'n0'));
+      multiExcluded.text(l('NMore', Globalize.format(numberOfExcluded, 'n0')));
       elem.el.appendChild(multiExcluded.el);
 
       let multiExcludedIcon = $$('div', {
@@ -104,7 +105,7 @@ export class BreadcrumbValueList {
     elem.on('click', () => {
       var elements: HTMLElement[] = [];
       _.forEach(valueElements, (valueElement) => {
-        if (!DeviceUtils.isMobileDevice()) {
+        if (!DeviceUtils.isMobileDevice() && !this.facet.searchInterface.isNewDesign()) {
           let separatorsClicked = $$('span', {
             className: 'coveo-facet-breadcrumb-separator'
           });

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -899,6 +899,9 @@
     "zh-cn": "更多",
     "zh-tw": "更多"
   },
+  "NMore": {
+    "en": "{0} more..."
+  },
   "Less": {
     "en": "Fewer",
     "fr": "Moins",


### PR DESCRIPTION
With this PR, collapsed breadcrumbs will now show "10 more..." instead of "10", the latter of which being confusing when using a numerical filter such as Year.

**Before:**
![image](https://cloud.githubusercontent.com/assets/5436916/15832705/71910dae-2bf1-11e6-8055-92f33d2e1159.png)
**After:**
![image](https://cloud.githubusercontent.com/assets/5436916/15832680/4c00d2c2-2bf1-11e6-87ee-da9e7fc6a681.png)

https://coveord.atlassian.net/browse/JSUI-798