### PR TITLE
Add mechanism to check for incoherent configuration versus what exists in local storage for results preferences

### DIFF
--- a/src/ui/ResultsPreferences/ResultsPreferences.ts
+++ b/src/ui/ResultsPreferences/ResultsPreferences.ts
@@ -13,6 +13,7 @@ import { Assert } from '../../misc/Assert';
 import { l } from '../../strings/Strings';
 import { $$ } from '../../utils/Dom';
 import _ = require('underscore');
+import { Defer } from '../../misc/Defer';
 
 export interface IResultsPreferencesOptions {
   enableOpenInOutlook?: boolean;
@@ -75,6 +76,8 @@ export class ResultsPreferences extends Component {
     Assert.exists(this.preferencesPanel);
 
     this.preferences = this.preferencePanelLocalStorage.load() || {};
+    this.adjustPreferencesToComponentConfig();
+
     ComponentOptions.initComponentOptions(this.element, ResultsPreferences, this.preferences);
 
     this.updateComponentOptionsModel();
@@ -167,6 +170,29 @@ export class ResultsPreferences extends Component {
     var preference = (<HTMLInputElement>e.target).value;
     this.usageAnalytics.logCustomEvent<IAnalyticsPreferencesChangeMeta>(analyticsActionCauseList.preferencesChange, { preferenceName: preference, preferenceType: type }, this.element);
     this.usageAnalytics.logSearchEvent<IAnalyticsPreferencesChangeMeta>(analyticsActionCauseList.preferencesChange, { preferenceName: preference, preferenceType: type });
+  }
+
+  private adjustPreferencesToComponentConfig() {
+    // This method is used when there are illogical configuration between what's saved in local storage (the preferences)
+    // and how the component is configured.
+    // This can happen if an admin change the component configuration after end users have already selected a preferences.
+    // We need to adapt the saved preferences to what's actually available in the component
+    let needToSave = false;
+    if (this.preferences.alwaysOpenInNewWindow && !this.options.enableOpenInNewWindow) {
+      this.preferences.alwaysOpenInNewWindow = null;
+      needToSave = true;
+    }
+
+    if (this.preferences.openInOutlook && !this.options.enableOpenInOutlook) {
+      this.preferences.openInOutlook = null;
+      needToSave = true;
+    }
+
+    if (needToSave) {
+      Defer.defer(()=> {
+        this.save();
+      });
+    }
   }
 }
 

--- a/test/ui/FacetTest.ts
+++ b/test/ui/FacetTest.ts
@@ -334,7 +334,7 @@ export function FacetTest() {
         expect(test.cmp.facetSort.activeSort.name.toLowerCase()).toBe('chisquare');
       });
 
