### PR TITLE
Add check for hideIfNoResults options before hiding the Recommendation Component

### DIFF
--- a/src/ui/Querybox/Querybox.ts
+++ b/src/ui/Querybox/Querybox.ts
@@ -89,14 +89,14 @@ export class Querybox extends Component {
      * The default value is `true`.
      */
     triggerQueryOnClear: ComponentOptions.buildBooleanOption({ defaultValue: true }),
-	/**
-	* Specifies a placeholder for input.
-	*/
+    /**
+    * Specifies a placeholder for input.
+    */
     placeholder: ComponentOptions.buildStringOption(),
-	/**
-	* Specifies whether the `QueryBox` gets the focus and is selected on initialization.
-	* The default value is `true`.
-	*/
+    /**
+    * Specifies whether the `QueryBox` gets the focus and is selected on initialization.
+    * The default value is `true`.
+    */
     autoFocus: ComponentOptions.buildBooleanOption({ defaultValue: true })
   };
 

--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -101,7 +101,11 @@ export class Recommendation extends SearchInterface {
 
     $$(this.element).on(QueryEvents.buildingQuery, (e: Event, args: IBuildingQueryEventArgs) => this.handleRecommendationBuildingQuery(args));
     $$(this.element).on(QueryEvents.querySuccess, (e: Event, args: IQuerySuccessEventArgs) => this.handleRecommendationQuerySuccess(args));
-    $$(this.element).on(QueryEvents.noResults, (e: Event, args: INoResultsEventArgs) => this.hide());
+    $$(this.element).on(QueryEvents.noResults, (e: Event, args: INoResultsEventArgs) => {
+      if (this.options.hideIfNoResults) {
+        this.hide();
+      }
+    });
     $$(this.element).on(QueryEvents.queryError, (e: Event, args: IQueryErrorEventArgs) => this.hide());
 
     // This is done to allow the component to be included in another search interface without triggering the parent events.

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -144,10 +144,19 @@ export function RecommendationTest() {
       });
 
       describe('exposes option hideIfNoResults', () => {
-        it('should hide the interface if there are no recommendations', () => {
+        it('should hide the interface if there are no recommendations and the option is true', () => {
+          options.hideIfNoResults = true;
+          test = Mock.optionsSearchInterfaceSetup<Recommendation, IRecommendationOptions>(Recommendation, options);
           Simulate.query(test.env, { results: FakeResults.createFakeResults(0) });
           expect(test.cmp.element.style.display).toEqual('none');
         });
+
+        it('should not hide the interface if there are no recommendations and the option is false', () => {
+          options.hideIfNoResults = false;
+          test = Mock.optionsSearchInterfaceSetup<Recommendation, IRecommendationOptions>(Recommendation, options);
+          Simulate.query(test.env, { results: FakeResults.createFakeResults(0) });
+          expect(test.cmp.element.style.display).toEqual('block');
+        })
 
         it('should show the interface if there are recommendations', () => {
           Simulate.query(test.env);


### PR DESCRIPTION


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
Better UT for the option.
https://coveord.atlassian.net/browse/JSUI-1118

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coveo/search-ui/171)
<!-- Reviewable:end -->
