### PR TITLE
JSUI-1831 - Replaced Google Maps API method `GET` by `POST`.

### DIFF
--- a/src/ui/Distance/GoogleApiPositionProvider.ts
+++ b/src/ui/Distance/GoogleApiPositionProvider.ts
@@ -22,7 +22,7 @@ export class GoogleApiPositionProvider implements IPositionProvider {
     return new EndpointCaller()
       .call<IGeolocationResponse>({
         errorsAsSuccess: false,
-        method: 'GET',
+        method: 'POST',
         queryString: [`key=${this.googleApiKey}`],
         requestData: {},
         responseType: 'json',


### PR DESCRIPTION



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)