### PR TITLE
Remove JS Doc from search endpoint decorators function, as they shoul…

### DIFF
--- a/gulpTasks/doc.js
+++ b/gulpTasks/doc.js
@@ -11,7 +11,7 @@ gulp.task('doc', function () {
     theme: 'docs/theme',
     name: 'Coveo search ui documentation',
     readme: 'README.md',
-    externalPattern: '**/{typings,lib}/**',
+    externalPattern: '**/{typings,lib,node_modules}/**',
     ignoreCompilerErrors: true
   });
   var src = app.expandInputFiles(['src/Doc.ts']);

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -880,24 +880,19 @@ export class SearchEndpoint implements ISearchEndpoint {
 }
 
 
-/**
- * It's taken for granted that methods using decorators have :
- * {@link IEndpointCallOptions} as their second to last parameter
- * {@link IEndpointCallParameters} as their last parameter
- * The default parameters for each member of the injected {@link IEndpointCallParameters} are the following:
- * url: '',
- * queryString: [],
- * requestData: {},
- * requestDataType: undefined,
- * method: '',
- * responseType: '',
- * errorsAsSuccess: false
- */
+// It's taken for granted that methods using decorators have :
+// IEndpointCallOptions as their second to last parameter
+// IEndpointCallParameters as their last parameter
+// The default parameters for each member of the injected {@link IEndpointCallParameters} are the following:
+// url: '',
+// queryString: [],
+// requestData: {},
+// requestDataType: undefined,
+// method: '',
+// responseType: '',
+// errorsAsSuccess: false
 
-/**
- * Add the base url
- * @param path The path to append to the url
- */
+
 function path(path: string) {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
     let originalMethod = descriptor.value;
@@ -926,10 +921,6 @@ function path(path: string) {
   };
 }
 
-/**
- * Add the alert url
- * @param path The path to append to the url
- */
 function alertsPath(path: string) {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
     let originalMethod = descriptor.value;
@@ -958,10 +949,6 @@ function alertsPath(path: string) {
   };
 }
 
-/**
- * Set the request data type
- * @param type The type to set
- */
 function requestDataType(type: string) {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
     let originalMethod = descriptor.value;
@@ -990,10 +977,6 @@ function requestDataType(type: string) {
   };
 }
 
-/**
- * Set the request data type
- * @param met The type to set
- */
 function method(met: string) {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
     let originalMethod = descriptor.value;
@@ -1021,10 +1004,6 @@ function method(met: string) {
   };
 }
 
-/**
- * Set the response type
- * @param resp The response type to set
- */
 function responseType(resp: string) {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
     let originalMethod = descriptor.value;
@@ -1052,9 +1031,6 @@ function responseType(resp: string) {
   };
 }
 
-/**
- * Add the accessToken to the query string arguments
- */
 function accessTokenInUrl(tokenKey: string = 'access_token') {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
     let originalMethod = descriptor.value;

--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -259,7 +259,7 @@ export class FacetSlider extends Component {
     /**
      * Specifies if the responsive mode should be enabled on the facets. Responsive mode will make the facet dissapear and instead be
      * availaible using a dropdown button. Responsive facets are enabled when the width of the element the search interface is bound to
-     * reaches 800 pixels. This value can be modified using {@link Facet..optionsresponsiveBreakpoint}.
+     * reaches 800 pixels. This value can be modified using {@link Facet.options.responsiveBreakpoint}.
      * The default value is `true`.
      */
     enableResponsiveMode: ComponentOptions.buildBooleanOption({ defaultValue: true }),


### PR DESCRIPTION



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
…d not be present in generated doc.

https://coveord.atlassian.net/browse/JSUI-1137