### PR TITLE
DOC-2 Document how to normalize facet values

### DIFF
--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -519,7 +519,7 @@ export class Facet extends Component {
      * those other values.
      *
      * ```html
-
+     *
      * <div class="CoveoFacet" data-field="@objecttype" data-title="Object Type" data-tab="All" data-allowed-values="Contact,Account,File"></div>
      * ```
      *

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -95,21 +95,22 @@ export interface IFacetOptions {
 
 
 /**
- * The Facet component displays a *facet* of the results for the current query. A facet consists of a list of values for
- * a given field occurring in the results, ordered using a configurable criteria.
+ * The `Facet` component displays a *facet* of the results for the current query. A facet is a list of values for a
+ * certain field occurring in the results, ordered using a configurable criteria (e.g., number of occurrences).
  *
- * The list of values is obtained using an {@link IGroupByRequest} operation performed at the same time as the main
- * query.
+ * The list of values is obtained using a [`GroupByRequest`]{@link IGroupByRequest} operation performed at the same time
+ * as the main query.
  *
- * The Facet component allows the user to drill down inside results by restricting them to certain field values. It also
- * allows filtering out values from the Facet itself, and can provide a search box to look for specific values inside
- * larger sets.
+ * The `Facet` component allows the end user to drill down inside a result set by restricting the result to certain
+ * field values. It also allows filtering out values from the facet itself, and can provide a search box to look for
+ * specific values inside larger sets.
  *
  * This is probably the most complex component in the Coveo JavaScript Search Framework and as such, it allows for many
- * different configuration options.
+ * configuration options.
  *
- * See also {@link FacetRange} and {@link HierarchicalFacet} (which extend this component), and {@link FacetSlider}
- * (which does not properly extend this component, but is very similar).
+ * See also the [`FacetRange`]{@link FacetRange} and [`HierarchicalFacet`]{@link HierarchicalFacet} components (which
+ * extend this component), and the [`FacetSlider`]{@link FacetSlider} component (which does not properly extend this
+ * component, but is very similar).
  */
 export class Facet extends Component {
   static ID = 'Facet';
@@ -135,7 +136,7 @@ export class Facet extends Component {
   static options: IFacetOptions = {
 
     /**
-     * Specifies the title to display at the top of the Facet.
+     * Specifies the title to display at the top of the facet.
      *
      * Default value is the localized string for `"NoTitle"`.
      */
@@ -146,33 +147,33 @@ export class Facet extends Component {
     }),
 
     /**
-     * Specifies the index field whose values the Facet should use.
+     * Specifies the index field whose values the facet should use.
      *
-     * This requires the given field to be configured correctly in the index as a Facet field (see
+     * This requires the given field to be configured correctly in the index as a *Facet field* (see
      * [Adding Fields to a Source](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=137)).
      *
-     * Specifying a value for this option is required for the Facet component to work.
+     * Specifying a value for this option is required for the `Facet` component to work.
      */
     field: ComponentOptions.buildFieldOption({ required: true, groupByField: true, section: 'Identification' }),
 
     headerIcon: ComponentOptions.buildIconOption({ deprecated: 'This option is exposed for legacy reasons, and the recommendation is to not use this option.' }),
 
     /**
-     * Specifies a unique identifier for the Facet. Among other things, this identifier serves the purpose of saving the
-     * facet state in the URL hash.
+     * Specifies a unique identifier for the facet. Among other things, this identifier serves the purpose of saving
+     * the facet state in the URL hash.
      *
-     * If you have two facets with the same field on the same page, you should specify an id value for at least one of
-     * those two facets. This id must be unique in the page.
+     * If you have two facets with the same field on the same page, you should specify an `id` value for at least one of
+     * those two facets. This `id` must be unique in the page.
      *
-     * Default value is the {@link Facet.options.field} option value.
+     * Default value is the [`field`]{@link Facet.options.field} option value.
      */
     id: ComponentOptions.buildStringOption({
       postProcessing: (value, options: IFacetOptions) => value || <string>options.field
     }),
 
     /**
-     * Specifies whether the field is configured in the index as a multi-value field (semicolon separated values such as
-     * `abc;def;ghi`).
+     * Specifies whether the facet [`field`]{@link Facet.options.field} is configured in the index as a multi-value
+     * field (semicolon separated values such as `abc;def;ghi`).
      *
      * Default value is `false`.
      */
@@ -181,32 +182,33 @@ export class Facet extends Component {
     lookupField: ComponentOptions.buildFieldOption({ deprecated: 'This option is exposed for legacy reasons, and the recommendation is to not use this option.' }),
 
     /**
-     * Specifies whether to display the Facet **Settings** menu.
+     * Specifies whether to display the facet **Settings** menu.
      *
-     * See also {@link Facet.options.enableSettingsFacetState}, {@link Facet.options.availableSorts} and
-     * {@link Facet.options.enableCollapse}.
+     * See also the [`enableSettingsFacetState`]{@link Facet.options.enableSettingsFacetState},
+     * [`availableSorts`]{@link Facet.options.availableSorts}, and
+     * [`enableCollapse`]{@link Facet.options.enableCollapse} options.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
      * Default value is `true`.
      */
     enableSettings: ComponentOptions.buildBooleanOption({ defaultValue: true, section: 'SettingsMenu', priority: 9 }),
 
     /**
-     * If {@link Facet.options.enableSettings} is `true`, specifies whether the **Save state** menu option is available
-     * in the Facet **Settings** menu.
+     * If the [`enableSettings`]{@link Facet.options.enableSettings} option is `true`, specifies whether the
+     * **Save state** menu option is available in the facet **Settings** menu.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
      * Default value is `false`.
      */
     enableSettingsFacetState: ComponentOptions.buildBooleanOption({ defaultValue: false, depend: 'enableSettings' }),
 
     /**
-     * If {@link Facet.options.enableSettings} is `true`, specifies the sort criteria options to display in the Facet
-     * **Settings** menu.
+     * If the [`enableSettings`]{@link Facet.options.enableSettings} option is `true`, specifies the sort criteria
+     * options to display in the facet **Settings** menu.
      *
      * Possible values are:
      * - `"occurrences"`
@@ -217,10 +219,10 @@ export class Facet extends Component {
      * - `"computedfielddescending"`
      * - `"custom"`
      *
-     * See the {@link IGroupByRequest.sortCriteria} for a description of each possible value.
+     * See {@link IGroupByRequest.sortCriteria} for a description of each possible value.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
      * Default value is `"occurrences,score,alphaAscending,alphaDescending"`.
      */
@@ -231,36 +233,42 @@ export class Facet extends Component {
     }),
 
     /**
-     * Specifies the criteria to use to sort the Facet values.
+     * Specifies the criteria to use to sort the facet values.
      *
      * See {@link IGroupByRequest.sortCriteria} for the list and description of possible values.
      *
-     * Default value is the first sort criteria specified in the {@link Facet.options.availableSorts} option, or
-     * `"occurrences"` if no sort criteria is specified.
+     * Default value is the first sort criteria specified in the [`availableSorts`]{@link Facet.options.availableSorts}
+     * option, or `occurrences` if no sort criteria is specified.
      */
     sortCriteria: ComponentOptions.buildStringOption({ postProcessing: (value, options: IFacetOptions) => value || (options.availableSorts.length > 0 ? options.availableSorts[0] : 'occurrences') }),
 
     /**
-     * Specifies a custom order by which to sort the Facet values.
+     * Specifies a custom order by which to sort the facet values.
      *
-     * For example, you could use this to specify a logical order for support tickets, such as
-     * `customSort : ["New","Opened","Feedback","Resolved"]`
+     * **Example:**
+     *
+     * You could use this option to specify a logical order for support tickets, such as:
+     * ```html
+     * <div class="CoveoFacet" data-field="@ticketstatus" data-title="Ticket Status" data-tab="All" data-custom-sort="New,Opened,Feedback,Resolved"></div>
+     * ```
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      */
     customSort: ComponentOptions.buildListOption<string>({ section: 'Identification' }),
 
     /**
-     * Specifies the maximum number of field values to display by default in the Facet before the user
-     * clicks **More**.
+     * Specifies the maximum number of field values to display by default in the facet before the user
+     * clicks the arrow to show more.
+     *
+     * See also the [`enableMoreLess`]{@link Facet.options.enableMoreLess} option.
      *
      * Default value is `5`. Minimum value is `0`.
      */
     numberOfValues: ComponentOptions.buildNumberOption({ defaultValue: 5, min: 0, section: 'Identification' }),
 
     /**
-     * Specifies the *injection depth* to use for the {@link IGroupByRequest} operation.
+     * Specifies the *injection depth* to use for the [`GroupByRequest`]{@link IGroupByRequest} operation.
      *
      * The injection depth determines how many results to scan in the index to ensure that the facet lists all potential
      * facet values. Increasing this value enhances the accuracy of the listed values at the cost of performance.
@@ -273,7 +281,7 @@ export class Facet extends Component {
 
     /**
      * Specifies whether to use the `AND` operator in the resulting filter when multiple values are selected in the
-     * Facet.
+     * facet.
      *
      * Setting this option to `true` means that documents must have all of the selected values to match the resulting
      * query.
@@ -284,9 +292,9 @@ export class Facet extends Component {
     useAnd: ComponentOptions.buildBooleanOption({ defaultValue: false }),
 
     /**
-     * Specifies whether to allow the user to toggle between the `OR` and `AND` modes in the Facet.
+     * Specifies whether to allow the user to toggle between the `OR` and `AND` modes in the facet.
      *
-     * Setting this option to `true` displays an icon in the top right corner of the Facet. The user can click this icon
+     * Setting this option to `true` displays an icon in the top right corner of the facet. The user can click this icon
      * to toggle between between the two modes.
      *
      * Default value is `false`.
@@ -294,66 +302,69 @@ export class Facet extends Component {
     enableTogglingOperator: ComponentOptions.buildBooleanOption({ defaultValue: false, alias: 'allowTogglingOperator' }),
 
     /**
-     * Specifies whether to display a search box at the bottom of the Facet for searching among the available values.
+     * Specifies whether to display a search box at the bottom of the facet for searching among the available facet
+     * [`field`]{@link Facet.options.field} values.
      *
-     * See also {@link Facet.options.facetSearchDelay}, {@link Facet.options.facetSearchIgnoreAccents},
-     * {@link Facet.options.numberOfValuesInFacetSearch}.
+     * See also the [`facetSearchDelay`]{@link Facet.options.facetSearchDelay},
+     * [`facetSearchIgnoreAccents`]{@link Facet.options.facetSearchIgnoreAccents}, and
+     * [`numberOfValuesInFacetSearch`]{@link Facet.options.numberOfValuesInFacetSearch} options.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
      * Default value is `true`.
      */
     enableFacetSearch: ComponentOptions.buildBooleanOption({ defaultValue: true, section: 'FacetSearch', priority: 8 }),
 
     /**
-     * If {@link Facet.options.enableFacetSearch} is `true`, specifies the delay (in milliseconds) before sending a
-     * search request to the server when the user starts typing in the Facet search box.
+     * If the [`enableFacetSearch`]{@link Facet.options.enableFacetSearch} option is `true`, specifies the delay (in
+     * milliseconds) before sending a search request to the server when the user starts typing in the facet search box.
      *
-     * Specifying a smaller value means results will arrive faster. However, chances of having to cancel many requests
-     * sent to the server will increase as the user keeps on typing new characters.
+     * Specifying a smaller value makes results appear faster. However, chances of having to cancel many requests
+     * sent to the server increase as the user keeps on typing new characters.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
      * Default value is `100`. Minimum value is `0`.
      */
     facetSearchDelay: ComponentOptions.buildNumberOption({ defaultValue: 100, min: 0, depend: 'enableFacetSearch' }),
 
     /**
-     * If {@link Facet.options.enableFacetSearch} is `true`, specifies whether to ignore accents in the Facet search
-     * box.
+     * If the [`enableFacetSearch`]{@link Facet.options.enableFacetSearch} option is `true`, specifies whether to ignore
+     * accents in the facet search box.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
      * Default value is `false`.
      */
     facetSearchIgnoreAccents: ComponentOptions.buildBooleanOption({ defaultValue: false, depend: 'enableFacetSearch' }),
 
     /**
-     * If {@link Facet.options.enableFacetSearch} is `true`, specifies the number of values to display in the Facet
-     * search results popup.
+     * If the [`enableFacetSearch`]{@link Facet.options.enableFacetSearch} option is `true`, specifies the number of v
+     * alues to display in the facet search results popup.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
      * Default value is `15`. Minimum value is `1`.
      */
     numberOfValuesInFacetSearch: ComponentOptions.buildNumberOption({ defaultValue: 15, min: 1 }),
 
     /**
-     * Specifies whether the Facet should push data to the {@link Breadcrumb} component.
+     * Specifies whether the facet should push data to the [`Breadcrumb`]{@link Breadcrumb} component.
      *
-     * See also {@link Facet.options.numberOfValuesInBreadcrumb}.
+     * See also the [`numberOfValuesInBreadcrumb`]{@link Facet.options.numberOfValuesInBreadcrumb} option.
      *
      * Default value is `true`.
      */
     includeInBreadcrumb: ComponentOptions.buildBooleanOption({ defaultValue: true }),
 
     /**
-     * If {@link Facet.options.includeInBreadcrumb} is `true`, specifies the maximum number of values that the Facet
-     * should display in the {@link Breadcrumb} before outputting a **See more** button.
+     * If the [`includeInBreadcrumb`]{@link Facet.options.includeInBreadcrumb} option is `true`, specifies the maximum
+     * number of values that the facet should display in the [`Breadcrumb`]{@link Breadcrumb} before outputting a
+     * **more...** button.
      *
      * Default value is `5` on a desktop computer and `3` on a mobile device. Minimum value is `0`.
      */
@@ -364,60 +375,63 @@ export class Facet extends Component {
     numberOfValuesInOmnibox: ComponentOptions.buildNumberOption({ defaultFunction: () => DeviceUtils.isMobileDevice() ? 3 : 5, min: 0, depend: 'includeInOmnibox', deprecated: 'This option is exposed for legacy reasons, and the recommendation is to not use this option.' }),
 
     /**
-     * Specifies the name of a field on which to execute an aggregate operation for all distinct values of the Facet
-     * field.
+     * Specifies the name of a field on which to execute an aggregate operation for all distinct values of the facet
+     * [`field`]{@link Facet.options.field}.
      *
-     * The Facet displays the result of the operation along with the number of occurrences for each value.
+     * The facet displays the result of the operation along with the number of occurrences for each value.
      *
-     * You can use this option to compute the sum of a field (like a money amount) for each listed Facet value.
+     * You can use this option to compute the sum of a field (like a money amount) for each listed facet value.
      *
-     * Works in conjunction with {@link Facet.options.computedFieldOperation},
-     * {@link Facet.options.computedFieldFormat} and {@link Facet.options.computedFieldCaption}.
+     * Works in conjunction with the [`computedFieldOperation`]{@link Facet.options.computedFieldOperation},
+     * [`computedFieldFormat`]{@link Facet.options.computedFieldFormat}, and
+     * [`computedFieldCaption`]{@link Facet.options.computedFieldCaption} options.
      */
     computedField: ComponentOptions.buildFieldOption({ section: 'ComputedField', priority: 7 }),
 
     /**
-     * Specifies the type of aggregate operation to perform on the {@link Facet.options.computedField}.
+     * Specifies the type of aggregate operation to perform on the [`computedField`]{@link Facet.options.computedField}.
      *
      * The possible values are:
-     * - `"sum"` - Computes the sum of the computed field values.
-     * - `"average"` - Computes the average of the computed field values.
-     * - `"minimum"` - Finds the minimum value of the computed field values.
-     * - `"maximum"` - Finds the maximum value of the computed field values.
+     * - `sum` - Computes the sum of the computed field values.
+     * - `average` - Computes the average of the computed field values.
+     * - `minimum` - Finds the minimum value of the computed field values.
+     * - `maximum` - Finds the maximum value of the computed field values.
      *
-     * Default value is `"sum"`.
+     * Default value is `sum`.
      */
     computedFieldOperation: ComponentOptions.buildStringOption({ defaultValue: 'sum', section: 'ComputedField' }),
 
     /**
-     * Specifies how to format the values resulting from a {@link Facet.options.computedFieldOperation}.
+     * Specifies how to format the values resulting from a
+     * [`computedFieldOperation`]{@link Facet.options.computedFieldOperation}.
      *
      * The Globalize library defines all available formats (see
      * [Globalize](https://github.com/klaaspieter/jquery-global#globalizeformat-value-format-culture-)).
      *
      * The most commonly used formats are:
-     * - `"c0"` - Formats the value as a currency.
-     * - `"n0"` - Formats the value as an integer.
-     * - `"n2"` - Formats the value as a floating point with 2 decimal digits.
+     * - `c0` - Formats the value as a currency.
+     * - `n0` - Formats the value as an integer.
+     * - `n2` - Formats the value as a floating point with 2 decimal digits.
      *
      * Default value is `"c0"`.
      */
     computedFieldFormat: ComponentOptions.buildStringOption({ defaultValue: 'c0', section: 'ComputedField' }),
 
     /**
-     * Specifies what the caption of the {@link Facet.options.computedField} should be in the settings menu for sorting.
+     * Specifies what the caption of the [`computedField`]{@link Facet.options.computedField} should be in the facet
+     * **Settings** menu for sorting.
      *
      * For example, setting this option to `"Money"` will display `"Money Ascending"` for computed field ascending.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
-     * Default value is the localized string for `"ComputedField"`.
+     * Default value is the localized string for `ComputedField`.
      */
     computedFieldCaption: ComponentOptions.buildLocalizedStringOption({ defaultValue: l('ComputedField'), section: 'ComputedField' }),
 
     /**
-     * Specifies whether the Facet should remain stable in its current position in the viewport while the mouse cursor
+     * Specifies whether the facet should remain stable in its current position in the viewport while the mouse cursor
      * is over it.
      *
      * Whenever the value selection changes in a facet, the search interface automatically performs a query. This new
@@ -428,10 +442,11 @@ export class Facet extends Component {
      * `<div class='coveo-bottomSpace'>` around the Facet container. The Facet adjusts the scroll amount of the page to
      * ensure that it does not move relatively to the mouse when the results are updated.
      *
-     * In some cases, the Facet also adds margins to the scrollContainer, if scrolling alone is not enough to
+     * In some cases, the facet also adds margins to the `scrollContainer`, if scrolling alone is not enough to
      * preserve position.
      *
-     * See also {@link Facet.options.paddingContainer} and {@link Facet.options.scrollContainer}.
+     * See also the [`paddingContainer`]{@link Facet.options.paddingContainer}, and
+     * [`scrollContainer`]{@link Facet.options.scrollContainer} options.
      *
      * Default value is `true`.
      */
@@ -440,17 +455,17 @@ export class Facet extends Component {
     /**
      * Specifies the parent container of the facets.
      *
-     * Used by the {@link Facet.options.preservePosition}.
+     * Used by the [`preservePosition`]{@link Facet.options.preservePosition} option.
      *
      * Default value is `element.parentElement`.
      */
     paddingContainer: ComponentOptions.buildSelectorOption({ defaultFunction: (element) => element.parentElement }),
 
     /**
-     * Specifies the HTML element (through a CSS selector) whose scroll amount the Facet should adjust to preserve its
+     * Specifies the HTML element (through a CSS selector) whose scroll amount the facet should adjust to preserve its
      * position when results are updated.
      *
-     * Used by {@link Facet.options.preservePosition}.
+     * Used by the [`preservePosition`]{@link Facet.options.preservePosition} option.
      *
      * Default value is `document.body`.
      */
@@ -459,64 +474,79 @@ export class Facet extends Component {
     /**
      * Specifies whether to enable the **More** and **Less** buttons in the Facet.
      *
-     * See also {@link Facet.options.pageSize}.
+     * See also the [`pageSize`]{@link Facet.options.pageSize} option.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
      * Default value is `true`.
      */
     enableMoreLess: ComponentOptions.buildBooleanOption({ defaultValue: true }),
 
     /**
-     * If {@link Facet.options.enableMoreLess} is `true`, specifies the number of additional results to fetch when
-     * clicking on the **More** button in the Facet.
+     * If the [`enableMoreLess`]{@link Facet.options.enableMoreLess} option is `true`, specifies the number of
+     * additional results to fetch when clicking the **More** button.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
      * Default value is `10`. Minimum value is `1`.
      */
     pageSize: ComponentOptions.buildNumberOption({ defaultValue: 10, min: 1, depend: 'enableMoreLess' }),
 
     /**
-     * If {@link Facet.options.enableSettings} is `true`, specifies whether the **Collapse \ Expand** menu option is
-     * available in the Facet **Settings** menu.
+     * If the [`enableSettings`]{@link Facet.options.enableSettings} option is `true`, specifies whether the
+     * **Collapse \ Expand** menu option is available in the facet **Settings** menu.
      *
      * **Note:**
-     * > The {@link FacetRange} component does not support this option.
+     * > The [`FacetRange`]{@link FacetRange} component does not support this option.
      *
      * Default value is `true`.
      */
     enableCollapse: ComponentOptions.buildBooleanOption({ defaultValue: true, depend: 'enableSettings' }),
 
     /**
-     * Specifies an explicit list of {@link IGroupByRequest.allowedValues} in the {@link IGroupByRequest}.
+     * Specifies an explicit list of [`allowedValues`]{@link IGroupByRequest.allowedValues} in the
+     * [`GroupByRequest`]{@link IGroupByRequest}.
      *
-     * This will whitelist the Facet content to some specific values.
+     * If you specify a list of values for this option, the facet uses only these values (if they are available in
+     * the current result set).
      *
-     * Example: `["File", "People"]`.
+     * **Example:**
+     *
+     * The following facet only uses the `Contact`, `Account`, and `File` values of the `@objecttype` field. Even if the
+     * current result set contains other `@objecttype` values, such as `Message`, or `Product`, the facet does not use
+     * those other values.
+     *
+     * ```html
+
+     * <div class="CoveoFacet" data-field="@objecttype" data-title="Object Type" data-tab="All" data-allowed-values="Contact,Account,File"></div>
+     * ```
+     *
+     * Default value is `undefined`, and the facet uses all available values for its
+     * [`field`]{@link Facet.options.field} in the current result set.
      */
     allowedValues: ComponentOptions.buildListOption<string>(),
 
     /**
-     * Specifies an additional query expression (query override) to add to each {@link IGroupByRequest} that this Facet
-     * performs.
+     * Specifies an additional query expression (query override) to add to each
+     * [`GroupByRequest`]{@link IGroupByRequest} that this facet performs.
      *
      * Example: `@date>=2014/01/01`
      */
     additionalFilter: ComponentOptions.buildStringOption(),
 
     /**
-     * Specifies whether this Facet only appears when a value is selected in its "parent" Facet.
+     * Specifies whether this facet only appears when a value is selected in its "parent" facet.
      *
-     * To specify the parent Facet, use its [id]{@link Facet.options.id}.
+     * To specify the parent facet, use its [`id`]{@link Facet.options.id}.
      *
-     * Remember that by default, a Facet id is the same as its [field]{@link Facet.options.field}.
+     * Remember that by default, a facet `id` value is the same as its [`field`]{@link Facet.options.field} option
+     * value.
      *
      * **Examples:**
      *
-     * First case: the "parent" Facet has no custom `id`:
+     * First case: the "parent" facet has no custom `id`:
      * ```html
      * <!-- "Parent" Facet: -->
      * <div class='CoveoFacet' data-field='@myfield' data-title='My Parent Facet'></div>
@@ -525,7 +555,7 @@ export class Facet extends Component {
      * <div class='CoveoFacet' data-field='@myotherfield' data-title='My Dependent Facet' data-depends-on='@myfield'></div>
      * ```
      *
-     * Second case: the "parent" Facet has a custom `id`:
+     * Second case: the "parent" facet has a custom `id`:
      * ```html
      * <!-- "Parent" Facet: -->
      * <div class='CoveoFacet' data-field='@myfield' data-title='My Parent Facet' data-id='myParentCustomId'></div>
@@ -539,29 +569,39 @@ export class Facet extends Component {
     dependsOn: ComponentOptions.buildStringOption(),
 
     /**
-     * Specifies a JSON object describing a mapping of Facet values to their desired captions.
+     * Specifies a JSON object describing a mapping of facet values to their desired captions. See
+     * [Normalizing Facet Value Captions](https://developers.coveo.com/x/jBsvAg).
      *
-     * You can only set this option in the {@link init} call of your search interface. You cannot set it directly in the
-     * markup as an HTML attribute.
+     * **Note:**
+     * > You cannot set this option directly in the component markup as an HTML attribute. You must either set it in the
+     * > [`init`]{@link init} call of your search interface (see
+     * > [Components - Passing Component Options in the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsintheinitCall)),
+     * > or before the `init` call, using the `options` top-level function (see
+     * > [Components - Passing Component Options Before the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsBeforetheinitCall)).
      *
-     * Example:
-     * ```
-     * // Using a Facet for file types
-     * var myValueCaption = {  "txt": "Text files","html": "Web page", [ etc ... ]};
+     * **Example:**
      *
-     * // You can set the option in the 'init' call using 'pure' JavaScript:
-     * Coveo.init(document.querySelector('#search'), {
-     *    Facet : {
-     *      valueCaption: myValueCaption
-     *    }
-     * })
+     * ```javascript
      *
-     * // Or  the jQuery extension
-     * $("#search").coveo("init", {
-     *    Facet: {
-     *      valueCaption: myValueCaption
-     *    }
-     * })
+     * var myValueCaptions = {
+     *   "txt" : "Text files",
+     *   "html" : "Web page",
+     *   [ ... ]
+     * };
+     *
+     * // You can set the option in the 'init' call:
+     * Coveo.init(document.querySelector("#search"), {
+     *   Facet : {
+     *     valueCaption : myValueCaptions
+     *   }
+     * });
+     *
+     * // Or before the 'init' call, using the 'options' top-level function:
+     * // Coveo.options(document.querySelector("#search"), {
+     * //  Facet : {
+     * //    valueCaption : myValueCaptions
+     * //  }
+     * // });
      * ```
      */
     valueCaption: ComponentOptions.buildCustomOption<IStringMap<string>>(() => {
@@ -569,14 +609,15 @@ export class Facet extends Component {
     }),
 
     /**
-     * Specifies whether to enable *responsive mode* for facets. Setting this options to `false` on any Facet or
-     * {@link FacetSlider} in a search interface disables responsive mode for all other facets in the search interface.
+     * Specifies whether to enable *responsive mode* for facets. Setting this options to `false` on any `Facet`, or
+     * [`FacetSlider`]{@link FacetSlider} component in a search interface disables responsive mode for all other facets
+     * in the search interface.
      *
      * Responsive mode displays all facets under a single dropdown button whenever the width of the HTML element which
      * the search interface is bound to reaches or falls behind a certain threshold (see
      * {@link SearchInterface.responsiveComponents}).
      *
-     * See also {@link Facet.options.dropdownHeaderLabel}.
+     * See also the [`dropdownHeaderLabel`]{@link Facet.options.dropdownHeaderLabel} option.
      *
      * Default value is `true`.
      */
@@ -585,12 +626,12 @@ export class Facet extends Component {
     responsiveBreakpoint: ComponentOptions.buildNumberOption({ defaultValue: 800, deprecated: 'This option is exposed for legacy reasons, and the recommendation is to not use this option.' }),
 
     /**
-     * If {@link Facet.options.enableResponsiveMode} is `true` for all facets and
+     * If the [`enableResponsiveMode`]{@link Facet.options.enableResponsiveMode} option is `true` for all facets and
      * {@link FacetSlider.options.enableResponsiveMode} is also `true` for all sliders, specifies the label of the
      * dropdown button that allows to display the facets when in responsive mode.
      *
-     * If more than one Facet or {@link FacetSlider} in the search interface specifies a value for this option, then the
-     * framework uses the first occurrence of the option.
+     * If more than one `Facet` or {@link FacetSlider} component in the search interface specifies a value for this
+     * option, the framework uses the first occurrence of the option.
      *
      * Default value is `Filters`.
      */
@@ -606,12 +647,12 @@ export class Facet extends Component {
   public operatorAttributeId: string;
 
   /**
-   * Renders and handles the Facet **Search** part of the component.
+   * Renders and handles the facet **Search** part of the component.
    */
   public facetSearch: FacetSearch;
 
   /**
-   * Renders and handles the Facet **Settings** part of the component
+   * Renders and handles the facet **Settings** part of the component
    */
   public facetSettings: FacetSettings;
   public facetSort: FacetSort;
@@ -642,13 +683,13 @@ export class Facet extends Component {
   private resize: (...args: any[]) => void;
 
   /**
-   * Creates a new Facet component. Binds multiple query events as well.
+   * Creates a new `Facet` component. Binds multiple query events as well.
    * @param element The HTMLElement on which to instantiate the component.
-   * @param options The options for the Facet component.
+   * @param options The options for the `Facet` component.
    * @param bindings The bindings that the component requires to function normally. If not set, these will be
    * automatically resolved (with a slower execution time).
-   * @param facetClassId The ID to use for this facet (as Facet inherited from by other component
-   * (e.g.: {@link FacetRange}). Default value is `Facet`.
+   * @param facetClassId The ID to use for this facet (as `Facet` inherited from by other component
+   * (e.g., [`FacetRange`]{@link FacetRange}). Default value is `Facet`.
    */
   constructor(public element: HTMLElement, public options: IFacetOptions, bindings?: IComponentBindings, facetClassId: string = Facet.ID) {
     super(element, facetClassId, bindings);
@@ -710,7 +751,7 @@ export class Facet extends Component {
    *
    * Does not trigger a query automatically.
    *
-   * @param value Can be a {@link FacetValue} or a string (e.g., `selectValue('foobar')` or
+   * @param value Can be a [`FacetValue`]{@link FacetValue} or a string (e.g., `selectValue('foobar')` or
    * `selectValue(new FacetValue('foobar'))`).
    */
   public selectValue(value: FacetValue): void;
@@ -727,7 +768,7 @@ export class Facet extends Component {
    *
    * Does not trigger a query automatically.
    *
-   * @param values Can be an array of {@link FacetValue} or a string array.
+   * @param values Can be an array of [`FacetValue`]{@link FacetValue} or an array of strings.
    */
   public selectMultipleValues(values: FacetValue[]): void;
   public selectMultipleValues(values: string[]): void;
@@ -745,7 +786,7 @@ export class Facet extends Component {
    *
    * Does not trigger a query automatically.
    *
-   * @param value Can be a {@link FacetValue} or a string (e.g., `deselectValue('foobar')` or
+   * @param value Can be a [`FacetValue`]{@link FacetValue} or a string (e.g., `deselectValue('foobar')` or
    * `deselectValue(new FacetValue('foobar'))`).
    */
   public deselectValue(value: FacetValue): void;
@@ -762,7 +803,7 @@ export class Facet extends Component {
    *
    * Does not trigger a query automatically.
    *
-   * @param values Can be an array of {@link FacetValue} or a string array.
+   * @param values Can be an array of [`FacetValue`]{@link FacetValue} or an array of strings.
    */
   public deselectMultipleValues(values: FacetValue[]): void
   public deselectMultipleValues(values: string[]): void
@@ -780,7 +821,7 @@ export class Facet extends Component {
    *
    * Does not trigger a query automatically.
    *
-   * @param value Can be a {@link FacetValue} or a string (e.g., `excludeValue('foobar')` or
+   * @param value Can be a [`FacetValue`]{@link FacetValue} or a string (e.g., `excludeValue('foobar')` or
    * `excludeValue(new FacetValue('foobar'))`).
    */
   public excludeValue(value: FacetValue): void;
@@ -797,7 +838,7 @@ export class Facet extends Component {
    *
    * Does not trigger a query automatically.
    *
-   * @param values Can be an array of {@link FacetValue} or a string array.
+   * @param values Can be an array of [`FacetValue`]{@link FacetValue} or an array of strings.
    */
   public excludeMultipleValues(values: FacetValue[]): void;
   public excludeMultipleValues(values: string[]): void;
@@ -815,7 +856,7 @@ export class Facet extends Component {
    *
    * Does not trigger a query automatically.
    *
-   * @param value Can be a {@link FacetValue} or a string.
+   * @param value Can be a [`FacetValue`]{@link FacetValue} or a string.
    */
   public unexcludeValue(value: FacetValue): void;
   public unexcludeValue(value: string): void;
@@ -831,7 +872,7 @@ export class Facet extends Component {
    *
    * Does not trigger a query automatically.
    *
-   * @param values Can be an array of {@link FacetValue} or a string array.
+   * @param values Can be an array of [`FacetValue`]{@link FacetValue} or an array of strings.
    */
   public unexcludeMultipleValues(values: FacetValue[]): void;
   public unexcludeMultipleValues(values: string[]): void;
@@ -849,7 +890,7 @@ export class Facet extends Component {
    * value if it is already selected).
    *
    * Does not trigger a query automatically.
-   * @param value Can be a {@link FacetValue} or a string.
+   * @param value Can be a [`FacetValue`]{@link FacetValue} or a string.
    */
   public toggleSelectValue(value: FacetValue): void;
   public toggleSelectValue(value: string): void;
@@ -866,7 +907,7 @@ export class Facet extends Component {
    *
    * Does not trigger a query automatically.
    *
-   * @param value Can be a {@link FacetValue} or a string.
+   * @param value Can be a [`FacetValue`]{@link FacetValue} or a string.
    */
   public toggleExcludeValue(value: FacetValue): void;
   public toggleExcludeValue(value: string): void;
@@ -878,7 +919,7 @@ export class Facet extends Component {
   }
 
   /**
-   * Returns the currently displayed values as a string array.
+   * Returns the currently displayed values as an array of strings.
    *
    * @returns {any[]} The currently displayed values.
    */
@@ -887,7 +928,7 @@ export class Facet extends Component {
   }
 
   /**
-   * Returns the currently displayed values as an array of {@link FacetValue}.
+   * Returns the currently displayed values as an array of [`FacetValue`]{@link FacetValue}.
    *
    * @returns {T[]} The currently displayed values.
    */
@@ -900,7 +941,7 @@ export class Facet extends Component {
   }
 
   /**
-   * Returns the currently selected values as an array of string.
+   * Returns the currently selected values as an array of strings.
    * @returns {string[]} The currently selected values.
    */
   public getSelectedValues(): string[] {
@@ -909,7 +950,7 @@ export class Facet extends Component {
   }
 
   /**
-   * Returns the currently excluded values as an array of string.
+   * Returns the currently excluded values as an array of strings.
    * @returns {string[]} The currently excluded values.
    */
   public getExcludedValues(): string[] {
@@ -918,7 +959,7 @@ export class Facet extends Component {
   }
 
   /**
-   * Resets the Facet by un-selecting all values, une-xcluding all values, and redrawing the Facet.
+   * Resets the facet by un-selecting all values, un-excluding all values, and redrawing the facet.
    */
   public reset(): void {
     this.ensureDom();
@@ -929,9 +970,10 @@ export class Facet extends Component {
   }
 
   /**
-   * Switches the Facet to `AND` mode.
+   * Switches the facet to `AND` mode.
    *
-   * See {@link Facet.options.useAnd} and {@link Facet.options.enableTogglingOperator}.
+   * See the [`useAnd`]{@link Facet.options.useAnd}, and
+   * [`enableTogglingOperator`]{@link Facet.options.enableTogglingOperator} options.
    */
   public switchToAnd(): void {
     this.ensureDom();
@@ -940,9 +982,10 @@ export class Facet extends Component {
   }
 
   /**
-   * Switches the Facet to `OR` mode.
+   * Switches the facet to `OR` mode.
    *
-   * See {@link Facet.options.useAnd} and {@link Facet.options.enableTogglingOperator}.
+   * See the [`useAnd`]{@link Facet.options.useAnd}, and
+   * [`enableTogglingOperator`]{@link Facet.options.enableTogglingOperator} options.
    */
   public switchToOr(): void {
     this.ensureDom();
@@ -951,21 +994,21 @@ export class Facet extends Component {
   }
 
   /**
-   * Returns the endpoint for the Facet.
-   * @returns {ISearchEndpoint} The endpoint for the Facet.
+   * Returns the endpoint for the facet.
+   * @returns {ISearchEndpoint} The endpoint for the Ffcet.
    */
   public getEndpoint(): ISearchEndpoint {
     return this.queryController.getEndpoint();
   }
 
   /**
-   * Changes the sort parameter for the Facet.
+   * Changes the sort parameter for the facet.
    *
    * See {@link Facet.options.availableSorts} for the list of possible values.
    *
    * Also triggers a new query.
    *
-   * @param criteria The new sort parameter for the Facet.
+   * @param criteria The new sort parameter for the facet.
    */
   public updateSort(criteria: string): void {
     this.ensureDom();
@@ -984,7 +1027,7 @@ export class Facet extends Component {
   }
 
   /**
-   * Shows a waiting animation in the Facet header (a spinner).
+   * Shows a waiting animation in the facet header (a spinner).
    */
   public showWaitingAnimation() {
     this.ensureDom();
@@ -1002,7 +1045,7 @@ export class Facet extends Component {
   }
 
   /**
-   * Hides the waiting animation in the Facet header.
+   * Hides the waiting animation in the facet header.
    */
   public hideWaitingAnimation(): void {
     this.ensureDom();
@@ -1048,9 +1091,9 @@ export class Facet extends Component {
   }
 
   /**
-   * Returns the configured caption for the given {@link FacetValue}.
+   * Returns the configured caption for the given [`FacetValue`]{@link FacetValue}.
    *
-   * @param facetValue The FacetValue whose caption the method should return.
+   * @param facetValue The `FacetValue` whose caption the method should return.
    */
   public getValueCaption(facetValue: IIndexFieldValue): string;
   public getValueCaption(facetValue: FacetValue): string;
@@ -1073,7 +1116,10 @@ export class Facet extends Component {
   }
 
   /**
-   * Shows the next page of results in the Facet.
+   * Shows the next page of results in the facet.
+   *
+   * See the [`enableMoreLess`]{@link Facet.options.enableMoreLess}, and [`pageSize`]{@link Facet.options.pageSize}
+   * options.
    *
    * Triggers a query if needed, or displays the already available values.
    */
@@ -1090,7 +1136,8 @@ export class Facet extends Component {
   /**
    * Shows less elements in the Facet (up to the original number of values).
    *
-   * See {@link Facet.options.numberOfValues}.
+   * See the [`enableMoreLess`]{@link Facet.options.enableMoreLess}, and
+   * [`numberOfValues`]{@link Facet.options.numberOfValues} options.
    */
   public showLess() {
     $$(this.lessElement).removeClass('coveo-active');
@@ -1102,7 +1149,7 @@ export class Facet extends Component {
   }
 
   /**
-   * Collapses the Facet.
+   * Collapses the facet.
    */
   public collapse() {
     this.ensureDom();

--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -40,52 +40,18 @@ export interface IFacetSliderOptions extends ISliderOptions {
 }
 
 /**
- * The FacetSlider component creates a facet containing a slider widget that allows the end user to filter results based
- * on a range of numerical values, rather than a "classic" multi-select {@link Facet} with a label and a count for each
- * value.
+ * The `FacetSlider` component creates a facet which contains a slider widget that allows the end user to filter results
+ * based on a range of numerical values (e.g., a date range, a price range, etc.).
  *
- * Note that this component does not inherit from the Facet component, and thus does not offer the same configuration
- * options. Also, some of the FacetSlider options cannot be set as a HTML attributes on the component and must rather be
- * configured in the {@link init} call of the search interface.
- *
- * **Examples:**
- *
- * Specifying the FacetSlider configuration using a JSON inside the init call. Note that the JSON follows the
- * FacetSlider options:
- *
- * ```javascript
- * // You can call the init script using "pure" JavaScript:
- * Coveo.init(document.querySelector('#search'), {
- *    FacetSlider: {
- *      field: "@size",
- *      start: 1000,
- *      end: 5000,
- *      rangeSlider: true,
- *      graph: {
- *        steps: 10
- *      }
- *    }
- * })
- *
- * // Or you can call the init script using the jQuery extension:
- * $('#search').coveo('init', {
- *    FacetSlider: {
- *      field: "@size",
- *      start: 1000,
- *      end: 5000,
- *      rangeSlider: true,
- *      graph: {
- *        steps: 10
- *      }
- *    }
- * })
- * ```
- *
- * Specifying the same FacetSlider configuration by setting the corresponding HTML attributes directly in the markup:
- *
- * ```html
- * <div class='CoveoFacetSlider' data-field='@size' data-start='1000' data-end='5000' data-range-slider='true' data-graph-steps='10'></div>
- * ```
+ * **Note:**
+ * > This component does **not** inherit from the [`Facet`]{@link Facet} component. Consequently, it does not offer the
+ * > same configuration options. Moreover, some of the `FacetSlider` options (see
+ * > [`getSteps`]{@link FacetSlider.options.getSteps} and [`valueCaption`]{@link FacetSlider.options.valueCaption})
+ * > cannot be configured as `data-` attributes in the markup. If you wish to configure those options, you must either
+ * > do so in the [`init`]{@link init} call of your search interface (see
+ * > [Components - Passing Component Options in the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsintheinitCall)),
+ * > or before the `init` call, using the `options` top-level function (see
+ * > [Components - Passing Component Options Before the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsBeforetheinitCall)).
  */
 export class FacetSlider extends Component {
 
@@ -96,65 +62,73 @@ export class FacetSlider extends Component {
   static options: IFacetSliderOptions = {
 
     /**
-     * Specifies the title to display on top of the FacetSlider component.
+     * Specifies the title to display on top of the `FacetSlider`.
      *
-     * Default value is the localized string for `"NoTitle"`.
+     * Default value is the localized string for `NoTitle`.
      */
     title: ComponentOptions.buildLocalizedStringOption({ defaultValue: l('NoTitle') }),
 
     /**
-     * Specifies whether the field for which you are requesting a range is a date field. This allows the FacetSlider to
-     * correctly build the outgoing [GroupByRequest]{@link IGroupByRequest} and render itself properly.
+     * Specifies whether the [`field`]{@link FacetSlider.options.field} for which you are requesting a range is a date
+     * field. This allows the `FacetSlider` to correctly build the outgoing [GroupByRequest]{@link IGroupByRequest} and
+     * render itself properly.
      *
      * Default value is `false`.
      */
     dateField: ComponentOptions.buildBooleanOption({ defaultValue: false }),
 
     /**
-     * Specifies the index field whose values the FacetSlider should use.
+     * Specifies the index field whose values the `FacetSlider` should use.
      *
-     * This requires the given field to be configured correctly in the index as a Facet field (see
+     * The field must be configured correctly as a Facet field in the index (see
      * [Adding Fields to a Source](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=137)).
      *
-     * Specifying a value for this option is required for the FacetSlider component to work.
+     * Specifying a value for this option is required for the `FacetSlider` component to work.
      */
     field: ComponentOptions.buildFieldOption({ groupByField: true, required: true }),
 
     /**
-     * Specifies a unique identifier for the FacetSlider. Among other things, this identifier serves the purpose of
+     * Specifies a unique identifier for the `FacetSlider`. Among other things, this identifier serves the purpose of
      * saving the facet state in the URL hash.
      *
-     * If you have two facets with the same field on the same page, you should specify a unique id value for at least
-     * one of those two facets. This id must be unique in the page.
+     * If you have two facets with the same field in the same page, you should specify a unique `id` value for at least
+     * one of those two facets. This `id` must be unique in the page.
      *
-     * Default value is the {@link FacetSlider.options.field} option value.
+     * Default value is the [`field`]{@link FacetSlider.options.field} option value.
      */
     id: ComponentOptions.buildStringOption({
       postProcessing: (value, options: IFacetSliderOptions) => value || <string>options.field
     }),
 
     /**
-     * Specifies the format to use to display values if they are dates.
+     * Specifies the format to use when displaying date values.
      *
-     * Default value is `"MMM dd, yyyy"`.
+     * See also the [`dateField`]{@link FacetSlider.options.dateField} option.
+     *
+     * Default value is `MMM dd, yyyy`.
      */
     dateFormat: ComponentOptions.buildStringOption(),
 
     /**
-     * Specifies the query to filter automatic minimum and maximum range of the slider.
+     * Specifies a query to filter automatic minimum and maximum values for the slider range.
      *
-     * This is especially useful for date ranges where the index may contain values which are not set, and thus the
-     * automatic range returns values from the year 1400 (earliest date from the boost C++ library).
+     * This is especially useful in the case of date ranges since the index may contain values which are not set, and
+     * thus return values from the year 1400 (the earliest date from the boost C++ library).
      *
-     * This option can be useful to do something like `queryOverride : @date>2000/01/01` or some arbitrary date which
-     * will filter out unwanted values.
+     * **Example:**
+     *
+     * The query override in the following markup filters out any `@date` value anterior to January 1st 2000.
+     * ```html
+     * <div class="CoveoFacetSlider" data-field="@date" data-date-field="true" data-query-override="@date>2000/01/01"></div>
+     * ```
      */
     queryOverride: ComponentOptions.buildStringOption(),
 
     /**
      * Specifies the starting boundary of the slider.
      *
-     * Date values are rounded to the nearest year when {@link FacetSlider.options.dateField} is `true`.
+     * Date values are rounded to the nearest year when you set the [`dateField`]{@link FacetSlider.options.dateField}
+     * option to `true`.
      *
      * Default value is the lowest available field value in the index.
      */
@@ -163,7 +137,8 @@ export class FacetSlider extends Component {
     /**
      * Specifies the ending boundary of the slider.
      *
-     * Date values are rounded to the nearest year when {@link FacetSlider.options.dateField} is `true`.
+     * Date values are rounded to the nearest year when you set the [`dateField`]{@link FacetSlider.options.dateField}
+     * option to `true`.
      *
      * Default value is the highest available field value in the index.
      */
@@ -186,12 +161,12 @@ export class FacetSlider extends Component {
     /**
      * Specifies the number of steps to split the slider into.
      *
-     * For example, if your range is [ 0 , 100 ] and you specify 10 steps, then the end user can move the slider only to
-     * the values [ 0, 10, 20, 30 ... , 100 ].
+     * For example, if your range is [ 0 , 100 ] and you specify `10` steps, then the end user can move the slider only
+     * to the values [ 0, 10, 20, 30 ... , 100 ].
      *
-     * For performance reasons, the maximum value for option is 1
+     * For performance reasons, the maximum value for this option is `100`
      *
-     * Default value is `undefined`, and the slider allows all values. Minimum value is `2`.
+     * Default value is `undefined`, and the slider allows up to 100 steps. Minimum value is `2`.
      */
     steps: ComponentOptions.buildNumberOption({ min: 2 }),
 
@@ -203,12 +178,12 @@ export class FacetSlider extends Component {
     rangeSlider: ComponentOptions.buildBooleanOption(),
 
     /**
-     * Specifies the caption options to use to display the field values.
+     * Specifies the caption options to use when displaying the field values.
      *
      * Available options are:
      * - enable (`data-display-as-value-enable`): boolean; specifies whether to display the caption as a value. Default
      * value is `true`.
-     * - unitSign (`data-display-as-value-unit-sign`): string; specifies the unit sign for this value (e.g., `"$"`).
+     * - unitSign (`data-display-as-value-unit-sign`): string; specifies the unit sign for this value (e.g., `$`).
      * Default value is `undefined`.
      * - separator (`data-display-as-value-separator`): string; specifies the character(s) to use as a separator in the
      * caption. Default value is `"-"`.
@@ -222,7 +197,7 @@ export class FacetSlider extends Component {
     }),
 
     /**
-     * Specifies the percentage caption options to use to display the field values.
+     * Specifies the percentage caption options to use when displaying the field values.
      *
      * Available options are:
      * - enable (`data-display-as-percent-enable`): boolean; specifies whether to display the caption as a percentage.
@@ -260,35 +235,41 @@ export class FacetSlider extends Component {
     }),
 
     /**
-     * Specifies a function to generate the steps for the FacetSlider (see {@link FacetSlider.options.steps}. This
-     * function receives the FacetSlider boundaries (see {@link FacetSlider.options.start} and
-     * {@link FacetSlider.options.end}) and must return an array of numbers (the steps).
+     * Specifies a function to generate the `FacetSlider` steps (see the [`steps`]{@link FacetSlider.options.steps}
+     * option). This function receives the `FacetSlider` boundaries (see the [`start`]{@link FacetSlider.options.start}
+     * and [`end`]{@link FacetSlider.options.end} options), and must return an array of numbers (the steps).
      *
-     * You can only set this option in the {@link init} call of your search interface. You cannot set it directly in the
-     * markup as an HTML attribute.
+     * **Note:**
+     * > You cannot set this option directly in the component markup as an HTML attribute. You must either set it in the
+     * > [`init`]{@link init} call of your search interface (see
+     * > [Components - Passing Component Options in the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsintheinitCall)),
+     * > or before the `init` call, using the `options` top-level function (see
+     * > [Components - Passing Component Options Before the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsBeforetheinitCall)).
      *
      * **Example:**
-     *
      * ```javascript
-     * // You can call the init script using "pure" JavaScript:
-     * Coveo.init(document.querySelector('#search'), {
-     *    FacetSlider: {
-     *      field: "@size",
-     *      getSteps: function(start, end) {
-     *        return [0,2,4,6,8,10];
-     *      }
-     *    }
-     * })
      *
-     * // Or you can call the init script using the jQuery extension:
-     * $('#search').coveo('init', {
+     * var myGetStepsFunction = function(start, end) {
+     *   var result = [];
+     *   for (i = start; i < end; i += 2) {
+     *     result.push(i);
+     *   }
+     *   return result;
+     * }
+     *
+     * // You can set the option in the 'init' call:
+     * Coveo.init(document.querySelector("#search"), {
      *    FacetSlider: {
-     *        field: "@size",
-     *        getSteps: function(start, end) {
-     *            return [0,2,4,6,8,10];
-     *        }
+     *      getSteps: myGetStepsFunction
      *    }
-     * })
+     * });
+     *
+     * // Or before the 'init' call, using the 'options' top-level function:
+     * // Coveo.options(document.querySelector("#search"), {
+     * //   FacetSlider : {
+     * //     valueCaption : myGetStepsFunction
+     * //   }
+     * // });
      * ```
      */
     getSteps: ComponentOptions.buildCustomOption<(start: number, end: number) => number[]>(() => {
@@ -296,34 +277,36 @@ export class FacetSlider extends Component {
     }),
 
     /**
-     * Specifies a function to generate the caption for the FacetSlider. Receives the current slider values
-     * (number[]) and must return the caption (string).
+     * Specifies a function to generate the value caption for the `FacetSlider`. This function receives the current
+     * slider values (number[]), and must return the caption (string).
      *
-     * You can only set this option in the {@link init} call of your search interface. You cannot set it directly in the
-     * markup as an HTML attribute.
+     * **Note:**
+     * > You cannot set this option directly in the component markup as an HTML attribute. You must either set it in the
+     * > [`init`]{@link init} call of your search interface (see
+     * > [Components - Passing Component Options in the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsintheinitCall)),
+     * > or before the `init` call, using the `options` top-level function (see
+     * > [Components - Passing Component Options Before the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsBeforetheinitCall)).
      *
      * **Example:**
-     *
      * ```javascript
-     * // You can call the init script using "pure" JavaScript:
-     * Coveo.init(document.querySelector('#search'), {
-     *    FacetSlider: {
-     *      field: "@size",
-     *      valueCaption: function(values) {
-     *        return values[0] + " hello" + ", " + values[1] + " world";
-     *      }
-     *    }
-     * })
      *
-     * // Or you can call the init script using the jQuery extension:
-     * $('#search').coveo('init', {
-     *    FacetSlider: {
-     *      field: "@size",
-     *      valueCaption: function(values) {
-     *        return values[0] + " hello" + ", " + values[1] + " world";
-     *      }
-     *    }
-     * })
+     * var myValueCaptionFunction = function(values) {
+     *   return "From " + values[0] + " to " + values[1];
+     * }
+     *
+     * // You can set the option in the 'init' call:
+     * Coveo.init(document.querySelector("#search"), {
+     *   FacetSlider: {
+     *     valueCaption: myValueCaptionFunction
+     *   }
+     * });
+     *
+     * // Or before the 'init' call, using the 'options' top-level function:
+     * // Coveo.options(document.querySelector("#search"), {
+     * //   FacetSlider : {
+     * //     valueCaption : myValueCaptionFunction
+     * //   }
+     * // });
      * ```
      */
     valueCaption: ComponentOptions.buildCustomOption<(values: number[]) => string>(() => {
@@ -332,22 +315,25 @@ export class FacetSlider extends Component {
     }),
 
     /**
-     * Specifies whether to enable *responsive mode* for facets. Setting this options to `false` on any {@link Facet} or
-     * {@link FacetSlider} in a search interface disables responsive mode for all other facets in the search interface.
+     * Specifies whether to enable *responsive mode* for facets. Setting this options to `false` on any
+     * [`Facet`]{@link Facet} or [`FacetSlider`]{@link FacetSlider} in a search interface disables responsive mode for
+     * all other facets in the search interface.
      *
      * Responsive mode displays all facets under a single dropdown button whenever the width of the HTML element which
      * the search interface is bound to reaches or falls behind a certain threshold (see
      * {@link SearchInterface.responsiveComponents}).
      *
-     * See also {@link FacetSlider.options.dropdownHeaderLabel}.
+     * See also the `FacetSlider` [`dropdownHeaderLabel`]{@link FacetSlider.options.dropdownHeaderLabel} option.
      *
      * Default value is `true`.
      */
     enableResponsiveMode: ComponentOptions.buildBooleanOption({ defaultValue: true }),
+
     /**
-     * Specifies the label of the button that allows to show the facets when in responsive mode. If it is specified more than once, the
-     * first occurence of the option will be used.
-     * The default value is "Filters".
+     * Specifies the label of the button which the end user can click to display the facets when in responsive mode. If
+     * this option is configured more than once, the button uses the first occurrence of the option as its label.
+     *
+     * Default value is "Filters".
      */
     dropdownHeaderLabel: ComponentOptions.buildLocalizedStringOption()
   };
@@ -377,9 +363,9 @@ export class FacetSlider extends Component {
   private delayedGraphData: ISliderGraphData[];
 
   /**
-   * Creates a new FacetSlider component. Binds multiple query events as well.
+   * Creates a new `FacetSlider` component. Binds multiple query events as well.
    * @param element The HTMLElement on which to instantiate the component.
-   * @param options The options for the FacetSlider component.
+   * @param options The options for the `FacetSlider` component.
    * @param bindings The bindings that the component requires to function normally. If not set, these will be
    * automatically resolved (with a slower execution time).
    * @param slider
@@ -443,7 +429,7 @@ export class FacetSlider extends Component {
   }
 
   /**
-   * Resets the FacetSlider (meaning that you need to set the range value as inactive).
+   * Resets the `FacetSlider` (meaning that you need to set the range value as inactive).
    */
   public reset() {
     if (this.slider) {
@@ -454,7 +440,7 @@ export class FacetSlider extends Component {
   }
 
   /**
-   * Gets the current selection in the FacetSlider.
+   * Gets the current selection in the slider.
    *
    * **Note:**
    * > This method returns an array of number for selected date values. These numbers represent a number of milliseconds
@@ -490,8 +476,8 @@ export class FacetSlider extends Component {
   }
 
   /**
-   * Indicates whether the FacetSlider is active. An active FacetSlider outputs an expression in the query when a search
-   * is performed.
+   * Indicates whether the `FacetSlider` is active. An active `FacetSlider` outputs an expression in the query when a
+   * search is performed.
    * @returns {boolean} `true` if the FacetSlider is active; `false` otherwise.
    */
   public isActive(): boolean {

--- a/src/ui/FieldSuggestions/FieldSuggestions.ts
+++ b/src/ui/FieldSuggestions/FieldSuggestions.ts
@@ -23,11 +23,11 @@ export interface IFieldSuggestionsOptions extends ISuggestionForOmniboxOptions {
 }
 
 /**
- * The FieldSuggestions component provides query suggestions based on a particular facet field. For example, you could
+ * The `FieldSuggestions` component provides query suggestions based on a particular facet field. For example, you could
  * use this component to provide auto-complete suggestions while the end user is typing a document
  * title.
  *
- * The query suggestions that this component provides appear in the {@link Omnibox} component.
+ * The query suggestions provided by this component appear in the {@link Omnibox} component.
  */
 export class FieldSuggestions extends Component {
   static ID = 'FieldSuggestions';
@@ -46,7 +46,7 @@ export class FieldSuggestions extends Component {
     /**
      * Specifies the facet field from which to provide suggestions.
      *
-     * Specifying a value for this option is required for the FieldSuggestions component to work.
+     * Specifying a value for this option is required for the `FieldSuggestions` component to work.
      */
     field: ComponentOptions.buildFieldOption({ required: true }),
 
@@ -54,15 +54,15 @@ export class FieldSuggestions extends Component {
      * Specifies a query override to apply when retrieving suggestions. You can use any valid query expression (see
      * [Coveo Query Syntax Reference](http://www.coveo.com/go?dest=adminhelp70&lcid=9&context=10005)).
      *
-     * Default value is `''`, which means that the component applies no query override by default.
+     * Default value is the empty string, and the component applies no query override.
      */
     queryOverride: ComponentOptions.buildStringOption({ defaultValue: '' }),
 
     /**
      * Specifies the z-index position at which the suggestions render themselves in the {@link Omnibox}.
      *
-     * When there are multiple suggestion providers (e.g., {@link Facet} or {@link AnalyticsSuggestions}), components
-     * with a higher omniboxZIndex values render themselves first.
+     * When there are multiple suggestion providers, components with higher `omniboxZIndex` values render themselves
+     * first.
      *
      * Default value is `51`. Minimum value is `0`.
      */
@@ -73,52 +73,72 @@ export class FieldSuggestions extends Component {
      * available when using the default Lightning Friendly Theme (see
      * [Lightning Friendly Theme](https://developers.coveo.com/x/Y4EAAg)).
      *
-     * Default value is the localized string for `"SuggestedResults"`.
+     * Default value is the localized string for `SuggestedResults`.
      */
     headerTitle: ComponentOptions.buildLocalizedStringOption({ defaultValue: l('SuggestedResults') }),
 
     /**
-     * Specifies the number of suggestions to render in the {@link Omnibox}.
+     * Specifies the number of suggestions to render in the [`Omnibox`]{@link Omnibox}.
      *
      * Default value is `5`. Minimum value is `1`.
      */
     numberOfSuggestions: ComponentOptions.buildNumberOption({ defaultValue: 5, min: 1 }),
 
     /**
-     * Specifies the event handler function to execute when the end user selects a suggested value un the
-     * {@link Omnibox}. By default, the query box text is replaced by what the end user selected and a new query is
+     * Specifies the event handler function to execute when the end user selects a suggested value in the
+     * [`Omnibox`]{@link Omnibox}. By default, the query box text is replaced by what the end user selected and a new query is
      * executed. You can, however, replace this default behavior by providing a callback function to execute when the
      * value is selected.
      *
-     * You can only set this option in the `init` call of your search interface. You cannot set it directly in the
-     * markup as an HTML attribute.
+     * **Note:**
+     * > You cannot set this option directly in the component markup as an HTML attribute. You must either set it in the
+     * > [`init`]{@link init} call of your search interface (see
+     * > [Components - Passing Component Options in the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsintheinitCall)),
+     * > or before the `init` call, using the `options` top-level function (see
+     * > [Components - Passing Component Options Before the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsBeforetheinitCall)).
      *
      * **Example:**
      *
      * ```javascript
-     * // You can call the init script using "pure" JavaScript:
-     * Coveo.init(document.querySelector('#search'), {
-     *    FieldSuggestions : {
-     *      omniboxSuggestionOptions : {
-     *        onSelect : function(valueSelected, populateOmniBoxEventArgs){
-     *          // Do something special when a value is selected.
-     *          // You receive the selected value as the first argument, and the Omnibox object as the second argument.
-     *        }
-     *      }
-     *    }
-     * })
      *
-     * // Or you can call the init script using the jQuery extension:
-     * $('#mySearch').coveo('init', {
+     * var myOnSelectFunction = function(selectedValue, populateOmniboxEventArgs) {
+     *
+     *   // Close the suggestion list when the user clicks a suggestion.
+     *   populateOmniboxEventArgs.closeOmnibox();
+     *
+     *   // Search for matching title results in the default endpoint.
+     *   Coveo.SearchEndpoint.endpoints["default"].search({
+     *     q: "@title=='" + selectedValue + "'"
+     *   }).done(function(results) {
+     *
+     *     // If more than one result is found, select a result that matches the selected title.
+     *     var foundResult = Coveo._.find(results.results, function(result) {
+     *       return selectedValue == result.raw.title;
+     *     });
+     *
+     *     // Open the found result in the current window, or log an error.
+     *     if (foundResult) {
+     *       window.location = foundResult.clickUri;
+     *     }
+     *     else {
+     *       new Coveo.Logger.warn("Selected suggested result '" + selectedValue + "' not found.");
+     *     }
+     *   });
+     * };
+     *
+     * // You can set the option in the 'init' call:
+     * Coveo.init(document.querySelector("#search"), {
      *    FieldSuggestions : {
-     *      omniboxSuggestionOptions : {
-     *        onSelect : function(valueSelected, populateOmniBoxEventArgs){
-     *          // Do something special when a value is selected.
-     *          // You receive the selected value as the first argument, and the Omnibox object as the second argument.
-     *        }
-     *      }
+     *      onSelect : myOnSelectFunction
      *    }
-     * })
+     * });
+     *
+     * // Or before the 'init' call, using the 'options' top-level function:
+     * // Coveo.options(document.querySelector("#search"), {
+     * //   FieldSuggestions : {
+     * //     onSelect : myOnSelectFunction
+     * //   }
+     * // });
      * ```
      */
     onSelect: ComponentOptions.buildCustomOption<ISuggestionForOmniboxOptionsOnSelect>(() => {
@@ -130,9 +150,9 @@ export class FieldSuggestions extends Component {
   private currentlyDisplayedSuggestions: { [suggestion: string]: { element: HTMLElement, pos: number } };
 
   /**
-   * Creates a new FieldSuggestions component.
+   * Creates a new `FieldSuggestions` component.
    * @param element The HTMLElement on which to instantiate the component.
-   * @param options The options for the FieldSuggestions component.
+   * @param options The options for the `FieldSuggestions` component.
    * @param bindings The bindings that the component requires to function normally. If not set, these will be
    * automatically resolved (with a slower execution time).
    */

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -22,8 +22,8 @@ import { exportGlobally } from '../../GlobalExports';
 import 'styling/_ResultLink';
 
 /**
- * The ResultLink component automatically transform a search result title into a clickable link pointing to the original
- * document.
+ * The `ResultLink` component automatically transform a search result title into a clickable link pointing to the
+ * original document.
  *
  * This component is a result template component (see [Result Templates](https://developers.coveo.com/x/aIGfAQ)).
  */
@@ -43,30 +43,21 @@ export class ResultLink extends Component {
   static options: IResultLinkOptions = {
 
     /**
-     * Specifies the field which the ResultLink should use to output its `href` attribute.
-     *
-     * By default, the component uses the `clickUri` field available on the document, but you can override this field
-     * by specifying a value for this option.
+     * Specifies the field to use to output the component `href` attribute value.
      *
      * **Tip:**
-     *
-     * > When you do not include a `field` option in your result template, you can include an `href` attribute on the
-     * > ResultLink element. When present, the `href` attribute value overrides the `clickUri` field, which is otherwise
-     * > the default field.
-     *
-     * > Specifying an `href` attribute is useful when you want to build the ResultLink using a custom script or by
-     * > concatenating the content of two or more variables.
+     * > Instead of specifying a value for the `field` option, you can directly add an `href` attribute to the
+     * > `ResultLink` HTML element. Then, you can use a custom script to generate the `href` value.
      *
      * **Examples:**
-     *
-     * - With the following markup, the ResultLink will output its `href` attribute using the `uri` field instead of the
-     * default `clickUri` field:
+     * - With the following markup, the `ResultLink` outputs its `href` value using the `@uri` field (rather than the
+     * default field):
      *
      * ```html
      * <a class="CoveoResultLink" field="@uri"></a>
      * ```
      *
-     * - In the following result template, the custom `getMyKBUri()` function will provide the `href`:
+     * - In the following result template, the custom `getMyKBUri()` function provides the `href` value:
      *
      * ```html
      * <script id="KnowledgeArticle" type="text/underscore" class="result-template">
@@ -76,131 +67,140 @@ export class ResultLink extends Component {
      * </script>
      * ```
      *
-     * See also [hrefTemplate]{@link ResultLink.options.hrefTemplate}, which can override this option.
+     * See also [`hrefTemplate`]{@link ResultLink.options.hrefTemplate}, which can override this option.
+     *
+     * By default, the component uses the document `@clickUri` field to output the value of its href attribute.
      */
     field: ComponentOptions.buildFieldOption(),
 
     /**
-     * Specifies whether the ResultLink should try to open in Microsoft Outlook.
+     * Specifies whether the component should try to open its link in Microsoft Outlook.
      *
-     * Setting this option to `true` is normally useful for ResultLink instances which are related to Microsoft Exchange
-     * emails.
+     * Setting this option to `true` is normally useful for `ResultLink` instances related to Microsoft Exchange emails.
      *
-     * If this option is `true`, clicking the ResultLink will call the {@link ResultLink.openLinkInOutlook} method
-     * instead of the {@link ResultLink.openLink} method.
+     * If this option is `true`, clicking the `ResultLink` calls the
+     * [`openLinkInOutlook`]{@link ResultLink.openLinkInOutlook} method instead of the
+     * [`openLink`]{@link ResultLink.openLink} method.
      *
      * Default value is `false`.
      */
     openInOutlook: ComponentOptions.buildBooleanOption({ defaultValue: false }),
 
     /**
-     * Specifies whether the ResultLink should open in the {@link Quickview} component rather than loading through the
-     * original URL.
+     * Specifies whether the component should open its link in the [`Quickview`]{@link Quickview} component rather than
+     * loading through the original URL.
      *
      * Default value is `false`.
      */
     openQuickview: ComponentOptions.buildBooleanOption({ defaultValue: false }),
 
     /**
-     * Specifies whether the ResultLink should open in a new window instead of opening in the current context.
+     * Specifies whether the component should open its link in a new window instead of opening it in the current
+     * context.
      *
-     * If this option is `true`, clicking the ResultLink will call the {@link ResultLink.openLinkInNewWindow} method
-     * instead of the {@link ResultLink.openLink} method.
+     * If this option is `true`, clicking the `ResultLink` calls the
+     * [`openLinkInNewWindow`]{@link ResultLink.openLinkInNewWindow} method instead of the
+     * [ `openLink`]{@link ResultLink.openLink} method.
      *
      * **Note:**
-     * > If a search page contains a {@link ResultsPreferences} component whose
-     * > [enableOpenInNewWindow]{@link ResultsPreferences.options.enableOpenInNewWindow} option is `true`, and the end
-     * > user checks the <b>Always open results in new window</b> box, then ResultLink components will always open in
-     * > a new window when the user clicks them, no matter what the value of their alwaysOpenInNewWindow option is.
+     * > If a search page contains a [`ResultPreferences`]{@link ResultsPreferences} component whose
+     * > [`enableOpenInNewWindow`]{@link ResultsPreferences.options.enableOpenInNewWindow} option is `true`, and the end
+     * > user checks the <b>Always open results in new window</b> box, `ResultLink` components in this page will always
+     * > open their links in a new window when the end user clicks them, no matter what the value of their
+     * > `alwaysOpenInNewWindow` option is.
      *
      * Default value is `false`.
      */
     alwaysOpenInNewWindow: ComponentOptions.buildBooleanOption({ defaultValue: false }),
 
     /**
-     * Specifies a template literal from which to generate the ResultLink `href` attribute (see
+     * Specifies a template literal from which to generate the `ResultLink` `href` attribute value (see
      * [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).
      *
-     * This option overrides the value of the [field]{@link ResultLink.options.field} option.
+     * This option overrides the [`field`]{@link ResultLink.options.field} option value.
      *
      * The template literal can reference any number of fields from the parent result. It can also reference global
      * scope properties.
      *
-     * Default value is `undefined`.
-     *
      * **Examples:**
      *
-     * - The following markup generates a ResultLink `href` such as `http://uri.com?id=documentTitle`:
+     * - The following markup generates an `href` value such as `http://uri.com?id=documentTitle`:
      *
      * ```html
      * <a class='CoveoResultLink' data-href-template='${clickUri}?id=${title}'></a>
      * ```
      *
-     * - The following markup generates a ResultLink `href` such as `localhost/fooBar`:
+     * - The following markup generates an `href` value such as `localhost/fooBar`:
      *
      * ```html
      * <a class='CoveoResultLink' data-href-template='${window.location.hostname}/{Foo.Bar}'></a>
      * ```
+     *
+     * Default value is `undefined`.
      */
     hrefTemplate: ComponentOptions.buildStringOption(),
 
     /**
-     * Specifies a template literal from which to generate the ResultLink display title (see
+     * Specifies a template literal from which to generate the `ResultLink` display title (see
      * [Template literals](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Template_literals)).
      *
-     * This option overrides the default ResultLink display title behavior.
+     * This option overrides the default `ResultLink` display title behavior.
      *
      * The template literal can reference any number of fields from the parent result. However, if the template literal
-     * references a key whose value is undefined in the parent result fields, then the ResultLink title displays the
+     * references a key whose value is undefined in the parent result fields, the `ResultLink` title displays the
      * name of this key instead.
      *
-     * This option is ignored if the ResultLink innerHTML contains any value.
-     *
-     * Default value is `undefined`.
+     * This option is ignored if the `ResultLink` innerHTML contains any value.
      *
      * **Examples:**
      *
-     * - The following markup generates a ResultLink display title such as `Case number: 123456` if both the
+     * - The following markup generates a `ResultLink` display title such as `Case number: 123456` if both the
      * `raw.objecttype` and `raw.objectnumber` keys are defined in the parent result fields:
      *
      * ```html
      * <a class="CoveoResultLink" data-title-template="${raw.objecttype} number: ${raw.objectnumber}"></a>
      * ```
      *
-     * - The following markup generates `${myField}` as a ResultLink display title if the `myField` key is undefined
+     * - The following markup generates `${myField}` as a `ResultLink` display title if the `myField` key is undefined
      * in the parent result fields:
      *
      * ```html
      * <a class="CoveoResultLink" data-title-template="${myField}"></a>
      * ```
      *
-     * - The following markup generates `Foobar` as a ResultLink display title, because the ResultLink innterHTML is not
-     * empty:
+     * - The following markup generates `Foobar` as a `ResultLink` display title, because the `ResultLink` innterHTML is
+     * not empty:
      *
      * ```html
      * <a class="CoveoResultLink" data-title-template="${will} ${be} ${ignored}">Foobar</a>
      * ```
+     *
+     * Default value is `undefined`.
      */
     titleTemplate: ComponentOptions.buildStringOption(),
 
     /**
-     * Specifies an event handler function to execute when the user clicks the ResultLink component.
+     * Specifies an event handler function to execute when the user clicks the `ResultLink` component.
      *
-     * The handler function takes a JavaScript [Event](https://developer.mozilla.org/en/docs/Web/API/Event) object and
-     * an {@link IQueryResult} as its parameters.
+     * The handler function takes a JavaScript [`Event`](https://developer.mozilla.org/en/docs/Web/API/Event) object and
+     * an [`IQueryResult`]{@link IQueryResult} as its parameters.
      *
      * Overriding the default behavior of the `onClick` event can allow you to execute specific code instead.
      *
-     * You can only set this option in the {@link init} call of your search interface. You cannot set it directly in the
-     * markup as an HTML attribute.
+     * **Note:**
+     * > You cannot set this option directly in the component markup as an HTML attribute. You must either set it in the
+     * > [`init`]{@link init} call of your search interface (see
+     * > [Components - Passing Component Options in the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsintheinitCall)),
+     * > or before the `init` call, using the `options` top-level function (see
+     * > [Components - Passing Component Options Before the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsBeforetheinitCall)).
      *
-     * **Examples:**
-     *
-     * - In the following code excerpt, the ResultLink opens the original document in a custom way instead of using the
-     * normal browser behavior:
-     *
+     * **Example:**
      * ```javascript
-     * Coveo.init(document.querySelector('#search'), {
+     *
+     *
+     *
+     * // You can set the option in the 'init' call:
+     * Coveo.init(document.querySelector("#search"), {
      *   ResultLink : {
      *     onClick : function(e, result) {
      *       e.preventDefault();
@@ -209,20 +209,17 @@ export class ResultLink extends Component {
      *     }
      *   }
      * });
-     * ```
      *
-     * - You can achieve the same result using the jQuery extension:
-     *
-     * ```javascript
-     * $("#search").coveo('init', {
-     *   ResultLink : {
-     *     onClick : function(e, result) {
-     *       e.preventDefault();
-     *       // Custom code to execute with the URI and title of the document.
-     *       openUriInASpecialTab(result.clickUri, result.title);
-     *     }
-     *   }
-     * });
+     * // Or before the 'init' call, using the 'options' top-level function:
+     * // Coveo.options(document.querySelector('#search'), {
+     * //   ResultLink : {
+     * //     onClick : function(e, result) {
+     * //       e.preventDefault();
+     * //       // Custom code to execute with the URI and title of the document.
+     * //       openUriInASpecialTab(result.clickUri, result.title);
+     * //     }
+     * //   }
+     * // });
      * ```
      */
     onClick: ComponentOptions.buildCustomOption<(e: Event, result: IQueryResult) => any>(() => {
@@ -233,9 +230,9 @@ export class ResultLink extends Component {
   private toExecuteOnOpen: (e?: Event) => void;
 
   /**
-   * Creates a new ResultLink component.
+   * Creates a new `ResultLink` component.
    * @param element The HTMLElement on which to instantiate the component.
-   * @param options The options for the ResultLink component.
+   * @param options The options for the `ResultLink` component.
    * @param bindings The bindings that the component requires to function normally. If not set, these will be
    * automatically resolved (with a slower execution time).
    * @param result The result to associate the component with.
@@ -280,7 +277,7 @@ export class ResultLink extends Component {
 
   /**
    * Opens the result in the same window, no matter how the actual component is configured for the end user.
-   * @param logAnalytics  If true, the method will take care of logging an analytic event.
+   * @param logAnalytics Specifies whether the method should log an analytics event.
    */
   public openLink(logAnalytics = true) {
     if (logAnalytics) {
@@ -291,7 +288,7 @@ export class ResultLink extends Component {
 
   /**
    * Opens the result in a new window, no matter how the actual component is configured for the end user.
-   * @param logAnalytics If true, the method will take care of logging an analytic event.
+   * @param logAnalytics Specifies whether the method should log an analytics event.
    */
   public openLinkInNewWindow(logAnalytics = true) {
     if (logAnalytics) {
@@ -301,12 +298,12 @@ export class ResultLink extends Component {
   }
 
   /**
-   * Try to open the result in Microsoft Outlook if the result has an `outlookformacuri` or `outlookuri` field.
+   * Tries to open the result in Microsoft Outlook if the result has an `outlookformacuri` or `outlookuri` field.
    *
-   * Normally, this means a result link for an email.
+   * Normally, this implies the result should be a link to an email.
    *
-   * If the needed fields are not present, this method will do nothing.
-   * @param logAnalytics If true, the method will take care of logging an analytic event.
+   * If the needed fields are not present, this method does nothing.
+   * @param logAnalytics Specifies whether the method should log an analytics event.
    */
   public openLinkInOutlook(logAnalytics = true) {
     if (this.hasOutlookField()) {
@@ -318,11 +315,11 @@ export class ResultLink extends Component {
   }
 
   /**
-   * Open the link in the same manner the end user would do.
+   * Opens the link in the same manner the end user would.
    *
-   * This essentially simulate a click on the result link.
+   * This essentially simulates a click on the result link.
    *
-   * @param logAnalytics If true, the method will take care of logging an analytic event.
+   * @param logAnalytics Specifies whether the method should log an analytics event.
    */
   public openLinkAsConfigured(logAnalytics = true) {
     if (this.toExecuteOnOpen) {

--- a/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
+++ b/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
@@ -48,14 +48,14 @@ export interface IResultsFiltersPreferencesOptions {
 }
 
 /**
- * The ResultFiltersPreferences component allows the end user to create custom filters to apply to queries. These
- * filters are saved in the local storage of the end user.
+ * The `ResultFiltersPreferences` component allows end users to create custom filters to apply to queries. These filters
+ * are saved to local storage.
  *
- * Only advanced end users who understand the Coveo query syntax should actually use this feature (see
+ * Only advanced end users who understand the Coveo query syntax should use this feature (see
  * [Coveo Query Syntax Reference](http://www.coveo.com/go?dest=adminhelp70&lcid=9&context=10005)).
  *
- * This component is normally accessible through the {@link Settings} menu. Its usual location in the DOM is inside the
- * {@link PreferencesPanel} component.
+ * This component is normally accessible through the [`Settings`]{@link Settings} menu. Its usual location in the DOM is
+ * inside the [`PreferencesPanel`]{@link PreferencesPanel} element.
  *
  * See also the {@link ResultsPreferences} component.
  */
@@ -75,7 +75,7 @@ export class ResultsFiltersPreferences extends Component {
   static options: IResultsFiltersPreferencesOptions = {
 
     /**
-     * Specifies whether to include the active filter(s) in the {@link Breadcrumb}.
+     * Specifies whether to display the active filter(s) in the [`Breadcrumb`]{@link Breadcrumb}.
      *
      * Default value is `true`.
      */
@@ -84,43 +84,59 @@ export class ResultsFiltersPreferences extends Component {
     /**
      * Specifies whether to show the **Create** button that allows the end user to create filters.
      *
-     * If you set this option to `false`, only the pre-populated {@link ResultsFiltersPreferences.options.filters} will
-     * be available to the end user.
+     * If you set this option to `false`, only the pre-populated
+     * [`filters`]{@link ResultsFiltersPreferences.options.filters} are available to the end user.
      *
      * Default value is `true`.
      */
     showAdvancedFilters: ComponentOptions.buildBooleanOption({ defaultValue: true }),
 
     /**
-     * Specifies the default filters that all end users can apply.
+     * Specifies the default filters which all end users can apply.
      *
-     * End users will not be able to modify or delete these filters. They do not count as "user-made" filters, but
-     * rather as "built-in" filters created by the developer of the search page.
+     * End users cannot modify or delete these filters. These filters do not count as "user-made" filters, but rather as
+     * "built-in" filters created by the developer of the search page.
      *
-     * You can only set this option in the `init` call of your search interface. You cannot set it directly in the
-     * markup as an HTML attribute.
+     * **Note:**
+     * > You cannot set this option directly in the component markup as an HTML attribute. You must either set it in the
+     * > [`init`]{@link init} call of your search interface (see
+     * > [Components - Passing Component Options in the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsintheinitCall)),
+     * > or before the `init` call, using the `options` top-level function (see
+     * > [Components - Passing Component Options Before the init Call](https://developers.coveo.com/x/PoGfAQ#Components-PassingComponentOptionsBeforetheinitCall)).
      *
      * Filters should follow this definition:
      *
-     * `filters: { [caption: string]: { expression: string; tab?: string[]; } }`;
+     * `filters : { [caption : string] : { expression : string, tab? : string[] } }`;
      *
      * **Example:**
      *
+     * var myFilters = {
+     *   "Only Google Drive Items" : {
+     *     expression : "@connectortype == 'GoogleDriveCrawler'",
+     *     tab : ["Tab1", "Tab2"]
+     *   },
+     *
+     *   "Another Filter" : {
+     *     expression : [ ... another expression ... ]
+     *   },
+     *
+     *   [ ... ]
+     * };
+     *
      * ```javascript
-     * Coveo.init(document.querySelector('#search'), {
+     * // You can set the option in the 'init' call:
+     * Coveo.init(document.querySelector("#search"), {
      *   ResultsFiltersPreferences : {
-     *     filters : {
-     *       "Only Google Drive Items" : {
-     *         expression : "@connectortype == 'GoogleDriveCrawler'"
-     *         tab: ['Tab1', 'Tab2'],
-     *       },
-     *       "Another Filter" : {
-     *         expression : [ ... another expression ... ]
-     *       },
-     *       [ ... ]
-     *     }
+     *     filters : myFilters
      *   }
      * });
+     *
+     * // Or before the 'init' call, using the 'options' top-level function:
+     * // Coveo.options(document.querySelector("#search"), {
+     * //   ResultsFiltersPreferences : {
+     *        filters : myFilters
+     *      }
+     * // });
      * ```
      *
      * Default value is `undefined`.
@@ -142,9 +158,9 @@ export class ResultsFiltersPreferences extends Component {
   private advancedFilterFormValidate: HTMLFormElement;
 
   /**
-   * Creates a new ResultsFiltersPreferences component.
+   * Creates a new `ResultsFiltersPreferences` component.
    * @param element The HTMLElement on which to instantiate the component.
-   * @param options The options for the ResultsFiltersPreferences component.
+   * @param options The options for the `ResultsFiltersPreferences` component.
    * @param bindings The bindings that the component requires to function normally. If not set, these will be
    * automatically resolved (with a slower execution time).
    */


### PR DESCRIPTION
DOC-690 - Document the usage of Coveo.options

(these two documentation issues were somehow related)

- Added link to the **Normalizing Facet Value Captions** article in `Facet.options.valueCaption`
- Changed the note that misleadingly said some options could only be set in the `init` call, added relevant links, and modified examples for:
    - `Facet.options.valueCaption`
    - `FacetSlider.options.getSteps`
    - `FacetSlider.options.valueCaption`
    - `FieldSuggestions.options.onSelect`
    - `ResultLink.options.onClick`
    - `ResultsFiltersPreferences.options.filters`

- Made mostly cosmetic changes to the `Facet`, `FacetSlider`, `FieldSuggestions`, `ResultLink`, and `ResultsFiltersPreferences` documentation.





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)