### PR TITLE
Allows CoveoSettings to preceed CoveoSearchbox instead of requiring a direct neighbour

### DIFF
--- a/sass/_Searchbox.scss
+++ b/sass/_Searchbox.scss
@@ -36,7 +36,7 @@
   }
 }
 
-.CoveoSettings + .CoveoSearchbox {
+.CoveoSettings ~ .CoveoSearchbox {
   margin-right: 76px;
 }
 


### PR DESCRIPTION
With this simple markup:

```html
<div class='coveo-search-section'>
   <div class="CoveoSettings"></div>
   <span>blublu</span>
   <div class="CoveoSearchbox" data-enable-omnibox="true"></div>
</div>
```

Before the change:

![ew](https://cloud.githubusercontent.com/assets/8355585/25351769/b430277c-28f7-11e7-8f3b-2c34499a396d.png)

After the change:

![alittlelessew](https://cloud.githubusercontent.com/assets/8355585/25351776/b5f2cc68-28f7-11e7-8ede-687321f32156.png)

In Coveo for Sitecore, Sitecore automatically adds a `code` tag that is invisible in the markup, so our UI is really ugly even though the end result should be the same. This change fixes it quite cleanly.

We could have put a workaround on our side, but I think it is also a small improvement on your side :)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)