### PR TITLE
Fix quickview header title not redirecting to result

### DIFF
--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -253,7 +253,6 @@ export class Quickview extends Component {
   }
 
   private createModalBox(openerObject: IQuickviewOpenerObject) {
-
     let computedModalBoxContent = $$('div');
     computedModalBoxContent.append(openerObject.content.el);
     this.modalbox = this.ModalBox.open(computedModalBoxContent.el, {

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -190,7 +190,6 @@ export class ResultLink extends Component {
   private openLinkThatIsNotAnAnchor() {
     if (!this.elementIsAnAnchor()) {
       $$(this.element).on('click', (ev: Event) => {
-        console.log('test');
         if (this.options.alwaysOpenInNewWindow) {
           if (this.options.openInOutlook) {
             this.openLinkInOutlook();

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -140,7 +140,6 @@ export class ResultLink extends Component {
     }
 
     this.element.setAttribute('tabindex', '0');
-
     Assert.exists(this.componentOptionsModel);
     Assert.exists(this.result);
 
@@ -191,6 +190,7 @@ export class ResultLink extends Component {
   private openLinkThatIsNotAnAnchor() {
     if (!this.elementIsAnAnchor()) {
       $$(this.element).on('click', (ev: Event) => {
+        console.log('test');
         if (this.options.alwaysOpenInNewWindow) {
           if (this.options.openInOutlook) {
             this.openLinkInOutlook();

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -140,6 +140,7 @@ export class ResultLink extends Component {
     }
 
     this.element.setAttribute('tabindex', '0');
+
     Assert.exists(this.componentOptionsModel);
     Assert.exists(this.result);
 

--- a/src/utils/DomUtils.ts
+++ b/src/utils/DomUtils.ts
@@ -87,7 +87,6 @@ export class DomUtils {
         <a class='coveo-quickview-pop-up-reminder'> ${options.title || ''}</a>
       </div>`;
     new Coveo[Coveo['Salesforce'] ? 'SalesforceResultLink' : 'ResultLink'](header.find('.coveo-quickview-pop-up-reminder'), undefined, bindings, result);
-    header.find('.coveo-quickview-pop-up-reminder').setAttribute('id', 'rl');
     return header;
   }
 }

--- a/src/utils/DomUtils.ts
+++ b/src/utils/DomUtils.ts
@@ -84,7 +84,7 @@ export class DomUtils {
       </div>
       <div class='coveo-quickview-left-header'>
         <span class='coveo-quickview-icon coveo-small ${fileType.icon}'></span>
-        <span class='coveo-quickview-pop-up-reminder'> ${options.title || ''}</span>
+        <a class='coveo-quickview-pop-up-reminder'> ${options.title || ''}</a>
       </div>`;
     new Coveo[Coveo['Salesforce'] ? 'SalesforceResultLink' : 'ResultLink'](header.find('.coveo-quickview-pop-up-reminder'), undefined, bindings, result);
     header.find('.coveo-quickview-pop-up-reminder').setAttribute('id', 'rl');

--- a/src/utils/DomUtils.ts
+++ b/src/utils/DomUtils.ts
@@ -87,6 +87,7 @@ export class DomUtils {
         <span class='coveo-quickview-pop-up-reminder'> ${options.title || ''}</span>
       </div>`;
     new Coveo[Coveo['Salesforce'] ? 'SalesforceResultLink' : 'ResultLink'](header.find('.coveo-quickview-pop-up-reminder'), undefined, bindings, result);
+    header.find('.coveo-quickview-pop-up-reminder').setAttribute('id', 'rl');
     return header;
   }
 }


### PR DESCRIPTION
This bug appeared when jquery was removed. In the jquery days, we used to be able to pass a jquery element or a string to the modal box to set the title. The quickview used this to set the result link. An onclick event was registered on a span then passed to the modal box. Now, since only strings can be passed to the modal box, the onclick event was lost in the process.

Fixed it by replacing the span by an anchor tag which causes the result link to use an href. I also verified that this was not happening anywhere else. To have an onclick event on the title element of the modal box, the event must be registered on the element in the modalbox, not the one that is passed to it.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)