### PR TITLE
ADUI-2562 - Need to fix style for Preferences in Content Browser

### DIFF
--- a/src/ui/ResultsPreferences/ResultsPreferences.ts
+++ b/src/ui/ResultsPreferences/ResultsPreferences.ts
@@ -193,7 +193,7 @@ export class ResultsPreferences extends Component {
       checkboxes.push(createCheckbox(l('AlwaysOpenInNewWindow')));
     }
 
-    this.element.appendChild(new FormGroup(checkboxes, l('ResultLink')).build());
+    this.element.appendChild(new FormGroup(checkboxes, l('ResultLinks')).build());
     this.fromPreferencesToCheckboxInput();
   }
 

--- a/src/ui/ShareQuery/ShareQuery.ts
+++ b/src/ui/ShareQuery/ShareQuery.ts
@@ -138,8 +138,8 @@ export class ShareQuery extends Component {
     this.buildLinkToThisQuery();
     this.buildCompleteQuery();
 
-    boxes.appendChild(this.buildTextBoxWithLabel(l('Link') + ':', this.linkToThisQuery));
-    boxes.appendChild(this.buildTextBoxWithLabel(l('CompleteQuery') + ':', this.completeQuery));
+    boxes.appendChild(this.buildTextBoxWithLabel(l('Link'), this.linkToThisQuery));
+    boxes.appendChild(this.buildTextBoxWithLabel(l('CompleteQuery'), this.completeQuery));
     content.appendChild(boxes);
 
     Component.pointElementsToDummyForm(content);

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -100,7 +100,7 @@
     "zh-tw": "清除 {0}"
   },
   "CompleteQuery": {
-    "en": "Complete Query",
+    "en": "Complete query",
     "fr": "Requête complète",
     "cs": "Celý dotaz",
     "da": "Afslut forespørgsel",
@@ -500,7 +500,7 @@
     "zh-tw": "喜好設定"
   },
   "LinkOpeningSettings": {
-    "en": "Link Opening Settings",
+    "en": "Link opening settings",
     "fr": "Réglage pour l'ouverture des liens",
     "cs": "Nastavení otevírání odkazů",
     "da": "Indstillinger til åbning af links",
@@ -550,7 +550,7 @@
     "zh-tw": "重新驗證 {0}"
   },
   "ResultsFilteringExpression": {
-    "en": "Results Filtering Expressions",
+    "en": "Results filtering expressions",
     "fr": "Expression de filtrage des résultats",
     "cs": "Výrazy pro filtrování výsledků",
     "da": "Tilkendegivelser filtrerer resultater",


### PR DESCRIPTION
- `ResultsPreferences`: used valid localized string for `ResultLinks`
- `ShareQuery`: removed colons after `Link` and `CompleteQuery` strings
- strings: fixed some minor casing issues.





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/coveo/search-ui/462)
<!-- Reviewable:end -->
