### PR TITLE
Support for "name" when interacting with search alerts

### DIFF
--- a/src/events/SearchAlertEvents.ts
+++ b/src/events/SearchAlertEvents.ts
@@ -9,8 +9,14 @@ export interface ISearchAlertsFailEventArgs {
   dom?: HTMLElement;
 }
 
+export interface ISearchAlertsPopulateMessageEventArgs {
+  dom: HTMLElement[];
+  text: string[];
+}
+
 export class SearchAlertsEvents {
   public static searchAlertsCreated = 'searchAlertsCreated';
   public static searchAlertsDeleted = 'searchAlertsDeleted';
   public static searchAlertsFail = 'searchAlertsFail';
+  public static searchAlertsPopulateMessage = 'searchAlertsPopulateMessage';
 }

--- a/src/events/SearchAlertEvents.ts
+++ b/src/events/SearchAlertEvents.ts
@@ -10,7 +10,6 @@ export interface ISearchAlertsFailEventArgs {
 }
 
 export interface ISearchAlertsPopulateMessageEventArgs {
-  dom: HTMLElement[];
   text: string[];
 }
 

--- a/src/rest/Subscription.ts
+++ b/src/rest/Subscription.ts
@@ -68,6 +68,10 @@ export interface ISubscriptionRequest {
    * Frequency of the alerts
    */
   frequency?: string;
+  /**
+   * The name that should be used by the API to identify this subscription
+   */
+  name: string;
 }
 
 /**

--- a/src/ui/Facet/BreadcrumbValuesList.ts
+++ b/src/ui/Facet/BreadcrumbValuesList.ts
@@ -10,7 +10,7 @@ import * as Globalize from 'globalize';
 export class BreadcrumbValueList {
   private expanded: FacetValue[];
   private collapsed: FacetValue[];
-  private elem: HTMLElement;
+  protected elem: HTMLElement;
   private valueContainer: HTMLElement;
 
   constructor(public facet: Facet, public facetValues: FacetValue[], public breadcrumbValueElementKlass: IBreadcrumbValueElementKlass) {
@@ -38,8 +38,18 @@ export class BreadcrumbValueList {
     return this.elem;
   }
 
+  public buildAsString(): string {
+    this.build();
+    if (this.elem) {
+      return `${this.facet.options.title}: ` + _.map($$(this.elem).findAll('.coveo-facet-breadcrumb-value'), (value: HTMLElement)=> {
+            return $$(value).text();
+          }).join(', ');
+    }
+    return ''
+  }
+
   private buildExpanded() {
-    _.each(this.expanded, (value: FacetValue, index?: number, list?) => {
+    _.each(this.expanded, (value: FacetValue, index?: number) => {
       if (index != 0 && !DeviceUtils.isMobileDevice() && !this.facet.searchInterface.isNewDesign()) {
         let separator = $$('span', {
           className: 'coveo-facet-breadcrumb-separator'

--- a/src/ui/Facet/BreadcrumbValuesList.ts
+++ b/src/ui/Facet/BreadcrumbValuesList.ts
@@ -41,11 +41,11 @@ export class BreadcrumbValueList {
   public buildAsString(): string {
     this.build();
     if (this.elem) {
-      return `${this.facet.options.title}: ` + _.map($$(this.elem).findAll('.coveo-facet-breadcrumb-value'), (value: HTMLElement)=> {
-            return $$(value).text();
-          }).join(', ');
+      return `${this.facet.options.title}: ` + _.map($$(this.elem).findAll('.coveo-facet-breadcrumb-value'), (value: HTMLElement) => {
+        return $$(value).text();
+      }).join(', ');
     }
-    return ''
+    return '';
   }
 
   private buildExpanded() {

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -53,7 +53,7 @@ import {KeyboardUtils, KEYBOARD} from '../../utils/KeyboardUtils';
 import {IStringMap} from '../../rest/GenericParam';
 import {FacetValuesOrder} from './FacetValuesOrder';
 import {ValueElement} from './ValueElement';
-import {SearchAlertsEvents, ISearchAlertsPopulateMessageEventArgs} from "../../events/SearchAlertEvents";
+import {SearchAlertsEvents, ISearchAlertsPopulateMessageEventArgs} from '../../events/SearchAlertEvents';
 
 export interface IFacetOptions {
   title?: string;
@@ -1000,7 +1000,7 @@ export class Facet extends Component {
   }
 
   protected initSearchAlertEvents() {
-    this.bind.onRootElement(SearchAlertsEvents.searchAlertsPopulateMessage, (args: ISearchAlertsPopulateMessageEventArgs)=> this.handlePopulateSearchAlerts(args));
+    this.bind.onRootElement(SearchAlertsEvents.searchAlertsPopulateMessage, (args: ISearchAlertsPopulateMessageEventArgs) => this.handlePopulateSearchAlerts(args));
   }
 
   protected handleOmniboxWithStaticValue(eventArg: IPopulateOmniboxEventArgs) {

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -53,6 +53,7 @@ import {KeyboardUtils, KEYBOARD} from '../../utils/KeyboardUtils';
 import {IStringMap} from '../../rest/GenericParam';
 import {FacetValuesOrder} from './FacetValuesOrder';
 import {ValueElement} from './ValueElement';
+import {SearchAlertsEvents, ISearchAlertsPopulateMessageEventArgs} from "../../events/SearchAlertEvents";
 
 export interface IFacetOptions {
   title?: string;
@@ -406,11 +407,10 @@ export class Facet extends Component {
      * The default value is `800`.
      */
     responsiveBreakpoint: ComponentOptions.buildNumberOption({ defaultValue: 800 }),
