### PR TITLE
Rework PrintableUri to create independant result link instead of inheriting

### DIFF
--- a/sass/_PrintableUri.scss
+++ b/sass/_PrintableUri.scss
@@ -4,10 +4,11 @@
   @include justify-content(flex-start);
   margin: 2px 0 5px 0;
   font-size: $font-size-smallest;
-  @include clickable();
   padding: 0 2px 0 2px;
+  
   @include display(flex);
   position: relative;
+
   &.CoveoResultLink:hover {
     text-decoration: none;
     color: $color-teal;

--- a/src/ui/PrintableUri/PrintableUri.ts
+++ b/src/ui/PrintableUri/PrintableUri.ts
@@ -12,6 +12,7 @@ import { IResultsComponentBindings } from '../Base/ResultsComponentBindings';
 import { StreamHighlightUtils } from '../../utils/StreamHighlightUtils';
 import * as _ from 'underscore';
 import { ComponentOptionsModel } from '../../models/ComponentOptionsModel';
+import { Component } from '../Base/Component';
 
 export interface IPrintableUriOptions extends IResultLinkOptions {}
 
@@ -22,7 +23,7 @@ export interface IPrintableUriOptions extends IResultLinkOptions {}
  *
  * This component is a result template component (see [Result Templates](https://developers.coveo.com/x/aIGfAQ)).
  */
-export class PrintableUri extends ResultLink {
+export class PrintableUri extends Component {
   static ID = 'PrintableUri';
   static options: IPrintableUriOptions = {};
   static doExport = () => {
@@ -30,8 +31,8 @@ export class PrintableUri extends ResultLink {
       PrintableUri: PrintableUri
     });
   };
-  private shortenedUri: string;
-  private uri: string;
+
+  private links: ResultLink[] = [];
 
   /**
    * Creates a new PrintableUri.
@@ -44,14 +45,69 @@ export class PrintableUri extends ResultLink {
   constructor(
     public element: HTMLElement,
     public options: IPrintableUriOptions,
-    bindings?: IResultsComponentBindings,
+    public bindings?: IResultsComponentBindings,
     public result?: IQueryResult
   ) {
-    super(element, ComponentOptions.initComponentOptions(element, PrintableUri, options), bindings, result);
+    super(element, PrintableUri.ID, bindings);
+    this.options = ComponentOptions.initComponentOptions(element, PrintableUri, options);
     this.options = _.extend({}, this.options, this.componentOptionsModel.get(ComponentOptionsModel.attributesEnum.resultLink));
+    this.renderUri(this.element, this.result);
   }
 
-  public renderParentsXml(element: HTMLElement, parentsXml: string) {
+  /**
+   * Opens the result in the same window, no matter how the actual component is configured for the end user.
+   * @param logAnalytics Specifies whether the method should log an analytics event.
+   */
+  public openLink(logAnalytics = true) {
+    _.last(this.links).openLink(logAnalytics);
+  }
+
+  /**
+   * Opens the result in a new window, no matter how the actual component is configured for the end user.
+   * @param logAnalytics Specifies whether the method should log an analytics event.
+   */
+  public openLinkInNewWindow(logAnalytics = true) {
+    _.last(this.links).openLinkInNewWindow(logAnalytics);
+  }
+
+  /**
+   * Opens the link in the same manner the end user would.
+   *
+   * This essentially simulates a click on the result link.
+   *
+   * @param logAnalytics Specifies whether the method should log an analytics event.
+   */
+  public openLinkAsConfigured(logAnalytics = true) {
+    _.last(this.links).openLinkAsConfigured(logAnalytics);
+  }
+
+  private renderUri(element: HTMLElement, result: IQueryResult) {
+    const parentsXml = Utils.getFieldValue(result, 'parents');
+    if (parentsXml) {
+      this.renderParentsXml(element, parentsXml);
+    } else if (this.options.titleTemplate) {
+      const link = new ResultLink(this.buildElementForResultLink(), this.options, this.bindings, this.result);
+      this.links.push(link);
+      this.element.appendChild(link.element);
+    } else {
+      this.renderShortenedUri();
+    }
+  }
+
+  private buildSeparator(): HTMLElement {
+    const separator = $$('span', { className: 'coveo-printable-uri-separator' }, ' > ');
+    return separator.el;
+  }
+
+  private buildHtmlToken(name: string, uri: string): HTMLElement {
+    let modifiedName = name.charAt(0).toUpperCase() + name.slice(1);
+    const resultPart = _.extend({}, this.result, { clickUri: uri, title: modifiedName });
+    const link = new ResultLink(this.buildElementForResultLink(), this.options, this.bindings, resultPart);
+    this.links.push(link);
+    return link.element;
+  }
+
+  private renderParentsXml(element: HTMLElement, parentsXml: string) {
     const xmlDoc: XMLDocument = Utils.parseXml(parentsXml);
     const parents = xmlDoc.getElementsByTagName('parent');
     const tokens: HTMLElement[] = [];
@@ -70,54 +126,32 @@ export class PrintableUri extends ResultLink {
     }
   }
 
-  public renderUri(element: HTMLElement, result?: IQueryResult) {
-    const parentsXml = Utils.getFieldValue(result, 'parents');
-    if (parentsXml) {
-      this.renderParentsXml(element, parentsXml);
+  private renderShortenedUri() {
+    let stringAndHoles: StringAndHoles;
+    if (this.result.printableUri.indexOf('\\') == -1) {
+      stringAndHoles = StringAndHoles.shortenUri(this.result.printableUri, $$(this.element).width());
     } else {
-      if (!this.options.titleTemplate) {
-        this.uri = result.clickUri;
-        let stringAndHoles: StringAndHoles;
-        if (result.printableUri.indexOf('\\') == -1) {
-          stringAndHoles = StringAndHoles.shortenUri(result.printableUri, $$(element).width());
-        } else {
-          stringAndHoles = StringAndHoles.shortenPath(result.printableUri, $$(element).width());
-        }
-        this.shortenedUri = HighlightUtils.highlightString(
-          stringAndHoles.value,
-          result.printableUriHighlights,
-          stringAndHoles.holes,
-          'coveo-highlight'
-        );
-        const link = $$('a', { className: 'coveo-printable-uri-part', title: result.printableUri });
-        link.setHtml(this.shortenedUri);
-        element.appendChild(link.el);
-      } else if (this.options.titleTemplate) {
-        const newTitle = this.parseStringTemplate(this.options.titleTemplate);
-        this.element.innerHTML = newTitle
-          ? StreamHighlightUtils.highlightStreamText(newTitle, this.result.termsToHighlight, this.result.phrasesToHighlight)
-          : this.result.clickUri;
-      }
+      stringAndHoles = StringAndHoles.shortenPath(this.result.printableUri, $$(this.element).width());
     }
-    element.title = this.result.printableUri;
-  }
-
-  public buildSeparator() {
-    const separator = $$('span', { className: 'coveo-printable-uri-separator' }, ' > ');
-    return separator.el;
-  }
-
-  public buildHtmlToken(name: string, uri: string) {
-    let modifiedName = name.charAt(0).toUpperCase() + name.slice(1);
-    const resultPart = _.extend({}, this.result, { clickUri: uri, title: modifiedName });
-    const link = new ResultLink(
-      $$('a', { className: 'CoveoResultLink coveo-printable-uri-part' }).el,
-      this.options,
-      this.bindings,
-      resultPart
+    const shortenedUri = HighlightUtils.highlightString(
+      stringAndHoles.value,
+      this.result.printableUriHighlights,
+      stringAndHoles.holes,
+      'coveo-highlight'
     );
-    return link.element;
+    const resultPart = _.extend({}, this.result, { title: shortenedUri });
+    const link = new ResultLink(this.buildElementForResultLink(), this.options, this.bindings, resultPart);
+    this.links.push(link);
+    this.element.appendChild(link.element);
+    this.element.title = this.result.printableUri;
+  }
+
+  private buildElementForResultLink(): HTMLElement {
+    return $$('a', {
+      className: 'CoveoResultLink coveo-printable-uri-part'
+    }).el;
   }
 }
+
 PrintableUri.options = _.extend({}, PrintableUri.options, ResultLink.options);
 Initialization.registerAutoCreateComponent(PrintableUri);

--- a/test/ui/PrintableUriTest.ts
+++ b/test/ui/PrintableUriTest.ts
@@ -1,3 +1,4 @@
+/// <reference path="../../lib/jasmine/index.d.ts" />
 import * as Mock from '../MockEnvironment';
 import { IPrintableUriOptions, PrintableUri } from '../../src/ui/PrintableUri/PrintableUri';
 import { IQueryResult } from '../../src/rest/QueryResult';
@@ -10,6 +11,10 @@ export function PrintableUriTest() {
     let test: Mock.IBasicComponentSetup<PrintableUri>;
     let fakeResult: IQueryResult;
 
+    const getFirstResultLinkElement = (cmp: PrintableUri): HTMLElement => {
+      return $$(cmp.element).find('.CoveoResultLink');
+    };
+
     beforeEach(() => {
       fakeResult = initFakeResult();
       test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
@@ -20,10 +25,6 @@ export function PrintableUriTest() {
     afterEach(function() {
       test = null;
       fakeResult = null;
-    });
-
-    it('should have its tabindex value set to 0', () => {
-      expect(test.cmp.element.getAttribute('tabindex')).toBe('0');
     });
 
     it('should display the XML correctly if the result has a non-null parents field', () => {
@@ -47,19 +48,19 @@ export function PrintableUriTest() {
     it('should shorten the printable uri correctly if the title is not a uri', () => {
       fakeResult.printableUri = 'This is not a Uri';
       test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
-      expect($$(test.cmp.element).find('a').innerText).toEqual('This is not a ...');
+      expect(getFirstResultLinkElement(test.cmp).innerText).toEqual('This is not a ...');
     });
 
     it('should shorten the printable uri correctly if the title is a single character', () => {
       fakeResult.printableUri = 'z';
       test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
-      expect($$(test.cmp.element).find('a').innerText).toEqual('...');
+      expect(getFirstResultLinkElement(test.cmp).innerText).toEqual('...');
     });
 
     it('should shorten the printable uri correctly', () => {
       fakeResult.printableUri = 'http://a.very.very.very.very.very.very.very.very.very.very.long.printable.uri';
       test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
-      expect($$(test.cmp.element).find('a').innerText).toEqual(
+      expect(getFirstResultLinkElement(test.cmp).innerText).toEqual(
         'http://a.very.very.very.very.very.very.very.very.very.very.long.printable....'
       );
     });
@@ -68,7 +69,7 @@ export function PrintableUriTest() {
       test.cmp.options.titleTemplate = '';
       fakeResult.printableUri = 'http://a.very.very.very.very.very.very.very.very.very.very.long.printable.uri';
       test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
-      expect($$(test.cmp.element).find('a').innerText).toEqual(
+      expect(getFirstResultLinkElement(test.cmp).innerText).toEqual(
         'http://a.very.very.very.very.very.very.very.very.very.very.long.printable....'
       );
     });
@@ -84,11 +85,12 @@ export function PrintableUriTest() {
           }
         })
       );
-      $$(test.cmp.element).trigger('click');
+
+      $$(getFirstResultLinkElement(test.cmp)).trigger('click');
     });
 
     it('sends an analytic event on click', () => {
-      $$(test.cmp.element).trigger('click');
+      $$(getFirstResultLinkElement(test.cmp)).trigger('click');
       expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
     });
 
@@ -105,14 +107,14 @@ export function PrintableUriTest() {
       });
 
       it('should replace fields in the href template by the results equivalent', () => {
-        let hrefTemplate = '${title}';
+        let hrefTemplate = '${summary}';
         test = Mock.optionsResultComponentSetup<PrintableUri, IPrintableUriOptions>(
           PrintableUri,
           { hrefTemplate: hrefTemplate },
           fakeResult
         );
         test.cmp.openLinkInNewWindow();
-        expect(window.open).toHaveBeenCalledWith(fakeResult.title, jasmine.anything());
+        expect(window.open).toHaveBeenCalledWith(fakeResult.summary, jasmine.anything());
       });
 
       it('should support nested values in result', () => {
@@ -182,7 +184,7 @@ export function PrintableUriTest() {
           { titleTemplate: titleTemplate },
           fakeResult
         );
-        expect(test.cmp.element.innerHTML).toEqual(fakeResult.raw['number'].toString());
+        expect(getFirstResultLinkElement(test.cmp).innerHTML).toEqual(fakeResult.raw['number'].toString());
       });
 
       it('should not parse standalone accolades', () => {
@@ -192,7 +194,7 @@ export function PrintableUriTest() {
           { titleTemplate: titleTemplate },
           fakeResult
         );
-        expect(test.cmp.element.innerHTML).toEqual(fakeResult.raw['number'].toString() + '{test}');
+        expect(getFirstResultLinkElement(test.cmp).innerHTML).toEqual(fakeResult.raw['number'].toString() + '{test}');
       });
 
       it('should support external fields', () => {
@@ -203,7 +205,7 @@ export function PrintableUriTest() {
           { titleTemplate: titleTemplate },
           fakeResult
         );
-        expect(test.cmp.element.innerHTML).toEqual('testExternal');
+        expect(getFirstResultLinkElement(test.cmp).innerHTML).toEqual('testExternal');
         window['Coveo']['test'] = undefined;
       });
 
@@ -215,7 +217,7 @@ export function PrintableUriTest() {
           { titleTemplate: titleTemplate },
           fakeResult
         );
-        expect(test.cmp.element.innerHTML).toEqual('testExternal');
+        expect(getFirstResultLinkElement(test.cmp).innerHTML).toEqual('testExternal');
         window['Coveo']['test'] = undefined;
       });
 
@@ -226,73 +228,27 @@ export function PrintableUriTest() {
           { titleTemplate: titleTemplate },
           fakeResult
         );
-        expect($$(test.cmp.element).text()).toEqual('${doesNotExist}');
+        expect($$(getFirstResultLinkElement(test.cmp)).text()).toEqual('${doesNotExist}');
       });
     });
 
     it('sends an analytics event on context menu', () => {
-      $$(test.cmp.element).trigger('contextmenu');
+      $$(getFirstResultLinkElement(test.cmp)).trigger('contextmenu');
       expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
     });
 
     describe('when logging the analytic event', () => {
-      it('should use the href if set', () => {
-        let element = $$('a');
-        let href = 'javascript:void(0)';
-        element.setAttribute('href', href);
-        test = Mock.advancedResultComponentSetup<PrintableUri>(
-          PrintableUri,
-          fakeResult,
-          new Mock.AdvancedComponentSetupOptions(element.el)
-        );
-        spyOn(test.cmp, 'openLink');
-
-        $$(test.cmp.element).trigger('click');
-
-        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledWith(
-          analyticsActionCauseList.documentOpen,
-          jasmine.objectContaining({ documentURL: href }),
-          fakeResult,
-          test.cmp.root
-        );
-      });
-
       it('should use the clickUri if the href is empty', () => {
-        $$(test.cmp.element).trigger('click');
+        $$(getFirstResultLinkElement(test.cmp)).trigger('click');
 
         expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledWith(
           analyticsActionCauseList.documentOpen,
           jasmine.objectContaining({ documentURL: fakeResult.clickUri }),
-          fakeResult,
+          jasmine.objectContaining({
+            uniqueId: fakeResult.uniqueId
+          }),
           test.cmp.root
         );
-      });
-    });
-
-    describe('when the element is a hyperlink', () => {
-      beforeEach(() => {
-        test = Mock.advancedResultComponentSetup<PrintableUri>(
-          PrintableUri,
-          fakeResult,
-          new Mock.AdvancedComponentSetupOptions($$('a').el)
-        );
-      });
-
-      it('should set the href to the result click uri', () => {
-        expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
-      });
-
-      it('should not override the href if it is set before the initialization', () => {
-        let element = $$('a');
-        let href = 'javascript:void(0)';
-        element.setAttribute('href', href);
-        test = Mock.advancedResultComponentSetup<PrintableUri>(
-          PrintableUri,
-          fakeResult,
-          new Mock.AdvancedComponentSetupOptions(element.el)
-        );
-
-        expect(test.cmp.element.getAttribute('href')).toEqual(href);
       });
     });
   });


### PR DESCRIPTION
This was changed recently this summer, but PrintableUri inheriting from ResultLink causes a lot of issues, mostly to do with multiple call to usage analytics being logged, as well as visual/css issues.

Instead of inheriting, I changed it so that the PrintableUri inherits only the available options from the ResultLink, and then create the component as required, and passing down the option set.

I exposed the needed methods from ResultLink to open the result link.

Since the PrintableUri can output multiple ResultLink, I've decided to always open the "last" link available from those methods, since this will always be the most "precise" link.

https://coveord.atlassian.net/browse/JSUI-1834





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)