### PR TITLE
DOC-1197 - Improve ResultListEvents & AnalyticsEvents reference doc

### DIFF
--- a/src/events/AnalyticsEvents.ts
+++ b/src/events/AnalyticsEvents.ts
@@ -6,113 +6,160 @@ export interface IAnalyticsSearchEventsArgs {
   searchEvents: IAPISearchEvent[];
 }
 
-export interface IAnalyticsDocumentViewEventArgs {
-  documentViewEvent: IAPIDocumentViewEvent;
-}
-
 export interface IAnalyticsCustomEventArgs {
   customEvent: IAPICustomEvent;
 }
 
 /**
- * Argument sent to all handlers bound on {@link AnalyticsEvents.changeAnalyticsCustomData}.
+ * The `IChangeAnalyticsCustomDataEventArgs` interface describes the object that all
+ * [`changeAnalyticsCustomData`]{@link AnalyticsEvents.changeAnalyticsCustomData} event handlers receive as an argument.
  *
- * It extends the {@link IChangeableAnalyticsDataObject} interface.
+ * This interface extends the [`IChangeableAnalyticsDataObject`]{@link IChangeableAnalyticsDataObject} interface.
  *
- * Take note that only the attributes described by {@link IChangeableAnalyticsDataObject} can be modified by external code.
+ * **Notes:**
+ * > * External code can only modify the attributes described by the `IChangeableAnalyticsDataObject` interface.
+ * > * When the analytics event being logged is a `ClickEvent`, the `ChangeAnalyticsCustomDataEventArgs` object also
+ * > contains a `resultData` attribute, which describes the [`QueryResult`]{@link IQueryResult} that was clicked.
+ * > External code **cannot** modify this object.
  */
 export interface IChangeAnalyticsCustomDataEventArgs extends IChangeableAnalyticsDataObject {
+
   /**
-   * The type of the event that was just triggered.
+   * The type of the usage analytics event.
    *
-   * This can help external code to discriminate the event that it wishes to modify.
+   * **Note:**
+   * > External code **cannot** modify the value of this attribute.
    */
   type: 'SearchEvent' | 'CustomEvent' | 'ClickEvent';
+
   /**
-   * The type of the event.
+   * The generic action type of the usage analytics event.
    *
-   * The type is normally a generic string that regroups all events triggered by the same feature or component.
+   * All analytics events that strongly relate to a certain feature or component usually share the same `actionType`.
    *
-   * For example, all analytics events related to the Searchbox will all use the same actionType.
+   * For instance, all usage analytics events relating to the [`Facet`]{@link Facet} component have `facet` as their
+   * `actionType`, whereas all usage analytics events relating to the [`Breadcrumb`]{@link Breadcrumb} component have
+   * `breadcrumb` as their `actionType`.
    *
-   * Analytics events related to Facets, on the other hand, would use a different actionType.
+   * **Note:**
+   * > External code **cannot** modify the value of this attribute.
    */
   actionType: string;
+
   /**
-   * The cause of the event.
+   * The cause of the usage analytics event.
    *
-   * All analytics events triggered by a different component will use a different action cause.
+   * For instance, triggering a query using the search box logs a usage analytics event with `searchBoxSubmit` as its
+   * `actionCause`, whereas triggering a query by selecting a facet value logs a usage analytics event with
+   * `facetSelect` as its `actionCause`.
    *
-   * For example, triggering a query by using the search box will send a `searchBoxSubmit` actionCause.
-   *
-   * Triggering a query with a facet selection, on the other hand, will send a `facetSelect`.
+   * **Note:**
+   * > External code **cannot** modify the value of this attribute.
    */
   actionCause: string;
 }
 
 /**
- * The interface that describe the metadata for every analytics event.
+ * The `IChangeableAnalyticsMetaObject` interface describes the metadata which can be sent along with any usage
+ * analytics event.
  */
 export interface IChangeableAnalyticsMetaObject {
+
   /**
-   * The metadata for every analytics event is a simple key value pair, where the value has to be a simple string.
+   * A metadata key-value pair to send along with the usage analytics event.
    *
-   * The value cannot be a complex object.
+   * **Notes:**
+   * > * A metadata key must contain only alphanumeric characters and underscores (the Coveo Usage Analytics REST
+   * > service automatically converts white spaces to underscores and uppercase characters to lowercase characters in key
+   * > names).
+   * > * A metadata value must be a simple string (no other type is allowed).
    */
   [name: string]: string;
 }
 
 /**
- * The interface that describe part of the analytics event that can be modified.
+ * The `IChangeableAnalyticsDataObject` interface describes the modifiable part of the object that all
+ * [`changeAnalyticsCustomData`]{@link AnalyticsEvents.changeAnalyticsCustomData} event handlers receive as an argument.
  */
 export interface IChangeableAnalyticsDataObject {
+
   /**
-   * The metadata for the current event.
+   * The metadata to send along with the usage analytics event.
    *
-   * External code can modify an existing value, or add a new key - value pair.
+   * **Note:**
+   * > External code **can** modify existing values, or add new key-value pairs in this attribute.
    */
   metaObject: IChangeableAnalyticsMetaObject;
+
   /**
-   * The originLevel1 property can be used to describe the high level origin of the event.
+   * The high-level origin of the usage analytics event.
    *
-   * For example, this can be the location of the search page, or any name that allows you to uniquely identify a search interface.
+   * For instance, this could be the name of the search hub, or a name that can uniquely identify the search page from
+   * which the usage analytics event originates.
    *
-   * If not provided, this value will be `default`.
+   * Default value is `default`.
+   *
+   * **Note:**
+   * > External code **can** modify the value of this attribute.
    */
   originLevel1: string;
+
   /**
-   * The originLevel2 property can be used to describe the mid level origin of the event.
+   * The mid-level origin of the usage analytics event.
    *
-   * By default, the framework will populate this with the currently selected tab.
+   * By default, the framework populates this attribute with the `data-id` of the currently selected tab in the search
+   * interface from which the usage analytics event originates.
+   *
+   * **Note:**
+   * > External code **can** modify the value of this attribute.
    */
   originLevel2: string;
+
   /**
-   * The originLevel3 property can be used to describe the low level origin of the event.
+   * The low-level origin of the usage analytics event.
    *
-   * By default, this property will be left empty.
+   * For instance, this could be the HTTP identifier of the page from which the usage analytics event originates.
+   *
+   * Default value is the empty string.
+   *
+   * **Note:**
+   * > External code **can** modify the value of this attribute.
    */
   originLevel3: string;
+
   /**
-   * The language of the search interface.
+   * The language of the search interface from which the usage analytics event originates.
    *
-   * By default, this will be populated by the currently loaded localization and culture file for the search interface.
+   * By default, the framework populates this attribute with the currently loaded localization and culture file of the
+   * search interface from which the usage analytics event originates.
+   *
+   * **Note:**
+   * > External code **can** modify the value of this attribute.
    */
   language: string;
 }
 
 /**
- * This static class is there to contains the different string definition for all the events related to analytics.
+ * The `AnalyticsEvents` static class contains the string definitions of all events that strongly relate to usage
+ * analytics.
+ *
+ * See [Events](https://developers.coveo.com/x/bYGfAQ).
  */
 export class AnalyticsEvents {
   public static searchEvent = 'analyticsSearchEvent';
   public static documentViewEvent = 'analyticsDocumentViewEvent';
   public static customEvent = 'analyticsCustomEvent';
+
   /**
-   * Triggered whenever an analytics event is logged. This event allows external code to modify the analytics data.
+   * Triggered whenever an analytics event is about to be logged.
    *
-   * All bound handlers will receive {@link IChangeAnalyticsCustomDataEventArgs} as an argument.
+   * This event allows external code to modify the analytics data before it is sent to the Coveo Usage Analytics REST
+   * service.
    *
-   * The string value is `changeAnalyticsCustomData`.
+   * All `changeAnalyticsCustomData` event handlers receive a
+   * [`ChangeAnalyticsCustomDataEventArgs`]{@link IChangeAnalyticsCustomDataEventArgs} object as an argument.
+   *
+   * @type {string} The string value is `changeAnalyticsCustomData`.
    */
   public static changeAnalyticsCustomData = 'changeAnalyticsCustomData';
 }

