### PR TITLE
remove min-width on smaller screen for manage alerts panel so that it can scroll laterally.

### DIFF
--- a/sass/notifications/_SubscriptionsPanel.scss
+++ b/sass/notifications/_SubscriptionsPanel.scss
@@ -17,6 +17,13 @@
     max-height: 600px;
     min-width: 500px;
   }
+
+  @media (max-width: 600px) {
+    .coveo-body {
+      min-width: inherit;
+    }
+  }
+
   .coveo-subscriptions-panel-fail {
     padding: 10px;
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-1413





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)