### PR TITLE
Recommendation: Only send actionsHistory in the triggered query

### DIFF
--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -69,9 +69,9 @@ export class Recommendation extends SearchInterface {
 
     /**
      * Specifies which options from the main {@link QueryBuilder} to use in the triggered query.
-     * The default value is ["expression", "advancedExpression", "constantExpression", "disjunctionExpression"]
+     * The default value is undefined
      */
-    optionsToUse: ComponentOptions.buildListOption({ defaultValue: ['expression', 'advancedExpression', 'constantExpression', 'disjunctionExpression'] }),
+    optionsToUse: ComponentOptions.buildListOption(),
 
     /**
      * Specifies whether or not to send the actions history along with the triggered query.

--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -69,6 +69,7 @@ export class Recommendation extends SearchInterface {
 
     /**
      * Specifies which options from the main {@link QueryBuilder} to use in the triggered query.
+     * Ex: <code data-options-to-use="expression, advancedExpression"></code> would add the expression and the advanced expression parts from the main query in the triggered query.
      * The default value is undefined
      */
     optionsToUse: ComponentOptions.buildListOption(),

--- a/src/ui/Templates/DefaultRecommendationTemplate.ts
+++ b/src/ui/Templates/DefaultRecommendationTemplate.ts
@@ -8,11 +8,11 @@ export class DefaultRecommendationTemplate extends Template {
     var template =
       `<div class="coveo-result-frame">
         <div class="coveo-result-row" style="align-items: center">
-          <div class="coveo-result-cell" style="flex-basis:40px;text-align:center;">
+          <div class="coveo-result-cell" style="flex-basis:40px; flex-shrink: 0; flex-grow: 0; text-align:center;">
             <span class="CoveoIcon" data-small="true">
             </span>
           </div>
-          <div class="coveo-result-cell" style="padding:0 0 3px 5px;font-size:10pt; flex-shrink: 1; min-width: 0">
+          <div class="coveo-result-cell" style="padding:0 0 3px 5px;font-size:10pt; min-width: 0">
             <a class="CoveoResultLink" style="display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis">
             </a>
           </div>

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -76,19 +76,6 @@ module Coveo {
         expect(simulation.queryBuilder.recommendation).toEqual('test');
       })
 
-      it('should modify the triggered query to match the mainInterface query', () => {
-        let queryBuilder: QueryBuilder = new QueryBuilder();
-        let query = 'test';
-        queryBuilder.expression.add(query);
-
-        Simulate.query(mainSearchInterface.env, {
-          queryBuilder: queryBuilder
-        });
-
-        let simulation = Simulate.query(test.env);
-        expect(simulation.queryBuilder.expression.build()).toEqual(query);
-      })
-
       it('should only copy the optionsToUse', () => {
 
         _.extend(options, { optionsToUse: ['expression'] });


### PR DESCRIPTION
I also fixed a small bug in the default recommendation result template.

https://coveord.atlassian.net/browse/JSUI-907

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coveo/search-ui/61)
<!-- Reviewable:end -->
