### PR TITLE
DOC-1289 - Fix `HiddenQuery` live example

### DIFF
--- a/docs/playground/src/PlaygroundConfiguration.ts
+++ b/docs/playground/src/PlaygroundConfiguration.ts
@@ -182,8 +182,11 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   HiddenQuery: {
     show: true,
+    options: {
+      title: 'This is the filter title'
+    },
     toExecute: ()=> {
-      let searchInterface = $$(document.body).find('.CoveoSearchInterface')
+      let searchInterface = $$(document.body).find('.component-container .CoveoSearchInterface');
       Coveo.state(searchInterface, 'hd', 'This is the filter description');
       Coveo.state(searchInterface, 'hq', '@uri');
     },


### PR DESCRIPTION
- Made the `.CoveoSearchInterface` CSS selector more specific (since
the blue header was added to the docs site, there are now two elements
with this class, which explains why this live example was not displaying
itself properly).
- Also specified the `title` option to make the example more complete.





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)