### PR TITLE
+ adds fetch more option to result list

### DIFF
--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -395,6 +395,10 @@ export var analyticsActionCauseList = {
     type: 'customfilters',
     metaMap: { customFilterName: 1, customFilterType: 2, customFilterExpression: 3 }
   },
+  fetchMoreResultsClick: <IAnalyticsActionCause>{
+    name: 'fetchMoreResultsClick',
+    type: 'getMoreResults'
+  },
   pagerNumber: <IAnalyticsActionCause>{
     name: 'pagerNumber',
     type: 'getMoreResults',

--- a/test/ui/ResultListTest.ts
+++ b/test/ui/ResultListTest.ts
@@ -191,6 +191,20 @@ export function ResultListTest() {
         expect(test.env.queryController.fetchMore).toHaveBeenCalledWith(26);
       });
 
+      it('fetchMoreResultsElement fetches more results when clicked', function () {
+        let fetchMoreElement = $$('div', { className: 'coveo-more-results' });
+        $$(document.body).append(fetchMoreElement.el);
+
+        test = Mock.basicComponentSetup<ResultList>(ResultList);
+
+        Simulate.query(test.env);
+        fetchMoreElement.el.click();
+
+        expect(test.env.queryController.fetchMore).toHaveBeenCalled();
+
+        fetchMoreElement.remove();
+      });
+
       it('fieldsToInclude allow to specify an array of fields to include in the query', function () {
         test = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, {
           fieldsToInclude: ['@field1', '@field2', '@field3']


### PR DESCRIPTION
A client asked how he could implement a "Fetch more results" button. I decided to add this option OOTB as my hackathon project.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
