### PR TITLE
Improve AdvancedSearch queries robustness

### DIFF
--- a/src/ui/AdvancedSearch/DocumentInput/AdvancedFieldInput.ts
+++ b/src/ui/AdvancedSearch/DocumentInput/AdvancedFieldInput.ts
@@ -2,6 +2,7 @@ import { Dropdown } from '../Form/Dropdown';
 import { TextInput } from '../Form/TextInput';
 import { $$ } from '../../../utils/Dom';
 import { DocumentInput } from './DocumentInput';
+import { QueryBuilder } from '../../Base/QueryBuilder';
 
 export class AdvancedFieldInput extends DocumentInput {
 
@@ -30,14 +31,19 @@ export class AdvancedFieldInput extends DocumentInput {
 
   public getValue(): string {
     let inputValue = this.input.getValue();
+    let builder = new QueryBuilder();
     if (inputValue) {
       switch (this.mode.getValue()) {
         case 'Contains':
-          return this.fieldName + '=' + inputValue;
+          builder.advancedExpression.addFieldExpression(this.fieldName, '=', [inputValue]);
+          return builder.build().aq;
+
         case 'DoesNotContain':
-          return this.fieldName + '<>' + inputValue;
+          builder.advancedExpression.addFieldExpression(this.fieldName, '<>', [inputValue]);
+          return builder.build().aq;
         default:
-          return this.fieldName + '==\"' + inputValue + '\"';
+          builder.advancedExpression.addFieldExpression(this.fieldName, '==', [inputValue]);
+          return builder.build().aq;
       }
     }
     return '';

--- a/src/ui/AdvancedSearch/DocumentInput/SimpleFieldInput.ts
+++ b/src/ui/AdvancedSearch/DocumentInput/SimpleFieldInput.ts
@@ -5,6 +5,7 @@ import { ISearchEndpoint } from '../../../rest/SearchEndpointInterface';
 import { DocumentInput } from './DocumentInput';
 import { $$ } from '../../../utils/Dom';
 import _ = require('underscore');
+import { QueryBuilder } from '../../Base/QueryBuilder';
 
 export class SimpleFieldInput extends DocumentInput {
 
@@ -30,7 +31,13 @@ export class SimpleFieldInput extends DocumentInput {
 
   public getValue(): string {
     let value = this.dropDown ? this.dropDown.getValue() : '';
-    return value ? this.fieldName + '==\"' + value + '\"' : '';
+    let queryBuilder = new QueryBuilder();
+    if (value) {
+      queryBuilder.advancedExpression.addFieldExpression(this.fieldName, '==', [value]);
+      return queryBuilder.build().aq;
+    } else {
+      return '';
+    }
   }
 
   private buildFieldSelect() {

--- a/src/ui/AdvancedSearch/DocumentInput/SizeInput.ts
+++ b/src/ui/AdvancedSearch/DocumentInput/SizeInput.ts
@@ -2,6 +2,7 @@ import { Dropdown } from '../Form/Dropdown';
 import { NumericSpinner } from '../Form/NumericSpinner';
 import { $$ } from '../../../utils/Dom';
 import { DocumentInput } from './DocumentInput';
+import { QueryBuilder } from '../../Base/QueryBuilder';
 
 
 export class SizeInput extends DocumentInput {
@@ -42,12 +43,15 @@ export class SizeInput extends DocumentInput {
 
   public getValue(): string {
     let size = this.getSizeInBytes();
+    let queryBuilder = new QueryBuilder();
     if (size) {
       switch (this.modeSelect.getValue()) {
         case 'AtLeast':
-          return '@size>=' + this.getSizeInBytes();
+          queryBuilder.advancedExpression.addFieldExpression('@size', '>=', [this.getSizeInBytes().toString()]);
+          return queryBuilder.build().aq;
         default:
-          return '@size<=' + this.getSizeInBytes();
+          queryBuilder.advancedExpression.addFieldExpression('@size', '<=', [this.getSizeInBytes().toString()]);
+          return queryBuilder.build().aq;
       }
     }
     return '';

--- a/test/ui/AdvancedSearch/DocumentInput/AdvancedFieldInputTest.ts
+++ b/test/ui/AdvancedSearch/DocumentInput/AdvancedFieldInputTest.ts
@@ -23,17 +23,17 @@ export function AdvancedFieldInputTest() {
     describe('getValue', () => {
       it('if contains, should return fieldName = value', () => {
         input.mode.selectValue('Contains');
-        expect(input.getValue()).toEqual(fieldName + '=' + value);
+        expect(input.getValue()).toEqual(`${fieldName}=${value}`);
       });
 
       it('if does not contains, should return fieldName <> value', () => {
         input.mode.selectValue('DoesNotContain');
-        expect(input.getValue()).toEqual(fieldName + '<>' + value);
+        expect(input.getValue()).toEqual(`${fieldName}<>${value}`);
       });
 
       it('if matches, should return fieldName == "value"', () => {
         input.mode.selectValue('Matches');
-        expect(input.getValue()).toEqual(fieldName + '=="' + value + '"');
+        expect(input.getValue()).toEqual(`${fieldName}==${value}`);
       });
     });
   });

--- a/test/ui/AdvancedSearch/DocumentInput/SimpleFieldInputTest.ts
+++ b/test/ui/AdvancedSearch/DocumentInput/SimpleFieldInputTest.ts
@@ -22,7 +22,7 @@ export function SimpleFieldInputTest() {
     describe('getValue', () => {
       it('should return fieldName == the value', () => {
         input.dropDown.selectValue('what');
-        expect(input.getValue()).toEqual('@test=="what"');
+        expect(input.getValue()).toEqual('@test==what');
       });
     });
 


### PR DESCRIPTION
Use query builder instead of string concat for AdvancedSearch component queries, in order to handle corner case more gracefully.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)