### PR TITLE
Allow placeholder attribute to be localized.

### DIFF
--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -150,7 +150,7 @@ export class Omnibox extends Component {
     /**
      * Specifies a placeholder for the input.
      */
-    placeholder: ComponentOptions.buildStringOption(),
+    placeholder: ComponentOptions.buildLocalizedStringOption(),
 
     /**
      * Specifies a timeout (in milliseconds) before rejecting suggestions in the Omnibox.


### PR DESCRIPTION
We weren't able to localized the placeholder attribute on the Omnibox component. This should hopefully resolve that.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)