### PR TITLE
JSUI-1418 (DOC) - ResultLink.alwaysOpenInNewWindow / ResultsPreferences interaction

### DIFF
--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -83,7 +83,7 @@ export class Omnibox extends Component {
      * results.
      *
      * Set this option as well as {@link Omnibox.options.enableSearchAsYouType} and
-     * {@link Omnibox.options.RevealQuerySuggestAddon} to `true` for a cool effect!
+     * {@link Omnibox.options.enableRevealQuerySuggestAddon} to `true` for a cool effect!
      *
      * Default value is `false`.
      */
@@ -92,8 +92,8 @@ export class Omnibox extends Component {
     /**
      * Specifies whether to automatically trigger a new query whenever the end user types new text inside the Omnibox.
      *
-     * Set this option as well a {@link Omnibox.options.inline} and {@link Omnibox.options.RevealQuerySuggestAddon} to
-     * `true` for a cool effect!
+     * Set this option as well a {@link Omnibox.options.inline} and
+     * {@link Omnibox.options.enableRevealQuerySuggestAddon} to `true` for a cool effect!
      *
      * Default value is `false`.
      */

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -67,7 +67,7 @@ export class ResultLink extends Component {
      * </script>
      * ```
      *
-     * See also {@link ResultLink.options.hrefTemplate}, which can override this option.
+     * See also [hrefTemplate]{@link ResultLink.options.hrefTemplate}, which can override this option.
      */
     field: ComponentOptions.buildFieldOption(),
 
@@ -98,6 +98,12 @@ export class ResultLink extends Component {
      * If this option is `true`, clicking the ResultLink will call the {@link ResultLink.openLinkInNewWindow} method
      * instead of the {@link ResultLink.openLink} method.
      *
+     * **Note:**
+     * > If a search page contains a {@link ResultsPreferences} component whose
+     * > [enableOpenInNewWindow]{@link ResultsPreferences.options.enableOpenInNewWindow} option is `true`, and the end
+     * > user checks the <b>Always open results in new window</b> box, then ResultLink components will always open in
+     * > a new window when the user clicks them, no matter what the value of their alwaysOpenInNewWindow option is.
+     *
      * Default value is `false`.
      */
     alwaysOpenInNewWindow: ComponentOptions.buildBooleanOption({ defaultValue: false }),
@@ -106,7 +112,7 @@ export class ResultLink extends Component {
      * Specifies a template literal from which to generate the ResultLink `href` attribute (see
      * [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).
      *
-     * This option overrides the value of {@link ResultLink.options.field}.
+     * This option overrides the value of the [field]{@link ResultLink.options.field} option.
      *
      * The template literal can reference any number of fields from the parent result. It can also reference global
      * scope properties.


### PR DESCRIPTION
Added some information about the option behavior when a search page contains a ResultsPreferences component

- Fixed some link spelling mistakes in Omnibox
- Made option names "prettier" in generated doc site for ResultLink component

https://coveord.atlassian.net/browse/JSUI-1418





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)