-
     /**
      * Specifies the label of the button that allows to show the facets when in responsive mode. If it is specified more than once, the
      * first occurence of the option will be used.
-     * The default value is "Filters". 
+     * The default value is "Filters".
      */
     dropdownHeaderLabel: ComponentOptions.buildLocalizedStringOption()
   };
@@ -488,7 +488,9 @@ export class Facet extends Component {
     this.initComponentStateEvents();
     this.initOmniboxEvents();
     this.initBreadCrumbEvents();
+    this.initSearchAlertEvents();
     this.updateNumberOfValues();
+
 
     this.resize = () => {
       if (!this.disabled) {
@@ -924,6 +926,12 @@ export class Facet extends Component {
     }
   }
 
+  protected handlePopulateSearchAlerts(args: ISearchAlertsPopulateMessageEventArgs) {
+    if (this.values.hasSelectedOrExcludedValues()) {
+      args.text.push(new BreadcrumbValueList(this, this.values.getSelected().concat(this.values.getExcluded()), BreadcrumbValueElement).buildAsString());
+    }
+  }
+
   protected initFacetQueryController() {
     this.facetQueryController = new FacetQueryController(this);
   }
@@ -989,6 +997,10 @@ export class Facet extends Component {
       this.bind.onRootElement(BreadcrumbEvents.populateBreadcrumb, (args: IPopulateBreadcrumbEventArgs) => this.handlePopulateBreadcrumb(args));
       this.bind.onRootElement(BreadcrumbEvents.clearBreadcrumb, (args: IClearBreadcrumbEventArgs) => this.handleClearBreadcrumb());
     }
+  }
+
+  protected initSearchAlertEvents() {
+    this.bind.onRootElement(SearchAlertsEvents.searchAlertsPopulateMessage, (args: ISearchAlertsPopulateMessageEventArgs)=> this.handlePopulateSearchAlerts(args));
   }
 
   protected handleOmniboxWithStaticValue(eventArg: IPopulateOmniboxEventArgs) {

--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -23,7 +23,7 @@ import {Utils} from '../../utils/Utils';
 import {ResponsiveComponentsUtils} from '../ResponsiveComponents/ResponsiveComponentsUtils';
 import {Initialization} from '../Base/Initialization';
 import d3 = require('d3');
-import {SearchAlertsEvents, ISearchAlertsPopulateMessageEventArgs} from "../../events/SearchAlertEvents";
+import {SearchAlertsEvents, ISearchAlertsPopulateMessageEventArgs} from '../../events/SearchAlertEvents';
 
 export interface IFacetSliderOptions extends ISliderOptions {
   dateField?: boolean;
@@ -334,7 +334,7 @@ export class FacetSlider extends Component {
     this.bind.onRootElement(QueryEvents.buildingQuery, (args: IBuildingQueryEventArgs) => this.handleBuildingQuery(args));
     this.bind.onRootElement(QueryEvents.doneBuildingQuery, (args: IDoneBuildingQueryEventArgs) => this.handleDoneBuildingQuery(args));
     this.bind.onRootElement(BreadcrumbEvents.populateBreadcrumb, (args: IPopulateBreadcrumbEventArgs) => this.handlePopulateBreadcrumb(args));
-    this.bind.onRootElement(SearchAlertsEvents.searchAlertsPopulateMessage, (args: ISearchAlertsPopulateMessageEventArgs)=> this.handlePopulateSearchAlerts(args));
+    this.bind.onRootElement(SearchAlertsEvents.searchAlertsPopulateMessage, (args: ISearchAlertsPopulateMessageEventArgs) => this.handlePopulateSearchAlerts(args));
     this.bind.onRootElement(BreadcrumbEvents.clearBreadcrumb, () => this.reset());
 
     this.onResize = _.debounce(() => {

--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -23,6 +23,7 @@ import {Utils} from '../../utils/Utils';
 import {ResponsiveComponentsUtils} from '../ResponsiveComponents/ResponsiveComponentsUtils';
 import {Initialization} from '../Base/Initialization';
 import d3 = require('d3');
+import {SearchAlertsEvents, ISearchAlertsPopulateMessageEventArgs} from "../../events/SearchAlertEvents";
 
 export interface IFacetSliderOptions extends ISliderOptions {
   dateField?: boolean;
@@ -333,6 +334,7 @@ export class FacetSlider extends Component {
     this.bind.onRootElement(QueryEvents.buildingQuery, (args: IBuildingQueryEventArgs) => this.handleBuildingQuery(args));
     this.bind.onRootElement(QueryEvents.doneBuildingQuery, (args: IDoneBuildingQueryEventArgs) => this.handleDoneBuildingQuery(args));
     this.bind.onRootElement(BreadcrumbEvents.populateBreadcrumb, (args: IPopulateBreadcrumbEventArgs) => this.handlePopulateBreadcrumb(args));
+    this.bind.onRootElement(SearchAlertsEvents.searchAlertsPopulateMessage, (args: ISearchAlertsPopulateMessageEventArgs)=> this.handlePopulateSearchAlerts(args));
     this.bind.onRootElement(BreadcrumbEvents.clearBreadcrumb, () => this.reset());
 
     this.onResize = _.debounce(() => {
@@ -461,6 +463,12 @@ export class FacetSlider extends Component {
     }
   }
 
+  private handlePopulateSearchAlerts(args: ISearchAlertsPopulateMessageEventArgs) {
+    if (this.isActive()) {
+      args.text.push($$(this.buildBreadcrumbFacetSlider()).text());
+    }
+  }
+
   private buildBreadcrumbFacetSlider(): HTMLElement {
     let elem = $$('div', {
       className: 'coveo-facet-slider-breadcrumb'
@@ -469,7 +477,7 @@ export class FacetSlider extends Component {
     let title = $$('span', {
       className: 'coveo-facet-slider-breadcrumb-title'
     });
-    title.text(this.options.title + ':');
+    title.text(this.options.title + ': ');
     elem.appendChild(title.el);
 
     let values = $$('span', {

--- a/src/ui/HierarchicalFacet/HierarchicalBreadcrumbValuesList.ts
+++ b/src/ui/HierarchicalFacet/HierarchicalBreadcrumbValuesList.ts
@@ -4,7 +4,7 @@ import {BreadcrumbValueList} from '../Facet/BreadcrumbValuesList';
 import {HierarchicalFacet, IValueHierarchy} from './HierarchicalFacet';
 import {FacetValue} from '../Facet/FacetValues';
 import {HierarchicalBreadcrumbValueElement} from './HierarchicalBreadcrumbValueElement';
-import {$$} from "../../utils/Dom";
+import {$$} from '../../utils/Dom';
 
 export class HierarchicalBreadcrumbValuesList extends BreadcrumbValueList {
   constructor(public facet: HierarchicalFacet, public facetValues: FacetValue[], public valueHierarchy: { [facetValue: string]: IValueHierarchy }) {
@@ -14,13 +14,13 @@ export class HierarchicalBreadcrumbValuesList extends BreadcrumbValueList {
   public buildAsString() {
     this.build();
     if (this.elem) {
-      let joined = `${this.facet.options.title}: ` + _.map($$(this.elem).findAll('.coveo-facet-breadcrumb-value'), (value: HTMLElement)=> {
-            _.each($$(value).findAll('.coveo-hierarchical-breadcrumb-separator'), (separator)=> {
-              // small right black triangle
-              $$(separator).text('\u25B8')
-            });
-            return $$(value).text();
-          }).join(', ');
+      let joined = `${this.facet.options.title}: ` + _.map($$(this.elem).findAll('.coveo-facet-breadcrumb-value'), (value: HTMLElement) => {
+        _.each($$(value).findAll('.coveo-hierarchical-breadcrumb-separator'), (separator) => {
+          // small right black triangle
+          $$(separator).text('\u25B8');
+        });
+        return $$(value).text();
+      }).join(', ');
       return joined;
     }
     return '';

--- a/src/ui/HierarchicalFacet/HierarchicalBreadcrumbValuesList.ts
+++ b/src/ui/HierarchicalFacet/HierarchicalBreadcrumbValuesList.ts
@@ -4,9 +4,25 @@ import {BreadcrumbValueList} from '../Facet/BreadcrumbValuesList';
 import {HierarchicalFacet, IValueHierarchy} from './HierarchicalFacet';
 import {FacetValue} from '../Facet/FacetValues';
 import {HierarchicalBreadcrumbValueElement} from './HierarchicalBreadcrumbValueElement';
+import {$$} from "../../utils/Dom";
 
 export class HierarchicalBreadcrumbValuesList extends BreadcrumbValueList {
   constructor(public facet: HierarchicalFacet, public facetValues: FacetValue[], public valueHierarchy: { [facetValue: string]: IValueHierarchy }) {
     super(facet, facetValues, HierarchicalBreadcrumbValueElement);
+  }
+
+  public buildAsString() {
+    this.build();
+    if (this.elem) {
+      let joined = `${this.facet.options.title}: ` + _.map($$(this.elem).findAll('.coveo-facet-breadcrumb-value'), (value: HTMLElement)=> {
+            _.each($$(value).findAll('.coveo-hierarchical-breadcrumb-separator'), (separator)=> {
+              // small right black triangle
+              $$(separator).text('\u25B8')
+            });
+            return $$(value).text();
+          }).join(', ');
+      return joined;
+    }
+    return '';
   }
 }

--- a/src/ui/HierarchicalFacet/HierarchicalFacet.ts
+++ b/src/ui/HierarchicalFacet/HierarchicalFacet.ts
@@ -25,8 +25,7 @@ import {IPopulateOmniboxEventArgs} from '../../events/OmniboxEvents';
 import {OmniboxHierarchicalValuesList} from './OmniboxHierarchicalValuesList';
 import {HierarchicalFacetValueElement} from './HierarchicalFacetValueElement';
 import {Initialization} from '../Base/Initialization';
-import {ISearchAlertsPopulateMessageEventArgs} from "../../events/SearchAlertEvents";
-import {HierarchicalBreadcrumbValueElement} from "./HierarchicalBreadcrumbValueElement";
+import {ISearchAlertsPopulateMessageEventArgs} from '../../events/SearchAlertEvents';
 
 export interface IHierarchicalFacetOptions extends IFacetOptions {
   delimitingCharacter?: string;

--- a/src/ui/HierarchicalFacet/HierarchicalFacet.ts
+++ b/src/ui/HierarchicalFacet/HierarchicalFacet.ts
@@ -25,6 +25,8 @@ import {IPopulateOmniboxEventArgs} from '../../events/OmniboxEvents';
 import {OmniboxHierarchicalValuesList} from './OmniboxHierarchicalValuesList';
 import {HierarchicalFacetValueElement} from './HierarchicalFacetValueElement';
 import {Initialization} from '../Base/Initialization';
+import {ISearchAlertsPopulateMessageEventArgs} from "../../events/SearchAlertEvents";
+import {HierarchicalBreadcrumbValueElement} from "./HierarchicalBreadcrumbValueElement";
 
 export interface IHierarchicalFacetOptions extends IFacetOptions {
   delimitingCharacter?: string;
@@ -447,6 +449,12 @@ export class HierarchicalFacet extends Facet implements IComponentBindings {
   protected handleDeferredQuerySuccess(data: IQuerySuccessEventArgs) {
     this.updateAppearanceDependingOnState();
     super.handleDeferredQuerySuccess(data);
+  }
+
+  protected handlePopulateSearchAlerts(args: ISearchAlertsPopulateMessageEventArgs) {
+    if (this.values.hasSelectedOrExcludedValues()) {
+      args.text.push(new HierarchicalBreadcrumbValuesList(this, this.values.getSelected().concat(this.values.getExcluded()), this.getAllValueHierarchy()).buildAsString());
+    }
   }
 
   protected handlePopulateBreadcrumb(args: IPopulateBreadcrumbEventArgs) {

--- a/src/ui/SearchAlerts/FollowItem.ts
+++ b/src/ui/SearchAlerts/FollowItem.ts
@@ -199,7 +199,8 @@ export class FollowItem extends Component {
 
     return {
       type: SUBSCRIPTION_TYPE.followDocument,
-      typeConfig: typeCofig
+      typeConfig: typeCofig,
+      name: title
     };
   }
 }

--- a/src/ui/SearchAlerts/SearchAlerts.ts
+++ b/src/ui/SearchAlerts/SearchAlerts.ts
@@ -306,7 +306,7 @@ export class SearchAlerts extends Component {
    */
   public followQuery() {
     let queryBuilder = this.queryController.createQueryBuilder({});
-    let request = SearchAlerts.buildFollowQueryRequest(queryBuilder.build(), this.options);
+    let request = this.buildFollowQueryRequest(queryBuilder.build(), this.options);
 
     this.queryController.getEndpoint().follow(request)
       .then((subscription: ISubscription) => {
@@ -346,7 +346,7 @@ export class SearchAlerts extends Component {
     return dom;
   }
 
-  private static buildFollowQueryRequest(query: IQuery, options: ISearchAlertsOptions): ISubscriptionRequest {
+  private buildFollowQueryRequest(query: IQuery, options: ISearchAlertsOptions): ISubscriptionRequest {
     let typeConfig: ISubscriptionQueryRequest = {
       query: query
     };
@@ -357,7 +357,8 @@ export class SearchAlerts extends Component {
 
     return {
       type: SUBSCRIPTION_TYPE.followQuery,
-      typeConfig: typeConfig
+      typeConfig: typeConfig,
+      name: this.message.getFollowQueryMessage(query.q)
     };
   }
 

--- a/src/ui/SearchAlerts/SearchAlerts.ts
+++ b/src/ui/SearchAlerts/SearchAlerts.ts
@@ -260,7 +260,7 @@ export class SearchAlerts extends Component {
     element.el.innerHTML = `
       <td class='coveo-subscriptions-panel-content-type'>${ l('SearchAlerts_Type_' + subscription.type)}</td>
       <td>
-        <div class='coveo-subscriptions-panel-context'>
+        <div class='coveo-subscriptions-panel-context' title='${context}'>
           ${ context}
         </div>
       </td>

--- a/src/ui/SearchAlerts/SearchAlertsMessage.ts
+++ b/src/ui/SearchAlerts/SearchAlertsMessage.ts
@@ -100,7 +100,7 @@ export class SearchAlertsMessage extends Component {
     this.message.el.innerHTML = `
       <div class='coveo-subscriptions-messages-message'>
         <div class='coveo-subscriptions-messages-info-close'></div>
-        <div class='coveo-subscriptions-messages-content' title='${message}'>${message}</span></div>
+        <div class='coveo-subscriptions-messages-content' title='${message}'>${message}</div>
       </div>`;
 
     this.message.toggleClass('coveo-subscriptions-messages-error', error);

--- a/src/ui/SearchAlerts/SearchAlertsMessage.ts
+++ b/src/ui/SearchAlerts/SearchAlertsMessage.ts
@@ -61,13 +61,14 @@ export class SearchAlertsMessage extends Component {
       text: []
     };
 
+    let getAdditionalTextFormatted = ()=> {
+      return _.map(populateMessageArguments.text, (text)=> {
+        return `${htmlFormatted ? '<li>' : '('}${_.escape(text)}${htmlFormatted ? '</li>' : ')'}`
+      }).join(' ')
+    };
+
     $$(this.root).trigger(SearchAlertsEvents.searchAlertsPopulateMessage, populateMessageArguments);
-    let additionalMessage =
-        `${htmlFormatted ? '<ul>' : ''}
-         ${_.map(populateMessageArguments.text, (text)=> {
-          return `${htmlFormatted ? '<li>' : '('} ${_.escape(text)}${htmlFormatted ? '</li>' : ')'}`
-        }).join(' ')}
-        ${htmlFormatted ? '</ul>' : ''}`;
+    let additionalMessage = `${htmlFormatted ? '<ul>' : ''}${getAdditionalTextFormatted()}${htmlFormatted ? '</ul>' : ''}`;
 
     let automaticallyBuiltMessage;
 

--- a/src/ui/SearchAlerts/SearchAlertsMessage.ts
+++ b/src/ui/SearchAlerts/SearchAlertsMessage.ts
@@ -2,15 +2,14 @@ import {Component} from '../Base/Component';
 import {ComponentOptions} from '../Base/ComponentOptions';
 import {IComponentBindings} from '../Base/ComponentBindings';
 import {
-    SearchAlertsEvents, ISearchAlertsEventArgs, ISearchAlertsFailEventArgs,
-    ISearchAlertsPopulateMessageEventArgs
+  SearchAlertsEvents, ISearchAlertsEventArgs, ISearchAlertsFailEventArgs,
+  ISearchAlertsPopulateMessageEventArgs
 } from '../../events/SearchAlertEvents';
 import {QueryEvents} from '../../events/QueryEvents';
 import {ISubscriptionItemRequest, SUBSCRIPTION_TYPE, ISubscriptionQueryRequest} from '../../rest/Subscription';
 import {PopupUtils, HorizontalAlignment, VerticalAlignment} from '../../utils/PopupUtils';
 import {l} from '../../strings/Strings';
 import {$$, Dom} from '../../utils/Dom';
-import {ModalBox} from '../../ExternalModulesShim';
 
 export interface ISearchAlertMessageOptions {
   closeDelay: number;
@@ -61,10 +60,10 @@ export class SearchAlertsMessage extends Component {
       text: []
     };
 
-    let getAdditionalTextFormatted = ()=> {
-      return _.map(populateMessageArguments.text, (text)=> {
-        return `${htmlFormatted ? '<li>' : '('}${_.escape(text)}${htmlFormatted ? '</li>' : ')'}`
-      }).join(' ')
+    let getAdditionalTextFormatted = () => {
+      return _.map(populateMessageArguments.text, (text) => {
+        return `${htmlFormatted ? '<li>' : '('}${_.escape(text)}${htmlFormatted ? '</li>' : ')'}`;
+      }).join(' ');
     };
 
     $$(this.root).trigger(SearchAlertsEvents.searchAlertsPopulateMessage, populateMessageArguments);
@@ -158,10 +157,10 @@ export class SearchAlertsMessage extends Component {
   }
 
   private close() {
-    /*if (this.message != null) {
+    if (this.message != null) {
       clearTimeout(this.closeTimeout);
       this.message.remove();
       this.message = null;
-     }*/
+    }
   }
 }

--- a/src/ui/SearchAlerts/SearchAlertsMessage.ts
+++ b/src/ui/SearchAlerts/SearchAlertsMessage.ts
@@ -1,12 +1,16 @@
 import {Component} from '../Base/Component';
 import {ComponentOptions} from '../Base/ComponentOptions';
 import {IComponentBindings} from '../Base/ComponentBindings';
-import {SearchAlertsEvents, ISearchAlertsEventArgs, ISearchAlertsFailEventArgs} from '../../events/SearchAlertEvents';
+import {
+    SearchAlertsEvents, ISearchAlertsEventArgs, ISearchAlertsFailEventArgs,
+    ISearchAlertsPopulateMessageEventArgs
+} from '../../events/SearchAlertEvents';
 import {QueryEvents} from '../../events/QueryEvents';
 import {ISubscriptionItemRequest, SUBSCRIPTION_TYPE, ISubscriptionQueryRequest} from '../../rest/Subscription';
 import {PopupUtils, HorizontalAlignment, VerticalAlignment} from '../../utils/PopupUtils';
 import {l} from '../../strings/Strings';
 import {$$, Dom} from '../../utils/Dom';
+import {ModalBox} from '../../ExternalModulesShim';
 
 export interface ISearchAlertMessageOptions {
   closeDelay: number;
@@ -51,6 +55,41 @@ export class SearchAlertsMessage extends Component {
     return 'coveo-subscriptions-messages';
   }
 
+  public getFollowQueryMessage(query?: string, htmlFormatted = false): string {
+    let populateMessageArguments: ISearchAlertsPopulateMessageEventArgs = {
+      dom: [],
+      text: []
+    };
+
+    $$(this.root).trigger(SearchAlertsEvents.searchAlertsPopulateMessage, populateMessageArguments);
+    let additionalMessage =
+        `${htmlFormatted ? '<ul>' : ''}
+         ${_.map(populateMessageArguments.text, (text)=> {
+          return `${htmlFormatted ? '<li>' : '('} ${_.escape(text)}${htmlFormatted ? '</li>' : ')'}`
+        }).join(' ')}
+        ${htmlFormatted ? '</ul>' : ''}`;
+
+    let automaticallyBuiltMessage;
+
+    if (query && additionalMessage) {
+      automaticallyBuiltMessage = `${_.escape(query)} ${additionalMessage}`;
+    }
+
+    if (query && !additionalMessage) {
+      automaticallyBuiltMessage = `${_.escape(query)}`;
+    }
+
+    if (!query && additionalMessage) {
+      automaticallyBuiltMessage = `${l('EmptyQuery')} ${additionalMessage}`;
+    }
+
+    if (!query && !additionalMessage) {
+      automaticallyBuiltMessage = l('EmptyQuery');
+    }
+
+    return automaticallyBuiltMessage;
+  }
+
   /**
    * Displays a message near the dom attribute.
    * @param dom Specifies where to display the message.
@@ -62,7 +101,7 @@ export class SearchAlertsMessage extends Component {
     this.message.el.innerHTML = `
       <div class='coveo-subscriptions-messages-message'>
         <div class='coveo-subscriptions-messages-info-close'></div>
-        <div class='coveo-subscriptions-messages-content' title='${message}'>${message}</div>
+        <div class='coveo-subscriptions-messages-content' title='${message}'>${message}</span></div>
       </div>`;
 
     this.message.toggleClass('coveo-subscriptions-messages-error', error);
@@ -91,7 +130,7 @@ export class SearchAlertsMessage extends Component {
     if (args.dom != null) {
       if (args.subscription.type == SUBSCRIPTION_TYPE.followQuery) {
         let typeConfig = <ISubscriptionQueryRequest>args.subscription.typeConfig;
-        this.showMessage($$(args.dom), l('SubscriptionsMessageFollowQuery', _.escape(typeConfig.query.q) || l('EmptyQuery')), false);
+        this.showMessage($$(args.dom), l('SubscriptionsMessageFollowQuery', this.getFollowQueryMessage(typeConfig.query.q, true)), false);
       } else {
         let typeConfig = <ISubscriptionItemRequest>args.subscription.typeConfig;
         this.showMessage($$(args.dom), l('SubscriptionsMessageFollow', _.escape(typeConfig.title)), false);
@@ -118,10 +157,10 @@ export class SearchAlertsMessage extends Component {
   }
 
   private close() {
-    if (this.message != null) {
+    /*if (this.message != null) {
       clearTimeout(this.closeTimeout);
       this.message.remove();
       this.message = null;
-    }
+     }*/
   }
 }

--- a/src/ui/SearchAlerts/SearchAlertsMessage.ts
+++ b/src/ui/SearchAlerts/SearchAlertsMessage.ts
@@ -56,7 +56,6 @@ export class SearchAlertsMessage extends Component {
 
   public getFollowQueryMessage(query?: string, htmlFormatted = false): string {
     let populateMessageArguments: ISearchAlertsPopulateMessageEventArgs = {
-      dom: [],
       text: []
     };
 

--- a/test/rest/SearchEndpointTest.ts
+++ b/test/rest/SearchEndpointTest.ts
@@ -519,7 +519,7 @@ export function SearchEndpointTest() {
             typeConfig: {
               query: qbuilder.build()
             },
-            name : 'asdasd'
+            name: 'asdasd'
           });
 
           promiseSuccess
@@ -654,7 +654,7 @@ export function SearchEndpointTest() {
         manageToken: '1',
         email: '42@coveo.com'
       },
-      name : 'asdasd'
+      name: 'asdasd'
     };
   }
 }

--- a/test/rest/SearchEndpointTest.ts
+++ b/test/rest/SearchEndpointTest.ts
@@ -518,7 +518,8 @@ export function SearchEndpointTest() {
             type: 'query',
             typeConfig: {
               query: qbuilder.build()
-            }
+            },
+            name : 'asdasd'
           });
 
           promiseSuccess
@@ -536,6 +537,7 @@ export function SearchEndpointTest() {
           expect(jasmine.Ajax.requests.mostRecent().url).toContain('accessToken=token');
           expect(jasmine.Ajax.requests.mostRecent().method).toBe('POST');
           expect(JSON.parse(jasmine.Ajax.requests.mostRecent().params).frequency).toBe('weekly');
+          expect(JSON.parse(jasmine.Ajax.requests.mostRecent().params).name).toBe('asdasd');
 
           jasmine.Ajax.requests.mostRecent().respondWith({
             status: 200,
@@ -651,7 +653,8 @@ export function SearchEndpointTest() {
       user: {
         manageToken: '1',
         email: '42@coveo.com'
-      }
+      },
+      name : 'asdasd'
     };
   }
 }

--- a/test/ui/SearchAlertsTest.ts
+++ b/test/ui/SearchAlertsTest.ts
@@ -7,7 +7,7 @@ import {$$} from '../../src/utils/Dom';
 import {SettingsEvents} from '../../src/events/SettingsEvents';
 import {Simulate} from '../Simulate';
 import {QueryBuilder} from '../../src/ui/Base/QueryBuilder';
-import {SearchAlertsEvents} from '../../src/events/SearchAlertEvents';
+import {SearchAlertsEvents, ISearchAlertsPopulateMessageEventArgs} from '../../src/events/SearchAlertEvents';
 
 export function SearchAlertsTest() {
   describe('SearchAlerts', function () {
@@ -149,6 +149,38 @@ export function SearchAlertsTest() {
           done();
         });
         test.cmp.followQuery();
+      });
+
+      it('should send the query property on follow query', ()=> {
+        let builder = new QueryBuilder();
+        builder.expression.add('yololo');
+        (<jasmine.Spy>test.cmp.queryController.createQueryBuilder).and.returnValue(builder);
+        test.cmp.followQuery();
+        expect(followMock).toHaveBeenCalledWith(
+            jasmine.objectContaining({
+              typeConfig: jasmine.objectContaining({
+                query: jasmine.objectContaining({
+                  q: jasmine.stringMatching('yololo')
+                })
+              })
+            }))
+      });
+
+      it('should send the name property on follow query', ()=> {
+        let builder = new QueryBuilder();
+        builder.expression.add('yololo');
+        (<jasmine.Spy>test.cmp.queryController.createQueryBuilder).and.returnValue(builder);
+
+        $$(test.env.root).on(SearchAlertsEvents.searchAlertsPopulateMessage, (e, args: ISearchAlertsPopulateMessageEventArgs)=> {
+          args.text.push('Something');
+          args.text.push('Another thing');
+        });
+
+        test.cmp.followQuery();
+        expect(followMock).toHaveBeenCalledWith(
+            jasmine.objectContaining({
+              name: 'yololo (Something) (Another thing)'
+            }));
       });
 
       it('should trigger a search alert failed event if there was a problem', (done) => {

--- a/test/ui/SearchAlertsTest.ts
+++ b/test/ui/SearchAlertsTest.ts
@@ -151,36 +151,36 @@ export function SearchAlertsTest() {
         test.cmp.followQuery();
       });
 
-      it('should send the query property on follow query', ()=> {
+      it('should send the query property on follow query', () => {
         let builder = new QueryBuilder();
         builder.expression.add('yololo');
         (<jasmine.Spy>test.cmp.queryController.createQueryBuilder).and.returnValue(builder);
         test.cmp.followQuery();
         expect(followMock).toHaveBeenCalledWith(
-            jasmine.objectContaining({
-              typeConfig: jasmine.objectContaining({
-                query: jasmine.objectContaining({
-                  q: jasmine.stringMatching('yololo')
-                })
+          jasmine.objectContaining({
+            typeConfig: jasmine.objectContaining({
+              query: jasmine.objectContaining({
+                q: jasmine.stringMatching('yololo')
               })
-            }))
+            })
+          }));
       });
 
-      it('should send the name property on follow query', ()=> {
+      it('should send the name property on follow query', () => {
         let builder = new QueryBuilder();
         builder.expression.add('yololo');
         (<jasmine.Spy>test.cmp.queryController.createQueryBuilder).and.returnValue(builder);
 
-        $$(test.env.root).on(SearchAlertsEvents.searchAlertsPopulateMessage, (e, args: ISearchAlertsPopulateMessageEventArgs)=> {
+        $$(test.env.root).on(SearchAlertsEvents.searchAlertsPopulateMessage, (e, args: ISearchAlertsPopulateMessageEventArgs) => {
           args.text.push('Something');
           args.text.push('Another thing');
         });
 
         test.cmp.followQuery();
         expect(followMock).toHaveBeenCalledWith(
-            jasmine.objectContaining({
-              name: 'yololo (Something) (Another thing)'
-            }));
+          jasmine.objectContaining({
+            name: 'yololo (Something) (Another thing)'
+          }));
       });
 
       it('should trigger a search alert failed event if there was a problem', (done) => {


### PR DESCRIPTION
This adds support for the "name" property in the search alert service.

This name property will be populated by the facets in the interface, much like they do for the breadcrumb.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)