### PR TITLE
Resize FieldTable when a thumbnail is loaded

### DIFF
--- a/sass/_FieldTable.scss
+++ b/sass/_FieldTable.scss
@@ -5,6 +5,7 @@
   background-color: $color-blueish-white;
   padding-bottom: 10px;
   position: relative;
+  word-break: break-all;
   th, td {
     font-size: $font-size-smaller;
   }

--- a/src/ui/FieldTable/FieldTable.ts
+++ b/src/ui/FieldTable/FieldTable.ts
@@ -139,6 +139,15 @@ export class FieldTable extends Component {
     }
   }
 
+  /**
+   * Update the toggle height if the content was dynamically resized so that the open and close animation can
+   * match the new content size.
+   */
+  public updateToggleHeight() {
+    this.updateToggleContainerHeight();
+    this.isExpanded ? this.expand() : this.minimize();
+  }
+
   protected isTogglable() {
     if (this.searchInterface.isNewDesign() && this.options.allowMinimization) {
       return true;
@@ -168,8 +177,7 @@ export class FieldTable extends Component {
     }
 
     setTimeout(() => {
-      this.updateToggleContainerHeight();
-      this.isExpanded ? this.expand() : this.minimize();
+      this.updateToggleHeight();
     }); // Wait until toggleContainer.scrollHeight is computed.
 
     const toggleAction = () => this.toggle(true);

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -156,7 +156,7 @@ export function RecommendationTest() {
           test = Mock.optionsSearchInterfaceSetup<Recommendation, IRecommendationOptions>(Recommendation, options);
           Simulate.query(test.env, { results: FakeResults.createFakeResults(0) });
           expect(test.cmp.element.style.display).toEqual('block');
-        })
+        });
 
         it('should show the interface if there are recommendations', () => {
           Simulate.query(test.env);

--- a/test/ui/ThumbnailTest.ts
+++ b/test/ui/ThumbnailTest.ts
@@ -4,6 +4,7 @@ import {SearchEndpoint} from '../../src/rest/SearchEndpoint';
 import {IQueryResult} from '../../src/rest/QueryResult';
 import {IThumbnailOptions} from '../../src/ui/Thumbnail/Thumbnail';
 import {$$} from '../../src/utils/Dom';
+import {FieldTable} from '../../src/ui/FieldTable/FieldTable';
 
 export function ThumbnailTest() {
   describe('Thumbnail', function () {
@@ -12,67 +13,79 @@ export function ThumbnailTest() {
     var endpoint: SearchEndpoint;
     var getRawDataStreamPromise: Promise<ArrayBuffer>;
 
-    beforeEach(function () {
+    beforeEach(() => {
       endpoint = Mock.mockSearchEndpoint();
       getRawDataStreamPromise = new Promise<ArrayBuffer>((resolve, reject) => { });
       endpoint.getRawDataStream = () => getRawDataStreamPromise;
       test = Mock.advancedResultComponentSetup<Thumbnail>(Thumbnail, undefined, <Mock.AdvancedComponentSetupOptions>{
-        modifyBuilder: (builder: Mock.MockEnvironmentBuilder) => builder.withResult().withEndpoint(endpoint)
+        modifyBuilder: (builder: Mock.MockEnvironmentBuilder) => builder.withElement($$('img').el).withResult().withEndpoint(endpoint)
       });
     });
 
-    describe('without JSONP', function () {
+    describe('without JSONP', () => {
       beforeEach(function () {
         endpoint.isJsonp = () => false;
         endpoint.getRawDataStream = () => new Promise<ArrayBuffer>((resolve, reject) => resolve(new ArrayBuffer(0)));
         test = Mock.advancedResultComponentSetup<Thumbnail>(Thumbnail, undefined, <Mock.AdvancedComponentSetupOptions>{
-          modifyBuilder: (builder: Mock.MockEnvironmentBuilder) => builder.withResult().withEndpoint(endpoint)
+          modifyBuilder: (builder: Mock.MockEnvironmentBuilder) => builder.withElement($$('img').el).withResult().withEndpoint(endpoint)
         });
       });
 
-      it('should use async call by default', function (done) {
+      it('should use async call by default', (done) => {
         setTimeout(function () {
           expect(test.cmp.element.getAttribute('src')).toBe('data:image/png;base64, ');
           done();
         }, 0);
       });
+
+      it('should try to resize FieldTable content if it\'s contained in one', (done) => {
+        let fakeFieldTable = Mock.basicResultComponentSetup<FieldTable>(FieldTable);
+        let spyResize = jasmine.createSpy('spyResize');
+        fakeFieldTable.cmp.updateToggleHeight = spyResize;
+        fakeFieldTable.cmp.element.appendChild(test.cmp.element);
+
+        setTimeout(function () {
+          expect(spyResize).toHaveBeenCalled();
+          done();
+        }, 0);
+      });
     });
 
-    describe('with JSONP', function () {
+    describe('with JSONP', () => {
       beforeEach(function () {
         endpoint.isJsonp = () => true;
         test = Mock.advancedResultComponentSetup<Thumbnail>(Thumbnail, undefined, <Mock.AdvancedComponentSetupOptions>{
-          modifyBuilder: (builder: Mock.MockEnvironmentBuilder) => builder.withResult().withEndpoint(endpoint)
+          modifyBuilder: (builder: Mock.MockEnvironmentBuilder) => builder.withElement($$('img').el).withResult().withEndpoint(endpoint)
         });
       });
 
-      it('should use direct url', function () {
+      it('should use direct url', () => {
         expect(test.cmp.element.getAttribute('src')).toEqual('http://datastream.uri');
       });
     });
 
-    it('should set a CSS class when no thumbnail is available', function () {
+    it('should set a CSS class when no thumbnail is available', () => {
       var result = <IQueryResult>{
         flags: ''
       };
       test = Mock.optionsResultComponentSetup<Thumbnail, IThumbnailOptions>(Thumbnail, undefined, result);
-      expect($$(test.cmp.element).hasClass('coveo-no-thumbnail')).toBe(true);
+      expect($$(test.cmp.img).hasClass('coveo-no-thumbnail')).toBe(true);
     });
 
-    describe('exposes options', function () {
-      it('noThumbnailClass should set the appropriate CSS class when no thumbnail is available', function () {
+    describe('exposes options', () => {
+      it('noThumbnailClass should set the appropriate CSS class when no thumbnail is available', () => {
         test = Mock.optionsResultComponentSetup<Thumbnail, IThumbnailOptions>(Thumbnail, <IThumbnailOptions>{
           noThumbnailClass: 'coveo-heyo-there-is-no-class'
         }, <IQueryResult>{ flags: '' });
 
-        expect($$(test.cmp.element).hasClass('coveo-heyo-there-is-no-class')).toBe(true);
-        expect($$(test.cmp.element).hasClass('coveo-no-thumbnail')).toBe(false);
+        expect($$(test.cmp.img).hasClass('coveo-heyo-there-is-no-class')).toBe(true);
+        expect($$(test.cmp.img).hasClass('coveo-no-thumbnail')).toBe(false);
       });
     });
 
 
-    it('should put in an empty image while loading', function () {
-      expect(test.cmp.element.getAttribute('src')).toEqual('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==');
+    it('should put in an empty image while loading', () => {
+      expect(test.cmp.img.getAttribute('src')).toEqual('data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==');
     });
   });
 }


### PR DESCRIPTION
This allows the "toggle" animation to work correctly when the Thumbnail content is resized.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
https://coveord.atlassian.net/browse/JSUI-1116

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coveo/search-ui/172)
<!-- Reviewable:end -->
