### PR TITLE
Remove jQuery from ambient typings file

### DIFF
--- a/src/Index.ts
+++ b/src/Index.ts
@@ -111,12 +111,13 @@ export {ChatterPostedBy} from './ui/ChatterPostedBy/ChatterPostedBy';
 export {ChatterTopic} from './ui/ChatterTopic/ChatterTopic';
 export {ChatterUtils} from './utils/ChatterUtils';
 export { Logo } from './ui/Logo/Logo';
+import {CoreHelpers} from './ui/Templates/CoreHelpers';
 
 // Webpack output a library target with a temporary name.
 // This is to allow end user to put CoveoJsSearch.Dependencie.js before or after the main CoveoJsSearch.js, without breaking
 // This code swap the current module to the "real" Coveo variable.
-
 let swapVar = () => {
+
   if (window['Coveo'] == undefined) {
     window['Coveo'] = this;
   } else {
@@ -124,6 +125,7 @@ let swapVar = () => {
       window['Coveo'][k] = this[k];
     });
   }
+  CoreHelpers.exportAllHelpersGlobally(window['Coveo']);
   if (window['__extends'] == undefined) {
     var __extends = function (d, b) {
       for (var p in b) {
@@ -139,5 +141,6 @@ let swapVar = () => {
     };
     window['__extends'] = __extends;
   }
+
 };
 swapVar();

--- a/src/ui/ShareQuery/ShareQuery.ts
+++ b/src/ui/ShareQuery/ShareQuery.ts
@@ -109,8 +109,7 @@ export class ShareQuery extends Component {
 
   private buildContent(): HTMLElement {
     let content = $$('div', { className: 'coveo-share-query-summary-info' }).el;
-    content.appendChild($$('span', { className: 'coveo-query-summary-info-title' }).el);
-    $$(content).text(l('ShareQuery'));
+    content.appendChild($$('span', { className: 'coveo-query-summary-info-title' }, l('ShareQuery')).el);
 
     let close = $$('div', { className: 'coveo-share-query-summary-info-close' }).el;
     close.appendChild($$('span').el);

--- a/src/ui/TemplateLoader/TemplateLoader.ts
+++ b/src/ui/TemplateLoader/TemplateLoader.ts
@@ -5,6 +5,7 @@ import {IComponentBindings} from '../Base/ComponentBindings';
 import {IQueryResult} from '../../rest/QueryResult';
 import {Assert} from '../../misc/Assert';
 import {Initialization, IInitializationParameters} from '../Base/Initialization';
+import {$$} from '../../utils/Dom';
 
 export interface ITemplateLoaderOptions {
   template: Template;
@@ -44,10 +45,14 @@ export class TemplateLoader extends Component {
         result: this.result
       };
 
-      var parents = $(this.element).parents('.' + Component.computeCssClassName(TemplateLoader));
-      _.each(parents, (parent) => {
-        var parentHTML = $(parent).clone().children().remove().end().get(0).outerHTML;
-        Assert.check(parentHTML.indexOf(this.element.outerHTML) === -1, 'TemplateLoader cannot load a template into itself.');
+      $(this.element);
+
+      var parents = $$(this.element).parents(Component.computeCssClassName(TemplateLoader));
+      _.each(parents, (parent: HTMLElement) => {
+        let clone = <HTMLElement>parent.cloneNode();
+        $$(clone).empty();
+        let outerHTMLParent = clone.outerHTML;
+        Assert.check(outerHTMLParent.indexOf(this.element.outerHTML) === -1, 'TemplateLoader cannot load a template into itself.');
       });
 
       this.element.innerHTML = this.options.template.instantiateToString(this.result, false);

--- a/src/ui/Templates/CoreHelpers.ts
+++ b/src/ui/Templates/CoreHelpers.ts
@@ -1,4 +1,4 @@
-import {TemplateHelpers} from './TemplateHelpers';
+import {TemplateHelpers, ITemplateHelperFunction} from './TemplateHelpers';
 import {ComponentOptions} from '../Base/ComponentOptions';
 import {IHighlight, IHighlightPhrase, IHighlightTerm} from '../../rest/Highlight';
 import {HighlightUtils, StringAndHoles} from '../../utils/HighlightUtils';
@@ -20,6 +20,7 @@ import {SearchEndpoint} from '../../rest/SearchEndpoint';
 import {ResultList} from '../ResultList/ResultList';
 import {StreamHighlightUtils} from '../../utils/StreamHighlightUtils';
 import Globalize = require('globalize');
+import {IStringMap} from '../../rest/GenericParam';
 
 /**
  * The core template helpers provided by default.
@@ -235,7 +236,19 @@ export interface ICoreHelpers {
 
 export class CoreHelpers {
   public constructor() {
+  }
 
+  /**
+   * For backward compatibility reason, the "global" template helper should be available under the
+   * coveo namespace.
+   * @param scope
+   */
+  public static exportAllHelpersGlobally(scope: IStringMap<any>) {
+    _.each(TemplateHelpers.getHelpers(), (helper: ITemplateHelperFunction, name: string) => {
+      if (scope[name] == undefined) {
+        scope[name] = helper;
+      }
+    });
   }
 }
 

--- a/src/utils/Dom.ts
+++ b/src/utils/Dom.ts
@@ -218,33 +218,43 @@ export class Dom {
   }
 
   /**
-   * Get the first element that matches the classname by testing the element itself and traversing up through its ancestors in the DOM tree.<br/>
+   * Get the first element that matches the classname by testing the element itself and traversing up through its ancestors in the DOM tree.
+   *
    * Stops at the body of the document
    * @param className A CSS classname
    */
   public closest(className: string): HTMLElement {
-    if (className.indexOf('.') == 0) {
-      className = className.substr(1);
+    return this.traverseAncestorForClass(this.el, className);
+  }
+
+  /**
+   * Get the first element that matches the classname by testing the element itself and traversing up through its ancestors in the DOM tree.
+   *
+   * Stops at the body of the document
+   * @returns {any}
+   */
+  public parent(className: string): HTMLElement {
+    if (this.el.parentElement == undefined) {
+      return undefined;
     }
-    var current = this.el, found = false;
-    while (!found) {
-      if ($$(current).hasClass(className)) {
-        found = true;
-      }
-      if (current.tagName.toLowerCase() == 'body') {
-        break;
-      }
-      if (current.parentElement == null) {
-        break;
-      }
-      if (!found) {
-        current = current.parentElement;
-      }
+    return this.traverseAncestorForClass(this.el.parentElement, className);
+  }
+
+  /**
+   *  Get all the ancestors of the current element that match the given className
+   *
+   *  Return an empty array if none found.
+   * @param className
+   * @returns {HTMLElement[]}
+   */
+  public parents(className: string): HTMLElement[] {
+    let parentsFound = [];
+    let parentFound = this.parent(className);
+    while (parentFound) {
+      parentsFound.push(parentFound);
+      parentFound = new Dom(parentFound).parent(className);
     }
-    if (found) {
-      return current;
-    }
-    return undefined;
+    return parentsFound;
   }
 
   /**
@@ -663,6 +673,30 @@ export class Dom {
     return false;
   }
 
+  private traverseAncestorForClass(current = this.el, className: string): HTMLElement {
+    if (className.indexOf('.') == 0) {
+      className = className.substr(1);
+    }
+    var found = false;
+    while (!found) {
+      if ($$(current).hasClass(className)) {
+        found = true;
+      }
+      if (current.tagName.toLowerCase() == 'body') {
+        break;
+      }
+      if (current.parentElement == null) {
+        break;
+      }
+      if (!found) {
+        current = current.parentElement;
+      }
+    }
+    if (found) {
+      return current;
+    }
+    return undefined;
+  }
 }
 
 export class Win {

--- a/src/utils/StreamHighlightUtils.ts
+++ b/src/utils/StreamHighlightUtils.ts
@@ -3,9 +3,10 @@ import {HighlightUtils} from './HighlightUtils';
 import {StringUtils} from './StringUtils';
 import {Utils} from './Utils';
 import {IHighlight} from '../rest/Highlight';
+import {$$} from './Dom';
 
 // \u2011: http://graphemica.com/%E2%80%91
-let nonWordBoundary = '[\\.\\-\\u2011\\s~=,.\\|\\/:\'`’;_()]';
+let nonWordBoundary = '[\\.\\-\\u2011\\s~=,.\\|\\/:\'`’;_()!?]';
 let regexStart = '(' + nonWordBoundary + '|^)(';
 export interface IStreamHighlightOptions {
   cssClass?: string;
@@ -22,11 +23,11 @@ export class StreamHighlightUtils {
   static highlightStreamHTML(stream: string, termsToHighlight: { [originalTerm: string]: string[] }, phrasesToHighlight: { [phrase: string]: { [originalTerm: string]: string[] } }, options?: IStreamHighlightOptions) {
     let opts = new DefaultStreamHighlightOptions().merge(options);
     let container = createStreamHTMLContainer(stream);
-    container.find('*').each((i: number, elem: HTMLElement) => {
-      let text = $(elem).text();
-      $(elem).html(HighlightUtils.highlightString(text, getRestHighlightsForAllTerms(text, termsToHighlight, phrasesToHighlight, opts), [], opts.cssClass));
+    _.each($$(container).findAll('*'), (elem: HTMLElement, i: number) => {
+      let text = $$(elem).text();
+      elem.innerHTML = HighlightUtils.highlightString(text, getRestHighlightsForAllTerms(text, termsToHighlight, phrasesToHighlight, opts), [], opts.cssClass);
     });
-    return container.html();
+    return container.innerHTML;
   }
 
   static highlightStreamText(stream: string, termsToHighlight: { [originalTerm: string]: string[] }, phrasesToHighlight: { [phrase: string]: { [originalTerm: string]: string[] } }, options?: IStreamHighlightOptions) {
@@ -96,7 +97,7 @@ function termsSorting(first: string, second: string) {
 }
 
 function createStreamHTMLContainer(stream: string) {
-  let container = $('<div />');
-  container.get(0).innerHTML = stream;
+  let container = $$('div').el;
+  container.innerHTML = stream;
   return container;
 }

--- a/test/Fake.ts
+++ b/test/Fake.ts
@@ -109,7 +109,7 @@ export class FakeResults {
     }
     var ret = FakeResults.createFakeResult(token);
     ret.totalNumberOfChildResults = totalNumberOfChildResult;
-    $.extend(ret, { childResults: childResults });
+    ret = _.extend(ret, { childResults: childResults });
     return ret;
   }
 
@@ -235,35 +235,6 @@ export class FakeResults {
     }
 
     return fieldValues;
-  }
-
-  static createFakeOmniboxData(token = 'test', numberOfRows = 1, numberOfSelectablePerRow = 1, zIndex = 1) {
-    var rows = [];
-    for (var i = 0; i < numberOfRows; i++) {
-      var selectables = FakeResults.createFakeOmniboxSelectableData(token + ':' + i, numberOfSelectablePerRow);
-      var element = $(`<div class='coveo-omnibox-section'></div>`);
-      _.each(selectables, (selectable) => {
-        element.append(selectable);
-      });
-      rows.push({ element: element.get(0), zIndex: zIndex + i });
-    }
-    return rows;
-  }
-
-  static createFakeDeferredOmniboxData(numberOfRows: number) {
-    var rows = [];
-    for (var i = 0; i < numberOfRows; i++) {
-      rows.push({ deferred: $.Deferred() });
-    }
-    return rows;
-  }
-
-  static createFakeOmniboxSelectableData(token: string, numberOfSelectables: number) {
-    var rows = [];
-    for (var i = 0; i < numberOfSelectables; i++) {
-      rows.push($(`<div class='coveo-omnibox-selectable'>${token + ':' + i}</div>`));
-    }
-    return rows;
   }
 
   static createFakeFeedItemResult(token: string, nbLikes: number = 0, nbTopics: number = 0, hasAttachment: boolean = false) {

--- a/test/Test.ts
+++ b/test/Test.ts
@@ -325,3 +325,6 @@ SentryLoggerTest();
 
 import {DebugTest} from './ui/DebugTest';
 DebugTest();
+
+import {StreamHighlightUtilsTest} from './utils/StreamHighlightUtilsTest';
+StreamHighlightUtilsTest();

--- a/test/ui/DebugTest.ts
+++ b/test/ui/DebugTest.ts
@@ -5,7 +5,6 @@ import {DebugEvents} from '../../src/events/DebugEvents';
 import {ModalBox} from '../../src/ExternalModulesShim';
 import {Simulate} from '../Simulate';
 import {KEYBOARD} from '../../src/utils/KeyboardUtils';
-import {InitializationEvents} from '../../src/events/InitializationEvents';
 
 export function DebugTest() {
   describe('Debug', () => {
@@ -23,7 +22,7 @@ export function DebugTest() {
       oldOpen = ModalBox.open;
       oldClose = ModalBox.close;
       ModalBox.open = open.and.returnValue({
-        wrapper: $$('div', undefined, $$('div', {className: 'coveo-title'}))
+        wrapper: $$('div', undefined, $$('div', { className: 'coveo-title' }))
       });
       ModalBox.close = close;
 

--- a/test/ui/ShareQueryTest.ts
+++ b/test/ui/ShareQueryTest.ts
@@ -15,10 +15,10 @@ export function ShareQueryTest() {
     });
 
     it('should render properly', function () {
-      expect($(test.cmp.element).find('.coveo-share-query-summary-info .coveo-query-summary-info-title')).not.toBeNull();
-      expect($(test.cmp.element).find('.coveo-share-query-summary-info .coveo-share-query-summary-info-close')).not.toBeNull();
-      expect($(test.cmp.element).find('.coveo-share-query-summary-info .coveo-share-query-summary-info-boxes')).not.toBeNull();
-      expect($(test.cmp.element).find('.coveo-share-query-summary-info .coveo-share-query-summary-info-boxes input')).not.toBeNull();
+      expect($$(test.cmp.element).find('.coveo-share-query-summary-info .coveo-query-summary-info-title')).not.toBeNull();
+      expect($$(test.cmp.element).find('.coveo-share-query-summary-info .coveo-share-query-summary-info-close')).not.toBeNull();
+      expect($$(test.cmp.element).find('.coveo-share-query-summary-info .coveo-share-query-summary-info-boxes')).not.toBeNull();
+      expect($$(test.cmp.element).find('.coveo-share-query-summary-info .coveo-share-query-summary-info-boxes input')).not.toBeNull();
     });
 
     it('should update according to result', function () {

--- a/test/utils/DomTest.ts
+++ b/test/utils/DomTest.ts
@@ -1,3 +1,5 @@
+/// <reference path="../../typings/main/ambient/jquery/index.d.ts" />
+
 import {registerCustomMatcher} from '../CustomMatchers';
 import {Dom} from '../../src/utils/Dom';
 import {$$} from '../../src/utils/Dom';
@@ -403,6 +405,80 @@ export function DomTests() {
         root.className = 'findme';
         root.appendChild(el);
         expect(new Dom(el).closest('findme')).toBe(root);
+      });
+
+      it('should find the first ancestor element using parent', function () {
+        let root = document.createElement('div');
+        let parentOne = $$('div', { className: 'foo' });
+        let parentTwo = $$('div', { className: 'foo' });
+        let parentThree = $$('div', { className: 'foo' });
+
+        let child = $$('div');
+
+        root.appendChild(parentOne.el);
+        parentOne.append(parentTwo.el);
+        parentTwo.append(parentThree.el);
+        parentThree.append(child.el);
+
+        expect(child.parent('foo')).toEqual(parentThree.el);
+      });
+
+      it('should not throw if there are no parent element using parent', function () {
+        let root = $$('div');
+        expect(() => root.parent('bar')).not.toThrow();
+      });
+
+      it('should return undefined if there is no match using parent', function () {
+        let root = document.createElement('div');
+        let parentOne = $$('div', { className: 'foo' });
+        let parentTwo = $$('div', { className: 'foo' });
+        let parentThree = $$('div', { className: 'foo' });
+
+        let child = $$('div');
+
+        root.appendChild(parentOne.el);
+        parentOne.append(parentTwo.el);
+        parentTwo.append(parentThree.el);
+        parentThree.append(child.el);
+
+        expect(child.parent('bar')).toBeUndefined();
+      });
+
+      it('should find all ancestor elements using parents', function () {
+        let root = document.createElement('div');
+        let parentOne = $$('div', { className: 'foo' });
+        let parentTwo = $$('div', { className: 'foo' });
+        let parentThree = $$('div', { className: 'foo' });
+
+        let child = $$('div');
+
+        root.appendChild(parentOne.el);
+        parentOne.append(parentTwo.el);
+        parentTwo.append(parentThree.el);
+        parentThree.append(child.el);
+
+        expect(child.parents('foo')).toEqual([parentThree.el, parentTwo.el, parentOne.el]);
+      });
+
+      it('should return empty array if there is no match using parents', function () {
+        let root = document.createElement('div');
+        let parentOne = $$('div', { className: 'foo' });
+        let parentTwo = $$('div', { className: 'foo' });
+        let parentThree = $$('div', { className: 'foo' });
+
+        let child = $$('div');
+
+        root.appendChild(parentOne.el);
+        parentOne.append(parentTwo.el);
+        parentTwo.append(parentThree.el);
+        parentThree.append(child.el);
+
+        expect(child.parents('bar')).toEqual([]);
+      });
+
+      it('should not fail if there is no parent element using parents', function () {
+        let root = $$('div');
+        expect(() => root.parents('bar')).not.toThrow();
       });
 
       it('should be able to tell if an element matches a selector', function () {

--- a/test/utils/StreamHighlightUtilsTest.ts
+++ b/test/utils/StreamHighlightUtilsTest.ts
@@ -1,0 +1,248 @@
+import {StreamHighlightUtils} from '../../src/utils/StreamHighlightUtils';
+
+export function StreamHighlightUtilsTest() {
+  describe('StreamHighlightUtils', () => {
+    function getHighlightResultForTerm(term, group, groupTerm, cssClass = 'coveo-highlight') {
+      return `<span class="${cssClass}" data-highlight-group="${group}" data-highlight-group-term="${groupTerm}">${term}</span>`;
+    }
+
+    function getHighlightResultForTermEscaped(term, group, groupTerm, cssClass = 'coveo-highlight') {
+      return `<span class="${cssClass}" data-highlight-group="${group}" data-highlight-group-term="${groupTerm}">${term}</span>`;
+    }
+
+    it('should work with basics', () => {
+      var toHighlight = 'a b';
+      var terms: { [originalTerm: string]: string[]; } = { 'a': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`${getHighlightResultForTerm('a', 1, 'a')} ${getHighlightResultForTerm('b', 2, 'b')}`);
+    });
+
+    it('should work with special char', () => {
+      var toHighlight = ';a;';
+      let terms: { [originalTerm: string]: string[]; } = { 'a': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`;${getHighlightResultForTerm('a', 1, 'a')};`);
+
+      toHighlight = '___a__';
+      terms = { 'a': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`___${getHighlightResultForTerm('a', 1, 'a')}__`);
+    });
+
+    it('should work globally in the string', () => {
+      var toHighlight = 'hahaha a a a';
+      var terms: { [originalTerm: string]: string[]; } = { 'a': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`hahaha ${getHighlightResultForTerm('a', 1, 'a')} ${getHighlightResultForTerm('a', 1, 'a') + ' ' + getHighlightResultForTerm('a', 1, 'a')}`);
+    });
+
+    it('should works correctly when terms are similar (eg: plurals)', () => {
+      var toHighlight = 'tree trees';
+      var terms: { [originalTerm: string]: string[]; } = { 'tree': ['trees'] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`${getHighlightResultForTerm('tree', 1, 'tree')} ${getHighlightResultForTerm('trees', 1, 'tree')}`);
+
+      toHighlight = 'tree trees tree trees_ ;tree; .trees';
+      terms = { 'tree': ['trees'] };
+      var singular = getHighlightResultForTerm('tree', 1, 'tree');
+      var plural = getHighlightResultForTerm('trees', 1, 'tree');
+
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`${singular} ${plural} ${singular} ${plural}_ ;${singular}; .${plural}`);
+
+      toHighlight = 'this is my friend';
+      var terms2: { [originalTerm: string]: string[]; } = { 'friends': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms2, {})).toEqual('this is my friend');
+    });
+
+
+    it('should be case insensitive by default', () => {
+      var toHighlight = 'this is my FRIEND';
+      var terms: { [originalTerm: string]: string[]; } = { 'friend': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`this is my ${getHighlightResultForTerm('FRIEND', 1, 'friend')}`);
+
+      toHighlight = 'this is my FRIEND friend Friend';
+      terms = { 'friend': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`this is my ${getHighlightResultForTerm('FRIEND', 1, 'friend')} ${getHighlightResultForTerm('friend', 1, 'friend')} ${getHighlightResultForTerm('Friend', 1, 'friend')}`);
+    });
+
+
+    it('should allow to choose the highlight css class with an option', () => {
+      var toHighlight = 'this is my friend';
+      var terms: { [originalTerm: string]: string[]; } = { 'friend': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, undefined, { cssClass: 'hello-world' })).toEqual(`this is my ${getHighlightResultForTerm('friend', 1, 'friend', 'hello-world')}`);
+    });
+
+    it('should allow to change the regex flags', () => {
+      var toHighlight = 'this is my Friend';
+      var terms: { [originalTerm: string]: string[]; } = { 'friend': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, undefined, { regexFlags: '' })).toEqual(`this is my Friend`);
+
+
+      toHighlight = 'this is my Friend friend Friend';
+      terms = { 'friend': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, undefined, { regexFlags: 'i' })).toEqual(`this is my ${getHighlightResultForTerm('Friend', 1, 'friend')} friend Friend`);
+    });
+
+
+    it('should work with html basics', () => {
+      var toHighlight = '<div>a b</div>';
+      var terms: { [originalTerm: string]: string[]; } = { 'a': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamHTML(toHighlight, terms, undefined)).toEqual(`<div>${getHighlightResultForTermEscaped('a', 1, 'a')} ${getHighlightResultForTermEscaped('b', 2, 'b')}</div>`);
+    });
+
+
+    it('should work with html and special char', () => {
+      var toHighlight = '<div>;a;</div>';
+      var terms: { [originalTerm: string]: string[]; } = { 'a': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamHTML(toHighlight, terms, undefined)).toEqual(`<div>;${getHighlightResultForTermEscaped('a', 1, 'a')};</div>`);
+
+      toHighlight = '<div>___a__</div>';
+      terms = { 'a': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamHTML(toHighlight, terms, undefined)).toEqual(`<div>___${getHighlightResultForTermEscaped('a', 1, 'a')}__</div>`);
+    });
+
+    it('should highlight html globally in the string', () => {
+      var toHighlight = '<div>hahaha</div> <div>a</div> <div>a</div> <div>a</div>';
+      var terms: { [originalTerm: string]: string[]; } = { 'a': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamHTML(toHighlight, terms, undefined)).toEqual(`<div>hahaha</div> <div>${getHighlightResultForTermEscaped('a', 1, 'a')}</div> <div>${getHighlightResultForTermEscaped('a', 1, 'a')}</div> <div>${getHighlightResultForTermEscaped('a', 1, 'a')}</div>`);
+    });
+
+
+    it('should work with html when terms are similar (eg: plurals)', () => {
+      var toHighlight = '<div>tree trees</div>';
+      var terms: { [originalTerm: string]: string[]; } = { 'tree': ['trees'] };
+      expect(StreamHighlightUtils.highlightStreamHTML(toHighlight, terms, undefined)).toEqual(`<div>${getHighlightResultForTermEscaped('tree', 1, 'tree')} ${getHighlightResultForTermEscaped('trees', 1, 'tree')}</div>`);
+
+      toHighlight = '<div><div>tree trees tree</div> trees_ ;tree;<span> .trees</span></div>';
+      terms = { 'tree': ['trees'] };
+      expect(StreamHighlightUtils.highlightStreamHTML(toHighlight, terms, undefined)).toEqual(`<div>${getHighlightResultForTermEscaped('tree', 1, 'tree')} ${getHighlightResultForTermEscaped('trees', 1, 'tree')} ${getHighlightResultForTermEscaped('tree', 1, 'tree')} ${getHighlightResultForTermEscaped('trees', 1, 'tree')}_ ;${getHighlightResultForTermEscaped('tree', 1, 'tree')}; .${getHighlightResultForTermEscaped('trees', 1, 'tree')}</div>`);
+
+      toHighlight = '<div>this is my friend</div>';
+      var terms2: { [originalTerm: string]: string[]; } = { 'friends': [] };
+      expect(StreamHighlightUtils.highlightStreamHTML(toHighlight, terms2, undefined)).toEqual(`<div>this is my friend</div>`);
+    });
+
+
+    it('should work with multiple terms with multiple expansions', () => {
+      var toHighlight = 'tree trees treetop';
+      var terms: { [originalTerm: string]: string[]; } = { 'tree': ['trees', 'treetop'] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, undefined)).toEqual(`${getHighlightResultForTerm('tree', 1, 'tree')} ${getHighlightResultForTerm('trees', 1, 'tree')} ${getHighlightResultForTerm('treetop', 1, 'tree')}`);
+    });
+
+    it('should work with terms and phrases', () => {
+      var toHighlight = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
+      var terms: { [originalTerm: string]: string[]; } = { 'lorem': [] };
+      var phrases: { [phrase: string]: { [originalTerm: string]: string[]; } } = {
+        'ipsum dolor sit amet': {
+          'ipsum': [],
+          'dolor': [],
+          'sit': [],
+          'amet': []
+        }
+      };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, phrases)).toEqual(`${getHighlightResultForTerm('Lorem', 1, 'lorem')} ${getHighlightResultForTerm('ipsum dolor sit amet', 2, 'ipsum dolor sit amet')}, consectetur adipiscing elit`);
+    });
+
+    it('should work with number and point', () => {
+      var toHighlight = 'Lorem ipsum 9.1.1 dolor sit amet';
+      let terms: { [originalTerm: string]: string[]; } = { 'lorem': [] };
+      var phrases: { [phrase: string]: { [originalTerm: string]: string[]; } } = { '9 1 1': { '9': [], '1': [] } };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, phrases)).toEqual(`${getHighlightResultForTerm('Lorem', 1, 'lorem')} ipsum ${getHighlightResultForTerm('9.1.1', 2, '9 1 1')} dolor sit amet`);
+
+      toHighlight = 'abc.qwerty';
+      terms = { 'abc': [], 'qwerty': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`${getHighlightResultForTerm('abc', 1, 'abc')}.${getHighlightResultForTerm('qwerty', 2, 'qwerty')}`);
+
+      toHighlight = 'abc. qwerty';
+      terms = { 'abc': [], 'qwerty': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`${getHighlightResultForTerm('abc', 1, 'abc')}. ${getHighlightResultForTerm('qwerty', 2, 'qwerty')}`);
+    });
+
+    it('should work with number and dash', () => {
+      var toHighlight = 'Lorem ipsum 9-1-1 dolor sit amet';
+      let terms: { [originalTerm: string]: string[]; } = { 'lorem': [] };
+      var phrases: { [phrase: string]: { [originalTerm: string]: string[]; } } = { '9 1 1': { '9': [], '1': [] } };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, phrases)).toEqual(`${getHighlightResultForTerm('Lorem', 1, 'lorem')} ipsum ${getHighlightResultForTerm('9-1-1', 2, '9 1 1')} dolor sit amet`);
+
+      toHighlight = 'abc-qwerty';
+      terms = { 'abc': [], 'qwerty': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`${getHighlightResultForTerm('abc', 1, 'abc')}-${getHighlightResultForTerm('qwerty', 2, 'qwerty')}`);
+
+      toHighlight = 'abc- qwerty';
+      terms = { 'abc': [], 'qwerty': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`${getHighlightResultForTerm('abc', 1, 'abc')}- ${getHighlightResultForTerm('qwerty', 2, 'qwerty')}`);
+
+      toHighlight = 'abc- qwerty. qwerty';
+      terms = { 'abc': [], 'qwerty': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`${getHighlightResultForTerm('abc', 1, 'abc')}- ${getHighlightResultForTerm('qwerty', 2, 'qwerty')}. ${getHighlightResultForTerm('qwerty', 2, 'qwerty')}`);
+
+      toHighlight = 'abc- qwerty- qwerty';
+      terms = { 'abc': [], 'qwerty': [], 'b': [] };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, terms, {})).toEqual(`${getHighlightResultForTerm('abc', 1, 'abc')}- ${getHighlightResultForTerm('qwerty', 2, 'qwerty')}- ${getHighlightResultForTerm('qwerty', 2, 'qwerty')}`);
+    });
+
+    it('should work with parenthesis', () => {
+      var toHighlight = 'Lorem (ipsum 9-1-1 dolor sit amet';
+      var phrases: { [phrase: string]: { [originalTerm: string]: string[]; } } = {
+        'lorem ipsum': {
+          'lorem': [],
+          'ipsum': []
+        }
+      };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, {}, phrases)).toEqual(`${getHighlightResultForTerm('Lorem (ipsum', 1, 'lorem ipsum')} 9-1-1 dolor sit amet`);
+    });
+
+    it('should work with :', () => {
+      var toHighlight = 'Lorem :ipsum 9-1-1 dolor sit amet';
+      var phrases: { [phrase: string]: { [originalTerm: string]: string[]; } } = {
+        'lorem ipsum': {
+          'lorem': [],
+          'ipsum': []
+        }
+      };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, {}, phrases)).toEqual(`${getHighlightResultForTerm('Lorem :ipsum', 1, 'lorem ipsum')} 9-1-1 dolor sit amet`);
+    });
+
+    it('should work with ~', () => {
+      var toHighlight = 'Lorem ~ipsum 9-1-1 dolor sit amet';
+      var phrases: { [phrase: string]: { [originalTerm: string]: string[]; } } = {
+        'lorem ipsum': {
+          'lorem': [],
+          'ipsum': []
+        }
+      };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, {}, phrases)).toEqual(`${getHighlightResultForTerm('Lorem ~ipsum', 1, 'lorem ipsum')} 9-1-1 dolor sit amet`);
+
+      toHighlight = 'Lorem~ipsum 9-1-1 dolor sit amet';
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, {}, phrases)).toEqual(`${getHighlightResultForTerm('Lorem~ipsum', 1, 'lorem ipsum')} 9-1-1 dolor sit amet`);
+    });
+
+    it('should work with `', () => {
+      var toHighlight = 'Lorem `ipsum 9-1-1 dolor sit amet';
+      var phrases: { [phrase: string]: { [originalTerm: string]: string[]; } } = {
+        'lorem ipsum': {
+          'lorem': [],
+          'ipsum': []
+        }
+      };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, {}, phrases)).toEqual(`${getHighlightResultForTerm('Lorem &#x60;ipsum', 1, 'lorem ipsum')} 9-1-1 dolor sit amet`);
+    });
+
+    it('should work with ?', () => {
+      var toHighlight = 'Lorem ipsum 9-1-1 dolor sit amet?';
+      var phrases: { [phrase: string]: { [originalTerm: string]: string[]; } } = {
+        'sit amet': {
+          'sit': [],
+          'amet': []
+        }
+      };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, {}, phrases)).toEqual(`Lorem ipsum 9-1-1 dolor ${getHighlightResultForTerm('sit amet', 1, 'sit amet')}?`);
+    });
+
+    it('should work with !', () => {
+      var toHighlight = 'Lorem ipsum 9-1-1 dolor sit amet!';
+      var phrases: { [phrase: string]: { [originalTerm: string]: string[]; } } = {
+        'sit amet': {
+          'sit': [],
+          'amet': []
+        }
+      };
+      expect(StreamHighlightUtils.highlightStreamText(toHighlight, {}, phrases)).toEqual(`Lorem ipsum 9-1-1 dolor ${getHighlightResultForTerm('sit amet', 1, 'sit amet')}!`);
+    });
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -399,6 +399,7 @@
     "test/ui/LogoTest.ts",
     "test/ui/RegisteredNamedMethodsTest.ts",
     "test/ui/FacetValuesOrderTest.ts",
-    "test/misc/SentryLoggerTest.ts"
+    "test/misc/SentryLoggerTest.ts",
+    "test/utils/StreamHighlightUtilsTest.ts"
   ]
 }

--- a/typings/browser.d.ts
+++ b/typings/browser.d.ts
@@ -1,3 +1,2 @@
-/// <reference path="browser/ambient/jquery/index.d.ts" />
 /// <reference path="browser/ambient/underscore/index.d.ts" />
 /// <reference path="browser/definitions/d3/index.d.ts" />

--- a/typings/main.d.ts
+++ b/typings/main.d.ts
@@ -1,3 +1,2 @@
-/// <reference path="main/ambient/jquery/index.d.ts" />
 /// <reference path="main/ambient/underscore/index.d.ts" />
 /// <reference path="main/definitions/d3/index.d.ts" />


### PR DESCRIPTION
This will make it so that any file that reference jQuery will stop compiling.
Re-import old tests for StreamHighlightUtils.

Export all template helpers under the Coveo namespace for backward compatibility.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
https://coveord.atlassian.net/browse/JSUI-1125