### PR TITLE
register component when responsive class has already been instanciated

### DIFF
--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -377,7 +377,6 @@ export class FacetSlider extends Component {
     super(element, FacetSlider.ID, bindings);
     this.options = ComponentOptions.initComponentOptions(element, FacetSlider, options);
 
-    debugger;
     ResponsiveFacets.init(this.root, this, this.options);
 
     if (this.options.excludeOuterBounds == null) {

--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -377,6 +377,7 @@ export class FacetSlider extends Component {
     super(element, FacetSlider.ID, bindings);
     this.options = ComponentOptions.initComponentOptions(element, FacetSlider, options);
 
+    debugger;
     ResponsiveFacets.init(this.root, this, this.options);
 
     if (this.options.excludeOuterBounds == null) {
@@ -510,7 +511,7 @@ export class FacetSlider extends Component {
     }
   }
 
-  // There is delayed graph data if at the time the facet slider tried to draw the facet was hidden in the
+  // There is delayed graph data if at the time the facet slider tried to draw, the facet was hidden in the
   // facet dropdown. This method will draw delayed graph data if it exists.
   public drawDelayedGraphData() {
     if (this.delayedGraphData != undefined && !this.isEmpty) {

--- a/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
@@ -151,12 +151,12 @@ export class ResponsiveComponentsManager {
         // Tabs need to be rendered last, so any dropdown header(eg: facet) is already there when the responsive tabs check for overflow.
         this.responsiveComponents.unshift(responsiveComponent);
       }
-      _.each(this.responsiveComponents, (responsiveComponent: IResponsiveComponent) => {
+    }
+    _.each(this.responsiveComponents, (responsiveComponent: IResponsiveComponent) => {
         if (responsiveComponent.registerComponent != null) {
           responsiveComponent.registerComponent(component);
         }
-      });
-    }
+    });
   }
 
   public disableComponent(ID: string) {

--- a/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
@@ -153,9 +153,9 @@ export class ResponsiveComponentsManager {
       }
     }
     _.each(this.responsiveComponents, (responsiveComponent: IResponsiveComponent) => {
-        if (responsiveComponent.registerComponent != null) {
-          responsiveComponent.registerComponent(component);
-        }
+      if (responsiveComponent.registerComponent != null) {
+        responsiveComponent.registerComponent(component);
+      }
     });
   }
 

--- a/test/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/test/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -7,6 +7,7 @@ export function ResponsiveComponentsManagerTest() {
 
   let root: Dom;
   let handleResizeEvent: any;
+  let registerComponent: any;
   let responsiveComponentsManager: ResponsiveComponentsManager;
   let responsiveComponent: any;
   let component: any;
@@ -19,9 +20,12 @@ export function ResponsiveComponentsManagerTest() {
       searchInterfaceMock.cmp.isNewDesign = () => true;
       root = $$(searchInterfaceMock.cmp.root);
       handleResizeEvent = jasmine.createSpy('handleResizeEvent');
+      registerComponent = jasmine.createSpy('registerComponent');
       responsiveComponent = function () {
         this.needDrodpownWrapper = () => { };
         this.handleResizeEvent = handleResizeEvent;
+        this.registerComponent = registerComponent;
+        this.ID = 'id';
       };
       component = {};
       responsiveComponentsManager = new ResponsiveComponentsManager(root);
@@ -51,6 +55,13 @@ export function ResponsiveComponentsManagerTest() {
         done();
       }, ResponsiveComponentsManager.RESIZE_DEBOUNCE_DELAY + 1);
 
+    });
+
+    it('registers component even when the corresponding responsive class has already been instanciated', () => {
+      responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+      responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+
+      expect(registerComponent).toHaveBeenCalledTimes(2);
     });
   });
 }


### PR DESCRIPTION
caused the facet slider to not be drawn on load, in mobile.
https://coveord.atlassian.net/browse/JSUI-1542





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)