### PR TITLE
Add a requestModifier function on endpoint calls

### DIFF
--- a/src/rest/EndpointCaller.ts
+++ b/src/rest/EndpointCaller.ts
@@ -74,6 +74,10 @@ export interface IRequestInfo<T> {
    * The method that was used for this request
    */
   method: string;
+  /**
+   * The headers for the request.
+   */
+  headers?: IStringMap<string>;
 }
 
 /**
@@ -146,6 +150,12 @@ export interface IEndpointCallerOptions {
    * Not used if accessToken is provided.
    */
   password?: string;
+  /**
+   * A function which will allow external code to modify all endpoint call parameters before they are sent by the browser.
+   *
+   * Used in very specific scenario where the network infrastructure require special request headers to be added or removed, for example.
+   */
+  requestModifier?: (params: IRequestInfo<any>) => IRequestInfo<any>;
 }
 
 // In ie8, XMLHttpRequest has no status property, so let's use this enum instead
@@ -197,6 +207,7 @@ export class EndpointCaller {
    * @returns {any} A promise of the given type
    */
   public call<T>(params: IEndpointCallParameters): Promise<ISuccessResponse<T>> {
+
     var requestInfo: IRequestInfo<T> = {
       url: params.url,
       queryString: params.errorsAsSuccess ? params.queryString.concat(['errorsAsSuccess=1']) : params.queryString,
@@ -205,6 +216,11 @@ export class EndpointCaller {
       begun: new Date(),
       method: params.method
     };
+    requestInfo.headers = this.buildRequestHeaders(requestInfo);
+    if (_.isFunction(this.options.requestModifier)) {
+      requestInfo = this.options.requestModifier(requestInfo);
+    }
+
 
     this.logger.trace('Performing REST request', requestInfo);
     var urlObject = this.parseURL(requestInfo.url);
@@ -250,20 +266,15 @@ export class EndpointCaller {
           sent = true;
           xmlHttpRequest.withCredentials = true;
 
-          // Set authentication depending on what we're using
-          if (this.options.accessToken) {
-            xmlHttpRequest.setRequestHeader('Authorization', 'Bearer ' + this.options.accessToken);
-          } else if (this.options.username && this.options.password) {
-            xmlHttpRequest.setRequestHeader('Authorization', 'Basic ' + btoa(this.options.username + ':' + this.options.password));
-          }
+          _.each(requestInfo.headers, (headerValue, headerKey) => {
+            xmlHttpRequest.setRequestHeader(headerKey, headerValue);
+          });
 
           if (requestInfo.method == 'GET') {
             xmlHttpRequest.send();
           } else if (requestInfo.requestDataType.indexOf('application/json') === 0) {
-            xmlHttpRequest.setRequestHeader('Content-Type', 'application/json; charset="UTF-8"');
             xmlHttpRequest.send(JSON.stringify(requestInfo.requestData));
           } else {
-            xmlHttpRequest.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset="UTF-8"');
             xmlHttpRequest.send(this.convertJsonToFormBody(requestInfo.requestData));
           }
 
@@ -497,5 +508,26 @@ export class EndpointCaller {
     } else {
       return false;
     }
+  }
+
+  private buildRequestHeaders<T>(requestInfo: IRequestInfo<T>): IStringMap<string> {
+    let headers: IStringMap<string> = {};
+    if (this.options.accessToken) {
+      headers['Authorization'] = `Bearer ${this.options.accessToken}`;
+    } else if (this.options.username && this.options.password) {
+      headers['Authorization'] = `Basic ${btoa(this.options.username + ':' + this.options.password)}`;
+    }
+
+    if (requestInfo.method == 'GET') {
+      return headers;
+    }
+
+    if (requestInfo.requestDataType.indexOf('application/json') === 0) {
+      headers['Content-Type'] = 'application/json; charset="UTF-8"';
+    } else {
+      headers['Content-Type'] = 'application/x-www-form-urlencoded; charset="UTF-8"';
+    }
+
+    return headers;
   }
 }

--- a/src/rest/GenericParam.ts
+++ b/src/rest/GenericParam.ts
@@ -1,3 +1,13 @@
+/**
+ * A JSON which contains type T.
+ *
+ * eg :
+ * ```
+ * IStringMap<boolean> -> {'foo' : true, 'bar' : false};
+ * IStringMap<number> -> {'foo' : 1 , 'bar' : 123}
+ * ```
+ *
+ */
 export interface IStringMap<T> {
   [paramName: string]: T;
 }

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -1,5 +1,5 @@
 import {ISearchEndpointOptions, ISearchEndpoint, IViewAsHtmlOptions} from './SearchEndpointInterface';
-import {EndpointCaller, IEndpointCallParameters, ISuccessResponse, IErrorResponse} from '../rest/EndpointCaller';
+import {EndpointCaller, IEndpointCallParameters, ISuccessResponse, IErrorResponse, IRequestInfo} from '../rest/EndpointCaller';
 import {IEndpointCallOptions} from '../rest/SearchEndpointInterface';
 import {IStringMap} from './GenericParam';
 import {Logger} from '../misc/Logger';
@@ -162,6 +162,16 @@ export class SearchEndpoint implements ISearchEndpoint {
 
   public reset() {
     this.createEndpointCaller();
+  }
+
+  /**
+   * Set a function which will allow external code to modify all endpoint call parameters before they are sent by the browser.
+   *
+   * Used in very specific scenario where the network infrastructure require special request headers to be added or removed, for example.
+   * @param requestModifier
+   */
+  public setRequestModifier(requestModifier: (params: IRequestInfo<any>) => IRequestInfo<any>) {
+    this.caller.options.requestModifier = requestModifier;
   }
 
   /**

--- a/test/rest/EndpointCallerTest.ts
+++ b/test/rest/EndpointCallerTest.ts
@@ -263,7 +263,28 @@ export function EndpointCallerTest() {
             response: FakeResults.createFakeResults()
           });
         });
+
+        it('should allow to modify the request with an option', function () {
+          let endpointCaller = new EndpointCaller({
+            accessToken: 'myToken',
+            requestModifier: (requestInfo) => {
+              requestInfo.method = 'GET';
+              return requestInfo;
+            }
+          });
+          endpointCaller.call({
+            method: 'POST',
+            requestData: {},
+            url: 'this is an XMLHTTPRequest',
+            queryString: [],
+            responseType: 'text',
+            errorsAsSuccess: false
+          });
+          expect(jasmine.Ajax.requests.mostRecent().method).toBe('GET');
+        });
       });
     });
+
+
   });
 }

--- a/test/rest/SearchEndpointTest.ts
+++ b/test/rest/SearchEndpointTest.ts
@@ -2,7 +2,7 @@ import {SearchEndpoint} from '../../src/rest/SearchEndpoint';
 import {FakeResults} from '../Fake';
 import {QueryBuilder} from '../../src/ui/Base/QueryBuilder';
 import {IQueryResults} from '../../src/rest/QueryResults';
-import {IErrorResponse} from '../../src/rest/EndpointCaller';
+import {IErrorResponse, IRequestInfo} from '../../src/rest/EndpointCaller';
 import {IQueryResult} from '../../src/rest/QueryResult';
 import {IListFieldValuesRequest} from '../../src/rest/ListFieldValuesRequest';
 import {IIndexFieldValue} from '../../src/rest/FieldValue';
@@ -185,6 +185,7 @@ export function SearchEndpointTest() {
 
         afterEach(function () {
           jasmine.Ajax.uninstall();
+          ep.reset();
         });
 
         it('for search', function (done) {
@@ -622,6 +623,17 @@ export function SearchEndpointTest() {
             status: 200,
             responseText: JSON.stringify({ id: 'foobar' })
           });
+        });
+
+        it('request can be modified', function () {
+          ep.setRequestModifier((requestInfo: IRequestInfo<any>) => {
+            requestInfo.headers['Potato'] = 'OmgPotatoes';
+            return requestInfo;
+          });
+          ep.search(new QueryBuilder().build());
+          expect(jasmine.Ajax.requests.mostRecent().requestHeaders).toEqual(jasmine.objectContaining({
+            'Potato': 'OmgPotatoes'
+          }));
         });
       });
     });


### PR DESCRIPTION
This will allow external code to modify all requests parameters before they are sent by the browser.

This will allow, for example, to modify the request headers, the request method, the queryString, etc.



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
…ll requests sent by the browser.

https://coveord.atlassian.net/browse/JSUI-1044

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coveo/search-ui/159)
<!-- Reviewable:end -->
