### PR TITLE
Fix overflow check for tab section in unusual contexts

### DIFF
--- a/sass/_ResponsiveTabs.scss
+++ b/sass/_ResponsiveTabs.scss
@@ -2,10 +2,7 @@
 
   #coveo-tab-dropdown-header {
     margin-left: auto;
-    height: 40px;
-    * {
-      line-height: 40px;
-    }
+    line-height: 22px;
   }
 
   .CoveoTab {

--- a/sass/_ResponsiveTabs.scss
+++ b/sass/_ResponsiveTabs.scss
@@ -1,8 +1,10 @@
 .coveo-small-tabs {
 
-  #coveo-tab-dropdown-header {
-    margin-left: auto;
-    line-height: 22px;
+  &.coveo-tab-section {
+    .coveo-tab-dropdown-header {
+      margin-left: auto;
+      line-height: 22px;
+    }
   }
 
   .CoveoTab {

--- a/sass/_ResponsiveTabs.scss
+++ b/sass/_ResponsiveTabs.scss
@@ -1,7 +1,11 @@
 .coveo-small-tabs {
 
-  .coveo-tab-dropdown-header {
+  #coveo-tab-dropdown-header {
     margin-left: auto;
+    height: 40px;
+    * {
+      line-height: 40px;
+    }
   }
 
   .CoveoTab {

--- a/sass/_Result.scss
+++ b/sass/_Result.scss
@@ -164,11 +164,10 @@
 
     &.coveo-clickable {
       cursor: pointer;
-    }
-
-    &:hover {
-      box-shadow: 0 0 0 2px $color-vibrant-blue;
-      border-color: $color-vibrant-blue;
+      &:hover {
+        box-shadow: 0 0 0 2px $color-vibrant-blue;
+        border-color: $color-vibrant-blue;
+      }
     }
 
     .coveo-result-row:first-child {

--- a/src/ui/ResponsiveComponents/ResponsiveTabs.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveTabs.ts
@@ -94,7 +94,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
 
   private addTabsToDropdown(tabs: HTMLElement[]): void {
     let currentTab;
-    if (!this.tabSection.find('#coveo-tab-dropdown-header')) {
+    if (!this.tabSection.find('.coveo-tab-dropdown-header')) {
       let facetDropdownHeader = this.tabSection.find('.coveo-facet-dropdown-header');
       if (facetDropdownHeader) {
         this.dropdownHeader.insertBefore(facetDropdownHeader);

--- a/src/ui/ResponsiveComponents/ResponsiveTabs.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveTabs.ts
@@ -94,7 +94,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
 
   private addTabsToDropdown(tabs: HTMLElement[]): void {
     let currentTab;
-    if (!this.tabSection.find('.coveo-tab-dropdown-header')) {
+    if (!this.tabSection.find('#coveo-tab-dropdown-header')) {
       let facetDropdownHeader = this.tabSection.find('.coveo-facet-dropdown-header');
       if (facetDropdownHeader) {
         this.dropdownHeader.insertBefore(facetDropdownHeader);
@@ -166,7 +166,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
   private isLargeFormatOverflowing(): boolean {
     let virtualTabSection = $$(<HTMLElement>this.tabSection.el.cloneNode(true));
 
-    let dropdownHeader = virtualTabSection.find('.coveo-tab-dropdown-header');
+    let dropdownHeader = virtualTabSection.find('#coveo-tab-dropdown-header');
     if (dropdownHeader) {
       virtualTabSection.el.removeChild(dropdownHeader);
     }
@@ -225,7 +225,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
     this.documentClickListener = event => {
       if (Utils.isHtmlElement(event.target)) {
         let eventTarget = $$(<HTMLElement>event.target);
-        if (!eventTarget.closest('coveo-tab-list-container') && !eventTarget.closest('coveo-tab-dropdown-header') && !eventTarget.closest('coveo-tab-dropdown')) {
+        if (!eventTarget.closest('coveo-tab-list-container') && !eventTarget.isDescendant(this.dropdownHeader.el) && !eventTarget.closest('coveo-tab-dropdown')) {
           this.closeDropdown();
         }
       }
@@ -334,7 +334,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
 
   private positionPopup() {
     PopupUtils.positionPopup(this.dropdownContent.el, this.dropdownHeader.el, this.coveoRoot.el,
-      { horizontal: HorizontalAlignment.INNERRIGHT, vertical: VerticalAlignment.BOTTOM }, this.coveoRoot.el);
+      { horizontal: HorizontalAlignment.INNERRIGHT, vertical: VerticalAlignment.BOTTOM, verticalOffset: 0 }, this.coveoRoot.el);
   }
 
   private getTabsInTabSection(): HTMLElement[] {

--- a/src/ui/ResponsiveComponents/ResponsiveTabs.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveTabs.ts
@@ -166,7 +166,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
   private isLargeFormatOverflowing(): boolean {
     let virtualTabSection = $$(<HTMLElement>this.tabSection.el.cloneNode(true));
 
-    let dropdownHeader = virtualTabSection.find('#coveo-tab-dropdown-header');
+    let dropdownHeader = virtualTabSection.find('.coveo-tab-dropdown-header');
     if (dropdownHeader) {
       virtualTabSection.el.removeChild(dropdownHeader);
     }
@@ -195,7 +195,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
   }
 
   private buildDropdownHeader(): Dom {
-    let dropdownHeader = $$('a', { className: 'coveo-dropdown-header', id: 'coveo-tab-dropdown-header' });
+    let dropdownHeader = $$('a', { className: 'coveo-dropdown-header coveo-tab-dropdown-header' });
     let content = $$('p');
     content.text(this.dropdownHeaderLabel);
     content.el.appendChild($$('span', { className: 'coveo-sprites-more-tabs' }).el);
@@ -225,7 +225,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
     this.documentClickListener = event => {
       if (Utils.isHtmlElement(event.target)) {
         let eventTarget = $$(<HTMLElement>event.target);
-        if (!eventTarget.closest('coveo-tab-list-container') && !eventTarget.isDescendant(this.dropdownHeader.el) && !eventTarget.closest('coveo-tab-dropdown')) {
+        if (!eventTarget.closest('coveo-tab-list-container') && !eventTarget.closest('coveo-tab-dropdown-header') && !eventTarget.closest('coveo-tab-dropdown')) {
           this.closeDropdown();
         }
       }

--- a/src/ui/ResponsiveComponents/ResponsiveTabs.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveTabs.ts
@@ -179,8 +179,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
         virtualTabSection.el.appendChild(tab.cloneNode(true));
       });
     }
-
-    this.coveoRoot.append(virtualTabSection.el);
+    virtualTabSection.insertBefore(this.tabSection.el);
 
     ResponsiveComponentsUtils.deactivateSmallTabs(this.coveoRoot);
     let isOverflowing = this.isOverflowing(virtualTabSection.el);
@@ -196,7 +195,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
   }
 
   private buildDropdownHeader(): Dom {
-    let dropdownHeader = $$('a', { className: 'coveo-dropdown-header coveo-tab-dropdown-header' });
+    let dropdownHeader = $$('a', { className: 'coveo-dropdown-header', id: 'coveo-tab-dropdown-header' });
     let content = $$('p');
     content.text(this.dropdownHeaderLabel);
     content.el.appendChild($$('span', { className: 'coveo-sprites-more-tabs' }).el);

--- a/src/ui/ResponsiveComponents/ResponsiveTabs.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveTabs.ts
@@ -334,7 +334,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
 
   private positionPopup() {
     PopupUtils.positionPopup(this.dropdownContent.el, this.dropdownHeader.el, this.coveoRoot.el,
-      { horizontal: HorizontalAlignment.INNERRIGHT, vertical: VerticalAlignment.BOTTOM, verticalOffset: 0 }, this.coveoRoot.el);
+      { horizontal: HorizontalAlignment.INNERRIGHT, vertical: VerticalAlignment.BOTTOM }, this.coveoRoot.el);
   }
 
   private getTabsInTabSection(): HTMLElement[] {

--- a/src/utils/Dom.ts
+++ b/src/utils/Dom.ts
@@ -666,6 +666,7 @@ export class Dom {
   public height(): number {
     return this.el.offsetHeight;
   }
+
   private traverseAncestorForClass(current = this.el, className: string): HTMLElement {
     if (className.indexOf('.') == 0) {
       className = className.substr(1);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-1375

When checking if the large format of the tab section would overflow, insert the fake tab section before the actual tab section. It was originally placed after the last child of the root interface which caused problems when the tab section was not placed in a way that it could use the whole width.

Also, fixed a small alignment issue with the "more" button for the responsive tabs.



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)