### PR TITLE
Issue with AdvancedSearch opened in external modal box VS search events

### DIFF
--- a/src/ui/AdvancedSearch/AdvancedSearch.ts
+++ b/src/ui/AdvancedSearch/AdvancedSearch.ts
@@ -82,7 +82,7 @@ export class AdvancedSearch extends Component {
   public inputs: IAdvancedSearchInput[] = [];
   public content: Dom;
 
-  private inputFactory = new AdvancedSearchInputFactory(this.queryController.getEndpoint());
+  private inputFactory = new AdvancedSearchInputFactory(this.queryController.getEndpoint(), this.root);
   private externalSections: IExternalAdvancedSearchSection[] = [];
   private modalbox: Coveo.ModalBox.ModalBox;
   private needToPopulateBreadcrumb = false;
@@ -158,7 +158,11 @@ export class AdvancedSearch extends Component {
       const clear = $$('span', {
         className: 'coveo-advanced-search-breadcrumb-clear'
       });
-      clear.on('click', () => this.handleClearBreadcrumb());
+      clear.on('click', () => {
+        this.handleClearBreadcrumb();
+        this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.breadcrumbAdvancedSearch, {});
+        this.queryController.executeQuery();
+      });
 
       elem.append(title.el);
       elem.append(clear.el);

--- a/src/ui/AdvancedSearch/AdvancedSearchInputFactory.ts
+++ b/src/ui/AdvancedSearch/AdvancedSearchInputFactory.ts
@@ -14,7 +14,7 @@ import { IFieldInputParameters } from './AdvancedSearchInput';
 
 export class AdvancedSearchInputFactory {
 
-  constructor(private endpoint: ISearchEndpoint) {
+  constructor(private endpoint: ISearchEndpoint, private root: HTMLElement) {
   }
 
   public create(name: string, options?: IFieldInputParameters): IAdvancedSearchInput {
@@ -45,43 +45,43 @@ export class AdvancedSearchInputFactory {
   }
 
   public createAllKeywordsInput(): AllKeywordsInput {
-    return new AllKeywordsInput();
+    return new AllKeywordsInput(this.root);
   }
 
   public createExactKeywordsInput(): ExactKeywordsInput {
-    return new ExactKeywordsInput();
+    return new ExactKeywordsInput(this.root);
   }
 
   public createAnyKeywordsInput(): AnyKeywordsInput {
-    return new AnyKeywordsInput();
+    return new AnyKeywordsInput(this.root);
   }
 
   public createNoneKeywordsInput(): NoneKeywordsInput {
-    return new NoneKeywordsInput();
+    return new NoneKeywordsInput(this.root);
   }
 
   public createAnytimeDateInput(): AnytimeDateInput {
-    return new AnytimeDateInput();
+    return new AnytimeDateInput(this.root);
   }
 
   public createInTheLastDateInput(): InTheLastDateInput {
-    return new InTheLastDateInput();
+    return new InTheLastDateInput(this.root);
   }
 
   public createBetweenDateInput(): BetweenDateInput {
-    return new BetweenDateInput();
+    return new BetweenDateInput(this.root);
   }
 
   public createSimpleFieldInput(name: string, field: string): SimpleFieldInput {
-    return new SimpleFieldInput(name, field, this.endpoint);
+    return new SimpleFieldInput(name, field, this.endpoint, this.root);
   }
 
   public createAdvancedFieldInput(name: string, field: string): AdvancedFieldInput {
-    return new AdvancedFieldInput(name, field);
+    return new AdvancedFieldInput(name, field, this.root);
   }
 
   public createSizeInput() {
-    return new SizeInput();
+    return new SizeInput(this.root);
   }
 
 }

--- a/src/ui/AdvancedSearch/DateInput/AnytimeDateInput.ts
+++ b/src/ui/AdvancedSearch/DateInput/AnytimeDateInput.ts
@@ -17,7 +17,7 @@ export class AnytimeDateInput extends DateInput {
     let radio = this.getRadio();
     radio.checked = true;
     $$(radio).on('change', () => {
-      if(this.root) {
+      if (this.root) {
         $$(this.root).trigger(AdvancedSearchEvents.executeAdvancedSearch);
       } else {
         $$(this.element).trigger(AdvancedSearchEvents.executeAdvancedSearch);

--- a/src/ui/AdvancedSearch/DateInput/AnytimeDateInput.ts
+++ b/src/ui/AdvancedSearch/DateInput/AnytimeDateInput.ts
@@ -4,8 +4,8 @@ import { $$ } from '../../../utils/Dom';
 import { AdvancedSearchEvents } from '../../../events/AdvancedSearchEvents';
 
 export class AnytimeDateInput extends DateInput {
-  constructor() {
-    super(l('Anytime'));
+  constructor(public root: HTMLElement) {
+    super(l('Anytime'), root);
   }
 
   public getValue() {
@@ -17,7 +17,11 @@ export class AnytimeDateInput extends DateInput {
     let radio = this.getRadio();
     radio.checked = true;
     $$(radio).on('change', () => {
-      $$(this.element).trigger(AdvancedSearchEvents.executeAdvancedSearch);
+      if(this.root) {
+        $$(this.root).trigger(AdvancedSearchEvents.executeAdvancedSearch);
+      } else {
+        $$(this.element).trigger(AdvancedSearchEvents.executeAdvancedSearch);
+      }
     });
     return this.element;
   }

--- a/src/ui/AdvancedSearch/DateInput/BetweenDateInput.ts
+++ b/src/ui/AdvancedSearch/DateInput/BetweenDateInput.ts
@@ -10,8 +10,8 @@ export class BetweenDateInput extends DateInput {
   public firstDatePicker: DatePicker = new DatePicker(this.onChange.bind(this));
   public secondDatePicker: DatePicker = new DatePicker(this.onChange.bind(this));
 
-  constructor() {
-    super(l('Between'));
+  constructor(public root: HTMLElement) {
+    super(l('Between'), root);
   }
 
   public reset() {

--- a/src/ui/AdvancedSearch/DateInput/DateInput.ts
+++ b/src/ui/AdvancedSearch/DateInput/DateInput.ts
@@ -11,7 +11,7 @@ export abstract class DateInput implements IAdvancedSearchInput {
   private radio: RadioButton;
   private error: HTMLElement;
 
-  constructor(public inputName: string) {
+  constructor(public inputName: string, public root: HTMLElement) {
     this.buildContent();
   }
 
@@ -90,7 +90,9 @@ export abstract class DateInput implements IAdvancedSearchInput {
   }
 
   protected onChange() {
-    if (this.element) {
+    if (this.root) {
+      $$(this.root).trigger(AdvancedSearchEvents.executeAdvancedSearch);
+    } else if (this.element) {
       $$(this.element).trigger(AdvancedSearchEvents.executeAdvancedSearch);
     }
   }

--- a/src/ui/AdvancedSearch/DateInput/InTheLastDateInput.ts
+++ b/src/ui/AdvancedSearch/DateInput/InTheLastDateInput.ts
@@ -9,8 +9,8 @@ export class InTheLastDateInput extends DateInput {
   public dropdown: Dropdown;
   public spinner: NumericSpinner;
 
-  constructor() {
-    super(l('InTheLast'));
+  constructor(public root: HTMLElement) {
+    super(l('InTheLast'), root);
   }
 
   public reset() {
@@ -31,6 +31,8 @@ export class InTheLastDateInput extends DateInput {
     input.append(this.dropdown.getElement());
 
     this.element.appendChild(input.el);
+
+    $$(this.getRadio()).on('change', this.onChange.bind(this));
     return this.element;
   }
 

--- a/src/ui/AdvancedSearch/DocumentInput/AdvancedFieldInput.ts
+++ b/src/ui/AdvancedSearch/DocumentInput/AdvancedFieldInput.ts
@@ -10,8 +10,8 @@ export class AdvancedFieldInput extends DocumentInput {
   public mode: Dropdown;
   public input: TextInput;
 
-  constructor(public inputName: string, public fieldName: string) {
-    super(inputName);
+  constructor(public inputName: string, public fieldName: string, public root: HTMLElement) {
+    super(inputName, root);
   }
 
   public reset() {

--- a/src/ui/AdvancedSearch/DocumentInput/DocumentInput.ts
+++ b/src/ui/AdvancedSearch/DocumentInput/DocumentInput.ts
@@ -8,7 +8,7 @@ export class DocumentInput implements IAdvancedSearchInput {
 
   protected element: HTMLElement;
 
-  constructor(public inputName: string) {
+  constructor(public inputName: string, public root: HTMLElement) {
   }
 
   public reset() {
@@ -35,7 +35,9 @@ export class DocumentInput implements IAdvancedSearchInput {
   }
 
   protected onChange() {
-    if (this.element) {
+    if (this.root) {
+      $$(this.root).trigger(AdvancedSearchEvents.executeAdvancedSearch);
+    } else if (this.element) {
       $$(this.element).trigger(AdvancedSearchEvents.executeAdvancedSearch);
     }
   }

--- a/src/ui/AdvancedSearch/DocumentInput/SimpleFieldInput.ts
+++ b/src/ui/AdvancedSearch/DocumentInput/SimpleFieldInput.ts
@@ -12,8 +12,8 @@ export class SimpleFieldInput extends DocumentInput {
   protected element: HTMLElement;
   public dropDown: Dropdown;
 
-  constructor(public inputName: string, public fieldName: string, private endpoint: ISearchEndpoint) {
-    super(inputName);
+  constructor(public inputName: string, public fieldName: string, private endpoint: ISearchEndpoint, public root: HTMLElement) {
+    super(inputName, root);
   }
 
   public reset() {

--- a/src/ui/AdvancedSearch/DocumentInput/SizeInput.ts
+++ b/src/ui/AdvancedSearch/DocumentInput/SizeInput.ts
@@ -15,8 +15,8 @@ export class SizeInput extends DocumentInput {
   public sizeInput: NumericSpinner;
   public sizeSelect: Dropdown;
 
-  constructor() {
-    super('Size');
+  constructor(public root: HTMLElement) {
+    super('Size', root);
   }
 
   public reset() {

--- a/src/ui/AdvancedSearch/KeywordsInput/AllKeywordsInput.ts
+++ b/src/ui/AdvancedSearch/KeywordsInput/AllKeywordsInput.ts
@@ -2,7 +2,7 @@ import { KeywordsInput } from './KeywordsInput';
 import { l } from '../../../strings/Strings';
 
 export class AllKeywordsInput extends KeywordsInput {
-  constructor() {
-    super(l('AllTheseWords'));
+  constructor(public root: HTMLElement) {
+    super(l('AllTheseWords'), root);
   }
 }

--- a/src/ui/AdvancedSearch/KeywordsInput/AnyKeywordsInput.ts
+++ b/src/ui/AdvancedSearch/KeywordsInput/AnyKeywordsInput.ts
@@ -3,8 +3,8 @@ import { l } from '../../../strings/Strings';
 import * as _ from 'underscore';
 
 export class AnyKeywordsInput extends KeywordsInput {
-  constructor() {
-    super(l('AnyOfTheseWords'));
+  constructor(public root: HTMLElement) {
+    super(l('AnyOfTheseWords'), root);
   }
 
   public getValue(): string {

--- a/src/ui/AdvancedSearch/KeywordsInput/ExactKeywordsInput.ts
+++ b/src/ui/AdvancedSearch/KeywordsInput/ExactKeywordsInput.ts
@@ -2,8 +2,8 @@ import { KeywordsInput } from './KeywordsInput';
 import { l } from '../../../strings/Strings';
 
 export class ExactKeywordsInput extends KeywordsInput {
-  constructor() {
-    super(l('ExactPhrase'));
+  constructor(public root: HTMLElement) {
+    super(l('ExactPhrase'), root);
   }
 
   public getValue(): string {

--- a/src/ui/AdvancedSearch/KeywordsInput/KeywordsInput.ts
+++ b/src/ui/AdvancedSearch/KeywordsInput/KeywordsInput.ts
@@ -8,7 +8,7 @@ export class KeywordsInput implements IAdvancedSearchInput {
 
   protected input: TextInput;
 
-  constructor(public inputName: string) {
+  constructor(public inputName: string, public root: HTMLElement) {
   }
 
   public reset() {
@@ -40,7 +40,9 @@ export class KeywordsInput implements IAdvancedSearchInput {
   }
 
   protected onChange() {
-    if (this.input) {
+    if (this.root) {
+      $$(this.root).trigger(AdvancedSearchEvents.executeAdvancedSearch);
+    } else if (this.input) {
       $$(this.input.getElement()).trigger(AdvancedSearchEvents.executeAdvancedSearch);
     }
   }

--- a/src/ui/AdvancedSearch/KeywordsInput/NoneKeywordsInput.ts
+++ b/src/ui/AdvancedSearch/KeywordsInput/NoneKeywordsInput.ts
@@ -3,8 +3,8 @@ import { l } from '../../../strings/Strings';
 import * as _ from 'underscore';
 
 export class NoneKeywordsInput extends KeywordsInput {
-  constructor() {
-    super(l('NoneOfTheseWords'));
+  constructor(public root: HTMLElement) {
+    super(l('NoneOfTheseWords'), root);
   }
 
   public getValue(): string {

--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -249,8 +249,8 @@ export var analyticsActionCauseList = {
     metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
   },
   breadcrumbAdvancedSearch: <IAnalyticsActionCause>{
-    name : 'breadcrumbAdvancedSearch',
-    type : 'breadcrumb'
+    name: 'breadcrumbAdvancedSearch',
+    type: 'breadcrumb'
   },
   breadcrumbResetAll: <IAnalyticsActionCause>{
     name: 'breadcrumbResetAll',

--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -248,6 +248,10 @@ export var analyticsActionCauseList = {
     type: 'breadcrumb',
     metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
   },
+  breadcrumbAdvancedSearch: <IAnalyticsActionCause>{
+    name : 'breadcrumbAdvancedSearch',
+    type : 'breadcrumb'
+  },
   breadcrumbResetAll: <IAnalyticsActionCause>{
     name: 'breadcrumbResetAll',
     type: 'breadcrumb',

--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -315,7 +315,9 @@ export class Recommendation extends SearchInterface implements IComponentBinding
       this.mainQuerySearchUID = args.results.searchUid;
       this.mainQueryPipeline = args.results.pipeline;
       this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.recommendation, {});
-      this.queryController.executeQuery();
+      this.queryController.executeQuery({
+        closeModalBox: false
+      });
     });
   }
 

--- a/test/ui/AdvancedSearch/AdvancedSearchTest.ts
+++ b/test/ui/AdvancedSearch/AdvancedSearchTest.ts
@@ -148,28 +148,47 @@ export function AdvancedSearchTest() {
           expect(simulation.queryBuilder.build().aq).toEqual('foo');
         });
 
-        it('should populate breadcrumb if the query is modified by any input', () => {
+        it('should populate breadcrumb if the query is modified by any input', (done) => {
           $$(test.env.root).on(BreadcrumbEvents.populateBreadcrumb, (e, args: IPopulateBreadcrumbEventArgs) => {
             expect(args.breadcrumbs.length).toEqual(1);
+            done();
           });
           const simulation = Simulate.query(test.env);
           expect(updateQuerySpy).toHaveBeenCalled();
+          Simulate.breadcrumb(test.env);
         });
 
-        it('should not populate breadcrumb if the query is not modified by any input', () => {
+        it('should not populate breadcrumb if the query is not modified by any input', (done) => {
           $$(test.env.root).on(BreadcrumbEvents.populateBreadcrumb, (e, args: IPopulateBreadcrumbEventArgs) => {
             expect(args.breadcrumbs.length).toEqual(0);
+            done();
           });
           updateQuerySpy.and.callFake((queryBuilder: QueryBuilder) => {
             // do nothing
           });
           const simulation = Simulate.query(test.env);
           expect(updateQuerySpy).toHaveBeenCalled();
+          Simulate.breadcrumb(test.env);
         });
 
         it('should call reset on each inputs when the breadcrumb is cleared', () => {
           $$(test.env.root).trigger(BreadcrumbEvents.clearBreadcrumb);
           expect(resetSpy).toHaveBeenCalled();
+        });
+
+        it('should call reset on each inputs when only this part of the breadcrumb is cleared', (done) => {
+          $$(test.env.root).on(BreadcrumbEvents.populateBreadcrumb, (e, args: IPopulateBreadcrumbEventArgs) => {
+            expect(args.breadcrumbs.length).toEqual(1);
+
+            const clear = $$(args.breadcrumbs[0].element).find('.coveo-advanced-search-breadcrumb-clear');
+            $$(clear).trigger('click');
+            expect(test.env.queryController.executeQuery).toHaveBeenCalled();
+            expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.breadcrumbAdvancedSearch, jasmine.any(Object));
+            done();
+
+          });
+          Simulate.query(test.env);
+          Simulate.breadcrumb(test.env);
         });
       });
     });

--- a/test/ui/AdvancedSearch/DateInput/BetweenDateInputTest.ts
+++ b/test/ui/AdvancedSearch/DateInput/BetweenDateInputTest.ts
@@ -7,7 +7,7 @@ export function BetweenDateInputTest() {
     let input: BetweenDateInput;
 
     beforeEach(function () {
-      input = new BetweenDateInput();
+      input = new BetweenDateInput($$('div').el);
       input.build();
       (<HTMLInputElement>$$((input.getElement())).find('input')).checked = true;
     });

--- a/test/ui/AdvancedSearch/DateInput/InTheLastDateInputTest.ts
+++ b/test/ui/AdvancedSearch/DateInput/InTheLastDateInputTest.ts
@@ -7,7 +7,7 @@ export function InTheLastDateInputTest() {
     let input: InTheLastDateInput;
 
     beforeEach(function () {
-      input = new InTheLastDateInput();
+      input = new InTheLastDateInput($$('div').el);
       input.build();
       (<HTMLInputElement>$$((input.getElement())).find('input')).checked = true;
     });

--- a/test/ui/AdvancedSearch/DocumentInput/AdvancedFieldInputTest.ts
+++ b/test/ui/AdvancedSearch/DocumentInput/AdvancedFieldInputTest.ts
@@ -1,4 +1,5 @@
 import { AdvancedFieldInput } from '../../../../src/ui/AdvancedSearch/DocumentInput/AdvancedFieldInput';
+import { $$ } from '../../../../src/utils/Dom';
 
 export function AdvancedFieldInputTest() {
   describe('AdvancedFieldInput', () => {
@@ -9,7 +10,7 @@ export function AdvancedFieldInputTest() {
     beforeEach(function () {
       value = 'what';
       fieldName = '@test';
-      input = new AdvancedFieldInput('test', fieldName);
+      input = new AdvancedFieldInput('test', fieldName, $$('div').el);
       input.build();
       input.input.setValue(value);
     });

--- a/test/ui/AdvancedSearch/DocumentInput/DocumentInputTest.ts
+++ b/test/ui/AdvancedSearch/DocumentInput/DocumentInputTest.ts
@@ -2,13 +2,14 @@ import { DocumentInput } from '../../../../src/ui/AdvancedSearch/DocumentInput/D
 import { QueryBuilder } from '../../../../src/ui/Base/QueryBuilder';
 import { ExpressionBuilder } from '../../../../src/ui/Base/ExpressionBuilder';
 import * as Mock from '../../../MockEnvironment';
+import { $$ } from '../../../../src/utils/Dom';
 
 export function DocumentInputTest() {
   describe('DocumentInput', () => {
     let input: DocumentInput;
 
     beforeEach(function () {
-      input = new DocumentInput('test');
+      input = new DocumentInput('test', $$('div').el);
       input.build();
     });
 

--- a/test/ui/AdvancedSearch/DocumentInput/SimpleFieldInputTest.ts
+++ b/test/ui/AdvancedSearch/DocumentInput/SimpleFieldInputTest.ts
@@ -1,6 +1,7 @@
 import { SimpleFieldInput } from '../../../../src/ui/AdvancedSearch/DocumentInput/SimpleFieldInput';
 import { SearchEndpoint } from '../../../../src/rest/SearchEndpoint';
 import * as Mock from '../../../MockEnvironment';
+import { $$ } from '../../../../src/utils/Dom';
 
 export function SimpleFieldInputTest() {
   describe('SimpleFieldInput', () => {
@@ -10,7 +11,7 @@ export function SimpleFieldInputTest() {
     beforeEach(function () {
       endpoint = Mock.mock<SearchEndpoint>(SearchEndpoint);
       mockListFieldValues();
-      input = new SimpleFieldInput('test', '@test', endpoint);
+      input = new SimpleFieldInput('test', '@test', endpoint, $$('div').el);
       input.build();
     });
 

--- a/test/ui/AdvancedSearch/DocumentInput/SizeInputTest.ts
+++ b/test/ui/AdvancedSearch/DocumentInput/SizeInputTest.ts
@@ -1,11 +1,12 @@
 import { SizeInput } from '../../../../src/ui/AdvancedSearch/DocumentInput/SizeInput';
+import { $$ } from '../../../../src/utils/Dom';
 
 export function SizeInputTest() {
   describe('SizeInput', () => {
     let input: SizeInput;
 
     beforeEach(function () {
-      input = new SizeInput();
+      input = new SizeInput($$('div').el);
       input.build();
     });
 

--- a/test/ui/AdvancedSearch/KeywordsInput/AnyKeywordsInputTest.ts
+++ b/test/ui/AdvancedSearch/KeywordsInput/AnyKeywordsInputTest.ts
@@ -1,11 +1,12 @@
 import { AnyKeywordsInput } from '../../../../src/ui/AdvancedSearch/KeywordsInput/AnyKeywordsInput';
+import { $$ } from '../../../../src/utils/Dom';
 
 export function AnyKeywordsInputTest() {
   describe('AnyKeywordsInput', () => {
     let input: AnyKeywordsInput;
 
     beforeEach(function () {
-      input = new AnyKeywordsInput();
+      input = new AnyKeywordsInput($$('div').el);
       input.build();
     });
 

--- a/test/ui/AdvancedSearch/KeywordsInput/ExactKeywordsInputTest.ts
+++ b/test/ui/AdvancedSearch/KeywordsInput/ExactKeywordsInputTest.ts
@@ -1,11 +1,12 @@
 import { ExactKeywordsInput } from '../../../../src/ui/AdvancedSearch/KeywordsInput/ExactKeywordsInput';
+import { $$ } from '../../../../src/utils/Dom';
 
 export function ExactKeywordsInputTest() {
   describe('ExactKeywordsInput', () => {
     let input: ExactKeywordsInput;
 
     beforeEach(function () {
-      input = new ExactKeywordsInput();
+      input = new ExactKeywordsInput($$('div').el);
       input.build();
     });
 

--- a/test/ui/AdvancedSearch/KeywordsInput/KeywordsInputTest.ts
+++ b/test/ui/AdvancedSearch/KeywordsInput/KeywordsInputTest.ts
@@ -1,6 +1,7 @@
 import { KeywordsInput } from '../../../../src/ui/AdvancedSearch/KeywordsInput/KeywordsInput';
 import { QueryBuilder } from '../../../../src/ui/Base/QueryBuilder';
 import { ExpressionBuilder } from '../../../../src/ui/Base/ExpressionBuilder';
+import { $$ } from '../../../../src/utils/Dom';
 import * as Mock from '../../../MockEnvironment';
 
 export function KeywordsInputTest() {
@@ -8,7 +9,7 @@ export function KeywordsInputTest() {
     let input: KeywordsInput;
 
     beforeEach(function () {
-      input = new KeywordsInput('test');
+      input = new KeywordsInput('test', $$('div').el);
       input.build();
     });
 

--- a/test/ui/AdvancedSearch/KeywordsInput/NoneKeywordsInputTest.ts
+++ b/test/ui/AdvancedSearch/KeywordsInput/NoneKeywordsInputTest.ts
@@ -1,11 +1,12 @@
 import { NoneKeywordsInput } from '../../../../src/ui/AdvancedSearch/KeywordsInput/NoneKeywordsInput';
+import { $$ } from '../../../../src/utils/Dom';
 
 export function NoneKeywordsInputTest() {
   describe('NoneKeywordsInput', () => {
     let input: NoneKeywordsInput;
 
     beforeEach(function () {
-      input = new NoneKeywordsInput();
+      input = new NoneKeywordsInput($$('div').el);
       input.build();
     });
 


### PR DESCRIPTION
Advanced search being opened in a modal box when the search interface is not global on the body would cause issue with queries not being triggered.

This changes the component so that it triggers it's event from the root of the interface instead of locally (which would bubble up before).


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)