### PR TITLE
Ignore all HTML elements matching the ignore parameters on initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10997,12 +10997,6 @@
       "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
       "dev": true
     },
-    "symbol-observable": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-      "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
-      "dev": true
-    },
     "symbol-tree": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",

--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -74,13 +74,13 @@ export class Initialization {
    * @param options
    */
   public static registerDefaultOptions(element: HTMLElement, options: {}): void {
-    let existing = element['CoveoDefaultOptions'] || {};
-    let updated = Utils.extendDeep(existing, options);
+    const existing = element['CoveoDefaultOptions'] || {};
+    const updated = Utils.extendDeep(existing, options);
     element['CoveoDefaultOptions'] = updated;
   }
 
   public static resolveDefaultOptions(element: HTMLElement, options: {}): {} {
-    let optionsForThisElement = element['CoveoDefaultOptions'];
+    const optionsForThisElement = element['CoveoDefaultOptions'];
 
     let optionsSoFar: {};
     if (Utils.exists(optionsForThisElement)) {
@@ -140,7 +140,7 @@ export class Initialization {
 
     // Register with both name (eg : Facet and CoveoFacet) to reduce possible confusion.
     // The id concept for component is fuzzy for a lot of people (include the Coveo prefix or not)
-    let registerById = id => {
+    const registerById = id => {
       if (Initialization.fieldsNeededForQueryByComponent[id] == null) {
         Initialization.fieldsNeededForQueryByComponent[id] = fields;
       } else {
@@ -235,7 +235,7 @@ export class Initialization {
     initSearchInterfaceFunction: (...args: any[]) => IInitResult
   ): Promise<{ elem: HTMLElement }> {
     Assert.exists(element);
-    let alreadyInitialized = Component.get(element, QueryController, true);
+    const alreadyInitialized = Component.get(element, QueryController, true);
     if (alreadyInitialized) {
       this.logger.error('This DOM element has already been initialized as a search interface, skipping initialization', element);
       return new Promise((resolve, reject) => {
@@ -260,7 +260,7 @@ export class Initialization {
         Initialization.performInitFunctionsOption(options, InitializationEvents.afterInitialization);
         $$(element).trigger(InitializationEvents.afterInitialization);
 
-        let searchInterface = <SearchInterface>Component.get(element, SearchInterface);
+        const searchInterface = <SearchInterface>Component.get(element, SearchInterface);
         if (searchInterface.options.autoTriggerQuery) {
           Initialization.logFirstQueryCause(searchInterface);
           let shouldLogInActionHistory = true;
@@ -308,9 +308,9 @@ export class Initialization {
    */
   public static initSearchInterface(element: HTMLElement, options: any = {}): IInitResult {
     options = Initialization.resolveDefaultOptions(element, options);
-    let searchInterface = new SearchInterface(element, options.SearchInterface, options.Analytics);
+    const searchInterface = new SearchInterface(element, options.SearchInterface, options.Analytics);
     searchInterface.options.originalOptionsObject = options;
-    let initParameters: IInitializationParameters = { options: options, bindings: searchInterface.getBindings() };
+    const initParameters: IInitializationParameters = { options: options, bindings: searchInterface.getBindings() };
     return Initialization.automaticallyCreateComponentsInside(element, initParameters, ['Recommendation']);
   }
 
@@ -340,9 +340,9 @@ export class Initialization {
       options.Searchbox.triggerQueryOnClear = false;
     }
 
-    let searchInterface = new StandaloneSearchInterface(element, options.StandaloneSearchInterface, options.Analytics);
+    const searchInterface = new StandaloneSearchInterface(element, options.StandaloneSearchInterface, options.Analytics);
     searchInterface.options.originalOptionsObject = options;
-    let initParameters: IInitializationParameters = { options: options, bindings: searchInterface.getBindings() };
+    const initParameters: IInitializationParameters = { options: options, bindings: searchInterface.getBindings() };
     return Initialization.automaticallyCreateComponentsInside(element, initParameters);
   }
 
@@ -355,15 +355,15 @@ export class Initialization {
   public static initRecommendationInterface(element: HTMLElement, options: any = {}): IInitResult {
     options = Initialization.resolveDefaultOptions(element, options);
     // Since a recommendation interface inherits from a search interface, we need to merge those if passed on init
-    let optionsForRecommendation = _.extend({}, options.SearchInterface, options.Recommendation);
+    const optionsForRecommendation = _.extend({}, options.SearchInterface, options.Recommendation);
     // If there is a main search interface, modify the loading animation for the recommendation interface to a "noop" element
     // We don't want 2 animation overlapping
     if (optionsForRecommendation.mainSearchInterface) {
       optionsForRecommendation.firstLoadingAnimation = $$('span').el;
     }
-    let recommendation = new window['Coveo']['Recommendation'](element, optionsForRecommendation, options.Analytics);
+    const recommendation = new window['Coveo']['Recommendation'](element, optionsForRecommendation, options.Analytics);
     recommendation.options.originalOptionsObject = options;
-    let initParameters: IInitializationParameters = { options: options, bindings: recommendation.getBindings() };
+    const initParameters: IInitializationParameters = { options: options, bindings: recommendation.getBindings() };
     return Initialization.automaticallyCreateComponentsInside(element, initParameters);
   }
 
@@ -381,7 +381,7 @@ export class Initialization {
   ): IInitResult {
     Assert.exists(element);
 
-    let codeToExecute: { (): Promise<Component>[] | void }[] = [];
+    const codeToExecute: { (): Promise<Component>[] | void }[] = [];
 
     let htmlElementsToIgnore: HTMLElement[] = [];
 
@@ -389,10 +389,10 @@ export class Initialization {
     // When a component is ignored, all it's children component should be ignored too.
     // Add them to the array of html elements that should be skipped.
     _.each(ignore, toIgnore => {
-      let rootsToIgnore = $$(element).findAll(`.${Component.computeCssClassNameForType(toIgnore)}`);
+      const rootsToIgnore = $$(element).findAll(`.${Component.computeCssClassNameForType(toIgnore)}`);
       if (rootsToIgnore && rootsToIgnore.length > 0) {
         _.each(rootsToIgnore, rootToIgnore => {
-          let childsElementsToIgnore = $$(rootToIgnore).findAll('*');
+          const childsElementsToIgnore = $$(rootToIgnore).findAll('*');
           htmlElementsToIgnore = htmlElementsToIgnore.concat(childsElementsToIgnore);
         });
       }
@@ -402,7 +402,7 @@ export class Initialization {
 
     _.each(Initialization.getListOfRegisteredComponents(), (componentClassId: string) => {
       if (!_.contains(ignore, componentClassId)) {
-        let classname = Component.computeCssClassNameForType(`${componentClassId}`);
+        const classname = Component.computeCssClassNameForType(`${componentClassId}`);
         let elements = $$(element).findAll('.' + classname);
         // From all the component we found which match the current className, remove those that should be ignored
         elements = _.difference(elements, htmlElementsToIgnore);
@@ -493,17 +493,17 @@ export class Initialization {
 
     let componentClass;
     if (methodName.indexOf('.') > 0) {
-      let splitArg = methodName.split('.');
+      const splitArg = methodName.split('.');
       Assert.check(splitArg.length == 2, 'Invalid method name, correct syntax is CoveoComponent.methodName.');
       componentClass = splitArg[0];
       methodName = <string>splitArg[1];
     }
 
-    let boundComponent = Component.get(element, componentClass);
+    const boundComponent = Component.get(element, componentClass);
     Assert.exists(boundComponent);
     Assert.exists(boundComponent[methodName]);
 
-    let originalMethodName = '__' + methodName;
+    const originalMethodName = '__' + methodName;
     if (!Utils.exists(boundComponent[originalMethodName])) {
       boundComponent[originalMethodName] = boundComponent[methodName];
     }
@@ -525,10 +525,10 @@ export class Initialization {
     const boxRef = Component.getComponentRef(fromInitTypeToBoxReference);
     if (boxRef) {
       new Logger(element).info('Initializing box of type ' + fromInitTypeToBoxReference);
-      let injectFunction: () => any = injectMarkup ? boxRef.getInjection : () => {};
-      let box = new boxRef(element, options[fromInitTypeToBoxReference], options.Analytics, injectFunction, options);
+      const injectFunction: () => any = injectMarkup ? boxRef.getInjection : () => {};
+      const box = new boxRef(element, options[fromInitTypeToBoxReference], options.Analytics, injectFunction, options);
       box.options.originalOptionsObject = options;
-      let initParameters: IInitializationParameters = { options: options, bindings: box.getBindings() };
+      const initParameters: IInitializationParameters = { options: options, bindings: box.getBindings() };
       return Initialization.automaticallyCreateComponentsInside(element, initParameters);
     } else {
       return {
@@ -548,7 +548,7 @@ export class Initialization {
     Assert.isNonEmptyString(methodName);
     Assert.exists(element);
 
-    let namedMethodHandler: (element: HTMLElement, ...args: any[]) => any = Initialization.namedMethods[methodName];
+    const namedMethodHandler: (element: HTMLElement, ...args: any[]) => any = Initialization.namedMethods[methodName];
     Assert.exists(namedMethodHandler);
 
     Initialization.logger.trace('Dispatching named method call of ' + methodName, element, args);
@@ -598,10 +598,10 @@ export class Initialization {
     Assert.isNonEmptyString(methodName);
     Assert.exists(element);
 
-    let boundComponent = Component.get(element);
+    const boundComponent = Component.get(element);
     Assert.exists(boundComponent);
 
-    let method = boundComponent[methodName];
+    const method = boundComponent[methodName];
     if (Utils.exists(method)) {
       return method.apply(boundComponent, args);
     } else {
@@ -610,9 +610,9 @@ export class Initialization {
   }
 
   private static logFirstQueryCause(searchInterface: SearchInterface) {
-    let firstQueryCause = HashUtils.getValue('firstQueryCause', HashUtils.getHash());
+    const firstQueryCause = HashUtils.getValue('firstQueryCause', HashUtils.getHash());
     if (firstQueryCause != null) {
-      let meta = HashUtils.getValue('firstQueryMeta', HashUtils.getHash()) || {};
+      const meta = HashUtils.getValue('firstQueryMeta', HashUtils.getHash()) || {};
       searchInterface.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList[firstQueryCause], meta);
     } else {
       if (Initialization.isSearchFromLink(searchInterface)) {
@@ -641,18 +641,18 @@ export class Initialization {
 
   private static initExternalComponents(element: HTMLElement, options?: any): Promise<Boolean> {
     if (options && options['externalComponents']) {
-      let searchInterface = <SearchInterface>Component.get(element, SearchInterface);
-      let queryStateModel = <QueryStateModel>Component.get(element, QueryStateModel);
-      let componentStateModel = <ComponentStateModel>Component.get(element, ComponentStateModel);
-      let queryController = <QueryController>Component.get(element, QueryController);
-      let componentOptionsModel = <ComponentOptionsModel>Component.get(element, ComponentOptionsModel);
-      let usageAnalytics = searchInterface.usageAnalytics;
+      const searchInterface = <SearchInterface>Component.get(element, SearchInterface);
+      const queryStateModel = <QueryStateModel>Component.get(element, QueryStateModel);
+      const componentStateModel = <ComponentStateModel>Component.get(element, ComponentStateModel);
+      const queryController = <QueryController>Component.get(element, QueryController);
+      const componentOptionsModel = <ComponentOptionsModel>Component.get(element, ComponentOptionsModel);
+      const usageAnalytics = searchInterface.usageAnalytics;
       Assert.exists(searchInterface);
       Assert.exists(queryStateModel);
       Assert.exists(queryController);
       Assert.exists(componentStateModel);
       Assert.exists(usageAnalytics);
-      let initParameters: IInitializationParameters = {
+      const initParameters: IInitializationParameters = {
         options: options,
         bindings: {
           searchInterface: searchInterface,
@@ -665,7 +665,7 @@ export class Initialization {
         }
       };
       const initializationOfExternalComponents = _.map(options['externalComponents'], (externalComponent: HTMLElement | IJQuery) => {
-        let elementToInstantiate = externalComponent;
+        const elementToInstantiate = externalComponent;
         if (Utils.isHtmlElement(elementToInstantiate)) {
           return Initialization.automaticallyCreateComponentsInside(<HTMLElement>elementToInstantiate, initParameters).initResult;
         } else if (JQueryUtils.isInstanceOfJQuery(elementToInstantiate)) {
@@ -736,20 +736,20 @@ export class LazyInitialization {
     initParameters: IInitializationParameters
   ): { factory: () => Promise<Component>[]; isLazyInit: boolean } {
     const factory = () => {
-      let promises: Promise<Component>[] = [];
+      const promises: Promise<Component>[] = [];
       _.each(elements, (matchingElement: HTMLElement) => {
         if (Component.get(matchingElement, componentClassId) == null) {
           // If options were provided, lookup options for this component class and
           // also for the element id. Merge them and pass those to the factory method.
           let optionsToUse = undefined;
           if (Utils.exists(initParameters.options)) {
-            let optionsForComponentClass = initParameters.options[componentClassId];
-            let optionsForElementId = initParameters.options[matchingElement.id];
-            let initOptions = initParameters.options['initOptions'] ? initParameters.options['initOptions'][componentClassId] : {};
+            const optionsForComponentClass = initParameters.options[componentClassId];
+            const optionsForElementId = initParameters.options[matchingElement.id];
+            const initOptions = initParameters.options['initOptions'] ? initParameters.options['initOptions'][componentClassId] : {};
             optionsToUse = Utils.extendDeep(optionsForElementId, initOptions);
             optionsToUse = Utils.extendDeep(optionsForComponentClass, optionsToUse);
           }
-          let initParamToUse = _.extend({}, initParameters, { options: optionsToUse });
+          const initParamToUse = _.extend({}, initParameters, { options: optionsToUse });
 
           promises.push(LazyInitialization.createComponentOfThisClassOnElement(componentClassId, matchingElement, initParamToUse));
         }
@@ -785,7 +785,7 @@ export class LazyInitialization {
         return null;
       }
 
-      let bindings: IComponentBindings = {};
+      const bindings: IComponentBindings = {};
       let options = {};
       let result: IQueryResult = undefined;
 
@@ -821,13 +821,13 @@ export class EagerInitialization {
           // also for the element id. Merge them and pass those to the factory method.
           let optionsToUse = undefined;
           if (Utils.exists(initParameters.options)) {
-            let optionsForComponentClass = initParameters.options[componentClassId];
-            let optionsForElementId = initParameters.options[matchingElement.id];
-            let initOptions = initParameters.options['initOptions'] ? initParameters.options['initOptions'][componentClassId] : {};
+            const optionsForComponentClass = initParameters.options[componentClassId];
+            const optionsForElementId = initParameters.options[matchingElement.id];
+            const initOptions = initParameters.options['initOptions'] ? initParameters.options['initOptions'][componentClassId] : {};
             optionsToUse = Utils.extendDeep(optionsForElementId, initOptions);
             optionsToUse = Utils.extendDeep(optionsForComponentClass, optionsToUse);
           }
-          let initParamToUse = _.extend({}, initParameters, { options: optionsToUse });
+          const initParamToUse = _.extend({}, initParameters, { options: optionsToUse });
           EagerInitialization.createComponentOfThisClassOnElement(componentClassId, matchingElement, initParamToUse);
         }
       });
@@ -847,8 +847,8 @@ export class EagerInitialization {
     Assert.isNonEmptyString(componentClassId);
     Assert.exists(element);
 
-    let eagerlyLoadedComponent: IComponentDefinition = Initialization.getRegisteredComponent(componentClassId);
-    let bindings: IComponentBindings = {};
+    const eagerlyLoadedComponent: IComponentDefinition = Initialization.getRegisteredComponent(componentClassId);
+    const bindings: IComponentBindings = {};
     let options = {};
     let result: IQueryResult = undefined;
 

--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -389,10 +389,12 @@ export class Initialization {
     // When a component is ignored, all it's children component should be ignored too.
     // Add them to the array of html elements that should be skipped.
     _.each(ignore, toIgnore => {
-      let rootToIgnore = $$(element).find(`.${Component.computeCssClassNameForType(toIgnore)}`);
-      if (rootToIgnore) {
-        let childsElementsToIgnore = $$(rootToIgnore).findAll('*');
-        htmlElementsToIgnore = htmlElementsToIgnore.concat(childsElementsToIgnore);
+      let rootsToIgnore = $$(element).findAll(`.${Component.computeCssClassNameForType(toIgnore)}`);
+      if (rootsToIgnore && rootsToIgnore.length > 0) {
+        _.each(rootsToIgnore, rootToIgnore => {
+          let childsElementsToIgnore = $$(rootToIgnore).findAll('*');
+          htmlElementsToIgnore = htmlElementsToIgnore.concat(childsElementsToIgnore);
+        });
       }
     });
 

--- a/test/ui/InitializationTest.ts
+++ b/test/ui/InitializationTest.ts
@@ -218,6 +218,23 @@ export function InitializationTest() {
       expect(Component.get(queryBox) instanceof Querybox).toBe(false);
     });
 
+    it('allow to automaticallyCreateComponentsInside and can ignore multiple repetitive components', () => {
+      let env = new Mock.MockEnvironmentBuilder().build();
+      const queryBox2 = $$('div', { className: 'CoveoQuerybox' }).el;
+      expect(Component.get(queryBox) instanceof Querybox).toBe(false);
+      expect(Component.get(queryBox2) instanceof Querybox).toBe(false);
+      Initialization.automaticallyCreateComponentsInside(
+        root,
+        {
+          options: {},
+          bindings: env
+        },
+        [Querybox.ID]
+      );
+      expect(Component.get(queryBox) instanceof Querybox).toBe(false);
+      expect(Component.get(queryBox2) instanceof Querybox).toBe(false);
+    });
+
     it('allow to automaticallyCreateComponentInside can ignore child components', () => {
       let env = new Mock.MockEnvironmentBuilder().build();
       let resultList = $$('div', { className: Component.computeCssClassNameForType(ResultList.ID) });

--- a/test/ui/InitializationTest.ts
+++ b/test/ui/InitializationTest.ts
@@ -11,7 +11,7 @@ import { Simulate } from '../Simulate';
 import { InitializationEvents } from '../../src/events/InitializationEvents';
 import { init } from '../../src/ui/Base/RegisteredNamedMethods';
 import { NoopComponent } from '../../src/ui/NoopComponent/NoopComponent';
-declare let $;
+declare const $;
 
 export function InitializationTest() {
   describe('Initialization', () => {
@@ -74,10 +74,10 @@ export function InitializationTest() {
     });
 
     it('should wait before resolving lazy init function to continue the framework initialization', done => {
-      let spy = jasmine.createSpy('spy');
+      const spy = jasmine.createSpy('spy');
       $$(root).on(InitializationEvents.afterInitialization, spy);
 
-      let promiseToResolve = new Promise<boolean>((resolve, reject) => {
+      const promiseToResolve = new Promise<boolean>((resolve, reject) => {
         setTimeout(() => {
           resolve(true);
         }, 500);
@@ -116,7 +116,7 @@ export function InitializationTest() {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       }).then(() => {
         expect(Component.get(queryBox) instanceof Querybox).toBe(true);
-        let newQueryBox = document.createElement('div');
+        const newQueryBox = document.createElement('div');
         $$(newQueryBox).addClass('CoveoQuerybox');
         root.appendChild(newQueryBox);
         expect(Component.get(newQueryBox) instanceof Querybox).toBe(false);
@@ -148,15 +148,15 @@ export function InitializationTest() {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       });
       expect(Component.get(queryBox) instanceof Querybox).toBe(true);
-      let sBox = <Querybox>Component.get(queryBox);
+      const sBox = <Querybox>Component.get(queryBox);
       expect(sBox.options.enableSearchAsYouType).toBe(true);
       expect(sBox.options.enablePartialMatch).toBe(true);
     });
 
     it('allows to registerAutoCreateComponent', () => {
-      let dummyCmp: any = jasmine.createSpy('foobar');
+      const dummyCmp: any = jasmine.createSpy('foobar');
       dummyCmp.ID = 'FooBar';
-      let dummyElem = document.createElement('div');
+      const dummyElem = document.createElement('div');
       $$(dummyElem).addClass('CoveoFooBar');
       root.appendChild(dummyElem);
 
@@ -168,7 +168,7 @@ export function InitializationTest() {
     });
 
     it('allows to check if isComponentClassIdRegistered', () => {
-      let dummyCmp: any = () => {};
+      const dummyCmp: any = () => {};
       dummyCmp.ID = 'CheckRegistration';
       Initialization.registerAutoCreateComponent(dummyCmp);
       expect(Initialization.isComponentClassIdRegistered('CheckRegistration')).toBe(true);
@@ -183,7 +183,7 @@ export function InitializationTest() {
     });
 
     it('allow to automaticallyCreateComponentsInside', () => {
-      let env = new Mock.MockEnvironmentBuilder().build();
+      const env = new Mock.MockEnvironmentBuilder().build();
       expect(Component.get(queryBox) instanceof Querybox).toBe(false);
       Initialization.automaticallyCreateComponentsInside(root, {
         options: {},
@@ -193,8 +193,8 @@ export function InitializationTest() {
     });
 
     it('allow to automaticallyCreateComponentInside, as well as childs components', () => {
-      let env = new Mock.MockEnvironmentBuilder().build();
-      let resultList = $$('div', { className: Component.computeCssClassNameForType(ResultList.ID) });
+      const env = new Mock.MockEnvironmentBuilder().build();
+      const resultList = $$('div', { className: Component.computeCssClassNameForType(ResultList.ID) });
       $$(queryBox).append(resultList.el);
       expect(Component.get(resultList.el) instanceof ResultList).toBe(false);
       Initialization.automaticallyCreateComponentsInside(root, {
@@ -205,7 +205,7 @@ export function InitializationTest() {
     });
 
     it('allow to automaticallyCreateComponentsInside and can ignore some components', () => {
-      let env = new Mock.MockEnvironmentBuilder().build();
+      const env = new Mock.MockEnvironmentBuilder().build();
       expect(Component.get(queryBox) instanceof Querybox).toBe(false);
       Initialization.automaticallyCreateComponentsInside(
         root,
@@ -219,8 +219,9 @@ export function InitializationTest() {
     });
 
     it('allow to automaticallyCreateComponentsInside and can ignore multiple repetitive components', () => {
-      let env = new Mock.MockEnvironmentBuilder().build();
+      const env = new Mock.MockEnvironmentBuilder().build();
       const queryBox2 = $$('div', { className: 'CoveoQuerybox' }).el;
+      env.root.appendChild(queryBox2);
       expect(Component.get(queryBox) instanceof Querybox).toBe(false);
       expect(Component.get(queryBox2) instanceof Querybox).toBe(false);
       Initialization.automaticallyCreateComponentsInside(
@@ -236,8 +237,8 @@ export function InitializationTest() {
     });
 
     it('allow to automaticallyCreateComponentInside can ignore child components', () => {
-      let env = new Mock.MockEnvironmentBuilder().build();
-      let resultList = $$('div', { className: Component.computeCssClassNameForType(ResultList.ID) });
+      const env = new Mock.MockEnvironmentBuilder().build();
+      const resultList = $$('div', { className: Component.computeCssClassNameForType(ResultList.ID) });
       $$(queryBox).append(resultList.el);
       expect(Component.get(resultList.el) instanceof ResultList).toBe(false);
       Initialization.automaticallyCreateComponentsInside(
@@ -252,7 +253,7 @@ export function InitializationTest() {
     });
 
     it('allow to automaticallyCreateComponentInside and will ignore elements that are already components', () => {
-      let env = new Mock.MockEnvironmentBuilder().build();
+      const env = new Mock.MockEnvironmentBuilder().build();
       expect(Component.get(queryBox) instanceof Querybox).toBe(false);
       Initialization.automaticallyCreateComponentsInside(root, {
         options: {},
@@ -272,7 +273,7 @@ export function InitializationTest() {
       Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       });
-      let patch = jasmine.createSpy('patch');
+      const patch = jasmine.createSpy('patch');
       Initialization.monkeyPatchComponentMethod('submit', queryBox, patch);
       (<Querybox>Component.get(queryBox)).submit();
       expect(patch).toHaveBeenCalled();
@@ -282,7 +283,7 @@ export function InitializationTest() {
       Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       });
-      let patch = jasmine.createSpy('patch');
+      const patch = jasmine.createSpy('patch');
       Initialization.monkeyPatchComponentMethod('Querybox.submit', queryBox, patch);
       (<Querybox>Component.get(queryBox)).submit();
       expect(patch).toHaveBeenCalled();
@@ -328,7 +329,7 @@ export function InitializationTest() {
     });
 
     it('can initialize external components', () => {
-      let external = $$('div', {
+      const external = $$('div', {
         className: 'CoveoPager'
       }).el;
 
@@ -342,7 +343,7 @@ export function InitializationTest() {
 
     it('can initialize external components passed in as a jquery instance', () => {
       Simulate.addJQuery();
-      let external = $('<div class="CoveoPager"></div>');
+      const external = $('<div class="CoveoPager"></div>');
       searchInterfaceOptions['externalComponents'] = [external];
       searchInterfaceOptions['SearchInterface'].autoTriggerQuery = false;
       Initialization.initializeFramework(root, searchInterfaceOptions, () => {


### PR DESCRIPTION
This allows the recommendation component to be added multiple time inside one search interface.

The recommendation component needs to be ignored at initialization, so that they can be instead initialized on their own.

https://coveord.atlassian.net/browse/JSUI-1766





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)