### PR TITLE
DOC-1198 Fully document the QuickviewEvents & OmniboxEvents classes

### DIFF
--- a/src/events/OmniboxEvents.ts
+++ b/src/events/OmniboxEvents.ts
@@ -3,6 +3,24 @@
 // The reference to magic-box with the triple slash is needed for dts-generator
 
 import { IOmniboxData, IOmniboxDataRow } from '../ui/Omnibox/OmniboxInterface';
+import { Omnibox } from '../ui/Omnibox/Omnibox';
+
+/**
+ * The `IPopulateOmniboxSuggestionsEventArgs` interface describes the object that all
+ * [`populateOmniboxSuggestions`]{@link OmniboxEvents.populateOmniboxSuggestions} event handlers receive as an argument.
+ */
+export interface IPopulateOmniboxSuggestionsEventArgs {
+
+  /**
+   * The [`Omnibox`]{@link Omnibox} component instance.
+   */
+  omnibox: Omnibox;
+
+  /**
+   * The list of resolved query completion suggestions, and/or query completion suggestion promises.
+   */
+  suggestions: Array<Coveo.MagicBox.Suggestion[] | Promise<Coveo.MagicBox.Suggestion[]>>;
+}
 
 export interface IPopulateOmniboxEventArgs extends IOmniboxData {
 }
@@ -14,14 +32,29 @@ export interface IOmniboxPreprocessResultForQueryEventArgs {
   result: Coveo.MagicBox.Result;
 }
 
-export interface ICloseOmniboxEventArgs {
-}
-
+/**
+ * The `OmniboxEvents` static class contains the string definitions of all events that strongly relate to the
+ * [`Omnibox`]{@link Omnibox} component.
+ */
 export class OmniboxEvents {
-  public static populateOmnibox = 'populateOmnibox';
-  public static openOmnibox = 'openOmnibox';
-  public static closeOmnibox = 'closeOmnibox';
 
+  public static populateOmnibox = 'populateOmnibox';
+
+  /**
+   * Triggered by the [`Omnibox`]{@link Omnibox} component before query completion suggestions are rendered.
+   *
+   * The out-of-the-box Coveo JavaScript Search Framework query completion suggestion addons (see the
+   * [`enableFieldAddon`]{@link Omnibox.options.enableFieldAddon},
+   * [`enableQueryExtensionAddon`]{@link Omnibox.options.enableQueryExtensionAddon}, and
+   * [`enableQuerySuggestAddon`]{@link Omnibox.options.enableQuerySuggestAddon} options of the `Omnibox`) push their
+   * respective suggestions in the argument object which is passed along with this event.
+   *
+   * All `populateOmniboxSuggestions` event handlers receive a
+   * [`PopulateOmniboxSuggestionsEventArgs`]{@link IPopulateOmniboxSuggestionsEventArgs} object as an argument.
+   *
+   * @type {string} The string value is `populateOmniboxSuggestions`.
+   */
   public static populateOmniboxSuggestions = 'populateOmniboxSuggestions';
+
   public static omniboxPreprocessResultForQuery = 'omniboxPreprocessResultForQuery';
 }

--- a/src/events/QuickviewEvents.ts
+++ b/src/events/QuickviewEvents.ts
@@ -1,8 +1,45 @@
+/**
+ * The `IQuickviewLoadedEventArgs` interface describes the object that all
+ * [`quickviewLoaded`]{@link QuickviewEvents.quickviewLoaded} event handlers receive as an argument.
+ */
 export interface IQuickviewLoadedEventArgs {
+
+  /**
+   * The amount of time it took to download the content to display in the quickview modal window (in milliseconds).
+   */
   duration: number;
 }
 
+/**
+ * The `QuickviewEvents` static class contains the string definitions of all events that strongly relate to the
+ * [`Quickview`]{@link Quickview} component.
+ */
 export class QuickviewEvents {
+
+  /**
+   * Triggered by the [`QuickviewDocument`]{@link QuickviewDocument} component when the content to display in the
+   * quickview modal window has just finished downloading.
+   *
+   * The [`Quickview`]{@link Quickview} component listens to this event to know when to remove its loading animation.
+   *
+   * All `quickviewLoaded` event handlers receive a [`QuickviewLoadedEventArgs`]{@link IQuickviewLoadedEventArgs} object
+   * as an argument.
+   *
+   * @type {string} The string value is `quickviewLoaded`.
+   */
   public static quickviewLoaded = 'quickviewLoaded';
+
+  /**
+   * Triggered by the [`QuickviewDocument`]{@link QuickviewDocument} component when the end user has just clicked the
+   * **Quickview** button/link to open the quickview modal window.
+   *
+   * This event allows external code to modify the terms to highlight before the content of the quickview modal window
+   * is rendered.
+   *
+   * All `openQuickview` event handlers receive an
+   * [`OpenQuickviewEventArgs`]{@link ResultListEvents.IOpenQuickviewEventArgs} object as an argument.
+   *
+   * @type {string} The string value is `openQuickview`.
+   */
   public static openQuickview = 'openQuickview';
 }

