### PR TITLE
Change outline rule for Tabs 

### DIFF
--- a/sass/_Tab.scss
+++ b/sass/_Tab.scss
@@ -29,8 +29,10 @@
     padding-bottom: 0px;
   }
 
-  &:hover, &:focus {
+  &:hover {
     color: $color-greyish-dark-blue;
+  }
+  &:active, &:active:focus, &.coveo-selected {
     outline: none;
   }
 }


### PR DESCRIPTION
Make it so that it's visible when it's focused with keyboard navigation

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

https://coveord.atlassian.net/browse/JSUI-1202