### PR TITLE
Add tabindex to follow item

### DIFF
--- a/gulpTasks/test.js
+++ b/gulpTasks/test.js
@@ -55,7 +55,7 @@ gulp.task('testDev', ['watchTest'], function (done) {
 gulp.task('remapCoverage', function (done) {
   return gulp.src(`${COVERAGE_DIR}/coverage-es5.json`)
     .pipe(remapIstanbul({
-      exclude: /(webpack|~\/d3\/|~\/es6-promise\/dist\/|~\/process\/|~\/underscore\/|vertx|~\/coveomagicbox\/|~\/d3-.*\/|~\/modal-box\/|~\/moment\/|~\/pikaday\/|test\/|lib\/|es6-promise|analytics|jstimezonedetect|latinize)/
+      exclude: /(webpack|~\/d3\/|~\/es6-promise\/dist\/|~\/process\/|~\/underscore\/|vertx|~\/coveomagicbox\/|~\/d3-.*\/|~\/modal-box\/|~\/moment\/|~\/pikaday\/|test\/|lib\/|es6-promise|analytics|jstimezonedetect|latinize|whatwg)/
     }))
     .pipe(rename('coverage.json'))
     .pipe(gulp.dest(COVERAGE_DIR));

--- a/sass/_SearchButton.scss
+++ b/sass/_SearchButton.scss
@@ -25,7 +25,7 @@
   }
 }
 
-.coveo-executing-query .CoveoSearchButton > .coveo-icon {
+.coveo-executing-query .CoveoSearchButton > .coveo-icon, .coveo-executing-query .CoveoSearchButton:hover > .coveo-icon {
   @extend .coveo-sprites-facet-loading;
   @include animation-name(coveo-spin);
   @include animation-timing-function(linear);

--- a/src/ui/SearchAlerts/FollowItem.ts
+++ b/src/ui/SearchAlerts/FollowItem.ts
@@ -14,6 +14,7 @@ import {
 import { QueryUtils } from '../../utils/QueryUtils';
 import _ = require('underscore');
 import { Utils } from '../../utils/Utils';
+import { KeyboardUtils, KEYBOARD } from '../../utils/KeyboardUtils';
 
 
 export interface IFollowItemOptions {
@@ -89,6 +90,8 @@ export class FollowItem extends Component {
     this.text = $$('span');
     this.container.append(this.text.el);
     this.container.on('click', () => this.toggleFollow());
+    this.container.setAttribute('tabindex', '0');
+    this.bind.on(this.container, 'keyup', KeyboardUtils.keypressAction(KEYBOARD.ENTER, () => this.toggleFollow()));
 
     this.bind.onRootElement(SearchAlertsEvents.searchAlertsDeleted, (args: ISearchAlertsEventArgs) => this.handleSubscriptionDeleted(args));
     this.bind.onRootElement(SearchAlertsEvents.searchAlertsCreated, (args: ISearchAlertsEventArgs) => this.handleSubscriptionCreated(args));

--- a/test/ui/FacetTest.ts
+++ b/test/ui/FacetTest.ts
@@ -334,7 +334,7 @@ export function FacetTest() {
         expect(test.cmp.facetSort.activeSort.name.toLowerCase()).toBe('chisquare');
       });
 
-      it('available sort with only no sorts should still work', ()=> {
+      it('available sort with only no sorts should still work', () => {
         test = Mock.optionsComponentSetup<Facet, IFacetOptions>(Facet, {
           field: '@field',
           availableSorts: ['nosort']

--- a/test/ui/FollowItemTest.ts
+++ b/test/ui/FollowItemTest.ts
@@ -108,7 +108,7 @@ export function FollowItemTest() {
         });
       });
 
-      it('should follow the document when pressing enter', (done)=> {
+      it('should follow the document when pressing enter', (done) => {
         if (Simulate.isPhantomJs()) {
           // Keypress simulation doesn't work well in phantom js
           expect(true).toBe(true);
@@ -171,10 +171,10 @@ export function FollowItemTest() {
         });
       });
 
-      it('should not throw if delete subscription fails from the endpoint', (done)=> {
+      it('should not throw if delete subscription fails from the endpoint', (done) => {
         (<jasmine.Spy>endpointMock.listSubscriptions).and.returnValue(Promise.resolve([{
           id: '123',
-          typeConfig: {id: result.raw.urihash}
+          typeConfig: { id: result.raw.urihash }
         }]));
         (<jasmine.Spy>endpointMock.deleteSubscription).and.returnValue(Promise.reject('oh no it fails'));
         test = Mock.advancedResultComponentSetup<FollowItem>(FollowItem, result, new Mock.AdvancedComponentSetupOptions(null, null, (env) => {
@@ -182,8 +182,8 @@ export function FollowItemTest() {
         }));
 
         Promise.resolve().then(() => {
-          expect(()=> {
-            test.cmp.toggleFollow()
+          expect(() => {
+            test.cmp.toggleFollow();
           }).not.toThrow();
           done();
         });
@@ -196,21 +196,21 @@ export function FollowItemTest() {
         }));
 
         Promise.resolve().then(() => {
-          expect(()=> {
-            test.cmp.toggleFollow()
+          expect(() => {
+            test.cmp.toggleFollow();
           }).not.toThrow();
           done();
         });
       });
     });
 
-    it('should handle subscription delete and follow from an event', ()=> {
+    it('should handle subscription delete and follow from an event', () => {
       let subscription = {
         subscription: {
           id: 'an id',
           user: 'an user',
           type: 'followDocument',
-          typeConfig: {id: result.raw['urihash']}
+          typeConfig: { id: result.raw['urihash'] }
         }
       };
       $$(test.env.root).trigger(SearchAlertsEvents.searchAlertsCreated, subscription);

--- a/test/ui/FollowItemTest.ts
+++ b/test/ui/FollowItemTest.ts
@@ -204,9 +204,19 @@ export function FollowItemTest() {
       });
     });
 
-    it('should handle subscription delete from an event', ()=> {
-
-      $$(test.cmp.element).trigger(SearchAlertsEvents.searchAlertsCreated, )
+    it('should handle subscription delete and follow from an event', ()=> {
+      let subscription = {
+        subscription: {
+          id: 'an id',
+          user: 'an user',
+          type: 'followDocument',
+          typeConfig: {id: result.raw['urihash']}
+        }
+      };
+      $$(test.env.root).trigger(SearchAlertsEvents.searchAlertsCreated, subscription);
+      expect($$(test.cmp.element).hasClass('coveo-follow-item-followed')).toBe(true);
+      $$(test.env.root).trigger(SearchAlertsEvents.searchAlertsDeleted, subscription);
+      expect($$(test.cmp.element).hasClass('coveo-follow-item-followed')).not.toBe(true);
     });
   });
 }


### PR DESCRIPTION
Blind keypress action for follow item
Add UT

Will allow to select and navigate the item using tab / enter for accessibility.

https://coveord.atlassian.net/browse/JSUI-1457





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)