### PR TITLE
defensive coding for icon option in card overlay

### DIFF
--- a/src/ui/Base/ComponentOptions.ts
+++ b/src/ui/Base/ComponentOptions.ts
@@ -746,13 +746,13 @@ export class ComponentOptions {
 
   static loadIconOption(element: HTMLElement, name: string, option: IComponentOptions<any>): string {
     let svgIconName = ComponentOptions.loadStringOption(element, name, option);
+    if (Utils.isNullOrUndefined(SVGIcons.icons[svgIconName])) {
+      new Logger(element).warn(`Icon with name ${svgIconName} not found.`);
+      return undefined;
+    }
     svgIconName = svgIconName.replace('coveo-sprites-replies', 'replies');
     svgIconName = svgIconName.replace('coveo-sprites-main-search-active', 'search');
     svgIconName = Utils.toCamelCase(svgIconName);
-    if (Utils.isNullOrUndefined(SVGIcons.icons[svgIconName])) {
-      new Logger(element).warn(`Icon with name ${svgIconName} not found.`);
-      svgIconName = undefined;
-    }
     return svgIconName;
   }
 

--- a/src/ui/Base/ComponentOptions.ts
+++ b/src/ui/Base/ComponentOptions.ts
@@ -377,7 +377,7 @@ export class ComponentOptions {
    *
    * > `data-foo="search"`
    *
-   * > `data-foo="facetExpand"`
+   * > `data-foo="facet-expand"`
    *
    * @param optionArgs The arguments to apply when building the option.
    * @returns {string} The resulting option value.
@@ -745,9 +745,13 @@ export class ComponentOptions {
   }
 
   static loadIconOption(element: HTMLElement, name: string, option: IComponentOptions<any>): string {
-    const svgIconName = ComponentOptions.loadStringOption(element, name, option);
+    let svgIconName = ComponentOptions.loadStringOption(element, name, option);
+    svgIconName = svgIconName.replace('coveo-sprites-replies', 'replies');
+    svgIconName = svgIconName.replace('coveo-main-search-active', 'search');
+    svgIconName = Utils.toCamelCase(svgIconName);
     if (Utils.isNullOrUndefined(SVGIcons.icons[svgIconName])) {
       new Logger(element).warn(`Icon with name ${svgIconName} not found.`);
+      svgIconName = undefined;
     }
     return svgIconName;
   }

--- a/src/ui/Base/ComponentOptions.ts
+++ b/src/ui/Base/ComponentOptions.ts
@@ -750,8 +750,12 @@ export class ComponentOptions {
       new Logger(element).warn(`Icon with name ${svgIconName} not found.`);
       return undefined;
     }
+
+    // Old card templates icons used these values as the icon option. These names have changed since we moved to SVG.
+    // This avoids breaking old default templates that people may still have after moving to 2.0.
     svgIconName = svgIconName.replace('coveo-sprites-replies', 'replies');
     svgIconName = svgIconName.replace('coveo-sprites-main-search-active', 'search');
+
     svgIconName = Utils.toCamelCase(svgIconName);
     return svgIconName;
   }

--- a/src/ui/Base/ComponentOptions.ts
+++ b/src/ui/Base/ComponentOptions.ts
@@ -747,7 +747,7 @@ export class ComponentOptions {
   static loadIconOption(element: HTMLElement, name: string, option: IComponentOptions<any>): string {
     let svgIconName = ComponentOptions.loadStringOption(element, name, option);
     svgIconName = svgIconName.replace('coveo-sprites-replies', 'replies');
-    svgIconName = svgIconName.replace('coveo-main-search-active', 'search');
+    svgIconName = svgIconName.replace('coveo-sprites-main-search-active', 'search');
     svgIconName = Utils.toCamelCase(svgIconName);
     if (Utils.isNullOrUndefined(SVGIcons.icons[svgIconName])) {
       new Logger(element).warn(`Icon with name ${svgIconName} not found.`);

--- a/src/ui/CardOverlay/CardOverlay.ts
+++ b/src/ui/CardOverlay/CardOverlay.ts
@@ -55,7 +55,7 @@ export class CardOverlay extends Component {
     /**
      * Specifies the icon to use for the overlay icon and for the button icon.
      *
-     * The name of the icon to use should be specified in lowerCamelCase.
+     * The name of the icon to use should be specified in dashed case. ie: facet-expand
      */
     icon: ComponentOptions.buildIconOption()
   };

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -325,6 +325,10 @@ export class Utils {
     return camelCased.replace(/([a-z][A-Z])/g, (g) => g[0] + '-' + g[1].toLowerCase());
   }
 
+  static toCamelCase(dashCased: string) {
+    return dashCased.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
+  }
+
   // Based on http://stackoverflow.com/a/8412989
   static parseXml(xml: string): XMLDocument {
     if (typeof DOMParser != 'undefined') {

--- a/templates/All/Card.html
+++ b/templates/All/Card.html
@@ -16,7 +16,7 @@
   </div>
   <div class="CoveoCardActionBar">
     <div class="CoveoQuickview"></div>
-    <div class="CoveoCardOverlay" data-title="Details" data-icon="coveo-sprites-replies">
+    <div class="CoveoCardOverlay" data-title="Details" data-icon="search">
       <table class="CoveoFieldTable" data-allow-minimization="false">
         <tbody>
           <tr data-field="@author" data-caption="Author">

--- a/templates/All/Card.html
+++ b/templates/All/Card.html
@@ -16,7 +16,7 @@
   </div>
   <div class="CoveoCardActionBar">
     <div class="CoveoQuickview"></div>
-    <div class="CoveoCardOverlay" data-title="Details" data-icon="search">
+    <div class="CoveoCardOverlay" data-title="Details" data-icon="coveo-sprites-replies">
       <table class="CoveoFieldTable" data-allow-minimization="false">
         <tbody>
           <tr data-field="@author" data-caption="Author">


### PR DESCRIPTION
Replace the old default icon names with the new ones, for the CardOverlay component. 
This is to avoid breaking old templates.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)