### PR TITLE
DOC-1416 Fix docs site job to make it check package version before

### DIFF
--- a/deploy.doc.sh
+++ b/deploy.doc.sh
@@ -30,13 +30,14 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 check_versions() {
-  packageVersion=$(ruby -rjson -e "j = JSON.parse(File.read('package.json')); puts j['version']")
+  source read.version.sh
+  packageVersion=${PACKAGE_JSON_VERSION}
   npmVersion=$(npm view coveo-search-ui version)
   compare_versions ${packageVersion} ${npmVersion}
   retval=$?
   if [ ${retval} == 2 ]; then
-    echo "Package version (${packageVersion}) is lower than current npm version (${npmVersion}). Aborting." >&2
-    exit 2
+    echo "Package version (${packageVersion}) is lower than current npm version (${npmVersion}). Skipping documentation site deployment."
+    exit 0
   fi
 }
 

--- a/deploy.doc.sh
+++ b/deploy.doc.sh
@@ -29,6 +29,40 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+check_versions() {
+  packageVersion=$(ruby -rjson -e "j = JSON.parse(File.read('package.json')); puts j['version']")
+  npmVersion=$(npm view coveo-search-ui version)
+  compare_versions ${packageVersion} ${npmVersion}
+  retval=$?
+  if [ ${retval} == 2 ]; then
+    echo "Package version (${packageVersion}) is lower than current npm version (${npmVersion}). Aborting." >&2
+    exit 2
+  fi
+}
+
+compare_versions() {
+  local v1=( $(echo "$1" | tr '.' ' ') )
+  local v2=( $(echo "$2" | tr '.' ' ') )
+  local len="$(min "${#v1[*]}" "${#v2[*]}")"
+  for ((i=0; i<len; i++))
+  do
+    [ "${v1[i]:-0}" -gt "${v2[i]:-0}" ] && return 1
+    [ "${v1[i]:-0}" -lt "${v2[i]:-0}" ] && return 2
+  done
+  return 0
+}
+
+min() {
+  local m="$1"
+  for n in "$@"
+  do
+    [ "$n" -lt "$m" ] && m="$n"
+  done
+  echo "$m"
+}
+
+check_versions
+
 set -o errexit #abort if any command fails
 me=$(basename "$0")
 


### PR DESCRIPTION
deploying

- Added logic at the very beginning of the script.

If the version number in the `package.json` file is lower than the
current version number on npm, the process immediately aborts (exits
with code 2).





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)