### PR TITLE
remove autofocus option on querybox

### DIFF
--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -409,10 +409,6 @@ export class Omnibox extends Component {
       }
     };
 
-    if (this.options.autoFocus) {
-      this.magicBox.focus();
-    }
-
     this.magicBox.ontabpress = () => {
       this.handleTabPress();
     };

--- a/src/ui/Querybox/Querybox.ts
+++ b/src/ui/Querybox/Querybox.ts
@@ -188,13 +188,6 @@ export class Querybox extends Component {
      * Default value is `true`.
      */
     triggerQueryOnClear: ComponentOptions.buildBooleanOption({ defaultValue: true }),
-
-    /**
-     * Specifies whether the Querybox should get auto focus and selection upon initialization.
-     *
-     * Default value is `true`.
-     */
-    autoFocus: ComponentOptions.buildBooleanOption({ defaultValue: true })
   };
 
   public magicBox: Coveo.MagicBox.Instance;
@@ -254,10 +247,6 @@ export class Querybox extends Component {
         this.triggerNewQuery(false);
       }
     };
-
-    if (this.options.autoFocus) {
-      this.magicBox.focus();
-    }
   }
 
   /**


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-1529

Having the ability to autofocus the searchbox caused the omnibox suggestions to appear automatically on load. It could also cause other issues such as stealing the focus from another element in the page.



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)