### PR TITLE
Change check on init for "dual" initialization

### DIFF
--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -537,6 +537,10 @@ export class Initialization {
     return Utils.exists(Component.get(element, null, true));
   }
 
+  public static isThereANonSearchInterfaceComponentBoundToThisElement(element: HTMLElement): boolean {
+    return Initialization.isThereASingleComponentBoundToThisElement(element) && !get(element, SearchInterface, true);
+  }
+
   private static dispatchMethodCallOnBoundComponent(methodName: string, element: HTMLElement, args: any[]): any {
     Assert.isNonEmptyString(methodName);
     Assert.exists(element);
@@ -697,20 +701,20 @@ export class LazyInitialization {
     Assert.isNonEmptyString(componentClassId);
     Assert.exists(element);
 
-    if (Initialization.isThereASingleComponentBoundToThisElement(element)) {
-      // This means a component already exists on this element.
-      // Do not re-initialize again.
+    // If another component exist on that element, we do not want to re-initialize again.
+    // The exception being the "SearchInterface", since in some case we want end user to initialize directly on the root of the interface
+    // For example, when we are initializing a standalone search box, we might want to target the div for the search box directly.
+    if (Initialization.isThereANonSearchInterfaceComponentBoundToThisElement(element)) {
       return null;
     }
 
     return LazyInitialization.getLazyRegisteredComponent(componentClassId).then((lazyLoadedComponent: IComponentDefinition) => {
       Assert.exists(lazyLoadedComponent);
 
-      if (Initialization.isThereASingleComponentBoundToThisElement(element)) {
-        // This means a component already exists on this element.
-        // Do not re-initialize again.
+      if (Initialization.isThereANonSearchInterfaceComponentBoundToThisElement(element)) {
         return null;
       }
+
       let bindings: IComponentBindings = {};
       let options = {};
       let result: IQueryResult = undefined;
@@ -778,10 +782,10 @@ export class EagerInitialization {
       result = initParameters.result;
     }
 
-    if (Initialization.isThereASingleComponentBoundToThisElement(element)) {
-      // This means a component already exists on this element.
-      // Do not re-initialize again.
-      EagerInitialization.logger.warn(`Skipping component of class ${componentClassId} because the element is already initialized as another component.`, element);
+    // If another component exist on that element, we do not want to re-initialize again.
+    // The exception being the "SearchInterface", since in some case we want end user to initialize directly on the root of the interface
+    // For example, when we are initializing a standalone search box, we might want to target the div for the search box directly.
+    if (Initialization.isThereANonSearchInterfaceComponentBoundToThisElement(element)) {
       return null;
     }
 

--- a/test/ui/RegisteredNamedMethodsTest.ts
+++ b/test/ui/RegisteredNamedMethodsTest.ts
@@ -9,6 +9,7 @@ import { mockUsageAnalytics } from '../MockEnvironment';
 import { LazyInitialization } from '../../src/ui/Base/Initialization';
 import { NoopComponent } from '../../src/ui/NoopComponent/NoopComponent';
 import { Defer } from '../../src/misc/Defer';
+import { SearchInterface } from '../../src/ui/SearchInterface/SearchInterface';
 
 export function RegisteredNamedMethodsTest() {
   describe('RegisteredNamedMethods', () => {
@@ -84,6 +85,16 @@ export function RegisteredNamedMethodsTest() {
       expect((<Component>Component.get(searchbox)).options.triggerQueryOnClear).toBe(false);
     });
 
+    it('should allow to call initSearchbox if the searchbox is on the root of the element', () => {
+      expect(() => RegisteredNamedMethod.initSearchbox(searchbox, '/search', {
+        Searchbox: { addSearchButton: false },
+        SearchInterface: { autoTriggerQuery: false }
+      })).not.toThrow();
+
+      expect((<Component>Component.get(searchbox, Searchbox)) instanceof Searchbox).toBe(true);
+      expect((<Component>Component.get(searchbox, SearchInterface)) instanceof SearchInterface).toBe(true);
+    });
+
     it('should allow to call init recommendation correctly', (done) => {
       expect(() => RegisteredNamedMethod.initRecommendation(root, undefined, undefined, {
         Searchbox: { addSearchButton: false },
@@ -94,8 +105,6 @@ export function RegisteredNamedMethodsTest() {
         expect((<Component>Component.get(searchbox)).options.addSearchButton).toBe(false);
         done();
       });
-
-
     });
 
     it('should allow to call execute query', () => {


### PR DESCRIPTION
Should not take the SearchInterface into account
https://coveord.atlassian.net/browse/JSUI-1693





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)