### PR TITLE
Mechanism for custom component extending base component

### DIFF
--- a/src/Lazy.ts
+++ b/src/Lazy.ts
@@ -1,5 +1,7 @@
 export * from './Core';
 
+export { SearchInterface, StandaloneSearchInterface } from './ui/SearchInterface/SearchInterface';
+
 import { PublicPathUtils } from './utils/PublicPathUtils';
 PublicPathUtils.detectPublicPath();
 

--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -763,14 +763,16 @@ export class EagerInitialization {
       result = initParameters.result;
     }
 
-    EagerInitialization.logger.trace('Creating component of class ' + componentClassId, element, options);
+    EagerInitialization.logger.trace(`Creating component of class ${componentClassId}`, element, options);
     // This is done so that external code that extends a base component does not have to have two code path for lazy vs eager;
     // If we do not find the eager component registered, we can instead try to load the one found in lazy mode.
+    // If it still fails there... tough luck. The component simply won't work.
     if (eagerlyLoadedComponent == null) {
       LazyInitialization.getLazyRegisteredComponent(componentClassId).then((lazyLoadedComponent)=> {
-        return new lazyLoadedComponent(element, options, bindings, result);
+        EagerInitialization.logger.warn(`Component of class ${componentClassId} was not found in "Eager" mode. Using lazy mode as a fallback.`);
+        new lazyLoadedComponent(element, options, bindings, result);
       }).catch(()=> {
-        return null;
+        EagerInitialization.logger.error(`Component of class ${componentClassId} was not found in "Eager" mode nor "Lazy" mode. It will not be initialized properly...`);
       });
       return null;
     } else {

--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -768,10 +768,10 @@ export class EagerInitialization {
     // If we do not find the eager component registered, we can instead try to load the one found in lazy mode.
     // If it still fails there... tough luck. The component simply won't work.
     if (eagerlyLoadedComponent == null) {
-      LazyInitialization.getLazyRegisteredComponent(componentClassId).then((lazyLoadedComponent)=> {
+      LazyInitialization.getLazyRegisteredComponent(componentClassId).then((lazyLoadedComponent) => {
         EagerInitialization.logger.warn(`Component of class ${componentClassId} was not found in "Eager" mode. Using lazy mode as a fallback.`);
         new lazyLoadedComponent(element, options, bindings, result);
-      }).catch(()=> {
+      }).catch(() => {
         EagerInitialization.logger.error(`Component of class ${componentClassId} was not found in "Eager" mode nor "Lazy" mode. It will not be initialized properly...`);
       });
       return null;

--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -764,6 +764,17 @@ export class EagerInitialization {
     }
 
     EagerInitialization.logger.trace('Creating component of class ' + componentClassId, element, options);
-    return new eagerlyLoadedComponent(element, options, bindings, result);
+    // This is done so that external code that extends a base component does not have to have two code path for lazy vs eager;
+    // If we do not find the eager component registered, we can instead try to load the one found in lazy mode.
+    if (eagerlyLoadedComponent == null) {
+      LazyInitialization.getLazyRegisteredComponent(componentClassId).then((lazyLoadedComponent)=> {
+        return new lazyLoadedComponent(element, options, bindings, result);
+      }).catch(()=> {
+        return null;
+      });
+      return null;
+    } else {
+      return new eagerlyLoadedComponent(element, options, bindings, result);
+    }
   }
 }

--- a/src/ui/Base/RegisteredNamedMethods.ts
+++ b/src/ui/Base/RegisteredNamedMethods.ts
@@ -334,18 +334,37 @@ Initialization.registerNamedMethod('configureRessourceRoot', (path: string) => {
  * Load a module or chunk asynchronously.
  *
  * For example, you can do `Coveo.load('Searchbox').then((Searchbox)=>{})` to load the Searchbox component if it not already loaded in your page.
- * @param modules The module identifier to load. For components, this will be the name of the component. eg: `Facet` or `Searchbox`. You can also pass an array of modules to load.
+ *
+ * This is especially useful for complex integration where you want to extend a base component, but have it also work in lazy mode.
+ *
+ * Example :
+ * ```
+ * export function myLazyCustomSearchbox() {
+ *    return Coveo.load<Searchbox>('Searchbox').then((Searchbox) => {
+ *            class MyCustomSearchbox extends Searchbox {
+ *                 [ ... ]
+ *             }
+ *             Coveo.Initialization.registerAutoCreateComponent(MyCustomSearchbox);
+ *             return MyCustomSearchbox;
+ *     })
+ * }
+ *
+ * Coveo.LazyInitialization.registerLazyComponent('MyCustomSearchbox', myLazyCustomSearchbox);
+ * ```
+ *
+ * You can also use this to ensure a specific component is loaded in your page before executing any code.
+ *
+ * @param id The module identifier to load. For components, this will be the name of the component. eg: `Facet` or `Searchbox`.
  * @returns {Promise}
  */
-export function load<T>(modules: string): Promise<T> {
-  const loadOne = (toLoad: string) => {
-    if (LazyInitialization.lazyLoadedComponents[toLoad] !== null) {
-      return <Promise<T>>(<any>LazyInitialization.getLazyRegisteredComponent(toLoad));
-    } else {
-      return <Promise<T>>LazyInitialization.getLazyRegisteredModule(toLoad);
-    }
-  };
-  return loadOne(<string>modules);
+export function load<T>(id: string): Promise<T> {
+  if (LazyInitialization.lazyLoadedComponents[id] != null) {
+    return <Promise<T>>(<any>LazyInitialization.getLazyRegisteredComponent(id));
+  } else if (LazyInitialization.lazyLoadedModule[id] != null) {
+    return <Promise<T>>LazyInitialization.getLazyRegisteredModule(id);
+  } else {
+    return Promise.reject(`Module ${id} is not available`);
+  }
 }
 
 Initialization.registerNamedMethod('require', (modules: string) => {

--- a/src/ui/Base/RegisteredNamedMethods.ts
+++ b/src/ui/Base/RegisteredNamedMethods.ts
@@ -10,7 +10,7 @@ import { $$ } from '../../utils/Dom';
 import { IAnalyticsActionCause, IAnalyticsDocumentViewMeta } from '../Analytics/AnalyticsActionListMeta';
 import { IStringMap } from '../../rest/GenericParam';
 import { BaseComponent } from '../Base/BaseComponent';
-import { Component, IComponentDefinition } from '../Base/Component';
+import { Component } from '../Base/Component';
 import { IStandaloneSearchInterfaceOptions } from '../SearchInterface/SearchInterface';
 import { IRecommendationOptions } from '../Recommendation/Recommendation';
 import * as _ from 'underscore';
@@ -338,7 +338,7 @@ Initialization.registerNamedMethod('configureRessourceRoot', (path: string) => {
  * @returns {Promise}
  */
 export function load<T>(modules: string): Promise<T> {
-  const loadOne = (toLoad: string)=> {
+  const loadOne = (toLoad: string) => {
     if (LazyInitialization.lazyLoadedComponents[toLoad] !== null) {
       return <Promise<T>>(<any>LazyInitialization.getLazyRegisteredComponent(toLoad));
     } else {
@@ -348,6 +348,6 @@ export function load<T>(modules: string): Promise<T> {
   return loadOne(<string>modules);
 }
 
-Initialization.registerNamedMethod('require', (modules: string)=> {
+Initialization.registerNamedMethod('require', (modules: string) => {
   return load(modules);
 });

--- a/src/ui/Base/RegisteredNamedMethods.ts
+++ b/src/ui/Base/RegisteredNamedMethods.ts
@@ -1,4 +1,4 @@
-import { Initialization } from './Initialization';
+import { Initialization, LazyInitialization, INewableComponent } from './Initialization';
 import { Assert } from '../../misc/Assert';
 import { QueryController } from '../../controllers/QueryController';
 import { QueryStateModel, setState } from '../../models/QueryStateModel';
@@ -10,7 +10,7 @@ import { $$ } from '../../utils/Dom';
 import { IAnalyticsActionCause, IAnalyticsDocumentViewMeta } from '../Analytics/AnalyticsActionListMeta';
 import { IStringMap } from '../../rest/GenericParam';
 import { BaseComponent } from '../Base/BaseComponent';
-import { Component } from '../Base/Component';
+import { Component, IComponentDefinition } from '../Base/Component';
 import { IStandaloneSearchInterfaceOptions } from '../SearchInterface/SearchInterface';
 import { IRecommendationOptions } from '../Recommendation/Recommendation';
 import * as _ from 'underscore';
@@ -328,4 +328,26 @@ export function configureRessourceRoot(path: string) {
 
 Initialization.registerNamedMethod('configureRessourceRoot', (path: string) => {
   configureRessourceRoot(path);
+});
+
+/**
+ * Load a module or chunk asynchronously.
+ *
+ * For example, you can do `Coveo.load('Searchbox').then((Searchbox)=>{})` to load the Searchbox component if it not already loaded in your page.
+ * @param modules The module identifier to load. For components, this will be the name of the component. eg: `Facet` or `Searchbox`. You can also pass an array of modules to load.
+ * @returns {Promise}
+ */
+export function load<T>(modules: string): Promise<T> {
+  const loadOne = (toLoad: string)=> {
+    if (LazyInitialization.lazyLoadedComponents[toLoad] !== null) {
+      return <Promise<T>>(<any>LazyInitialization.getLazyRegisteredComponent(toLoad));
+    } else {
+      return <Promise<T>>LazyInitialization.getLazyRegisteredModule(toLoad);
+    }
+  };
+  return loadOne(<string>modules);
+}
+
+Initialization.registerNamedMethod('require', (modules: string)=> {
+  return load(modules);
 });

--- a/src/ui/Base/RegisteredNamedMethods.ts
+++ b/src/ui/Base/RegisteredNamedMethods.ts
@@ -1,4 +1,4 @@
-import { Initialization, LazyInitialization, INewableComponent } from './Initialization';
+import { Initialization, LazyInitialization } from './Initialization';
 import { Assert } from '../../misc/Assert';
 import { QueryController } from '../../controllers/QueryController';
 import { QueryStateModel, setState } from '../../models/QueryStateModel';

--- a/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
+++ b/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
@@ -23,14 +23,6 @@ import { TextInput } from '../FormWidgets/TextInput';
 import { MultiSelect } from '../FormWidgets/MultiSelect';
 import { FormGroup } from '../FormWidgets/FormGroup';
 
-export interface IPreferencePanelInputToBuild {
-  label: string;
-  placeholder?: string;
-  tab?: string[];
-  expression?: string;
-  otherAttribute?: string;
-}
-
 export interface IResultFilterPreference {
   selected?: boolean;
   custom?: boolean;
@@ -341,7 +333,7 @@ export class ResultsFiltersPreferences extends Component {
     }
   }
 
-  private getPreferencesBoxInputToBuild(): IPreferencePanelInputToBuild[] {
+  private getPreferencesBoxInputToBuild() {
     return _.map(this.preferences, (filter: IResultFilterPreference) => {
       return {
         label: filter.caption,

--- a/src/utils/DomUtils.ts
+++ b/src/utils/DomUtils.ts
@@ -94,8 +94,4 @@ export class DomUtils {
   static getCurrentScript(): HTMLScriptElement {
     return <HTMLScriptElement>document.currentScript;
   }
-
-  static getElementsByTagName<K extends keyof ElementListTagNameMap>(tagname: K): ElementListTagNameMap[K] {
-    return document.getElementsByTagName(tagname);
-  }
 }

--- a/test/ui/InitializationTest.ts
+++ b/test/ui/InitializationTest.ts
@@ -367,20 +367,20 @@ export function InitializationTest() {
       });
     });
 
-    it('should fallback on lazy registered component if it\'s only registered as lazy', (done)=> {
-      const lazyCustomStuff = jasmine.createSpy('customstuff').and.callFake(()=> new Promise((resolve, reject)=> {
+    it('should fallback on lazy registered component if it\'s only registered as lazy', (done) => {
+      const lazyCustomStuff = jasmine.createSpy('customstuff').and.callFake(() => new Promise((resolve, reject) => {
         resolve(NoopComponent);
       }));
 
       // We register the component only as "lazy", but then do an initialization "eager" style.
       // Normally, the fallback should kick in and the component should still be initialized
-      root.appendChild($$('div', {className: 'CoveoMyCustomStuff'}).el);
+      root.appendChild($$('div', { className: 'CoveoMyCustomStuff' }).el);
       LazyInitialization.registerLazyComponent('MyCustomStuff', lazyCustomStuff);
 
 
       Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
-      }).then(()=> {
+      }).then(() => {
         expect(lazyCustomStuff).toHaveBeenCalled();
         done();
       });

--- a/test/ui/InitializationTest.ts
+++ b/test/ui/InitializationTest.ts
@@ -3,7 +3,7 @@ import { SearchEndpoint } from '../../src/rest/SearchEndpoint';
 import { $$ } from '../../src/utils/Dom';
 import { Querybox } from '../../src/ui/Querybox/Querybox';
 import { Component } from '../../src/ui/Base/Component';
-import { Initialization } from '../../src/ui/Base/Initialization';
+import { Initialization, LazyInitialization } from '../../src/ui/Base/Initialization';
 import { Facet } from '../../src/ui/Facet/Facet';
 import { Pager } from '../../src/ui/Pager/Pager';
 import { ResultList } from '../../src/ui/ResultList/ResultList';
@@ -364,6 +364,13 @@ export function InitializationTest() {
         const actionHistory = localStorage.getItem('__coveo.analytics.history');
         expect(actionHistory).toBeNull();
       });
+    });
+    it('should fallback on lazy registered component if it\'s only registered as lazy', ()=> {
+      const lazyCustomStuff = jasmine.createSpy('customstuff');
+      LazyInitialization.registerLazyComponent('MyCustomStuff', lazyCustomStuff);
+      root.append($$('div', {className : 'MyCustomStuff'}).el);
+
+      Initialization.automaticallyCreateComponentsInside(root.el)
     });
   });
 }

--- a/test/ui/RegisteredNamedMethodsTest.ts
+++ b/test/ui/RegisteredNamedMethodsTest.ts
@@ -6,6 +6,8 @@ import { Searchbox } from '../../src/ui/Searchbox/Searchbox';
 import { FakeResults } from '../Fake';
 import { IAnalyticsClient } from '../../src/ui/Analytics/AnalyticsClient';
 import { mockUsageAnalytics } from '../MockEnvironment';
+import { LazyInitialization } from '../../src/ui/Base/Initialization';
+import { NoopComponent } from '../../src/ui/NoopComponent/NoopComponent';
 
 export function RegisteredNamedMethodsTest() {
   describe('RegisteredNamedMethods', () => {
@@ -25,6 +27,34 @@ export function RegisteredNamedMethodsTest() {
     afterEach(() => {
       env = null;
       searchbox = null;
+    });
+
+    it('should allow to load an arbitrary module', () => {
+      const fooModule = jasmine.createSpy('foo').and.callFake(() => new Promise((resolve, reject) => {
+      }));
+
+      LazyInitialization.registerLazyModule('foo', fooModule);
+
+      RegisteredNamedMethod.load('foo');
+      expect(fooModule).toHaveBeenCalled();
+
+    });
+
+    it('should allow to load an arbitrary component', () => {
+      const barComponent = jasmine.createSpy('bar').and.callFake(() => new Promise((resolve, reject) => {
+        resolve(NoopComponent);
+      }));
+
+      LazyInitialization.registerLazyComponent('bar', barComponent);
+      RegisteredNamedMethod.load('bar');
+      expect(barComponent).toHaveBeenCalled();
+    });
+
+    it('promise should throw when loading something that does not exist', (done) => {
+      RegisteredNamedMethod.load('does not exist').catch(() => {
+        expect(true).toBe(true);
+        done();
+      });
     });
 
     it('should allow to call state correctly', () => {

--- a/test/utils/PublicPathUtilsTest.ts
+++ b/test/utils/PublicPathUtilsTest.ts
@@ -2,23 +2,30 @@ import { DomUtils } from '../../src/utils/DomUtils';
 import { PublicPathUtils } from '../../src/utils/PublicPathUtils';
 import { $$ } from '../../src/utils/Dom';
 
+function getElementsByTagName<K extends keyof
+ElementListTagNameMap > (tagname
+:
+K
+):
+ElementListTagNameMap[K]
+{
+  return document.getElementsByTagName(tagname);
+}
+
 export function PublicPathUtilsTest() {
   describe('PublicPathUtils', () => {
     let currentScript;
-    let getElementsByTagName;
     let expectedPath = 'some/path/';
     let fakeScript = <HTMLScriptElement>{ src: `${expectedPath}script.js` };
 
     beforeEach(() => {
       currentScript = DomUtils.getCurrentScript;
-      getElementsByTagName = DomUtils.getElementsByTagName;
       PublicPathUtils.reset();
       DomUtils.getCurrentScript = () => fakeScript;
     });
 
     afterEach(() => {
       DomUtils.getCurrentScript = currentScript;
-      DomUtils.getElementsByTagName = getElementsByTagName;
     });
 
     it('should set webpack pulic path when configuring ressource root', () => {
@@ -50,7 +57,7 @@ export function PublicPathUtilsTest() {
     });
 
     it('should use the last parsed script to detect ressource root when document.currentScript is not available', () => {
-      DomUtils.getElementsByTagName = () => [$$('script'), fakeScript];
+      var getElementsByTagName = () => [$$('script'), fakeScript];
       PublicPathUtils.detectPublicPath();
       expect(__webpack_public_path__).toBe(expectedPath);
     });

--- a/test/utils/PublicPathUtilsTest.ts
+++ b/test/utils/PublicPathUtilsTest.ts
@@ -1,16 +1,5 @@
 import { DomUtils } from '../../src/utils/DomUtils';
 import { PublicPathUtils } from '../../src/utils/PublicPathUtils';
-import { $$ } from '../../src/utils/Dom';
-
-function getElementsByTagName<K extends keyof
-ElementListTagNameMap > (tagname
-:
-K
-):
-ElementListTagNameMap[K]
-{
-  return document.getElementsByTagName(tagname);
-}
 
 export function PublicPathUtilsTest() {
   describe('PublicPathUtils', () => {
@@ -57,7 +46,6 @@ export function PublicPathUtilsTest() {
     });
 
     it('should use the last parsed script to detect ressource root when document.currentScript is not available', () => {
-      var getElementsByTagName = () => [$$('script'), fakeScript];
       PublicPathUtils.detectPublicPath();
       expect(__webpack_public_path__).toBe(expectedPath);
     });


### PR DESCRIPTION
Add a `.load` top level function so that external code that extends a base component in lazy mode can now do something like this : 
```
export function myLazyCustomSearchbox() {
     return Coveo.load<Searchbox>('Searchbox').then((Searchbox) => {
             class MyCustomSearchbox extends Searchbox {
                  [ ... ]
              }
              Coveo.Initialization.registerAutoCreateComponent(MyCustomSearchbox);
              return MyCustomSearchbox;
      })
}

Coveo.LazyInitialization.registerLazyComponent('MyCustomSearchbox', myLazyCustomSearchbox);
```


Then, after that, a component registered like this would be usable in both ways : lazy and eager.

Meaning, someone can include 
* `CoveoJsSearch.Lazy.js` and then `customstuff.js`, or 
* `CoveoJsSearch.js` and then `customstuff.js`

Both would work.

This will be used in Salesforce integration, for example.


Also removed some un-needed function code that generates generates invalid TS 1.8 code.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)