### PR TITLE
Alias Initialization and CoveoJQuery module

### DIFF
--- a/src/Index.ts
+++ b/src/Index.ts
@@ -90,7 +90,6 @@ export {OmniboxResultList} from './ui/OmniboxResultList/OmniboxResultList';
 export {CurrentTab} from './ui/CurrentTab/CurrentTab';
 export {QueryboxQueryParameters} from './ui/Querybox/QueryboxQueryParameters';
 export {ImageResultList} from './ui/ImageResultList/ImageResultList';
-export {CoveoJQuery} from './ui/Base/CoveoJQuery';
 export {jQueryInstance as $} from './ui/Base/CoveoJQuery';
 export {underscoreInstance as _} from './ui/Base/CoveoUnderscore';
 export {FollowItem} from './ui/SearchAlerts/FollowItem';

--- a/src/UIBaseModules.ts
+++ b/src/UIBaseModules.ts
@@ -6,5 +6,8 @@ export {RootComponent} from './ui/Base/RootComponent';
 export {QueryBuilder} from './ui/Base/QueryBuilder';
 export {ExpressionBuilder} from './ui/Base/ExpressionBuilder';
 export {IResultsComponentBindings} from './ui/Base/ResultsComponentBindings';
+// Export Initialization under both name, for legacy reason and old code in the wild that
+// reference the old CoveoJQuery module
 export {Initialization} from './ui/Base/Initialization';
-export {CoveoJQuery} from './ui/Base/CoveoJQuery';
+export {Initialization as CoveoJQuery} from './ui/Base/Initialization';
+export {initCoveoJQuery} from './ui/Base/CoveoJQuery';

--- a/src/UIBaseModules.ts
+++ b/src/UIBaseModules.ts
@@ -5,5 +5,6 @@ export {BaseComponent} from './ui/Base/BaseComponent';
 export {RootComponent} from './ui/Base/RootComponent';
 export {QueryBuilder} from './ui/Base/QueryBuilder';
 export {ExpressionBuilder} from './ui/Base/ExpressionBuilder';
-export {Initialization} from './ui/Base/Initialization';
 export {IResultsComponentBindings} from './ui/Base/ResultsComponentBindings';
+export {Initialization} from './ui/Base/Initialization';
+export {CoveoJQuery} from './ui/Base/CoveoJQuery';

--- a/src/ui/Base/CoveoJQuery.ts
+++ b/src/ui/Base/CoveoJQuery.ts
@@ -1,6 +1,5 @@
 import {Initialization, IInitializationParameters} from './Initialization';
 import {IComponentDefinition} from './Component';
-export * from './Initialization';
 
 interface IWindow {
   $: any;

--- a/src/ui/Base/CoveoJQuery.ts
+++ b/src/ui/Base/CoveoJQuery.ts
@@ -1,5 +1,6 @@
 import {Initialization, IInitializationParameters} from './Initialization';
 import {IComponentDefinition} from './Component';
+export * from './Initialization';
 
 interface IWindow {
   $: any;
@@ -8,14 +9,11 @@ interface IWindow {
 // This class is essentially only there for legacy reasons : If there is any code in the wild that called this directly,
 // we don't want this to break.
 export class CoveoJQuery {
-  public static automaticallyCreateComponentsInside(element: HTMLElement, initParameters: IInitializationParameters, ignore?: string[]) {
-    return Initialization.automaticallyCreateComponentsInside(element, initParameters, ignore);
-  }
-
-  public static registerAutoCreateComponent(cmp: IComponentDefinition) {
-    return Initialization.registerAutoCreateComponent(cmp);
-  }
 }
+
+_.each(<any>_.keys(Initialization), (v: string) => {
+  CoveoJQuery[v] = Initialization[v];
+})
 
 export var jQueryInstance: JQuery;
 

--- a/src/ui/Base/CoveoJQuery.ts
+++ b/src/ui/Base/CoveoJQuery.ts
@@ -6,15 +6,6 @@ interface IWindow {
   $: any;
 }
 
-// This class is essentially only there for legacy reasons : If there is any code in the wild that called this directly,
-// we don't want this to break.
-export class CoveoJQuery {
-}
-
-_.each(<any>_.keys(Initialization), (v: string) => {
-  CoveoJQuery[v] = Initialization[v];
-})
-
 export var jQueryInstance: JQuery;
 
 if (jQueryIsDefined()) {
@@ -28,7 +19,7 @@ if (jQueryIsDefined()) {
   })
 }
 
-function initCoveoJQuery() {
+export function initCoveoJQuery() {
   jQueryInstance = window['$'];
   if (window['Coveo'] == undefined) {
     window['Coveo'] = {};


### PR DESCRIPTION
For legacy reason and older code in the wild that still reference the old module, export the Initialization module under both name


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coveo/search-ui/149)
<!-- Reviewable:end -->
