### PR TITLE
Properly use the advanced expression in facet search

### DIFF
--- a/src/controllers/FacetQueryController.ts
+++ b/src/controllers/FacetQueryController.ts
@@ -18,6 +18,8 @@ import {IQueryBuilderExpression} from '../ui/Base/QueryBuilder';
 
 export class FacetQueryController {
   public expressionToUseForFacetSearch: string;
+  public basicExpressionToUseForFacetSearch: string;
+  public advancedExpressionToUseForFacetSearch: string;
   public constantExpressionToUseForFacetSearch: string;
   public lastGroupByRequestIndex: number;
   public lastGroupByRequest: IGroupByRequest;
@@ -79,13 +81,14 @@ export class FacetQueryController {
       groupByRequest.advancedQueryOverride = queryOverrideObject.advanced;
       groupByRequest.constantQueryOverride = queryOverrideObject.constant;
       this.expressionToUseForFacetSearch = queryOverrideObject.withoutConstant;
+      this.basicExpressionToUseForFacetSearch = queryOverrideObject.basic;
+      this.advancedExpressionToUseForFacetSearch = queryOverrideObject.advanced;
       this.constantExpressionToUseForFacetSearch = queryOverrideObject.constant;
     } else {
       let parts = queryBuilder.computeCompleteExpressionParts();
-      this.expressionToUseForFacetSearch = parts.withoutConstant;
-      if (this.expressionToUseForFacetSearch == null) {
-        this.expressionToUseForFacetSearch = '@uri';
-      }
+      this.expressionToUseForFacetSearch = parts.withoutConstant == null ? '@uri' : parts.withoutConstant;
+      this.basicExpressionToUseForFacetSearch = parts.basic == null ? '@uri' : parts.basic;
+      this.advancedExpressionToUseForFacetSearch = parts.advanced;
       this.constantExpressionToUseForFacetSearch = parts.constant;
     }
     this.lastGroupByRequestIndex = queryBuilder.groupByRequests.length;

--- a/src/ui/Facet/FacetSearchParameters.ts
+++ b/src/ui/Facet/FacetSearchParameters.ts
@@ -85,7 +85,7 @@ export class FacetSearchParameters {
     var lastQuery = _.clone(this.facet.queryController.getLastQuery());
     if (!lastQuery) {
       // There should normally always be a last query available
-      // If not, just create en empty one.
+      // If not, just create an empty one.
       lastQuery = new QueryBuilder().build();
     }
     lastQuery.q = this.facet.facetQueryController.expressionToUseForFacetSearch;

--- a/src/ui/Facet/FacetSearchParameters.ts
+++ b/src/ui/Facet/FacetSearchParameters.ts
@@ -88,9 +88,9 @@ export class FacetSearchParameters {
       // If not, just create an empty one.
       lastQuery = new QueryBuilder().build();
     }
-    lastQuery.q = this.facet.facetQueryController.expressionToUseForFacetSearch;
+    lastQuery.q = this.facet.facetQueryController.basicExpressionToUseForFacetSearch;
     lastQuery.cq = this.facet.facetQueryController.constantExpressionToUseForFacetSearch;
-    lastQuery.aq = null;
+    lastQuery.aq = this.facet.facetQueryController.advancedExpressionToUseForFacetSearch;
     lastQuery.enableDidYouMean = false;
     lastQuery.firstResult = 0;
     lastQuery.numberOfResults = 0;

--- a/test/ui/FacetSearchParametersTest.ts
+++ b/test/ui/FacetSearchParametersTest.ts
@@ -124,13 +124,15 @@ export function FacetSearchParametersTest() {
         spy.and.returnValue(builder.build());
 
         mockFacet.facetQueryController = <FacetQueryController>{};
-        mockFacet.facetQueryController.expressionToUseForFacetSearch = '@asdf';
-        mockFacet.facetQueryController.constantExpressionToUseForFacetSearch = '@qwerty';
+        mockFacet.facetQueryController.basicExpressionToUseForFacetSearch = '@basic';
+        mockFacet.facetQueryController.advancedExpressionToUseForFacetSearch = '@advanced';
+        mockFacet.facetQueryController.constantExpressionToUseForFacetSearch = '@constant';
 
         var params = new FacetSearchParameters(mockFacet);
         expect(params.getQuery().partialMatch).toBe(true);
-        expect(params.getQuery().q).toBe('@asdf');
-        expect(params.getQuery().cq).toBe('@qwerty');
+        expect(params.getQuery().q).toBe('@basic');
+        expect(params.getQuery().aq).toBe('@advanced');
+        expect(params.getQuery().cq).toBe('@constant');
       });
 
       it('should use the same group by parameters as the facet', () => {


### PR DESCRIPTION
Use the `q` and `aq` field to launch a search in the facet search. Originally the basic and advanced expression were merged to build the query. This caused problems when using `disableQuerySyntax` and having an advanced expression at the same time.

Even though it is not used anymore, I didn't remove the `expressionToUseForFacetSearch` member on the FacetQueryController since its public and removing it could possibly break some implementations.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)