### PR TITLE
Fix link to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ All resources will be available under `node_modules/coveo-search-ui/bin`. You ca
 
 If you are already using a module bundler (Browserify, webpack, Babel, etc.), then you can simply `require('coveo-search-ui')`.
 
-You can also download the latest version [here](http://productupdate.coveo.com/analytics?id=36346).
+You can also download the latest version [here](http://productupdate.coveo.com/?product=coveo-search-ui&version=1).
 
 ## Basic usage
 


### PR DESCRIPTION



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
This link will always download the last coveo-search-ui 1.0 version