--- a/src/ui/Omnibox/FieldAddon.ts
+++ b/src/ui/Omnibox/FieldAddon.ts
@@ -1,6 +1,6 @@
 ///<reference path='Omnibox.ts'/>
-import { Omnibox, IPopulateOmniboxSuggestionsEventArgs, IOmniboxSuggestion, MagicBox } from './Omnibox';
-import { OmniboxEvents } from '../../events/OmniboxEvents';
+import { Omnibox, IOmniboxSuggestion, MagicBox } from './Omnibox';
+import { OmniboxEvents, IPopulateOmniboxSuggestionsEventArgs } from '../../events/OmniboxEvents';
 import { IFieldDescription } from '../../rest/FieldDescription';
 import { IEndpointError } from '../../rest/EndpointError';
 import * as _ from 'underscore';

--- a/src/ui/Omnibox/OldOmniboxAddon.ts
+++ b/src/ui/Omnibox/OldOmniboxAddon.ts
@@ -1,7 +1,12 @@
 ///<reference path="Omnibox.ts"/>
-import { Omnibox, IPopulateOmniboxSuggestionsEventArgs, IOmniboxSuggestion } from './Omnibox';
+import { Omnibox, IOmniboxSuggestion } from './Omnibox';
 import { IOmniboxDataRow } from './OmniboxInterface';
-import { OmniboxEvents, IPopulateOmniboxEventArgs, IPopulateOmniboxEventRow } from '../../events/OmniboxEvents';
+import {
+  OmniboxEvents,
+  IPopulateOmniboxEventArgs,
+  IPopulateOmniboxEventRow,
+  IPopulateOmniboxSuggestionsEventArgs
+} from '../../events/OmniboxEvents';
 import { $$ } from '../../utils/Dom';
 import { Utils } from '../../utils/Utils';
 import * as _ from 'underscore';

--- a/src/ui/Omnibox/QueryExtensionAddon.ts
+++ b/src/ui/Omnibox/QueryExtensionAddon.ts
@@ -1,6 +1,6 @@
 ///<reference path='Omnibox.ts'/>
-import { OmniboxEvents } from '../../events/OmniboxEvents';
-import { Omnibox, IPopulateOmniboxSuggestionsEventArgs, IOmniboxSuggestion, MagicBox } from './Omnibox';
+import { OmniboxEvents, IPopulateOmniboxSuggestionsEventArgs } from '../../events/OmniboxEvents';
+import { Omnibox, IOmniboxSuggestion, MagicBox } from './Omnibox';
 import { IExtension } from '../../rest/Extension';
 import * as _ from 'underscore';
 

--- a/src/ui/Omnibox/QuerySuggestAddon.ts
+++ b/src/ui/Omnibox/QuerySuggestAddon.ts
@@ -1,9 +1,9 @@
 ///<reference path="Omnibox.ts"/>
-import { Omnibox, IPopulateOmniboxSuggestionsEventArgs, IOmniboxSuggestion } from './Omnibox';
+import { Omnibox, IOmniboxSuggestion } from './Omnibox';
 import { $$, Dom } from '../../utils/Dom';
 import { IQuerySuggestCompletion, IQuerySuggestRequest, IQuerySuggestResponse } from '../../rest/QuerySuggest';
 import { ComponentOptionsModel } from '../../models/ComponentOptionsModel';
-import { OmniboxEvents } from '../../events/OmniboxEvents';
+import { OmniboxEvents, IPopulateOmniboxSuggestionsEventArgs } from '../../events/OmniboxEvents';
 import { StringUtils } from '../../utils/StringUtils';
 import * as _ from 'underscore';
 


### PR DESCRIPTION
`QuickviewEvents.ts`:
- Documented everything.

`OmniboxEvents.ts`:
- Moved the `IPopulateOmniboxSuggestionsEventArgs` interface definition
from `Omnibox.txt`to `OmniboxEvents.ts` (refactored imports accordingly)
- Removed the unused `openOmnibox` and `closeOmnibox` events.
- Documented the `populateOmniboxSuggestions` event and its related
args interface.

`FieldAddon.ts`, `OldOmniboxAddon.ts`, `QueryExtensionAddon.ts`, and
`QuerySuggestAddon.ts`:
- Refactored `IPopulateOmniboxSuggestionsEventArgs` import.

`Omnibox.ts`:
- Removed unused `InitializationEvents` import.
- Some documentation improvements.





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)