### PR TITLE
Fix HashEncoding using single quotes

### DIFF
--- a/src/utils/HashUtils.ts
+++ b/src/utils/HashUtils.ts
@@ -154,34 +154,31 @@ export class HashUtils {
   }
 
   public static encodeArray(array: string[]): string {
-    var arrayReturn = [];
-    _.each(array, (value) => {
-      arrayReturn.push(encodeURIComponent(value));
+    var arrayReturn = _.map(array, (value) => {
+      return encodeURIComponent(value);
     });
     return HashUtils.DELIMITER.arrayStart + arrayReturn.join(',') + HashUtils.DELIMITER.arrayEnd;
   }
 
   public static encodeObject(obj: Object): string {
-    var ret = HashUtils.DELIMITER.objectStart;
-    var retArray = [];
-    _.each(<_.Dictionary<any>>obj, (val, key?, obj?) => {
-      var retValue = '';
-      retValue += '"' + encodeURIComponent(key) + '"' + ':'
-      if (_.isArray(val)) {
-        retValue += HashUtils.encodeArray(val)
-      } else if (_.isObject(val)) {
-        retValue += HashUtils.encodeObject(val);
-      } else {
-        if (_.isNumber(val) || _.isBoolean(val)) {
-          retValue += encodeURIComponent(val)
-        } else {
-          retValue += '"' + encodeURIComponent(val) + '"'
-        }
-      }
-      retArray.push(retValue)
+    var retArray = _.map(<_.Dictionary<any>>obj, (val, key?, obj?) => {
+      return `"${encodeURIComponent(key)}":${this.encodeValue(val)}`;
     })
-    ret += retArray.join(' , ');
-    return ret + HashUtils.DELIMITER.objectEnd;
+    return HashUtils.DELIMITER.objectStart + retArray.join(' , ') + HashUtils.DELIMITER.objectEnd;
+  }
+
+  private static encodeValue(val: any) {
+    var encodedValue = '';
+    if (_.isArray(val)) {
+      encodedValue = HashUtils.encodeArray(val);
+    } else if (_.isObject(val)) {
+      encodedValue = HashUtils.encodeObject(val);
+    } else if (_.isNumber(val) || _.isBoolean(val)) {
+      encodedValue = encodeURIComponent(val);
+    } else {
+      encodedValue = '"' + encodeURIComponent(val) + '"';
+    }
+    return encodedValue;
   }
 
   private static decodeObject(obj: string): Object {

--- a/src/utils/HashUtils.ts
+++ b/src/utils/HashUtils.ts
@@ -166,7 +166,7 @@ export class HashUtils {
     var retArray = [];
     _.each(<_.Dictionary<any>>obj, (val, key?, obj?) => {
       var retValue = '';
-      retValue += '\'' + encodeURIComponent(key) + '\'' + ' : '
+      retValue += '"' + encodeURIComponent(key) + '"' + ':'
       if (_.isArray(val)) {
         retValue += HashUtils.encodeArray(val)
       } else if (_.isObject(val)) {
@@ -175,7 +175,7 @@ export class HashUtils {
         if (_.isNumber(val) || _.isBoolean(val)) {
           retValue += encodeURIComponent(val)
         } else {
-          retValue += '\'' + encodeURIComponent(val) + '\''
+          retValue += '"' + encodeURIComponent(val) + '"'
         }
       }
       retArray.push(retValue)


### PR DESCRIPTION
Causing problems when serializing Standalone searchbox's 'firstQueryMeta'. It was serializing with single-quotes, which caused the JSON parsing to fail on initializing the search page. (JSON.parse doesn't like single-quotes for key/value delimiter)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coveo/search-ui/53)
<!-- Reviewable:end -->
