### PR TITLE
JSUI-1148 - Update Plop generator to make linter quite content

### DIFF
--- a/plop/plopTemplates/plop.component.template.hbs
+++ b/plop/plopTemplates/plop.component.template.hbs
@@ -13,7 +13,7 @@ export interface I{{cmpName}}Options  {
  * Be as specific as possible on what the component does, and how to use it.
  */
 export class {{cmpName}} extends Component {
-  static ID = '{{cmpName}}'
+  static ID = '{{cmpName}}';
 
   /**
    * @componentOptions
@@ -24,7 +24,7 @@ export class {{cmpName}} extends Component {
      * Be as specific as possible on what the options does, as well as it's default value, if any.
      */
     changeMe: ComponentOptions.buildBooleanOption()
-  }
+  };
 
   constructor(public element: HTMLElement, public options?: I{{cmpName}}Options, bindings?: IComponentBindings) {
     super(element, {{cmpName}}.ID, bindings);

--- a/plop/plopTemplates/plop.component.test.template.hbs
+++ b/plop/plopTemplates/plop.component.test.template.hbs
@@ -1,7 +1,7 @@
 import * as Mock from '../MockEnvironment';
 import { {{cmpName}}, I{{cmpName}}Options } from '../../src/ui/{{cmpName}}/{{cmpName}}';
-import {Simulate} from '../Simulate';
-import {$$} from '../../src/utils/Dom';
+import { Simulate } from '../Simulate';
+import { $$ } from '../../src/utils/Dom';
 
 export function {{cmpName}}Test() {
   describe('{{cmpName}}', () => {
@@ -17,6 +17,6 @@ export function {{cmpName}}Test() {
 
     it('should put test here', () => {
 
-    })
-  })
+    });
+  });
 }


### PR DESCRIPTION
Now, when using Plop, our beloved *pretty-typescript* shouldn't complain anymore.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
https://coveord.atlassian.net/browse/JSUI-1148