-      it('available sort with only no sorts should still work', ()=> {
+      it('available sort with only no sorts should still work', () => {
         test = Mock.optionsComponentSetup<Facet, IFacetOptions>(Facet, {
           field: '@field',
           availableSorts: ['nosort']

--- a/test/ui/ResultsPreferencesTest.ts
+++ b/test/ui/ResultsPreferencesTest.ts
@@ -28,18 +28,18 @@ export function ResultsPreferencesTest() {
 
     describe('with incoherent configuration', ()=> {
 
-      it('will adjust the preferences for outlook correctly', (done)=> {
+      it('will adjust the preferences for outlook correctly', (done) => {
         localStorage.setItem('coveo-ResultsPreferences', JSON.stringify({openInOutlook: true}));
-        expect(()=> test = Mock.advancedComponentSetup<ResultsPreferences>(ResultsPreferences, new Mock.AdvancedComponentSetupOptions(element.el, {enableOpenInOutlook: false}))).not.toThrow();
+        expect(() => test = Mock.advancedComponentSetup<ResultsPreferences>(ResultsPreferences, new Mock.AdvancedComponentSetupOptions(element.el, {enableOpenInOutlook: false}))).not.toThrow();
         Defer.defer(()=> {
           expect(JSON.parse(localStorage.getItem('coveo-ResultsPreferences')).openInOutlook).toBe(false);
           done();
         });
       });
 
-      it('will adjust the preferences for open in new window correctly', (done)=> {
+      it('will adjust the preferences for open in new window correctly', (done) => {
         localStorage.setItem('coveo-ResultsPreferences', JSON.stringify({alwaysOpenInNewWindow: true}));
-        expect(()=> test = Mock.advancedComponentSetup<ResultsPreferences>(ResultsPreferences, new Mock.AdvancedComponentSetupOptions(element.el, {enableOpenInNewWindow: false}))).not.toThrow();
+        expect(() => test = Mock.advancedComponentSetup<ResultsPreferences>(ResultsPreferences, new Mock.AdvancedComponentSetupOptions(element.el, {enableOpenInNewWindow: false}))).not.toThrow();
         Defer.defer(()=> {
           expect(JSON.parse(localStorage.getItem('coveo-ResultsPreferences')).alwaysOpenInNewWindow).toBe(false);
           done();

--- a/test/ui/ResultsPreferencesTest.ts
+++ b/test/ui/ResultsPreferencesTest.ts
@@ -6,6 +6,9 @@ import { Component } from '../../src/ui/Base/Component';
 import { PreferencesPanel } from '../../src/ui/PreferencesPanel/PreferencesPanel';
 import { l } from '../../src/strings/Strings';
 import { PreferencesPanelEvents } from '../../src/events/PreferencesPanelEvents';
+import { Defer } from '../../src/misc/Defer';
+import { Simulate } from '../Simulate';
+import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
 
 export function ResultsPreferencesTest() {
   describe('ResultsPreferences', function () {
@@ -20,6 +23,60 @@ export function ResultsPreferencesTest() {
 
     afterEach(() => {
       element = null;
+      localStorage.removeItem('coveo-ResultsPreferences');
+    });
+
+    describe('with incoherent configuration', ()=> {
+
+      it('will adjust the preferences for outlook correctly', (done)=> {
+        localStorage.setItem('coveo-ResultsPreferences', JSON.stringify({openInOutlook: true}));
+        expect(()=> test = Mock.advancedComponentSetup<ResultsPreferences>(ResultsPreferences, new Mock.AdvancedComponentSetupOptions(element.el, {enableOpenInOutlook: false}))).not.toThrow();
+        Defer.defer(()=> {
+          expect(JSON.parse(localStorage.getItem('coveo-ResultsPreferences')).openInOutlook).toBe(false);
+          done();
+        });
+      });
+
+      it('will adjust the preferences for open in new window correctly', (done)=> {
+        localStorage.setItem('coveo-ResultsPreferences', JSON.stringify({alwaysOpenInNewWindow: true}));
+        expect(()=> test = Mock.advancedComponentSetup<ResultsPreferences>(ResultsPreferences, new Mock.AdvancedComponentSetupOptions(element.el, {enableOpenInNewWindow: false}))).not.toThrow();
+        Defer.defer(()=> {
+          expect(JSON.parse(localStorage.getItem('coveo-ResultsPreferences')).alwaysOpenInNewWindow).toBe(false);
+          done();
+        });
+      });
+    });
+
+    describe('when an input changes', ()=> {
+      let input: HTMLInputElement;
+
+      beforeEach(()=> {
+        test = Mock.advancedComponentSetup<ResultsPreferences>(ResultsPreferences, new Mock.AdvancedComponentSetupOptions(element.el, {enableOpenInNewWindow: true}));
+        input = <HTMLInputElement>$$(test.cmp.element).find(`input[value='${l('AlwaysOpenInNewWindow')}']`);
+      });
+
+      afterEach(()=> {
+        input = null;
+      });
+
+      it('will log an analytics custom event', () => {
+        $$(input).trigger('change');
+        expect(test.env.usageAnalytics.logCustomEvent).toHaveBeenCalledWith(analyticsActionCauseList.preferencesChange, jasmine.objectContaining({
+          preferenceName: jasmine.any(String)
+        }), test.cmp.element);
+      });
+
+      it('will log an analytics search event', () => {
+        $$(input).trigger('change');
+        expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.preferencesChange, jasmine.objectContaining({
+          preferenceName: jasmine.any(String)
+        }));
+      });
+
+      it('will trigger a query when the input is changed', ()=> {
+        $$(input).trigger('change');
+        expect(test.env.queryController.executeQuery).toHaveBeenCalled();
+      });
     });
 
     describe('exposes enableOpenInOutlook', () => {


### PR DESCRIPTION
UT

https://coveord.atlassian.net/browse/JSUI-1489





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)