--- a/src/events/ResultListEvents.ts
+++ b/src/events/ResultListEvents.ts
@@ -1,26 +1,103 @@
 import { IQueryResult } from '../rest/QueryResult';
 import { IQueryResults } from '../rest/QueryResults';
+import { ValidLayout } from '../ui/ResultLayout/ResultLayout';
 
+/**
+ * The `IDisplayedNewResultEventArgs` interface describes the object that all
+ * [`newResultDisplayed`]{@link ResultListEvents.newResultDisplayed} event handlers receive as an argument.
+ */
 export interface IDisplayedNewResultEventArgs {
+
+  /**
+   * The query result that was just displayed by the [`ResultList`]{@link ResultList} component.
+   */
   result: IQueryResult;
+
+  /**
+   * The HTML element which was rendered by the  the displayed result.
+   */
   item: HTMLElement;
 }
 
-export interface IDisplayedNewResultsEventArgs {
-}
-
+/**
+ * The `IOpenQuickviewEventArgs` interface describes the object that all
+ * [`openQuickview`]{@link ResultList.openQuickview} event handlers receive as an argument.
+ */
 export interface IOpenQuickviewEventArgs {
+
+  /**
+   * The array of query expression terms to highlight in the quickview modal window.
+   */
   termsToHighlight: any;
 }
 
