### PR TITLE
Modify the highlighting in PrintableUri when the title gets modified.

### DIFF
--- a/src/ui/PrintableUri/PrintableUri.ts
+++ b/src/ui/PrintableUri/PrintableUri.ts
@@ -9,7 +9,7 @@ import 'styling/_PrintableUri';
 import { ResultLink } from '../ResultLink/ResultLink';
 import { IResultLinkOptions } from '../ResultLink/ResultLinkOptions';
 import { IResultsComponentBindings } from '../Base/ResultsComponentBindings';
-import { StreamHighlightUtils, getRestHighlightsForAllTerms, DefaultStreamHighlightOptions } from '../../utils/StreamHighlightUtils';
+import { getRestHighlightsForAllTerms, DefaultStreamHighlightOptions } from '../../utils/StreamHighlightUtils';
 import * as _ from 'underscore';
 import { ComponentOptionsModel } from '../../models/ComponentOptionsModel';
 import { Component } from '../Base/Component';
@@ -102,8 +102,11 @@ export class PrintableUri extends Component {
 
   private buildHtmlToken(name: string, uri: string): HTMLElement {
     let modifiedName = name.charAt(0).toUpperCase() + name.slice(1);
-    const resultPart: IQueryResult = _.extend({}, this.result, { clickUri: uri, title: modifiedName });
-    resultPart.titleHighlights = this.getModifiedHighlightsForModifiedResultTitle(modifiedName);
+    const resultPart: IQueryResult = _.extend({}, this.result, {
+      clickUri: uri,
+      title: modifiedName,
+      titleHighlights: this.getModifiedHighlightsForModifiedResultTitle(modifiedName)
+    });
     const link = new ResultLink(this.buildElementForResultLink(modifiedName), this.options, this.bindings, resultPart);
     this.links.push(link);
     return link.element;
@@ -141,8 +144,10 @@ export class PrintableUri extends Component {
       stringAndHoles.holes,
       'coveo-highlight'
     );
-    const resultPart: IQueryResult = _.extend({}, this.result, { title: shortenedUri });
-    resultPart.titleHighlights = this.getModifiedHighlightsForModifiedResultTitle(shortenedUri);
+    const resultPart: IQueryResult = _.extend({}, this.result, {
+      title: shortenedUri,
+      titleHighlights: this.getModifiedHighlightsForModifiedResultTitle(shortenedUri)
+    });
     const link = new ResultLink(this.buildElementForResultLink(this.result.printableUri), this.options, this.bindings, resultPart);
     this.links.push(link);
     this.element.appendChild(link.element);

--- a/src/ui/PrintableUri/PrintableUri.ts
+++ b/src/ui/PrintableUri/PrintableUri.ts
@@ -9,10 +9,11 @@ import 'styling/_PrintableUri';
 import { ResultLink } from '../ResultLink/ResultLink';
 import { IResultLinkOptions } from '../ResultLink/ResultLinkOptions';
 import { IResultsComponentBindings } from '../Base/ResultsComponentBindings';
-import { StreamHighlightUtils } from '../../utils/StreamHighlightUtils';
+import { StreamHighlightUtils, getRestHighlightsForAllTerms, DefaultStreamHighlightOptions } from '../../utils/StreamHighlightUtils';
 import * as _ from 'underscore';
 import { ComponentOptionsModel } from '../../models/ComponentOptionsModel';
 import { Component } from '../Base/Component';
+import { IHighlight } from '../../rest/Highlight';
 
 export interface IPrintableUriOptions extends IResultLinkOptions {}
 
@@ -86,7 +87,7 @@ export class PrintableUri extends Component {
     if (parentsXml) {
       this.renderParentsXml(element, parentsXml);
     } else if (this.options.titleTemplate) {
-      const link = new ResultLink(this.buildElementForResultLink(), this.options, this.bindings, this.result);
+      const link = new ResultLink(this.buildElementForResultLink(result.printableUri), this.options, this.bindings, this.result);
       this.links.push(link);
       this.element.appendChild(link.element);
     } else {
@@ -101,8 +102,9 @@ export class PrintableUri extends Component {
 
   private buildHtmlToken(name: string, uri: string): HTMLElement {
     let modifiedName = name.charAt(0).toUpperCase() + name.slice(1);
-    const resultPart = _.extend({}, this.result, { clickUri: uri, title: modifiedName });
-    const link = new ResultLink(this.buildElementForResultLink(), this.options, this.bindings, resultPart);
+    const resultPart: IQueryResult = _.extend({}, this.result, { clickUri: uri, title: modifiedName });
+    resultPart.titleHighlights = this.getModifiedHighlightsForModifiedResultTitle(modifiedName);
+    const link = new ResultLink(this.buildElementForResultLink(modifiedName), this.options, this.bindings, resultPart);
     this.links.push(link);
     return link.element;
   }
@@ -139,17 +141,27 @@ export class PrintableUri extends Component {
       stringAndHoles.holes,
       'coveo-highlight'
     );
-    const resultPart = _.extend({}, this.result, { title: shortenedUri });
-    const link = new ResultLink(this.buildElementForResultLink(), this.options, this.bindings, resultPart);
+    const resultPart: IQueryResult = _.extend({}, this.result, { title: shortenedUri });
+    resultPart.titleHighlights = this.getModifiedHighlightsForModifiedResultTitle(shortenedUri);
+    const link = new ResultLink(this.buildElementForResultLink(this.result.printableUri), this.options, this.bindings, resultPart);
     this.links.push(link);
     this.element.appendChild(link.element);
-    this.element.title = this.result.printableUri;
   }
 
-  private buildElementForResultLink(): HTMLElement {
+  private buildElementForResultLink(title: string): HTMLElement {
     return $$('a', {
-      className: 'CoveoResultLink coveo-printable-uri-part'
+      className: 'CoveoResultLink coveo-printable-uri-part',
+      title
     }).el;
+  }
+
+  private getModifiedHighlightsForModifiedResultTitle(newTitle: string): IHighlight[] {
+    return getRestHighlightsForAllTerms(
+      newTitle,
+      this.result.termsToHighlight,
+      this.result.phrasesToHighlight,
+      new DefaultStreamHighlightOptions()
+    );
   }
 }
 

--- a/src/utils/StreamHighlightUtils.ts
+++ b/src/utils/StreamHighlightUtils.ts
@@ -27,7 +27,7 @@ export interface IStreamHighlightOptions {
   regexFlags?: string;
 }
 
-class DefaultStreamHighlightOptions extends Options implements IStreamHighlightOptions {
+export class DefaultStreamHighlightOptions extends Options implements IStreamHighlightOptions {
   constructor(public cssClass = 'coveo-highlight', public shorten = 0, public regexFlags = 'gi') {
     super();
   }
@@ -75,7 +75,7 @@ export class StreamHighlightUtils {
   }
 }
 
-function getRestHighlightsForAllTerms(
+export function getRestHighlightsForAllTerms(
   toHighlight: string,
   termsToHighlight: { [originalTerm: string]: string[] },
   phrasesToHighlight: { [phrase: string]: { [originalTerm: string]: string[] } },


### PR DESCRIPTION
Since we are doing title modification in the PrintableUri (to shorten or split in XML parts), the keyword highlighting that comes from the index need client side manipulation to match correctly.

https://coveord.atlassian.net/browse/JSUI-1859

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)