### PR TITLE
Compact values before trying to build the analytics custom data

### DIFF
--- a/src/ui/AnalyticsSuggestions/AnalyticsSuggestions.ts
+++ b/src/ui/AnalyticsSuggestions/AnalyticsSuggestions.ts
@@ -125,12 +125,14 @@ export class AnalyticsSuggestions extends Component {
         }
         let element = this.suggestionForOmnibox.buildOmniboxElement(this.resultsToBuildWith, args);
         this.currentlyDisplayedSuggestions = {};
-        _.map($$(element).findAll('.coveo-omnibox-selectable'), (selectable, i?) => {
-          this.currentlyDisplayedSuggestions[$$(selectable).text()] = {
-            element: selectable,
-            pos: i
-          };
-        });
+        if (element) {
+          _.map($$(element).findAll('.coveo-omnibox-selectable'), (selectable, i?) => {
+            this.currentlyDisplayedSuggestions[$$(selectable).text()] = {
+              element: selectable,
+              pos: i
+            };
+          });
+        }
         resolve({
           element: element,
           zIndex: this.options.omniboxZIndex
@@ -161,9 +163,9 @@ export class AnalyticsSuggestions extends Component {
 
   private cleanCustomData(toClean: string[], rejectLength = 256) {
     // Filter out only consecutive values that are the identical
-    toClean = _.filter(toClean, (partial: string, pos?: number, array?: string[]) => {
+    toClean = _.compact(_.filter(toClean, (partial: string, pos?: number, array?: string[]) => {
       return pos === 0 || partial !== array[pos - 1];
-    });
+    }));
 
     // Custom dimensions cannot be an array in analytics service: Send a string joined by ; instead.
     // Need to replace ;

--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -308,7 +308,7 @@ export class Omnibox extends Component {
 
     this.magicBox.onselect = (suggestion: IOmniboxSuggestion) => {
       let index = _.indexOf(this.lastSuggestions, suggestion);
-      let suggestions = _.map(this.lastSuggestions, (suggestion) => suggestion.text);
+      let suggestions = _.compact(_.map(this.lastSuggestions, (suggestion) => suggestion.text));
       this.magicBox.clearSuggestion();
       this.updateQueryState();
       // A bit tricky here : When it's reveal auto suggestions
@@ -427,9 +427,9 @@ export class Omnibox extends Component {
 
   private cleanCustomData(toClean: string[], rejectLength = 256) {
     // Filter out only consecutive values that are the identical
-    toClean = _.filter(toClean, (partial: string, pos?: number, array?: string[]) => {
+    toClean = _.compact(_.filter(toClean, (partial: string, pos?: number, array?: string[]) => {
       return pos === 0 || partial !== array[pos - 1];
-    });
+    }));
 
     // Custom dimensions cannot be an array in analytics service: Send a string joined by ; instead.
     // Need to replace ;
@@ -468,7 +468,7 @@ export class Omnibox extends Component {
     if (!Utils.isNullOrEmptyString(text)) {
       this.partialQueries.push(text);
     }
-    return suggestionsEventArgs.suggestions;
+    return _.compact(suggestionsEventArgs.suggestions);
   }
 
   private handleBeforeRedirect() {


### PR DESCRIPTION
This can cuase issue with reveal suggestions on select


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)


Find element only when there is something to search in AnalyticsSuggestions

https://coveord.atlassian.net/browse/JSUI-1232