### PR TITLE
Arrange for autoTriggerQuery to be false

### DIFF
--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -81,7 +81,15 @@ export class Recommendation extends SearchInterface implements IComponentBinding
      * Hides the component if there a no results / recommendations.
      * The default value is false.
      */
-    hideIfNoResults: ComponentOptions.buildBooleanOption({ defaultValue: true })
+    hideIfNoResults: ComponentOptions.buildBooleanOption({defaultValue: true}),
+    autoTriggerQuery: ComponentOptions.buildBooleanOption({
+      postProcessing: (value: boolean, options: IRecommendationOptions)=> {
+        if (options.mainSearchInterface) {
+          return false;
+        }
+        return value;
+      }
+    })
 
   };
 
@@ -91,7 +99,6 @@ export class Recommendation extends SearchInterface implements IComponentBinding
 
   constructor(public element: HTMLElement, public options: IRecommendationOptions = {}, public analyticsOptions = {}, _window = window) {
     super(element, ComponentOptions.initComponentOptions(element, Recommendation, options), analyticsOptions, _window);
-
     if (!this.options.id) {
       this.generateDefaultId();
     }

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -164,6 +164,20 @@ export function RecommendationTest() {
         });
       });
 
+      it('exposes option autoTriggerQuery that should be set to false if there is a main search interface', ()=> {
+        expect(options.mainSearchInterface).toBeDefined();
+        options.autoTriggerQuery = true;
+        test = Mock.optionsSearchInterfaceSetup<Recommendation, IRecommendationOptions>(Recommendation, options);
+        expect(test.cmp.options.autoTriggerQuery).toBe(false);
+      });
+
+      it('exposes options autoTriggerQuery that should be left as it is if there is no main search interface', ()=> {
+        options.mainSearchInterface = null;
+        options.autoTriggerQuery = true;
+        test = Mock.optionsSearchInterfaceSetup<Recommendation, IRecommendationOptions>(Recommendation, options);
+        expect(test.cmp.options.autoTriggerQuery).toBe(true);
+      })
+
       it('should hide on query error', () => {
         Simulate.query(test.env, { error: { message: 'oh noes', type: 'bad', name: 'foobar' } });
         expect(test.cmp.element.style.display).toEqual('none');


### PR DESCRIPTION
If the recommendation component is linked to a main search interface, autoTriggerQuery should automatically switch to false, because the main search interface should be the one managing the query.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

https://coveord.atlassian.net/browse/JSUI-1197