### PR TITLE
Fix missing ellipsis args

### DIFF
--- a/src/ui/Base/RegisteredNamedMethods.ts
+++ b/src/ui/Base/RegisteredNamedMethods.ts
@@ -109,7 +109,7 @@ Initialization.registerNamedMethod('executeQuery', (element: HTMLElement) => {
  * @param args
  * @returns {any}
  */
-export function state(element: HTMLElement, args: any[]): any {
+export function state(element: HTMLElement, ...args: any[]): any {
   Assert.exists(element);
   var model = <QueryStateModel>Component.resolveBinding(element, QueryStateModel);
   return setState(model, args);


### PR DESCRIPTION
After updating to the most recent version, it was causing a compile problem on our side on the line `Coveo.state(this.element, "sort", this.options.defaultSortCriteriaLowercase);` :smile: 

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coveo/search-ui/141)
<!-- Reviewable:end -->
