### PR TITLE
DOC-458 Settings doc rev: removed FollowItem 

### DIFF
--- a/src/ui/Settings/Settings.ts
+++ b/src/ui/Settings/Settings.ts
@@ -25,7 +25,6 @@ export interface ISettingsOptions {
  * This component can reference several components to populate its popup menu:
  * - {@link AdvancedSearch}
  * - {@link ExportToExcel}
- * - {@link FollowItem}
  * - {@link PreferencesPanel} (see also {@link ResultsFiltersPreferences} and {@link ResultsPreferences})
  * - {@link SearchAlerts} (see also {@link SearchAlertsMessage})
  * - {@link ShareQuery}


### PR DESCRIPTION
Removed FollowItem from the list of components that can populate the Settings menu.





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)