+/**
+ * The `IChangeLayoutEventArgs` interface describes the object that all
+ * [`ChangeLayout`]{@link ResultListEvents.changeLayout} event handlers receive as an argument.
+ */
 export interface IChangeLayoutEventArgs {
-  layout: string;
+
+  /**
+   * The name of the new layout.
+   *
+   */
+  layout: ValidLayout;
+
+  /**
+   * The current page of results.
+   */
   results?: IQueryResults;
 }
 
+/**
+ * The `ResultListEvents` static class contains the string definitions of all events that strongly relate to the result
+ * list.
+ *
+ * See [Events](https://developers.coveo.com/x/bYGfAQ).
+ */
 export class ResultListEvents {
+
+  /**
+   * Triggered when the result list has just finished rendering the current page of results.
+   *
+   * @type {string} The string value is `newResultsDisplayed`.
+   */
   public static newResultsDisplayed = 'newResultsDisplayed';
+
+  /**
+   * Triggered each time the result list has just finished rendering a single result.
+   *
+   * All `newResultDisplayed` event handlers receive a
+   * [`DisplayedNewResultEventArgs`]{@link IDisplayedNewResultEventArgs} object as an argument.
+   *
+   * @type {string} The string value is `newResultDisplayed`.
+   */
   public static newResultDisplayed = 'newResultDisplayed';
+
+  /**
+   * Triggered by the [`ResultLink`]{@link ResultLink} result template component when its
+   * [`openQuickview`]{@link ResultLink.options.openQuickview} option is set to `true` and the end user clicks the
+   * result link. The [`Quickview`]{@link Quickview} component listens to this event to be able to open the quickview
+   * modal window in reaction.
+   *
+   * See also the [`openQuickview`]{@link QuickviewEvents.openQuickview} event (which is identical to this one, except
+   * that it is triggered by the [`QuickviewDocument`] result template component instead).
+   *
+   * All `openQuickview` event handlers receive an [`OpenQuickviewEventArgs`]{@link IOpenQuickviewEventArgs} object as
+   * an argument
+   *
+   * @type {string} The string value is `openQuickview`.
+   */
   public static openQuickview = 'openQuickview';
+
+  /**
+   * Triggered by the [`ResultLayout`]{@link ResultLayout} component whenever the current result layout changes (see
+   * [Result Layouts](https://developers.coveo.com/x/yQUvAg)).
+   *
+   * All `changeLayout` event handlers receive a [`ChangeLayoutEventArgs`]{@link IChangeLayoutEventArgs} object as an
+   * argument.
+   *
+   * @type {string} The string value is `changeLayout`.
+   */
   public static changeLayout = 'changeLayout';
 }


### PR DESCRIPTION
`ResultListEvents`
- Documented `ResultListEvents` static class and related args
interfaces.
- Removed unused `IDisplayedNewResultEventArgs` interface.
- Imported `ValidLayouts` type and changed type of
`IChangeLayoutEventArgs.layout` accordingly.

`AnalyticsEvents`
- Removed unused `IAnalyticsDocumentViewEventArgs` interface.
- Improved documentation of `changeAnalyticsCustomData` and its related
args interfaces.





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)