### PR TITLE
rework ResultLayout to remove possible multiple queries + analytics events

### DIFF
--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -139,7 +139,7 @@ export class QueryController extends RootComponent {
 
   /**
    * Return the last query results set.
-   * @returns {IQueryResults|Array}
+   * @returns {IQueryResults}
    */
   public getLastResults() {
     return this.lastQueryResults;

--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -138,6 +138,14 @@ export class QueryController extends RootComponent {
   }
 
   /**
+   * Return the last query results set.
+   * @returns {IQueryResults|Array}
+   */
+  public getLastResults() {
+    return this.lastQueryResults;
+  }
+
+  /**
    * Execute a query and return a Promise of IQueryResults.<br/>
    * This will execute the normal query flow, triggering all the necessary query events (newQuery <br/>
    * All components present in the interface will act accordingly (modify the query and render results if needed).

--- a/src/events/ResultListEvents.ts
+++ b/src/events/ResultListEvents.ts
@@ -1,4 +1,5 @@
 import {IQueryResult} from '../rest/QueryResult';
+import {IQueryResults} from '../rest/QueryResults';
 
 export interface IDisplayedNewResultEventArgs {
   result: IQueryResult;
@@ -14,6 +15,7 @@ export interface IOpenQuickviewEventArgs {
 
 export interface IChangeLayoutEventArgs {
   layout: string;
+  results?: IQueryResults;
 }
 
 export class ResultListEvents {

--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -183,6 +183,10 @@ export interface IAnalyticsSearchAlertsFollowDocumentMeta extends IAnalyticsDocu
   contentIDValue: string;
 }
 
+export interface IAnalyticsResultsLayoutChange {
+  resultsLayoutChangeTo: string;
+}
+
 export var analyticsActionCauseList = {
   interfaceLoad: <IAnalyticsActionCause>{
     name: 'interfaceLoad',
@@ -511,5 +515,9 @@ export var analyticsActionCauseList = {
   searchAlertsUnfollowQuery: <IAnalyticsActionCause>{
     name: 'unfollowQuery',
     type: 'searchAlerts'
+  },
+  resultsLayoutChange: <IAnalyticsActionCause>{
+    name: 'changeResultsLayout',
+    type: 'resultsLayout'
   }
 };

--- a/src/ui/ResultLayout/ResultLayout.ts
+++ b/src/ui/ResultLayout/ResultLayout.ts
@@ -11,10 +11,15 @@ import {$$} from '../../utils/Dom';
 import {IQueryErrorEventArgs, IQuerySuccessEventArgs} from '../../events/QueryEvents';
 import {QueryStateModel, QUERY_STATE_ATTRIBUTES} from '../../models/QueryStateModel';
 import {MODEL_EVENTS, IAttributesChangedEventArg} from '../../models/Model';
+import {analyticsActionCauseList, IAnalyticsResultsLayoutChange} from '../Analytics/AnalyticsActionListMeta';
+import {IQueryResults} from '../../rest/QueryResults';
 
 export interface IResultLayoutOptions {
 }
 
+/**
+ * The possible valid and supported layout
+ */
 export type ValidLayout = 'list' | 'card' | 'table';
 
 /**
@@ -27,9 +32,16 @@ export type ValidLayout = 'list' | 'card' | 'table';
 export class ResultLayout extends Component {
   static ID = 'ResultLayout';
 
+  /**
+   * The possible valid and supported layout
+   */
   public static validLayouts: ValidLayout[] = ['list', 'card', 'table'];
+  /**
+   * The current active layout
+   */
+  public currentLayout: string;
 
-  private currentLayout: string;
+
   private buttons: { [key: string]: HTMLElement };
   private resultLayoutSection: HTMLElement;
 
@@ -58,21 +70,40 @@ export class ResultLayout extends Component {
 
   /**
    * Change the current layout.
+   *
+   * Trigger a new query.
+   *
    * @param layout The new layout. Available values are `list`, `card` and `table`.
+   * You need a valid {@link ResultList} component with the matching layout configured for this to work correctly end to end.
    */
   public changeLayout(layout: ValidLayout) {
     Assert.check(_.contains(_.keys(this.buttons), layout), 'Layout not available or invalid');
+
     if (layout !== this.currentLayout || this.getModelValue() === '') {
-      this.bind.trigger(this.root, ResultListEvents.changeLayout, <IChangeLayoutEventArgs>{
-        layout: layout
-      });
-      if (this.currentLayout) {
-        $$(this.buttons[this.currentLayout]).removeClass('coveo-selected');
-      }
-      $$(this.buttons[layout]).addClass('coveo-selected');
+
       this.setModelValue(layout);
-      this.currentLayout = layout;
+      const lastResults = this.queryController.getLastResults();
+      this.setLayout(layout, lastResults);
+      if (lastResults) {
+        this.usageAnalytics.logCustomEvent<IAnalyticsResultsLayoutChange>(analyticsActionCauseList.resultsLayoutChange, {
+          resultsLayoutChangeTo: layout
+        }, this.element);
+      } else {
+        this.usageAnalytics.logSearchEvent<IAnalyticsResultsLayoutChange>(analyticsActionCauseList.resultsLayoutChange, {
+          resultsLayoutChangeTo: layout
+        });
+        this.queryController.executeQuery();
+      }
     }
+  }
+
+  private setLayout(layout: ValidLayout, results?: IQueryResults) {
+    if (this.currentLayout) {
+      $$(this.buttons[this.currentLayout]).removeClass('coveo-selected');
+    }
+    $$(this.buttons[layout]).addClass('coveo-selected');
+    this.currentLayout = layout;
+    $$(this.element).trigger(ResultListEvents.changeLayout, <IChangeLayoutEventArgs>{ layout: layout, results: results });
   }
 
   private handleQuerySuccess(args: IQuerySuccessEventArgs) {
@@ -87,9 +118,9 @@ export class ResultLayout extends Component {
     const modelLayout = this.getModelValue();
     const newLayout = _.find(_.keys(this.buttons), l => l === modelLayout);
     if (newLayout !== undefined) {
-      this.changeLayout(<ValidLayout>newLayout);
+      this.setLayout(<ValidLayout>newLayout);
     } else {
-      this.changeLayout(<ValidLayout>_.keys(this.buttons)[0]);
+      this.setLayout(<ValidLayout>_.keys(this.buttons)[0]);
     }
   }
 

--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -231,8 +231,7 @@ export class ResultList extends Component {
     this.bind.onRootElement<IQuerySuccessEventArgs>(QueryEvents.querySuccess, (args: IQuerySuccessEventArgs) => this.handleQuerySuccess(args));
     this.bind.onRootElement<IDuringQueryEventArgs>(QueryEvents.duringQuery, (args: IDuringQueryEventArgs) => this.handleDuringQuery());
     this.bind.onRootElement<IQueryErrorEventArgs>(QueryEvents.queryError, (args: IQueryErrorEventArgs) => this.handleQueryError());
-
-    $$(this.root).on(ResultListEvents.changeLayout, (e, args: IChangeLayoutEventArgs) => this.handleChangeLayout(args));
+    $$(this.root).on(ResultListEvents.changeLayout, (e: Event, args: IChangeLayoutEventArgs) => this.handleChangeLayout(args));
 
     if (this.options.enableInfiniteScroll) {
       this.handlePageChanged();
@@ -476,8 +475,16 @@ export class ResultList extends Component {
   }
 
   private handleChangeLayout(args: IChangeLayoutEventArgs) {
-    args.layout === this.options.layout ? this.enable() : this.disable();
-    this.queryController.executeQuery();
+    if (args.layout === this.options.layout) {
+      this.enable();
+      if (args.results) {
+        Defer.defer(() => {
+          this.renderResults(this.buildResults(args.results));
+        });
+      }
+    } else {
+      this.disable();
+    }
   }
 
   private getAutoSelectedFieldsToInclude() {

--- a/test/controllers/QueryControllerTest.ts
+++ b/test/controllers/QueryControllerTest.ts
@@ -4,6 +4,7 @@ import {$$} from '../../src/utils/Dom';
 import {FakeResults} from '../Fake';
 import {QueryBuilder} from '../../src/ui/Base/QueryBuilder';
 import {IQuery} from '../../src/rest/Query';
+import {QueryEvents, IBuildingQueryEventArgs} from '../../src/events/QueryEvents';
 
 export function QueryControllerTest() {
   describe('QueryController', function () {
@@ -49,6 +50,37 @@ export function QueryControllerTest() {
         firstResult: 10,
         numberOfResults: 50
       }), jasmine.any(Object));
+    });
+
+    it('should allow to get the last query', (done) => {
+      $$(test.cmp.element).on(QueryEvents.buildingQuery, (e, args: IBuildingQueryEventArgs) => {
+        args.queryBuilder.expression.add('mamamia');
+      });
+      var search = <jasmine.Spy>test.env.searchEndpoint.search;
+      var results = FakeResults.createFakeResults();
+      search.and.returnValue(new Promise((resolve, reject) => {
+        resolve(results);
+      }));
+
+      test.cmp.executeQuery();
+      setTimeout(() => {
+        expect(test.cmp.getLastQuery().q).toContain('mamamia');
+        done();
+      }, 10);
+    });
+
+    it('should allow to get the last query results', (done) => {
+      var search = <jasmine.Spy>test.env.searchEndpoint.search;
+      var results = FakeResults.createFakeResults();
+      search.and.returnValue(new Promise((resolve, reject) => {
+        resolve(results);
+      }));
+
+      test.cmp.executeQuery();
+      setTimeout(() => {
+        expect(test.cmp.getLastResults()).toEqual(results);
+        done();
+      }, 10);
     });
 
     describe('trigger query events', function () {

--- a/test/ui/ResultLayoutTest.ts
+++ b/test/ui/ResultLayoutTest.ts
@@ -73,26 +73,20 @@ export function ResultLayoutTest() {
         });
 
         it('calls changeLayout with the new value on queryStateChanged if it is available', function () {
-          let changeLayoutSpy = jasmine.createSpy('changeLayoutSpy');
-          test.cmp.changeLayout = changeLayoutSpy;
           test.env.queryStateModel.set(QueryStateModel.attributesEnum.layout, 'card');
-          expect(changeLayoutSpy).toHaveBeenCalledWith('card');
+          expect(test.cmp.currentLayout).toBe('card');
         });
 
         it('calls changeLayout with its first layout if no value is provided', function () {
-          let changeLayoutSpy = jasmine.createSpy('changeLayoutSpy');
-          test.cmp.changeLayout = changeLayoutSpy;
           test.env.queryStateModel.set(QueryStateModel.attributesEnum.layout, 'list');
           test.env.queryStateModel.set(QueryStateModel.attributesEnum.layout, '');
-          expect(changeLayoutSpy).toHaveBeenCalledWith('list');
+          expect(test.cmp.currentLayout).toBe('list');
         });
 
         it('calls changeLayout with its first layout if an invalid value is provided', function () {
-          let changeLayoutSpy = jasmine.createSpy('changeLayoutSpy');
-          test.cmp.changeLayout = changeLayoutSpy;
           test.env.queryStateModel.set(QueryStateModel.attributesEnum.layout, 'list');
           test.env.queryStateModel.set(QueryStateModel.attributesEnum.layout, 'Emacs <3');
-          expect(changeLayoutSpy).toHaveBeenCalledWith('list');
+          expect(test.cmp.currentLayout).toBe('list');
         });
       });
     });


### PR DESCRIPTION
Retrieve last results if possible, instead of doing a new query on layout change.

https://coveord.atlassian.net/browse/JSUI-1370





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)