### PR TITLE
translations over filetypes captions

### DIFF
--- a/gulpTasks/strings.js
+++ b/gulpTasks/strings.js
@@ -3,8 +3,8 @@ const strings = require('../strings/strings');
 const stringValidations = require('../strings/stringsValidations');
 
 gulp.task('strings', [ 'fileTypes' ], function (done) {
-  var dict = strings.load('./strings/strings.json', { module: 'Coveo' });
-  dict.merge(strings.load('./bin/strings/filetypesNew.json'));
+  const dict = strings.load('./bin/strings/filetypesNew.json');
+  dict.merge(strings.load('./strings/strings.json', { module: 'Coveo' }));
 
   dict.writeDeclarationFile('./src/strings/Strings.ts');
   dict.writeDefaultLanguage('./src/strings/DefaultLanguage.ts', 'en', './strings/cultures/globalize.culture.en-US.js', true);

--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -97,12 +97,11 @@ export class FacetSearch {
         if ($$(this.searchResults).css('display') == 'none') {
           this.searchResults.style.display = '';
         }
-        let self = this;
-        EventsUtils.addPrefixedEvent(this.search, 'AnimationEnd', function (evt) {
-          PopupUtils.positionPopup(self.searchResults, nextTo, self.root,
+        EventsUtils.addPrefixedEvent(this.search, 'AnimationEnd', evt => {
+          PopupUtils.positionPopup(this.searchResults, nextTo, this.root,
             { horizontal: HorizontalAlignment.CENTER, vertical: VerticalAlignment.BOTTOM }
           );
-          EventsUtils.removePrefixedEvent(self.search, 'AnimationEnd', this);
+          EventsUtils.removePrefixedEvent(this.search, 'AnimationEnd', this);
         });
       } else {
         PopupUtils.positionPopup(this.searchResults, nextTo, this.root,


### PR DESCRIPTION
We recently added strings translations that were taken from the objectypes/filetypes files without their prefix:
```    out[objecttype.toLowerCase()] = json.objecttype[objecttype].captions;```

This caused the "list" string translation to be overwrited with its object type caption which is `marketing list`.

It's not necessarily wrong to do this as a backup so I inversed the order the strings translations were generated. Now the strings translations will overwrite the file types and object types captions.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)