### PR TITLE
 Auto reload for .html files + remove all SearchAlerts components from templates

### DIFF
--- a/gulpTasks/dev.js
+++ b/gulpTasks/dev.js
@@ -22,9 +22,6 @@ const server = new WebpackDevServer(compiler, {
   contentBase: 'bin/',
   publicPath: 'http://localhost:8080/js/',
   disableHostCheck: true,
-  /*headers: {
-    'Content-Security-Policy': "script-src 'self' code.jquery.com static.cloud.coveo.com 'unsafe-inline'"
-  },*/
   stats: {
     colors: true,
     publicPath: true

--- a/gulpTasks/dev.js
+++ b/gulpTasks/dev.js
@@ -7,70 +7,71 @@ const buildUtilities = require('../gulpTasks/buildUtilities.js');
 const _ = require('underscore');
 const path = require('path');
 const fs = require('fs');
+const glob = require('glob');
 
-let webpackConfig = require('../webpack.config.js');
+const webpackConfig = require('../webpack.config.js');
 webpackConfig.entry['CoveoJsSearch.Lazy'].unshift('webpack-dev-server/client?http://localhost:8080/');
 const compiler = webpack(webpackConfig);
 
-let webpackConfigTest = require('../webpack.test.config.js');
+const webpackConfigTest = require('../webpack.test.config.js');
 webpackConfigTest.entry['tests'].unshift('webpack-dev-server/client?http://localhost:8081/');
 const compilerTest = webpack(webpackConfigTest);
 
-let debouncedLinkToExternal = _.debounce(()=> {
-  console.log('... Compiler done ... Linking external projects'.black.bgGreen);
-  buildUtilities.exec('node', ['./environments/link.externally.js'], undefined, function () {
-  })
-}, 1000);
-
-compiler.plugin('done', ()=> {
-  debouncedLinkToExternal();
+const server = new WebpackDevServer(compiler, {
+  compress: true,
+  contentBase: 'bin/',
+  publicPath: 'http://localhost:8080/js/',
+  disableHostCheck: true,
+  /*headers: {
+    'Content-Security-Policy': "script-src 'self' code.jquery.com static.cloud.coveo.com 'unsafe-inline'"
+  },*/
+  stats: {
+    colors: true,
+    publicPath: true
+  }
 });
 
-gulp.task('dev', ['setup', 'deleteCssFile'], (done)=> {
-  let server = new WebpackDevServer(compiler, {
-    compress: true,
-    contentBase: 'bin/',
-    publicPath: 'http://localhost:8080/js/',
-    disableHostCheck: true,
-    /*headers: {
-      'Content-Security-Policy': "script-src 'self' code.jquery.com static.cloud.coveo.com 'unsafe-inline'"
-    },*/
-    stats: {
-      colors: true,
-      publicPath: true
-    }
+const debouncedLinkToExternal = _.debounce(() => {
+  console.log('... Compiler done ... Linking external projects'.black.bgGreen);
+  buildUtilities.exec('node', ['./environments/link.externally.js'], undefined, function() {});
+}, 1000);
+
+const watchHtmlPagesOnce = _.once(() => {
+  glob('bin/*.html', (err, files) => {
+    files.forEach(file => {
+      fs.watch(file, () => {
+        server.sockets.forEach(socket => {
+          // Sending an "ok" message triggers a simple page reload in the client
+          socket.write(JSON.stringify({ type: 'ok' }));
+        });
+      });
+    });
   });
-  server.listen(8080, 'localhost', ()=> {
-  });
+});
+
+compiler.plugin('done', () => {
+  debouncedLinkToExternal();
+  watchHtmlPagesOnce();
+});
+
+gulp.task('dev', ['setup', 'deleteCssFile'], done => {
+  server.listen(8080, 'localhost', () => {});
   done();
 });
 
-gulp.task('deleteCssFile', (done) => {
+gulp.task('deleteCssFile', done => {
   // Rely on dynamically loaded style.
   // fs.unlink('./bin/css/CoveoFullSearchNewDesign.css', () => {
-      done();
+  done();
   // });
-})
+});
 
-gulp.task('devTest', ['setupTests'], function (done) {
+gulp.task('devTest', ['setupTests'], function(done) {
   var serverTests = new WebpackDevServer(compilerTest, {
     contentBase: 'bin/',
     publicPath: '/tests/',
     compress: true
   });
-  serverTests.listen(8081, 'localhost', ()=> {
-  });
+  serverTests.listen(8081, 'localhost', () => {});
   done();
 });
-/*
-gulp.task('devPlayground', function (done) {
-  var serverPlayground = new WebpackDevServer(compilerPlayground, {
-    contentBase: 'docgen/',
-    publicPath: '/assets/gen/js/',
-    compress: true
- });
-  serverPlayground.listen(8082, 'localhost', ()=> {
- });
-  done();
- });
- */

--- a/gulpTasks/dev.js
+++ b/gulpTasks/dev.js
@@ -17,16 +17,7 @@ const webpackConfigTest = require('../webpack.test.config.js');
 webpackConfigTest.entry['tests'].unshift('webpack-dev-server/client?http://localhost:8081/');
 const compilerTest = webpack(webpackConfigTest);
 
-const server = new WebpackDevServer(compiler, {
-  compress: true,
-  contentBase: 'bin/',
-  publicPath: 'http://localhost:8080/js/',
-  disableHostCheck: true,
-  stats: {
-    colors: true,
-    publicPath: true
-  }
-});
+let server;
 
 const debouncedLinkToExternal = _.debounce(() => {
   console.log('... Compiler done ... Linking external projects'.black.bgGreen);
@@ -52,6 +43,16 @@ compiler.plugin('done', () => {
 });
 
 gulp.task('dev', ['setup', 'deleteCssFile'], done => {
+  server = new WebpackDevServer(compiler, {
+    compress: true,
+    contentBase: 'bin/',
+    publicPath: 'http://localhost:8080/js/',
+    disableHostCheck: true,
+    stats: {
+      colors: true,
+      publicPath: true
+    }
+  });
   server.listen(8080, 'localhost', () => {});
   done();
 });

--- a/gulpTasks/test.js
+++ b/gulpTasks/test.js
@@ -12,51 +12,54 @@ const coveralls = require('coveralls');
 
 const COVERAGE_DIR = path.resolve('bin/coverage');
 
-gulp.task('setupTests', function () {
-  return event_stream.merge(
-      gulp.src('./test/lib/**/*')
-          .pipe(gulp.dest('./bin/tests/lib')),
-
-      gulp.src('./test/SpecRunner.html')
-          .pipe(replace(/\.\.\/bin\/tests\/tests\.js/, 'tests.js'))
-          .pipe(gulp.dest('./bin/tests/'))
-  ).pipe(event_stream.wait())
+gulp.task('setupTests', function() {
+  return event_stream
+    .merge(
+      gulp.src('./test/lib/**/*').pipe(gulp.dest('./bin/tests/lib')),
+      gulp
+        .src('./test/SpecRunner.html')
+        .pipe(replace(/\.\.\/bin\/tests\/tests\.js/, 'tests.js'))
+        .pipe(gulp.dest('./bin/tests/'))
+    )
+    .pipe(event_stream.wait());
 });
 
 gulp.task('coverage', ['lcovCoverage']);
 
-gulp.task('test', ['setupTests', 'buildTest'], function (done) {
-  new TestServer({
-    configFile: path.resolve('./karma.conf.js')
-  }, (exitCode) => {
-    if (exitCode) {
-      // Fail CI builds if any test fails (since karma will exit 1 on any error) 
-      throw new Error(exitCode);
-    } else {
-      done();
+gulp.task('test', ['setupTests', 'buildTest'], function(done) {
+  new TestServer(
+    {
+      configFile: path.resolve('./karma.conf.js')
+    },
+    exitCode => {
+      if (exitCode) {
+        // Fail CI builds if any test fails (since karma will exit 1 on any error)
+        throw new Error(exitCode);
+      } else {
+        done();
+      }
     }
-  }).start();
+  ).start();
 });
 
-gulp.task('buildTest', shell.task([
-  'node node_modules/webpack/bin/webpack.js --config webpack.test.config.js'
-]));
+gulp.task('buildTest', shell.task(['node node_modules/webpack/bin/webpack.js --config webpack.test.config.js']));
 
-gulp.task('uploadCoverage', ['lcovCoverage'], shell.task([
-  'cat bin/coverage/lcov.info | ./node_modules/.bin/coveralls'
-]));
+gulp.task('uploadCoverage', ['lcovCoverage'], shell.task(['cat bin/coverage/lcov.info | ./node_modules/.bin/coveralls']));
 
-gulp.task('remapCoverage', function (done) {
-  return gulp.src(`${COVERAGE_DIR}/coverage-es5.json`)
-    .pipe(remapIstanbul({
-      basePath: '.',
-      exclude: filesToExclude
-    }))
+gulp.task('remapCoverage', function(done) {
+  return gulp
+    .src(`${COVERAGE_DIR}/coverage-es5.json`)
+    .pipe(
+      remapIstanbul({
+        basePath: '.',
+        exclude: filesToExclude
+      })
+    )
     .pipe(rename('coverage.json'))
     .pipe(gulp.dest(COVERAGE_DIR));
 });
 
-gulp.task('lcovCoverage', ['remapCoverage'], function (done) {
+gulp.task('lcovCoverage', ['remapCoverage'], function(done) {
   // Convert JSON coverage from remap-istanbul to lcov format (needed for Sonar).
   combineCoverage({
     dir: COVERAGE_DIR,
@@ -70,7 +73,7 @@ gulp.task('lcovCoverage', ['remapCoverage'], function (done) {
 
 function filesToExclude(fileName) {
   const entryFile = /search-ui[\/\\]bin[\/\\]tests[\/\\]tests.js/;
-  const whiteList = /search-ui[\/\\](src|test)/;
-  
+  const whiteList = /search-ui[\/\\](src.+\.ts)/;
+
   return !entryFile.test(fileName) && !whiteList.test(fileName);
 }

--- a/templates/DynamicsCrm/CardDynamicsCrm.html
+++ b/templates/DynamicsCrm/CardDynamicsCrm.html
@@ -42,6 +42,5 @@
         </tbody>
       </table>
     </div>
-    <div class="CoveoFollowItem"></div>
   </div>
 </div>

--- a/templates/Lithium/CardLithiumThread.html
+++ b/templates/Lithium/CardLithiumThread.html
@@ -52,6 +52,5 @@
     <div class="CoveoCardOverlay" data-title="Replies" data-icon="replies">
       <span class="CoveoResultFolding" data-result-template-id="CardLithiumChildResult"></span>
     </div>
-    <div class="CoveoFollowItem"></div>
   </div>
 </div>

--- a/templates/People/CardPeople.html
+++ b/templates/People/CardPeople.html
@@ -33,6 +33,5 @@
         </tbody>
       </table>
     </div>
-    <div class="CoveoFollowItem"></div>
   </div>
 </div>

--- a/templates/Salesforce/CardSalesforce.html
+++ b/templates/Salesforce/CardSalesforce.html
@@ -60,6 +60,5 @@
         </tbody>
       </table>
     </div>
-    <div class="CoveoFollowItem"></div>
   </div>
 </div>

--- a/templates/SharePoint/CardSharePoint.html
+++ b/templates/SharePoint/CardSharePoint.html
@@ -46,6 +46,5 @@
         </tbody>
       </table>
     </div>
-    <div class="CoveoFollowItem"></div>
   </div>
 </div>

--- a/templates/SharePoint/CardSharePointList.html
+++ b/templates/SharePoint/CardSharePointList.html
@@ -46,6 +46,5 @@
         </tbody>
       </table>
     </div>
-    <div class="CoveoFollowItem"></div>
   </div>
 </div>

--- a/templates/Slack/CardSlack.html
+++ b/templates/Slack/CardSlack.html
@@ -38,6 +38,5 @@
         </tbody>
       </table>
     </div>
-    <div class="CoveoFollowItem"></div>
   </div>
 </div>

--- a/templates/YouTube/CardYouTubePlaylistItem.html
+++ b/templates/YouTube/CardYouTubePlaylistItem.html
@@ -34,6 +34,5 @@
         </tbody>
       </table>
     </div>
-    <div class="CoveoFollowItem"></div>
   </div>
 </div>

--- a/templates/YouTube/CardYouTubeVideo.html
+++ b/templates/YouTube/CardYouTubeVideo.html
@@ -1,30 +1,30 @@
 <div class="coveo-result-frame" style="padding: 0">
-    <div class="CoveoBackdrop coveo-result-row" data-image-field="@ytthumbnailurl" data-overlay-color="rgb(38, 62, 85)" data-overlay-gradient="true">
-      <div style="padding: 20px">
-        <div class="coveo-result-row" style="margin-bottom: 15px">
-          <div class="coveo-result-cell" style="width: 32px; flex-grow:0">
-            <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
-          </div>
-          <div class="coveo-result-cell" style="padding-left: 10px; ">
-            <span class="CoveoResultLink" style="color: white"></span>
-          </div>
+  <div class="CoveoBackdrop coveo-result-row" data-image-field="@ytthumbnailurl" data-overlay-color="rgb(38, 62, 85)" data-overlay-gradient="true">
+    <div style="padding: 20px">
+      <div class="coveo-result-row" style="margin-bottom: 15px">
+        <div class="coveo-result-cell" style="width: 32px; flex-grow:0">
+          <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
         </div>
-        <div class="coveo-result-row" style="margin-bottom: 20px">
-          <div class="coveo-result-cell" style="padding-top:5px; padding-bottom:5px">
-            <div class="CoveoExcerpt" style="color: white;"></div>
-          </div>
+        <div class="coveo-result-cell" style="padding-left: 10px; ">
+          <span class="CoveoResultLink" style="color: white"></span>
         </div>
       </div>
-      <div class="coveo-result-row" style="display: flex; justify-content: space-between; margin: 0; color: white;">
-        <div class="coveo-result-cell" style="background-color: rgba(38, 62, 85, 0.8); padding: 10px 10px 10px 20px; display: inline-block;">
-          <span class="CoveoFieldValue" data-field="@ytviewcount" data-helper="number" data-helper-options-format="n"></span>
-          <span class="CoveoText" data-value="views"></span>
-        </div>
-        <div class="coveo-result-cell" style="background-color: rgba(38, 62, 85, 0.8); padding: 10px 20px 10px 10px; display: inline-block;">
-          <span class="CoveoFieldValue" data-field="@ytvideoduration" data-helper="timeSpan" data-helper-options-is-milliseconds="false"></span>
+      <div class="coveo-result-row" style="margin-bottom: 20px">
+        <div class="coveo-result-cell" style="padding-top:5px; padding-bottom:5px">
+          <div class="CoveoExcerpt" style="color: white;"></div>
         </div>
       </div>
     </div>
+    <div class="coveo-result-row" style="display: flex; justify-content: space-between; margin: 0; color: white;">
+      <div class="coveo-result-cell" style="background-color: rgba(38, 62, 85, 0.8); padding: 10px 10px 10px 20px; display: inline-block;">
+        <span class="CoveoFieldValue" data-field="@ytviewcount" data-helper="number" data-helper-options-format="n"></span>
+        <span class="CoveoText" data-value="views"></span>
+      </div>
+      <div class="coveo-result-cell" style="background-color: rgba(38, 62, 85, 0.8); padding: 10px 20px 10px 10px; display: inline-block;">
+        <span class="CoveoFieldValue" data-field="@ytvideoduration" data-helper="timeSpan" data-helper-options-is-milliseconds="false"></span>
+      </div>
+    </div>
+  </div>
 
   <div class="coveo-result-row" style="padding: 20px">
     <div class="coveo-result-cell">
@@ -43,6 +43,5 @@
         </tbody>
       </table>
     </div>
-    <div class="CoveoFollowItem"></div>
   </div>
 </div>


### PR DESCRIPTION
With this, changing a .html file in the bin folder in dev mode will automatically reload the page.

Also removed all the FollowItem components from the default pages. The search alerts service is not available for 99% of clients anyway...

I also modified the regex for code coverage, it was reporting coverage on ./test files, which is not what we want. For example, if you go on the link that coveralls is outputting on each PR, you'll see it reporting 100% coverage on test utility functions.

This is probably why it bumped to ~90% when you changed that @samisayegh :P  


https://coveord.atlassian.net/browse/JSUI-1800


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)