### PR TITLE
Log error message at top level of init call in both lazy and eager mode

### DIFF
--- a/src/misc/Logger.ts
+++ b/src/misc/Logger.ts
@@ -1,4 +1,6 @@
 // Ensure that we're not going to get console is undefined error in IE8-9
+
+/* istanbul ignore next */
 if (!window['console']) {
   console = <any>{
     log: function () {
@@ -44,7 +46,7 @@ if (!window['console']) {
   };
 }
 
-
+/* istanbul ignore next */
 export class Logger {
   static TRACE = 1;
   static DEBUG = 2;

--- a/src/misc/Logger.ts
+++ b/src/misc/Logger.ts
@@ -91,7 +91,15 @@ export class Logger {
 
   private log(level: string, stuff: any[]) {
     if (window['console'] && console.log) {
-      console.log([level, this.owner].concat(stuff));
+      if (console.error && level == 'ERROR') {
+        console.error([level, this.owner].concat(stuff));
+      } else if (console.info && level == 'INFO') {
+        console.info([level, this.owner].concat(stuff));
+      } else if (console.warn && level == 'WARN') {
+        console.warn([level, this.owner].concat(stuff));
+      } else {
+        console.log([level, this.owner].concat(stuff));
+      }
       if (Logger.executionTime) {
         console.timeEnd('Execution time');
         console.time('Execution time');


### PR DESCRIPTION
Otherwise the errors gets "eaten" and it gets very hard to debug in lazy mode when something fails in the constructor of a component.

Also pimp up the Logger class a bit to use the appropriate console method when they are available.

https://coveord.atlassian.net/browse/JSUI-1709





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)