### PR TITLE
Add flex wrap rule for input section

### DIFF
--- a/sass/_AdvancedSearch.scss
+++ b/sass/_AdvancedSearch.scss
@@ -5,7 +5,6 @@ $spaceBetween: 0 5px;
 }
 
 .coveo-advanced-search-section {
-  min-width: 500px;
   margin: 20px 0;
 }
 
@@ -54,6 +53,7 @@ $spaceBetween: 0 5px;
 .coveo-advanced-search-document-input-section {
   margin: 20px 0;
   @include display(flex);
+  @include flex-wrap(wrap);
   align-items: center;
 
   .coveo-dropdown {
@@ -139,4 +139,12 @@ $spaceBetween: 0 5px;
   height: 35px;
   display: block;
   margin: 15px 0 15px auto;
+}
+
+.coveo-size-input-mode-section {
+  display: inline-block;
+  width: 80%;
+  & > * {
+    margin: 5px 0px 5px 0px;
+  }
 }

--- a/src/ui/AdvancedSearch/DocumentInput/SizeInput.ts
+++ b/src/ui/AdvancedSearch/DocumentInput/SizeInput.ts
@@ -20,14 +20,17 @@ export class SizeInput extends DocumentInput {
 
   public build(): HTMLElement {
     let sizeInput = $$(super.build());
+    let sizeInputSection = $$('div', { className: 'coveo-size-input-mode-section' });
+
     this.modeSelect = new Dropdown(this.onChange.bind(this), SizeInput.modes);
     this.modeSelect.setId('coveo-size-input-mode');
-    sizeInput.append(this.modeSelect.getElement());
+    sizeInputSection.append(this.modeSelect.getElement());
     this.sizeInput = new NumericSpinner(this.onChange.bind(this));
-    sizeInput.append(this.sizeInput.getElement());
+    sizeInputSection.append(this.sizeInput.getElement());
     this.sizeSelect = new Dropdown(this.onChange.bind(this), SizeInput.sizes);
     this.sizeSelect.setId('coveo-size-input-select');
-    sizeInput.append(this.sizeSelect.getElement());
+    sizeInputSection.append(this.sizeSelect.getElement());
+    sizeInput.append(sizeInputSection.el);
     this.element = sizeInput.el;
     return this.element;
   }


### PR DESCRIPTION



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
Add a section wrapper for date, so it all align nicely on mobile

https://coveord.atlassian.net/browse/JSUI-1209