### PR TITLE
Modified the required check on component options

### DIFF
--- a/src/ui/Base/ComponentOptions.ts
+++ b/src/ui/Base/ComponentOptions.ts
@@ -317,8 +317,6 @@ export class ComponentOptions {
           values[name] = value;
         }
       }
-      Assert.check(!(values[name] == undefined && optionDefinition.required), componentID + '.' + name + ' is required');
-
     }
     for (let i = 0; i < names.length; i++) {
       let name = names[i];

--- a/src/ui/Sort/Sort.ts
+++ b/src/ui/Sort/Sort.ts
@@ -28,15 +28,18 @@ export class Sort extends Component {
    */
   static options: ISortOptions = {
     /**
-     * The criterion for sorting<br/>
+     * The criterion for sorting
+     *
      * The available criteria are:
      * - `relevancy`
      * - `Date`
      * - `qre`
      * - `@fieldname` (replace fieldname with an actual field name (e.g. <code>@syssize</code>)
      *
-     * A direction (ascending or descending) can be specified, for example "date ascending".<br/>
-     * A Sort component can have multiple criteria, passed as a list.<br/>
+     * A direction (ascending or descending) can be specified, for example "date ascending".
+     *
+     * A Sort component can have multiple criteria, passed as a list.
+     *
      * This option is required.
      */
     sortCriteria: ComponentOptions.buildCustomListOption((values: string[] | SortCriteria[]) => {
@@ -49,7 +52,8 @@ export class Sort extends Component {
       });
     }, { required: true }),
     /**
-     * The caption to display on the element.<br/>
+     * The caption to display on the element.
+     *
      * If not specified, the component will use the tag body.
      */
     caption: ComponentOptions.buildLocalizedStringOption({ required: true })
@@ -93,7 +97,8 @@ export class Sort extends Component {
 
   /**
    * Select the Sort component.
-   * @param direction The sort direction (e.g. ascending, descending)<br/>
+   * @param direction The sort direction (e.g. ascending, descending).
+   *
    * Will trigger a query if the selection made the criteria change (if it was toggled).
    */
   public select(direction?: string) {

--- a/test/ui/ComponentOptionsTest.ts
+++ b/test/ui/ComponentOptionsTest.ts
@@ -232,7 +232,7 @@ export function ComponentOptionsTest() {
               required: true
             })
           };
-          expect(() => { ComponentOptions.initComponentOptions(elem, { options, ID: 'fooID' }); }).toThrow();
+          expect(() => { ComponentOptions.initComponentOptions(elem, { options, ID: 'fooID' }); }).not.toThrow();
         });
 
         it('which initializes the options of a component with postProcessing', () => {

--- a/test/ui/SortTest.ts
+++ b/test/ui/SortTest.ts
@@ -220,6 +220,15 @@ export function SortTest() {
       expect(test.env.element.innerText).toEqual('overrider');
     });
 
+    it('should use the body if the data-caption is not defined', () => {
+      test = Mock.advancedComponentSetup<Sort>(Sort, <Mock.AdvancedComponentSetupOptions>{
+        element: Dom.createElement('div', {
+          'data-sort-criteria': 'relevancy',
+        }, 'notgettingreplaced')
+      });
+      expect(test.env.element.innerText).toEqual('notgettingreplaced');
+    });
+
     it('should remove unnecessary spaces between sort and direction', function () {
       test = buildSort('date            ascending');
       expect(test.cmp.options.sortCriteria[0].toString()).toEqual('date ascending');


### PR DESCRIPTION
This ensure that the UI will not fail on initialization if any component is badly configured.

We should not have these kind of behaviour where a single badly configured component can crash the whole initialization. It's better if that single component does not work correctly, but the rest of the interface keeps working.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

https://coveord.atlassian.net/browse/JSUI-1123