### PR TITLE
Hide specific responsive components on no results / query error.

### DIFF
--- a/sass/_ResponsiveComponents.scss
+++ b/sass/_ResponsiveComponents.scss
@@ -30,6 +30,10 @@
     .coveo-sprites-more-tabs {
       margin-left: 10px;
     }
+
+    &.coveo-hidden {
+      display: none;
+    }
   }
 
   .coveo-tab-section {

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownHeader.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownHeader.ts
@@ -1,4 +1,4 @@
-import {Dom} from '../../../utils/Dom';
+import {Dom, $$} from '../../../utils/Dom';
 
 export class ResponsiveDropdownHeader {
 
@@ -20,5 +20,13 @@ export class ResponsiveDropdownHeader {
 
   public cleanUp() {
     this.element.detach();
+  }
+
+  public hide() {
+    $$(this.element).addClass('coveo-hidden');
+  }
+
+  public show() {
+    $$(this.element).removeClass('coveo-hidden');
   }
 }

--- a/src/ui/ResponsiveComponents/ResponsiveFacets.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveFacets.ts
@@ -10,6 +10,7 @@ import {FacetSlider} from '../FacetSlider/FacetSlider';
 import {ResponsiveDropdown} from './ResponsiveDropdown/ResponsiveDropdown';
 import {ResponsiveDropdownContent} from './ResponsiveDropdown/ResponsiveDropdownContent';
 import {ResponsiveDropdownHeader} from './ResponsiveDropdown/ResponsiveDropdownHeader';
+import {QueryEvents, IQuerySuccessEventArgs} from '../../events/QueryEvents';
 
 export class ResponsiveFacets implements IResponsiveComponent {
 
@@ -43,8 +44,8 @@ export class ResponsiveFacets implements IResponsiveComponent {
     this.bindDropdownContentEvents();
     this.registerOnOpenHandler();
     this.registerOnCloseHandler();
+    this.registerQueryEvents();
     this.logger = new Logger(this);
-
     if (Utils.isNullOrUndefined(options.responsiveBreakpoint)) {
       this.breakpoint = ResponsiveFacets.RESPONSIVE_BREAKPOINT;
     } else {
@@ -140,6 +141,12 @@ export class ResponsiveFacets implements IResponsiveComponent {
     this.dropdown.registerOnCloseHandler(this.dismissFacetSearches, this);
   }
 
+  private registerQueryEvents() {
+    this.coveoRoot.on(QueryEvents.noResults, ()=> this.handleNoResults());
+    this.coveoRoot.on(QueryEvents.querySuccess, (e: Event, data: IQuerySuccessEventArgs)=> this.handleQuerySuccess(data));
+    this.coveoRoot.on(QueryEvents.queryError, ()=> this.handleQueryError());
+  }
+
   private bindDropdownContentEvents() {
     this.dropdown.dropdownContent.element.on('scroll', _.debounce(() => {
       _.each(this.facets, facet => {
@@ -192,5 +199,21 @@ export class ResponsiveFacets implements IResponsiveComponent {
     }
 
     return dropdownHeaderLabel;
+  }
+
+  private handleNoResults() {
+    this.dropdown.dropdownHeader.hide();
+  }
+
+  private handleQueryError() {
+    this.dropdown.dropdownHeader.hide();
+  }
+
+  private handleQuerySuccess(data: IQuerySuccessEventArgs) {
+    if (data.results.totalCount === 0) {
+      this.dropdown.dropdownHeader.hide();
+    } else {
+      this.dropdown.dropdownHeader.show();
+    }
   }
 }

--- a/src/ui/ResponsiveComponents/ResponsiveFacets.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveFacets.ts
@@ -142,9 +142,9 @@ export class ResponsiveFacets implements IResponsiveComponent {
   }
 
   private registerQueryEvents() {
-    this.coveoRoot.on(QueryEvents.noResults, ()=> this.handleNoResults());
-    this.coveoRoot.on(QueryEvents.querySuccess, (e: Event, data: IQuerySuccessEventArgs)=> this.handleQuerySuccess(data));
-    this.coveoRoot.on(QueryEvents.queryError, ()=> this.handleQueryError());
+    this.coveoRoot.on(QueryEvents.noResults, () => this.handleNoResults());
+    this.coveoRoot.on(QueryEvents.querySuccess, (e: Event, data: IQuerySuccessEventArgs) => this.handleQuerySuccess(data));
+    this.coveoRoot.on(QueryEvents.queryError, () => this.handleQueryError());
   }
 
   private bindDropdownContentEvents() {

--- a/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
@@ -197,11 +197,11 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
 
   private registerQueryEvents() {
     let recommendationInstance = <Recommendation>get(this.recommendationRoot.el, SearchInterface);
-    if (recommendationInstance.options.hideIfNoResults) {
-      this.coveoRoot.on(QueryEvents.querySuccess, (e: Event, data: IQuerySuccessEventArgs)=>this.handleRecommnendationQuerySucess(data));
-      this.coveoRoot.on(QueryEvents.noResults, (e: Event, args: INoResultsEventArgs) => this.handleRecommendationNoResults());
+    if (recommendationInstance && recommendationInstance.options.hideIfNoResults) {
+      this.coveoRoot.on(QueryEvents.querySuccess, (e: Event, data: IQuerySuccessEventArgs) => this.handleRecommnendationQuerySucess(data));
+      this.coveoRoot.on(QueryEvents.noResults, (e: Event, data: INoResultsEventArgs) => this.handleRecommendationNoResults());
     }
-    this.coveoRoot.on(QueryEvents.queryError, ()=> this.handleRecommendationQueryError());
+    this.coveoRoot.on(QueryEvents.queryError, () => this.handleRecommendationQueryError());
   }
 
   private handleRecommnendationQuerySucess(data: IQuerySuccessEventArgs) {

--- a/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
@@ -12,6 +12,8 @@ import {l} from '../../strings/Strings';
 import {FacetSlider} from '../FacetSlider/FacetSlider';
 import {Facet} from '../Facet/Facet';
 import {Component} from '../Base/Component';
+import {get} from '../Base/RegisteredNamedMethods';
+import {QueryEvents, IQuerySuccessEventArgs, INoResultsEventArgs} from '../../events/QueryEvents';
 
 export class ResponsiveRecommendation implements IResponsiveComponent {
 
@@ -50,7 +52,7 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
     return null;
   }
 
-  constructor(public coveoRoot: Dom, public ID: string, options: IResponsiveComponentOptions, responsiveDropdown?: ResponsiveDropdown) {
+  constructor(public coveoRoot: Dom, public ID: string, options: IResponsiveComponentOptions, public responsiveDropdown?: ResponsiveDropdown) {
     this.recommendationRoot = this.getRecommendationRoot();
     this.dropdownHeaderLabel = options.dropdownHeaderLabel;
     this.breakpoint = this.defineResponsiveBreakpoint(options);
@@ -60,6 +62,7 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
     this.facetSliders = this.getFacetSliders();
     this.registerOnOpenHandler();
     this.registerOnCloseHandler();
+    this.registerQueryEvents();
     this.dropdownContainer = $$('div', { className: ResponsiveRecommendation.DROPDOWN_CONTAINER_CSS_CLASS_NAME });
   }
 
@@ -190,5 +193,33 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
 
   private getRecommendationRoot(): Dom {
     return $$(this.coveoRoot.find('.' + Component.computeCssClassName(Recommendation)));
+  }
+
+  private registerQueryEvents() {
+    let recommendationInstance = <Recommendation>get(this.recommendationRoot.el, SearchInterface);
+    if (recommendationInstance.options.hideIfNoResults) {
+      this.coveoRoot.on(QueryEvents.querySuccess, (e: Event, data: IQuerySuccessEventArgs)=>this.handleRecommnendationQuerySucess(data));
+      this.coveoRoot.on(QueryEvents.noResults, (e: Event, args: INoResultsEventArgs) => this.handleRecommendationNoResults());
+    }
+    this.coveoRoot.on(QueryEvents.queryError, ()=> this.handleRecommendationQueryError());
+  }
+
+  private handleRecommnendationQuerySucess(data: IQuerySuccessEventArgs) {
+    if (data.results.totalCount === 0) {
+      this.dropdown.close();
+      this.dropdown.dropdownHeader.hide();
+    } else {
+      this.dropdown.dropdownHeader.show();
+    }
+  }
+
+  private handleRecommendationNoResults() {
+    this.dropdown.close();
+    this.dropdown.dropdownHeader.hide();
+  }
+
+  private handleRecommendationQueryError() {
+    this.dropdown.close();
+    this.dropdown.dropdownHeader.hide();
   }
 }

--- a/test/ui/ResponsiveComponents/ResponsiveFacetsTest.ts
+++ b/test/ui/ResponsiveComponents/ResponsiveFacetsTest.ts
@@ -10,6 +10,8 @@ import {FacetSearch} from '../../../src/ui/Facet/FacetSearch';
 import {FacetSlider} from '../../../src/ui/FacetSlider/FacetSlider';
 import {FacetSearchValuesList} from '../../../src/ui/Facet/FacetSearchValuesList';
 import * as Mock from '../../MockEnvironment';
+import {QueryEvents} from '../../../src/events/QueryEvents';
+import {FakeResults} from '../../Fake';
 
 export function ResponsiveFacetsTest() {
   describe('ResponsiveFacets', () => {
@@ -52,7 +54,7 @@ export function ResponsiveFacetsTest() {
       responsiveDropdown = jasmine.createSpyObj('responsiveDropdown', ['registerOnOpenHandler', 'registerOnCloseHandler', 'cleanUp', 'open', 'close', 'disablePopupBackground']);
       responsiveDropdownContent = jasmine.createSpyObj('responsiveDropdownContent', ['positionDropdown', 'hideDropdown', 'cleanUp', 'element']);
       responsiveDropdownContent.element = $$('div');
-      responsiveDropdownHeader = jasmine.createSpyObj('responsiveDropdownHeader', ['open', 'close', 'cleanUp']);
+      responsiveDropdownHeader = jasmine.createSpyObj('responsiveDropdownHeader', ['open', 'close', 'cleanUp', 'show', 'hide']);
       responsiveDropdownHeader.element = $$('div', { className: dropdownHeaderClassName });
       responsiveDropdown.dropdownContent = responsiveDropdownContent;
       responsiveDropdown.dropdownHeader = responsiveDropdownHeader;
@@ -115,6 +117,26 @@ export function ResponsiveFacetsTest() {
         shouldSwitchToSmallMode();
         responsiveFacets.handleResizeEvent();
         expect(ResponsiveComponentsUtils.activateSmallFacet).toHaveBeenCalled();
+      });
+
+      it('should hide on query error', () => {
+        root.trigger(QueryEvents.queryError);
+        expect(responsiveDropdownHeader.hide).toHaveBeenCalled();
+      });
+
+      it('should hide on query success with 0 results', () => {
+        root.trigger(QueryEvents.querySuccess, { results: FakeResults.createFakeResults(0) });
+        expect(responsiveDropdownHeader.hide).toHaveBeenCalled();
+      });
+
+      it('should show on query success with more than 0 results', () => {
+        root.trigger(QueryEvents.querySuccess, { results: FakeResults.createFakeResults() });
+        expect(responsiveDropdownHeader.show).toHaveBeenCalled();
+      });
+
+      it('should hide on no results', () => {
+        root.trigger(QueryEvents.noResults, { results: FakeResults.createFakeResults() });
+        expect(responsiveDropdownHeader.hide).toHaveBeenCalled();
       });
     });
 


### PR DESCRIPTION
When there are no results or a query error, hide the ResponsiveRecommendation and ResponsiveFacets component.



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)