### PR TITLE
Keep Recommendation from going in infinite hidden mode

### DIFF
--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -626,9 +626,9 @@ export class QueryController extends RootComponent {
 
   private lastHistoryEventIsCurrentPageView(currentHistory: CoveoAnalytics.HistoryElement) {
     let validHistory = currentHistory[0] &&
-        currentHistory[0].name &&
-        currentHistory[0].name.toLowerCase() == 'pageview' &&
-        currentHistory[0].value;
+      currentHistory[0].name &&
+      currentHistory[0].name.toLowerCase() == 'pageview' &&
+      currentHistory[0].value;
     if (validHistory) {
       let link = document.createElement('a');
       link.setAttribute('href', currentHistory[0].value);

--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -14,7 +14,7 @@ import {ComponentStateModel} from '../../models/ComponentStateModel';
 import {ComponentOptionsModel} from '../../models/ComponentOptionsModel';
 import {IAnalyticsNoMeta, analyticsActionCauseList} from '../Analytics/AnalyticsActionListMeta';
 import {BaseComponent} from '../Base/BaseComponent';
-import {Recommendation} from "../Recommendation/Recommendation";
+import {Recommendation} from '../Recommendation/Recommendation';
 
 /**
  * Represent the initialization parameters required to init a new component.

--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -119,7 +119,9 @@ export class Recommendation extends SearchInterface implements IComponentBinding
   }
 
   public hide(): void {
-    this.displayStyle = this.element.style.display;
+    if (!this.displayStyle) {
+      this.displayStyle = this.element.style.display;
+    }
     $$(this.element).hide();
   }
 

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -168,6 +168,22 @@ export function RecommendationTest() {
         Simulate.query(test.env, { error: { message: 'oh noes', type: 'bad', name: 'foobar' } });
         expect(test.cmp.element.style.display).toEqual('none');
       });
+
+      it('should not be stuck in hide mode if hide is called multiple time', () => {
+        test.cmp.hide();
+        test.cmp.hide();
+        expect(test.cmp.element.style.display).toEqual('none');
+        test.cmp.show();
+        expect(test.cmp.element.style.display).toEqual('block');
+      });
+
+      it('should not be stuck in visible mode if show is called multiple time', () => {
+        test.cmp.show();
+        test.cmp.show();
+        expect(test.cmp.element.style.display).toEqual('block');
+        test.cmp.hide();
+        expect(test.cmp.element.style.display).toEqual('none');
+      });
     });
   });
 }


### PR DESCRIPTION
If a piece of code calls the recommendation component "hide" method two times in a row, the component gets stuck in hidden mode.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
https://coveord.atlassian.net/browse/JSUI-1198