### PR TITLE
Added "initializationOptions" default JSON object option

### DIFF
--- a/src/ui/Base/ComponentOptions.ts
+++ b/src/ui/Base/ComponentOptions.ts
@@ -382,7 +382,7 @@ export class ComponentOptions {
   static buildSelectorOption(optionArgs?: IComponentOptions<HTMLElement>): HTMLElement {
     return ComponentOptions.buildOption<HTMLElement>(ComponentOptionsType.SELECTOR, ComponentOptions.loadSelectorOption, optionArgs);
   }
-  
+
   static buildChildHtmlElementOption(optionArgs?: IComponentOptionsChildHtmlElementOptionArgs): HTMLElement {
     return ComponentOptions.buildOption<HTMLElement>(ComponentOptionsType.CHILD_HTML_ELEMENT, ComponentOptions.loadChildHtmlElementOption, optionArgs);
   }
@@ -390,8 +390,6 @@ export class ComponentOptions {
   static buildTemplateOption(optionArgs?: IComponentOptionsTemplateOptionArgs): Template {
     return ComponentOptions.buildOption<Template>(ComponentOptionsType.TEMPLATE, ComponentOptions.loadTemplateOption, optionArgs);
   }
-
-  
 
   static buildCustomOption<T>(converter: (value: string) => T, optionArgs?: IComponentOptions<T>): T {
     let loadOption: IComponentOptionsLoadOption<T> = (element: HTMLElement, name: string, option: IComponentOptionsOption<T>) => {

--- a/src/ui/Base/ComponentOptions.ts
+++ b/src/ui/Base/ComponentOptions.ts
@@ -382,7 +382,7 @@ export class ComponentOptions {
   static buildSelectorOption(optionArgs?: IComponentOptions<HTMLElement>): HTMLElement {
     return ComponentOptions.buildOption<HTMLElement>(ComponentOptionsType.SELECTOR, ComponentOptions.loadSelectorOption, optionArgs);
   }
-
+  
   static buildChildHtmlElementOption(optionArgs?: IComponentOptionsChildHtmlElementOptionArgs): HTMLElement {
     return ComponentOptions.buildOption<HTMLElement>(ComponentOptionsType.CHILD_HTML_ELEMENT, ComponentOptions.loadChildHtmlElementOption, optionArgs);
   }
@@ -390,6 +390,8 @@ export class ComponentOptions {
   static buildTemplateOption(optionArgs?: IComponentOptionsTemplateOptionArgs): Template {
     return ComponentOptions.buildOption<Template>(ComponentOptionsType.TEMPLATE, ComponentOptions.loadTemplateOption, optionArgs);
   }
+
+  
 
   static buildCustomOption<T>(converter: (value: string) => T, optionArgs?: IComponentOptions<T>): T {
     let loadOption: IComponentOptionsLoadOption<T> = (element: HTMLElement, name: string, option: IComponentOptionsOption<T>) => {
@@ -488,6 +490,10 @@ export class ComponentOptions {
     let logger = new Logger(this);
     if (values == null) {
       values = {};
+    }
+    let initializationOptions = ComponentOptions.loadJSONStringAsObjectOption(element, 'initializationOptions', {});
+    if (!Utils.isNullOrUndefined(initializationOptions)) {
+      values = _.extend({}, initializationOptions, values);
     }
     let names: string[] = _.keys(options);
     for (let i = 0; i < names.length; i++) {
@@ -703,6 +709,20 @@ export class ComponentOptions {
     let foundElements = ComponentOptions.loadChildrenHtmlElementFromSelector(element, selector);
     if (foundElements.length > 0) {
       return new TemplateList(_.compact(_.map(foundElements, (element) => ComponentOptions.createResultTemplateFromElement(element))));
+    }
+    return null;
+  }
+
+  static loadJSONStringAsObjectOption(element: HTMLElement, name: string, option: IComponentOptions<any>): {
+    [name: string]: any
+  } {
+    let foundObject = ComponentOptions.loadStringOption(element, name, option);
+    if (Utils.isNonEmptyString(foundObject)) {
+      try {
+        return JSON.parse(foundObject);
+      } catch (exception) {
+        Assert.fail(`Could not parse the object from attribute: ${name}.`);
+      }
     }
     return null;
   }

--- a/test/ui/ComponentOptionsTest.ts
+++ b/test/ui/ComponentOptionsTest.ts
@@ -148,7 +148,8 @@ export function ComponentOptionsTest() {
           'data-my-selector': '#CoveoSearchbox',
           'data-my-child-selector': '#CoveoSearchboxChild',
           'data-my-template-selector': '#CoveoTemplate',
-          'data-my-template-id': 'CoveoTemplateId'
+          'data-my-template-id': 'CoveoTemplateId',
+          'data-initialization-options': '{}'
         });
         scrollElem.appendChild(elem);
         childElem = Dom.createElement('div', {
@@ -301,6 +302,29 @@ export function ComponentOptionsTest() {
           };
           let initOptions = ComponentOptions.initComponentOptions(elem, { options, ID: 'fooID' });
           expect(initOptions.myAttr).toBeUndefined();
+        });
+
+        it('which adds initializationOptions to the component options', () => {
+          let options = {
+            testString: ComponentOptions.buildStringOption({
+              attrName:'fooptions',
+              defaultValue:'shouldnotbe'
+            }),
+          };
+          elem.setAttribute('data-initialization-options', '{ "fooptions": "bar" }');
+          let initOptions = ComponentOptions.initComponentOptions(elem, { options, ID: 'fooID' });
+          expect(initOptions.fooptions).toBe('bar');
+        });
+
+        it('which keeps values over initializationOptions', () => {
+          let options = {
+            testString: ComponentOptions.buildStringOption({
+              attrName:'fooptions'
+            }),
+          };
+          elem.setAttribute('data-initialization-options', '{ "fooptions": "shouldnotoverridebar" }');
+          let initOptions = ComponentOptions.initComponentOptions(elem, { options, ID: 'fooID' }, { fooptions: 'bar' });
+          expect(initOptions.fooptions).toBe('bar');
         });
       });
 
@@ -463,6 +487,23 @@ export function ComponentOptionsTest() {
         it('which loads an html template from the html element matching the name in the html element option', () => {
           let option = ComponentOptions.loadTemplateOption(elem, 'coveoChild', {}, doc);
           expect(option.getType()).toBe('TemplateList');
+        });
+      });
+
+      describe('loadJSONStringAsObjectOption', () => {
+        it('which loads an object option', () => {
+          elem.setAttribute('data-initialization-options', '{ "fooptions": "bar" }');
+          let option = ComponentOptions.loadJSONStringAsObjectOption(elem, 'initializationOptions', {});
+          expect(option['fooptions']).toBe('bar');
+        });
+        it('which loads an object with nested option', () => {
+          elem.setAttribute('data-initialization-options', '{ "fooptions": { "nested": "option" } }');
+          let option = ComponentOptions.loadJSONStringAsObjectOption(elem, 'initializationOptions', {});
+          expect(option['fooptions']['nested']).toBe('option');
+        });
+        it('which throws with an invalid object', () => {
+          elem.setAttribute('data-initialization-options', '{ "somethinginvalid" }');
+          expect(() => ComponentOptions.loadJSONStringAsObjectOption(elem, 'initializationOptions', {})).toThrow();
         });
       });
 


### PR DESCRIPTION
Allows to define `data-initialization-options='{"attribute":"value"}'` in the markup. 

Useful if you want to output a JSON configuration generated from a server instead of using JavaScript initialization calls.

This is the least worst way I have found to do this, don't hesitate if you have better implementation ideas :) 

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)