### PR TITLE
Log a generic analytics event for advanced search.

### DIFF
--- a/src/ui/AdvancedSearch/AdvancedSearch.ts
+++ b/src/ui/AdvancedSearch/AdvancedSearch.ts
@@ -11,6 +11,7 @@ import {$$} from '../../utils/Dom';
 import {IAdvancedSearchInput, IAdvancedSearchPrebuiltInput, IAdvancedSearchSection, IExternalAdvancedSearchSection} from './AdvancedSearchInput';
 import {AdvancedSearchInputFactory} from './AdvancedSearchInputFactory';
 import {IQueryOptions} from '../../controllers/QueryController';
+import {IAnalyticsNoMeta, analyticsActionCauseList} from '../Analytics/AnalyticsActionListMeta';
 
 export interface IAdvancedSearchOptions {
   includeKeywords?: boolean;
@@ -65,6 +66,7 @@ export class AdvancedSearch extends Component {
    * Launch the advanced search query.
    */
   public executeAdvancedSearch() {
+    this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.advancedSearch, {});
     this.queryController.executeQuery();
   }
 

--- a/src/ui/AdvancedSearch/Form/Dropdown.ts
+++ b/src/ui/AdvancedSearch/Form/Dropdown.ts
@@ -23,7 +23,7 @@ export class Dropdown {
   constructor(public onChange: () => void = () => {
   }, protected listOfValues: string[], private getDisplayValue: (string) => string = l, private label?: string) {
     this.buildContent();
-    this.select(0);
+    this.select(0, false);
     this.bindEvents();
   }
 
@@ -65,8 +65,8 @@ export class Dropdown {
    * Select a value from it's 0 based index in the {@link Dropdown.listOfValues}.
    * @param index
    */
-  public select(index: number) {
-    this.selectOption(this.options[index]);
+  public select(index: number, executeOnChange = true) {
+    this.selectOption(this.options[index], executeOnChange);
   }
 
   /**
@@ -97,7 +97,7 @@ export class Dropdown {
     });
   }
 
-  private selectOption(option: HTMLElement) {
+  private selectOption(option: HTMLElement, executeOnChange = true) {
     this.selectedIcon.detach();
     let content = $$(option).find('span');
     $$(content).prepend(this.selectedIcon.el);
@@ -105,7 +105,9 @@ export class Dropdown {
     this.selected.setAttribute('value', value);
     this.selected.text(this.getDisplayValue(value));
     this.close();
-    this.onChange();
+    if (executeOnChange) {
+      this.onChange();
+    }
   }
 
 

--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -458,5 +458,9 @@ export var analyticsActionCauseList = {
   recommendationOpen: <IAnalyticsActionCause>{
     name: 'recommendationOpen',
     type: 'recommendation'
+  },
+  advancedSearch: <IAnalyticsActionCause>{
+    name: 'advancedSearch',
+    type: 'advancedSearch'
   }
 };

--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -14,7 +14,7 @@ import {ComponentStateModel} from '../../models/ComponentStateModel';
 import {ComponentOptionsModel} from '../../models/ComponentOptionsModel';
 import {IAnalyticsNoMeta, analyticsActionCauseList} from '../Analytics/AnalyticsActionListMeta';
 import {BaseComponent} from '../Base/BaseComponent';
-import {Recommendation} from "../Recommendation/Recommendation";
+import {Recommendation} from '../Recommendation/Recommendation';
 
 /**
  * Represent the initialization parameters required to init a new component.

--- a/test/ui/AdvancedSearch/AdvancedSearchTest.ts
+++ b/test/ui/AdvancedSearch/AdvancedSearchTest.ts
@@ -11,6 +11,7 @@ import {DatePicker} from '../../../src/ui/AdvancedSearch/Form/DatePicker';
 import {BaseFormTypes} from '../../../src/ui/AdvancedSearch/AdvancedSearchInput';
 import {AdvancedComponentSetupOptions} from '../../MockEnvironment';
 import {MockEnvironmentBuilder} from '../../MockEnvironment';
+import {analyticsActionCauseList} from '../../../src/ui/Analytics/AnalyticsActionListMeta';
 
 export function AdvancedSearchTest() {
   describe('AdvancedSearch', () => {
@@ -101,6 +102,11 @@ export function AdvancedSearchTest() {
       it('should execute a query', () => {
         test.cmp.executeAdvancedSearch();
         expect(test.cmp.queryController.executeQuery).toHaveBeenCalled();
+      });
+
+      it('should log an analytics event', () => {
+        test.cmp.executeAdvancedSearch();
+        expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.advancedSearch, jasmine.objectContaining({}));
       });
     });
 

--- a/test/ui/AdvancedSearch/Form/DropdownTest.ts
+++ b/test/ui/AdvancedSearch/Form/DropdownTest.ts
@@ -46,6 +46,20 @@ export function DropdownTest() {
         dropdown.select(1);
         expect(dropdown.getValue()).toEqual(values[1]);
       });
+
+      it('should execute the onchange function by default when a selection is made', () => {
+        let onchangeSpy = jasmine.createSpy('onchange');
+        dropdown.onChange = onchangeSpy;
+        dropdown.select(1);
+        expect(onchangeSpy).toHaveBeenCalled();
+      });
+
+      it('should not execute the onchange function if specified', () => {
+        let onchangeSpy = jasmine.createSpy('onchange');
+        dropdown.onChange = onchangeSpy;
+        dropdown.select(1, false);
+        expect(onchangeSpy).not.toHaveBeenCalled();
+      });
     });
 
     describe('selectValue', () => {


### PR DESCRIPTION
Add a parameter so that select drop does not trigger a query on load.
Add UT

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

https://coveord.atlassian.net/browse/JSUI-1194