### PR TITLE
Fixed translations.

### DIFF
--- a/src/ui/CardOverlay/CardOverlay.ts
+++ b/src/ui/CardOverlay/CardOverlay.ts
@@ -7,7 +7,7 @@ import { $$ } from '../../utils/Dom';
 import { Assert } from '../../misc/Assert';
 import { KeyboardUtils, KEYBOARD } from '../../utils/KeyboardUtils';
 import { exportGlobally } from '../../GlobalExports';
-
+import { l } from '../../strings/Strings';
 import 'styling/_CardOverlay';
 
 export interface ICardOverlayOptions {
@@ -148,7 +148,7 @@ export class CardOverlay extends Component {
     if (this.options.icon) {
       element.appendChild($$('span', { className: 'coveo-icon ' + this.options.icon }).el);
     }
-    element.appendChild($$('span', { className: 'coveo-label' }, this.options.title).el);
+    element.appendChild($$('span', { className: 'coveo-label' }, l(this.options.title)).el);
     element.setAttribute('tabindex', '0');
     $$(element).on('click', () => this.toggleOverlay());
     this.bind.on(element, 'keyup', KeyboardUtils.keypressAction(KEYBOARD.ENTER, () => this.toggleOverlay()));

--- a/src/ui/Debug/Debug.ts
+++ b/src/ui/Debug/Debug.ts
@@ -401,7 +401,7 @@ export class Debug extends RootComponent {
     }
     const valueDom = $$('div');
     valueDom.text(stringValue);
-    valueDom.on('dblclick', ()=> {
+    valueDom.on('dblclick', () => {
       this.selectElementText(valueDom.el);
     });
 

--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -131,7 +131,7 @@ export class ResultsPerPage extends Component {
   private initComponent(element: HTMLElement) {
     this.span = $$('span', {
       className: 'coveo-results-per-page-text'
-    }, l('Results per page')).el;
+    }, l('ResultsPerPage')).el;
     element.appendChild(this.span);
     this.list = $$('ul', {
       className: 'coveo-results-per-page-list'


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-1551

Fixed translations:
 'Results Per Page' translation wouldn't show because it was written improperly ('Results Per Page' instead of 'ResultsPerPage'). The key wasn't recognized. 

'Details' had no function called on it for translation, added that. Both words are only defined for french and english. Other languages will use the default (english).




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)