### PR TITLE
Return empty array when there's no tab in the page for results preference

### DIFF
--- a/sass/_FullSearchGrid.scss
+++ b/sass/_FullSearchGrid.scss
@@ -6,7 +6,6 @@ $max-width: 1200px;
 $grid-columns: 10;
 $gutter: 0em;
 $page-width: 1000px;
-$border-box-sizing: false;
 
 .CoveoSearchInterface {
 

--- a/sass/neat/grid/_grid.scss
+++ b/sass/neat/grid/_grid.scss
@@ -1,3 +1,4 @@
+$border-box-sizing: false;
 @if $border-box-sizing == true {
   * {
     @include box-sizing(border-box);

--- a/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
+++ b/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
@@ -346,6 +346,8 @@ export class ResultsFiltersPreferences extends Component {
         let tab = <Tab>Component.get(tabElement);
         return tab.options.id;
       });
+    } else {
+      return [];
     }
   }
 


### PR DESCRIPTION
Also fix an issue with border box being set globally on the page.

https://coveord.atlassian.net/browse/JSUI-1621





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)