### PR TITLE
Add actionsHistory to all search and querySuggest calls

### DIFF
--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -25,6 +25,7 @@ import { QueryError } from '../rest/QueryError';
 import { Utils } from '../utils/Utils';
 import * as _ from 'underscore';
 import { shim } from '../misc/PromisesShim';
+import { history } from 'coveo.analytics';
 shim();
 
 export class DefaultSearchEndpointOptions implements ISearchEndpointOptions {
@@ -284,10 +285,11 @@ export class SearchEndpoint implements ISearchEndpoint {
   @path('/')
   @method('POST')
   @responseType('text')
+  @includeActionsHistory()
   public search(query: IQuery, callOptions?: IEndpointCallOptions, callParams?: IEndpointCallParameters): Promise<IQueryResults> {
     Assert.exists(query);
 
-    callParams.requestData = query;
+    callParams.requestData = _.extend({}, callParams.requestData, _.omit(query, (queryParam) => Utils.isNullOrUndefined(queryParam)));
 
     this.logger.info('Performing REST query', query);
 
@@ -600,12 +602,14 @@ export class SearchEndpoint implements ISearchEndpoint {
    * @returns {Promise<IQuerySuggestResponse>} A Promise of query suggestions.
    */
   @path('/querySuggest')
-  @method('GET')
+  @method('POST')
   @responseType('text')
+  @includeActionsHistory()
   public getQuerySuggest(request: IQuerySuggestRequest, callOptions?: IEndpointCallOptions, callParams?: IEndpointCallParameters): Promise<IQuerySuggestResponse> {
     this.logger.info('Get Query Suggest', request);
-    callParams.requestData = request;
-    return this.performOneCall<IQuerySuggestResponse>(callParams);
+
+    callParams.requestData = _.extend({}, callParams.requestData, _.omit(request, (parameter) => Utils.isNullOrUndefined(parameter)));
+    return this.performOneCall<IQuerySuggestResponse>(callParams, callOptions);
   }
 
   // This is a non documented method to ensure backward compatibility for the old query suggest call.
@@ -939,29 +943,39 @@ export class SearchEndpoint implements ISearchEndpoint {
 // responseType: '',
 // errorsAsSuccess: false
 
+function decoratorSetup(target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
+  return {
+    originalMethod: descriptor.value,
+    nbParams: target[key].prototype.constructor.length
+  };
+}
+
+function defaultDecoratorEndpointCallParameters() {
+  const params: IEndpointCallParameters = {
+    url: '',
+    queryString: [],
+    requestData: {},
+    method: '',
+    responseType: '',
+    errorsAsSuccess: false
+  };
+  return params;
+}
+
 
 function path(path: string) {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
-    let originalMethod = descriptor.value;
-    let nbParams = target[key].prototype.constructor.length;
+    const { originalMethod, nbParams } = decoratorSetup(target, key, descriptor);
 
     descriptor.value = function (...args: any[]) {
-      let uri = this.buildBaseUri(path);
+      const url = this.buildBaseUri(path);
       if (args[nbParams - 1]) {
-        args[nbParams - 1].url = uri;
+        args[nbParams - 1].url = url;
       } else {
-        let params: IEndpointCallParameters = {
-          url: uri,
-          queryString: [],
-          requestData: {},
-          method: '',
-          responseType: '',
-          errorsAsSuccess: false
-        };
-        args[nbParams - 1] = params;
+        const endpointCallParams = _.extend(defaultDecoratorEndpointCallParameters(), { url: url });
+        args[nbParams - 1] = endpointCallParams;
       }
-      let result = originalMethod.apply(this, args);
-      return result;
+      return originalMethod.apply(this, args);
     };
 
     return descriptor;
@@ -970,26 +984,17 @@ function path(path: string) {
 
 function alertsPath(path: string) {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
-    let originalMethod = descriptor.value;
-    let nbParams = target[key].prototype.constructor.length;
+    const { originalMethod, nbParams } = decoratorSetup(target, key, descriptor);
 
     descriptor.value = function (...args: any[]) {
-      let uri = this.buildSearchAlertsUri(path);
+      const url = this.buildSearchAlertsUri(path);
       if (args[nbParams - 1]) {
-        args[nbParams - 1].url = uri;
+        args[nbParams - 1].url = url;
       } else {
-        let params: IEndpointCallParameters = {
-          url: uri,
-          queryString: [],
-          requestData: {},
-          method: '',
-          responseType: '',
-          errorsAsSuccess: false
-        };
-        args[nbParams - 1] = params;
+        const endpointCallParams = _.extend(defaultDecoratorEndpointCallParameters(), { url: url });
+        args[nbParams - 1] = endpointCallParams;
       }
-      let result = originalMethod.apply(this, args);
-      return result;
+      return originalMethod.apply(this, args);
     };
 
     return descriptor;
@@ -998,53 +1003,33 @@ function alertsPath(path: string) {
 
 function requestDataType(type: string) {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
-    let originalMethod = descriptor.value;
-    let nbParams = target[key].prototype.constructor.length;
+    const { originalMethod, nbParams } = decoratorSetup(target, key, descriptor);
 
     descriptor.value = function (...args: any[]) {
       if (args[nbParams - 1]) {
         args[nbParams - 1].requestDataType = type;
       } else {
-        let params: IEndpointCallParameters = {
-          url: '',
-          queryString: [],
-          requestData: {},
-          requestDataType: type,
-          method: '',
-          responseType: '',
-          errorsAsSuccess: false
-        };
-        args[nbParams - 1] = params;
+        const endpointCallParams = _.extend(defaultDecoratorEndpointCallParameters(), { requestDataType: type });
+        args[nbParams - 1] = endpointCallParams;
       }
-      let result = originalMethod.apply(this, args);
-      return result;
+      return originalMethod.apply(this, args);
     };
-
     return descriptor;
   };
 }
 
 function method(met: string) {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
-    let originalMethod = descriptor.value;
-    let nbParams = target[key].prototype.constructor.length;
+    const { originalMethod, nbParams } = decoratorSetup(target, key, descriptor);
 
     descriptor.value = function (...args: any[]) {
       if (args[nbParams - 1]) {
         args[nbParams - 1].method = met;
       } else {
-        let params: IEndpointCallParameters = {
-          url: '',
-          queryString: [],
-          requestData: {},
-          method: met,
-          responseType: '',
-          errorsAsSuccess: false
-        };
-        args[nbParams - 1] = params;
+        const endpointCallParams = _.extend(defaultDecoratorEndpointCallParameters(), { method: met });
+        args[nbParams - 1] = endpointCallParams;
       }
-      let result = originalMethod.apply(this, args);
-      return result;
+      return originalMethod.apply(this, args);
     };
 
     return descriptor;
@@ -1053,25 +1038,16 @@ function method(met: string) {
 
 function responseType(resp: string) {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
-    let originalMethod = descriptor.value;
-    let nbParams = target[key].prototype.constructor.length;
+    const { originalMethod, nbParams } = decoratorSetup(target, key, descriptor);
 
     descriptor.value = function (...args: any[]) {
       if (args[nbParams - 1]) {
         args[nbParams - 1].responseType = resp;
       } else {
-        let params: IEndpointCallParameters = {
-          url: '',
-          queryString: [],
-          requestData: {},
-          method: '',
-          responseType: resp,
-          errorsAsSuccess: false
-        };
-        args[nbParams - 1] = params;
+        const endpointCallParams = _.extend(defaultDecoratorEndpointCallParameters(), { responseType: resp });
+        args[nbParams - 1] = endpointCallParams;
       }
-      let result = originalMethod.apply(this, args);
-      return result;
+      return originalMethod.apply(this, args);
     };
 
     return descriptor;
@@ -1080,26 +1056,40 @@ function responseType(resp: string) {
 
 function accessTokenInUrl(tokenKey: string = 'access_token') {
   return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
-    let originalMethod = descriptor.value;
-    let nbParams = target[key].prototype.constructor.length;
+    const { originalMethod, nbParams } = decoratorSetup(target, key, descriptor);
 
     descriptor.value = function (...args: any[]) {
-      let queryString = this.buildAccessToken(tokenKey);
+      const queryString = this.buildAccessToken(tokenKey);
       if (args[nbParams - 1]) {
         args[nbParams - 1].queryString = args[nbParams - 1].queryString.concat(queryString);
       } else {
-        let params: IEndpointCallParameters = {
-          url: '',
-          queryString: queryString,
-          requestData: {},
-          method: '',
-          responseType: '',
-          errorsAsSuccess: false
-        };
-        args[nbParams - 1] = params;
+        const endpointCallParams = _.extend(defaultDecoratorEndpointCallParameters(), { queryString: queryString });
+        args[nbParams - 1] = endpointCallParams;
       }
-      let result = originalMethod.apply(this, args);
-      return result;
+      return originalMethod.apply(this, args);
+    };
+
+    return descriptor;
+  };
+}
+
+function includeActionsHistory(historyStore: CoveoAnalytics.HistoryStore = new history.HistoryStore()) {
+  return function (target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
+    const { originalMethod, nbParams } = decoratorSetup(target, key, descriptor);
+
+    descriptor.value = function (...args: any[]) {
+      let historyFromStore = historyStore.getHistory();
+      if (historyFromStore == null) {
+        historyFromStore = [];
+      }
+
+      if (args[nbParams - 1]) {
+        args[nbParams - 1].requestData.actionsHistory = historyFromStore;
+      } else {
+        const endpointCallParams = _.extend(defaultDecoratorEndpointCallParameters(), { requestData: { actionsHistory: historyFromStore } });
+        args[nbParams - 1] = endpointCallParams;
+      }
+      return originalMethod.apply(this, args);
     };
 
     return descriptor;

--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -127,8 +127,10 @@ export class Recommendation extends SearchInterface implements IComponentBinding
      * However, setting this option to `false` can be useful to display side results in a search page.
      *
      * Default value is `true`.
+     * 
+     * @deprecated This option is now deprecated. The correct way to control this behaviour is to configure an appropriate machine learning model in the administration interface (Recommendation, Relevance tuning, Query suggestions)
      */
-    sendActionsHistory: ComponentOptions.buildBooleanOption({ defaultValue: true }),
+    sendActionsHistory: ComponentOptions.buildBooleanOption({ defaultValue: true, deprecated: 'This option is now deprecated. The correct way to control this behaviour is to configure an appropriate machine learning model in the administration interface (Recommendation, Relevance tuning, Query suggestions)' }),
 
     /**
      * Specifies whether to hide the Recommendations component if no result or recommendation is available.
@@ -360,9 +362,6 @@ export class Recommendation extends SearchInterface implements IComponentBinding
   private addRecommendationInfoInQuery(data: IBuildingQueryEventArgs) {
     if (!_.isEmpty(this.options.userContext)) {
       data.queryBuilder.addContext(JSON.parse(this.options.userContext));
-    }
-    if (this.options.sendActionsHistory) {
-      data.queryBuilder.actionsHistory = this.getHistory();
     }
 
     data.queryBuilder.recommendation = this.options.id;

--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -127,7 +127,7 @@ export class Recommendation extends SearchInterface implements IComponentBinding
      * However, setting this option to `false` can be useful to display side results in a search page.
      *
      * Default value is `true`.
-     * 
+     *
      * @deprecated This option is now deprecated. The correct way to control this behaviour is to configure an appropriate machine learning model in the administration interface (Recommendation, Relevance tuning, Query suggestions)
      */
     sendActionsHistory: ComponentOptions.buildBooleanOption({ defaultValue: true, deprecated: 'This option is now deprecated. The correct way to control this behaviour is to configure an appropriate machine learning model in the administration interface (Recommendation, Relevance tuning, Query suggestions)' }),

--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -128,7 +128,7 @@ export class Recommendation extends SearchInterface implements IComponentBinding
      *
      * Default value is `true`.
      *
-     * @deprecated This option is now deprecated. The correct way to control this behaviour is to configure an appropriate machine learning model in the administration interface (Recommendation, Relevance tuning, Query suggestions)
+     * @deprecated This option is now deprecated. The correct way to control this behavior is to configure an appropriate machine learning model in the administration interface (Recommendation, Relevance tuning, Query suggestions).
      */
     sendActionsHistory: ComponentOptions.buildBooleanOption({ defaultValue: true, deprecated: 'This option is now deprecated. The correct way to control this behaviour is to configure an appropriate machine learning model in the administration interface (Recommendation, Relevance tuning, Query suggestions)' }),
 

--- a/test/rest/SearchEndpointTest.ts
+++ b/test/rest/SearchEndpointTest.ts
@@ -230,6 +230,14 @@ export function SearchEndpointTest() {
           });
         });
 
+        it('should not override actions history if specified manually on a search call', () => {
+          const qbuilder = new QueryBuilder();
+          const historyAsString = JSON.stringify([{ name: 'foo', value: 'bar' }]);
+          qbuilder.actionsHistory = historyAsString;
+          const promiseSuccess = ep.search(qbuilder.build());
+          expect(jasmine.Ajax.requests.mostRecent().params).toContain(`actionsHistory=${encodeURIComponent(historyAsString)}`);
+        });
+
         it('for getRawDataStream', (done) => {
           const fakeResult = FakeResults.createFakeResult();
           const promiseSuccess = ep.getRawDataStream(fakeResult.uniqueId, '$Thumbnail');

--- a/test/rest/SearchEndpointTest.ts
+++ b/test/rest/SearchEndpointTest.ts
@@ -202,6 +202,7 @@ export function SearchEndpointTest() {
           expect(jasmine.Ajax.requests.mostRecent().params).toContain('q=batman');
           expect(jasmine.Ajax.requests.mostRecent().params).toContain('numberOfResults=153');
           expect(jasmine.Ajax.requests.mostRecent().params).toContain('enableCollaborativeRating=true');
+          expect(jasmine.Ajax.requests.mostRecent().params).toContain('actionsHistory=');
           expect(jasmine.Ajax.requests.mostRecent().method).toBe('POST');
           promiseSuccess
             .then((data: IQueryResults) => {
@@ -499,11 +500,13 @@ export function SearchEndpointTest() {
           });
 
           expect(jasmine.Ajax.requests.mostRecent().url).toContain(ep.getBaseUri() + '/querySuggest?');
-          expect(jasmine.Ajax.requests.mostRecent().url).toContain('q=foobar');
-          expect(jasmine.Ajax.requests.mostRecent().url).toContain('count=10');
           expect(jasmine.Ajax.requests.mostRecent().url).toContain('organizationId=myOrgId');
           expect(jasmine.Ajax.requests.mostRecent().url).toContain('potatoe=mashed');
-          expect(jasmine.Ajax.requests.mostRecent().method).toBe('GET');
+
+          expect(jasmine.Ajax.requests.mostRecent().params).toContain('q=foobar');
+          expect(jasmine.Ajax.requests.mostRecent().params).toContain('count=10');
+          expect(jasmine.Ajax.requests.mostRecent().params).toContain('actionsHistory=');
+          expect(jasmine.Ajax.requests.mostRecent().method).toBe('POST');
 
           // Not real extensions, but will suffice for test purpose
           promiseSuccess
@@ -530,7 +533,7 @@ export function SearchEndpointTest() {
           });
 
           expect(jasmine.Ajax.requests.mostRecent().url).toContain(ep.getBaseUri() + '/querySuggest?');
-          expect(jasmine.Ajax.requests.mostRecent().url).toContain('q=foobar');
+          expect(jasmine.Ajax.requests.mostRecent().params).toContain('q=foobar');
 
           // Not real extensions, but will suffice for test purpose
           promiseSuccess

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -127,30 +127,6 @@ export function RecommendationTest() {
         expect(simulation.queryBuilder.context).toBeUndefined();
       });
 
-      describe('exposes option sendActionHistory', () => {
-        it('should add the actionsHistory in the triggered query', () => {
-          let simulation = Simulate.query(test.env);
-          expect(simulation.queryBuilder.actionsHistory).toEqual(JSON.stringify(actionsHistory));
-        });
-
-        it('should add the actionsHistory even if the user context is not specified', () => {
-          options = {
-            mainSearchInterface: mainSearchInterface.env.root
-          };
-          test = Mock.optionsSearchInterfaceSetup<Recommendation, IRecommendationOptions>(Recommendation, options);
-          test.cmp.historyStore = store;
-          let simulation = Simulate.query(test.env);
-          expect(simulation.queryBuilder.actionsHistory).toEqual(JSON.stringify(actionsHistory));
-        });
-
-        it('should not send the actionsHistory if false', () => {
-          options.sendActionsHistory = false;
-          test = Mock.optionsSearchInterfaceSetup<Recommendation, IRecommendationOptions>(Recommendation, options);
-          let simulation = Simulate.query(test.env);
-          expect(simulation.queryBuilder.actionsHistory).toBeUndefined();
-        });
-      });
-
       describe('exposes option hideIfNoResults', () => {
         it('should hide the interface if there are no recommendations and the option is true', () => {
           options.hideIfNoResults = true;


### PR DESCRIPTION
Machine learning will soon benefit from using actions history on all search and query suggestions calls to provide "personalized" relevance tuning and query suggestions.

This PR adds the needed parameters in those 2 call by adding a new decorator and using it for those 2 API calls.

https://coveord.atlassian.net/browse/JSUI-1604

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)