### PR TITLE
set node prod env for minimizing

### DIFF
--- a/gulpTasks/compile.js
+++ b/gulpTasks/compile.js
@@ -24,8 +24,8 @@ gulp.task('compileTSOnly', shell.task([
   'node node_modules/webpack/bin/webpack.js --config ./webpack.tsonly.config.js'
 ]));
 
-gulp.task('minimize', ['addEolDependencies'], shell.task([
-  'node node_modules/webpack/bin/webpack.js --optimize-minimize'
+gulp.task('minimize', ['addEolDependencies', 'setNodeProdEnv'], shell.task([
+  'node --max_old_space_size=8192 node_modules/webpack/bin/webpack.js --env minimize'
 ]));
 
 gulp.task('deprecatedDependencies', function () {

--- a/gulpTasks/nodeEnv.js
+++ b/gulpTasks/nodeEnv.js
@@ -1,11 +1,6 @@
 const gulp = require('gulp');
 
 // NODE_ENV=production sets an environement variable that will allow other tasks to know what we are build for.
-gulp.task('setNodeDevEnv', function(done) {
-    process.env.NODE_ENV = 'development';
-    done();
-});
-
 gulp.task('setNodeProdEnv', function(done) {
     process.env.NODE_ENV = 'production';
     done();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "testChunks": "node chunkTesters/chunk.tester.js",
     "build": "gulp",
     "tsonly": "gulp compileTSOnly",
-    "minimize": "node --max_old_space_size=8192 node_modules/webpack/bin/webpack.js --env minimize",
+    "minimize": "gulp minimize",
     "doc": "gulp doc",
     "docsitemap": "gulp docsitemap",
     "injectTag": "gulp injectTag",


### PR DESCRIPTION
We were not setting the node environment variable to `production` when minimizing so the css would be included in the bundle, just like when using the dev server.
![screenshot from 2017-06-15 11-12-28](https://user-images.githubusercontent.com/6422665/27188276-a744dc96-51bb-11e7-8b4c-923efa98bb62.png)


https://coveord.atlassian.net/browse/JSUI-1668





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)