### PR TITLE
Core Helper -> Remove usage of arguments.caller

### DIFF
--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -116,7 +116,8 @@ export class ResultList extends Component {
     autoSelectFieldsToInclude: ComponentOptions.buildBooleanOption({ defaultValue: false })
   };
 
-  private currentlyDisplayedResults: IQueryResult[] = [];
+  public static resultCurrentlyBeingRendered: IQueryResult = null;
+  public currentlyDisplayedResults: IQueryResult[] = [];
   private fetchingMoreResults: Promise<IQueryResults>;
   private reachedTheEndOfResults = false;
 
@@ -184,6 +185,7 @@ export class ResultList extends Component {
         res.push(resultElement);
       }
     });
+    ResultList.resultCurrentlyBeingRendered = null;
     return res;
   }
 
@@ -195,6 +197,7 @@ export class ResultList extends Component {
   public buildResult(result: IQueryResult): HTMLElement {
     Assert.exists(result);
     QueryUtils.setStateObjectOnQueryResult(this.queryStateModel.get(), result);
+    ResultList.resultCurrentlyBeingRendered = result;
     var resultElement = this.options.resultTemplate.instantiateToElement(result);
     if (resultElement != null) {
       Component.bindResultToElement(resultElement, result);
@@ -309,6 +312,7 @@ export class ResultList extends Component {
       var results = data.results;
       this.logger.trace('Received query results from new query', results);
       this.hideWaitingAnimation();
+      ResultList.resultCurrentlyBeingRendered = undefined;
       this.currentlyDisplayedResults = [];
       this.renderResults(this.buildResults(data.results));
       this.currentlyDisplayedResults = results.results;
@@ -350,9 +354,8 @@ export class ResultList extends Component {
   }
 
   private handleNewQuery() {
-    if (!this.disabled) {
-      $$(this.element).show();
-    }
+    $$(this.element).show();
+    ResultList.resultCurrentlyBeingRendered = undefined;
   }
 
   private handleBuildingQuery(args: IBuildingQueryEventArgs) {

--- a/src/ui/Templates/TemplateHelpers.ts
+++ b/src/ui/Templates/TemplateHelpers.ts
@@ -25,10 +25,7 @@ export class TemplateHelpers {
     Assert.isNonEmptyString(name);
     Assert.exists(helper);
 
-    if (UnderscoreTemplate.isLibraryAvailable()) {
-      TemplateHelpers.registerTemplateHelperInUnderscore(name, helper);
-    }
-
+    TemplateHelpers.registerTemplateHelperInUnderscore(name, helper);
     TemplateHelpers.helpers[name] = helper;
   }
 
@@ -43,7 +40,6 @@ export class TemplateHelpers {
   private static registerTemplateHelperInUnderscore(name: string, helper: ITemplateHelperFunction) {
     Assert.isNonEmptyString(name);
     Assert.exists(helper);
-    Assert.check(UnderscoreTemplate.isLibraryAvailable());
     UnderscoreTemplate.registerTemplateHelper(name, helper);
   }
 }

--- a/test/Test.ts
+++ b/test/Test.ts
@@ -90,6 +90,7 @@
 /// <reference path="ui/AuthenticationProviderTest.ts" />
 /// <reference path="ui/CurrentTabTest.ts" />
 /// <reference path="ui/QueryboxQueryParametersTest.ts" />
+/// <reference path="ui/ResultListTest.ts" />
 /// <reference path="ui/ImageResultListTest.ts" />
 /// <reference path="ui/SearchAlertsTest.ts" />
 /// <reference path="ui/FollowItemTest.ts" />

--- a/test/ui/ResultListTest.ts
+++ b/test/ui/ResultListTest.ts
@@ -1,7 +1,7 @@
 /// <reference path="../Test.ts" />
 module Coveo {
   describe('ResultList', function () {
-    var test: Mock.IBasicComponentSetup<ResultList>;
+    let test: Mock.IBasicComponentSetup<ResultList>;
 
     beforeEach(function () {
       test = Mock.basicComponentSetup<ResultList>(ResultList);
@@ -12,34 +12,55 @@ module Coveo {
       test = null;
     })
 
+    it('should allow to return the currently displayed result', () => {
+      expect(ResultList.resultCurrentlyBeingRendered).toBeNull();
+      let data = FakeResults.createFakeResult();
+      test.cmp.buildResult(data);
+      expect(ResultList.resultCurrentlyBeingRendered).toBe(data);
+    })
+
+    it('should set currently displayed result to undefined when they are all rendered', () => {
+      let data = FakeResults.createFakeResults(13);
+      test.cmp.buildResults(data);
+      expect(ResultList.resultCurrentlyBeingRendered).toBeNull();
+    })
+
+    it('should reset currently displayed on new query', () => {
+      let data = FakeResults.createFakeResult();
+      test.cmp.buildResult(data);
+      expect(ResultList.resultCurrentlyBeingRendered).toBe(data);
+      Simulate.query(test.env);
+      expect(ResultList.resultCurrentlyBeingRendered).toBeNull();
+    })
+
     it('should allow to build a single result element', function () {
-      var data = FakeResults.createFakeResult();
-      var built = test.cmp.buildResult(data);
+      let data = FakeResults.createFakeResult();
+      let built = test.cmp.buildResult(data);
       expect(built).toBeDefined();
-      var rs = $$(built).find('.CoveoResultLink');
+      let rs = $$(built).find('.CoveoResultLink');
       expect($$(rs).text()).toBe(data.title);
     })
 
     it('should allow to build multiple results element', function () {
-      var data = FakeResults.createFakeResults(13);
-      var built = test.cmp.buildResults(data);
+      let data = FakeResults.createFakeResults(13);
+      let built = test.cmp.buildResults(data);
       expect(built.length).toBe(13);
-      var rs = $$(built[0]).find('.CoveoResultLink');
+      let rs = $$(built[0]).find('.CoveoResultLink');
       expect($$(rs).text()).toBe(data.results[0].title);
       rs = $$(built[12]).find('.CoveoResultLink');
       expect($$(rs).text()).toBe(data.results[12].title);
     })
 
     it('should allow to render results inside the result list', function () {
-      var data = FakeResults.createFakeResults(13);
+      let data = FakeResults.createFakeResults(13);
       test.cmp.renderResults(test.cmp.buildResults(data));
       expect($$(test.cmp.element).findAll('.CoveoResult').length).toBe(13);
     })
 
     it('should trigger result displayed event when rendering', function () {
-      var data = FakeResults.createFakeResults(6);
-      var spyResult = jasmine.createSpy('spyResult');
-      var spyResults = jasmine.createSpy('spyResults');
+      let data = FakeResults.createFakeResults(6);
+      let spyResult = jasmine.createSpy('spyResult');
+      let spyResults = jasmine.createSpy('spyResults');
       $$(test.cmp.element).on(ResultListEvents.newResultDisplayed, spyResult);
       $$(test.cmp.element).on(ResultListEvents.newResultsDisplayed, spyResults);
       test.cmp.renderResults(test.cmp.buildResults(data));
@@ -48,8 +69,8 @@ module Coveo {
     })
 
     it('should render itself correctly after a full query', function () {
-      var spyResult = jasmine.createSpy('spyResult');
-      var spyResults = jasmine.createSpy('spyResults');
+      let spyResult = jasmine.createSpy('spyResult');
+      let spyResults = jasmine.createSpy('spyResults');
       $$(test.cmp.element).on(ResultListEvents.newResultDisplayed, spyResult);
       $$(test.cmp.element).on(ResultListEvents.newResultsDisplayed, spyResults);
       Simulate.query(test.env);
@@ -76,7 +97,7 @@ module Coveo {
 
     describe('exposes options', function () {
       it('resultContainer allow to specify where to render results', function () {
-        var aNewContainer = document.createElement('div');
+        let aNewContainer = document.createElement('div');
         expect(aNewContainer.children.length).toBe(0);
         test = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, {
           resultContainer: aNewContainer
@@ -86,8 +107,8 @@ module Coveo {
       })
 
       it('resultTemplate allow to specify a template manually', function () {
-        var tmpl: UnderscoreTemplate = Mock.mock<UnderscoreTemplate>(UnderscoreTemplate);
-        var asSpy = <any>tmpl;
+        let tmpl: UnderscoreTemplate = Mock.mock<UnderscoreTemplate>(UnderscoreTemplate);
+        let asSpy = <any>tmpl;
         asSpy.instantiateToElement.and.returnValue(document.createElement('div'));
         test = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, {
           resultTemplate: tmpl
@@ -125,7 +146,7 @@ module Coveo {
       })
 
       it('waitAnimationContainer allow to specify where to display the animation', function () {
-        var aNewContainer = document.createElement('div');
+        let aNewContainer = document.createElement('div');
         test = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, {
           waitAnimation: 'fade',
           waitAnimationContainer: aNewContainer
@@ -165,7 +186,7 @@ module Coveo {
         test = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, {
           fieldsToInclude: ['@field1', '@field2', '@field3']
         })
-        var simulation = Simulate.query(test.env);
+        let simulation = Simulate.query(test.env);
         expect(simulation.queryBuilder.fieldsToInclude).toContain('field1');
         expect(simulation.queryBuilder.fieldsToInclude).toContain('field2');
         expect(simulation.queryBuilder.fieldsToInclude).toContain('field3');


### PR DESCRIPTION
This cause problem at run time, as use strict is declared, and this is not allowed.
Instead, use the ResultList to specify the currently rendered result.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coveo/search-ui/35)
<!-- Reviewable:end -->
