### PR TITLE
dont always return false in keyboard utils

### DIFF
--- a/src/ui/Facet/ValueElement.ts
+++ b/src/ui/Facet/ValueElement.ts
@@ -143,14 +143,14 @@ export class ValueElement {
       if (eventBindings.omniboxObject) {
         this.omniboxCloseEvent(eventBindings.omniboxObject);
       }
-      event.stopPropagation();
-      event.preventDefault();
+
       this.handleExcludeClick(eventBindings);
 
       if (this.facet && this.facet.facetSearch && this.facet.facetSearch.completelyDismissSearch) {
         this.facet.facetSearch.completelyDismissSearch();
       }
-      return false;
+      event.stopPropagation();
+      event.preventDefault();
     };
     $$(this.renderer.excludeIcon).on('click', excludeAction);
 
@@ -163,10 +163,11 @@ export class ValueElement {
       if (eventBindings.pinFacet) {
         this.facet.pinFacetPosition();
       }
-      event.preventDefault();
+
       $$(this.renderer.checkbox).trigger('change');
-      return false;
+      event.preventDefault();
     };
+
     $$(this.renderer.label).on('click', selectAction);
 
     $$(this.renderer.stylishCheckbox).on('keydown', KeyboardUtils.keypressAction([

--- a/src/utils/KeyboardUtils.ts
+++ b/src/utils/KeyboardUtils.ts
@@ -76,9 +76,9 @@ export class KeyboardUtils {
         const eventCode = e.charCode || e.keyCode;
         if (eventCode) {
           if (_.isArray(keyCode) && _.contains(keyCode, eventCode)) {
-            return action(e);
+            action(e);
           } else if (eventCode === keyCode) {
-            return action(e);
+            action(e);
           }
         }
       }

--- a/src/utils/KeyboardUtils.ts
+++ b/src/utils/KeyboardUtils.ts
@@ -76,13 +76,12 @@ export class KeyboardUtils {
         const eventCode = e.charCode || e.keyCode;
         if (eventCode) {
           if (_.isArray(keyCode) && _.contains(keyCode, eventCode)) {
-            action(e);
+            return action(e);
           } else if (eventCode === keyCode) {
-            action(e);
+            return action(e);
           }
         }
       }
-      return false;
     };
   }
 }


### PR DESCRIPTION
When returning false in an event handler, the behaviour is not the same when in a jQuery event, see here http://stackoverflow.com/questions/1357118/event-preventdefault-vs-return-false. Return false will call `preventDefault` and `stopPropagation` when using jQuery. Doing the same thing using the native method `addEventListener` will have no effect. 

The `keypressAction` method would always return false which would break keyboard navigation when using jQuery. 

https://coveord.atlassian.net/browse/JSUI-1585

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coveo/search-ui/460)
<!-- Reviewable:end -->
