### PR TITLE
Add processing for non alpha numeric character for jQuery events

### DIFF
--- a/test/utils/DomTest.ts
+++ b/test/utils/DomTest.ts
@@ -1,3 +1,4 @@
+/// <reference path="../../lib/jasmine/index.d.ts" />
 import { registerCustomMatcher } from '../CustomMatchers';
 import { Dom } from '../../src/utils/Dom';
 import { $$ } from '../../src/utils/Dom';
@@ -360,9 +361,7 @@ export function DomTests() {
         el.click();
         el.click();
         el.click();
-        expect(spy).toHaveBeenCalled();
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).not.toHaveBeenCalledTimes(3);
       });
 
       it('using off should work properly', () => {
@@ -397,55 +396,38 @@ export function DomTests() {
         expect(spy2).eventHandlerToHaveBeenCalledWith({ bar: 'baz' });
       });
 
-      it('using on with a non alpha numeric character should work properly', () => {
+      it('using "on" with a non alpha numeric character should work properly', () => {
         const spy = jasmine.createSpy('spy');
         new Dom(el).on('this contains space', spy);
-        const event = new CustomEvent('thiscontainsspace', {
-          detail: {
-            lorem: 'ipsum'
-          }
-        });
+        const event = new CustomEvent('thiscontainsspace');
 
         el.dispatchEvent(event);
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
-      it('using one with multiple non alpha numeric character events should work properly', () => {
+      it('using "on" with multiple non alpha numeric character events should work properly', () => {
         const spy = jasmine.createSpy('spy');
         new Dom(el).on(['this contains space', 'this:contains space too'], spy);
-        const event = new CustomEvent('thiscontainsspace', {
-          detail: {
-            lorem: 'ipsum'
-          }
-        });
-        const event2 = new CustomEvent('this:containsspacetoo', {
-          detail: {
-            lorem: 'ipsum'
-          }
-        });
+        const event = new CustomEvent('thiscontainsspace');
+        const event2 = new CustomEvent('this:containsspacetoo');
 
         el.dispatchEvent(event);
         el.dispatchEvent(event2);
         expect(spy).toHaveBeenCalledTimes(2);
       });
 
-      it('using one with a non alpha numeric character should work properly', () => {
+      it('using "one" with a non alpha numeric character should work properly', () => {
         const spy = jasmine.createSpy('spy');
         new Dom(el).one('this contains space', spy);
-        const event = new CustomEvent('thiscontainsspace', {
-          detail: {
-            lorem: 'ipsum'
-          }
-        });
+        const event = new CustomEvent('thiscontainsspace');
 
         el.dispatchEvent(event);
         el.dispatchEvent(event);
         el.dispatchEvent(event);
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).not.toHaveBeenCalledTimes(3);
       });
 
-      it('using trigger with a non alpha numeric character should work properly', () => {
+      it('using "trigger" with a non alpha numeric character should work properly', () => {
         const spy = jasmine.createSpy('spy');
         el.addEventListener('thiscontainsspace', spy);
 
@@ -587,7 +569,7 @@ export function DomTests() {
         Simulate.removeJQuery();
       });
 
-      it('using on should work properly', () => {
+      it('using "on" should work properly', () => {
         const spy = jasmine.createSpy('spy');
         new Dom(el).on('click', spy);
         el.click();
@@ -621,14 +603,14 @@ export function DomTests() {
         expect(spy3).toHaveBeenCalledTimes(3);
       });
 
-      it('using on with non alpha numeric character should work properly', () => {
+      it('using "on" with non alpha numeric character should work properly', () => {
         const spy = jasmine.createSpy('spy');
         new Dom(el).on('this contains space', spy);
         window['Coveo']['$'](el).trigger('thiscontainsspace');
         expect(spy).toHaveBeenCalledTimes(1);
       });
 
-      it('using one should work properly', () => {
+      it('using "one" should work properly', () => {
         const spy = jasmine.createSpy('spy');
         new Dom(el).one('click', spy);
         el.click();
@@ -636,20 +618,18 @@ export function DomTests() {
         el.click();
         expect(spy).toHaveBeenCalled();
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).not.toHaveBeenCalledTimes(3);
       });
 
-      it('using one with non alpha numeric character should work properly', () => {
+      it('using "one" with non alpha numeric character should work properly', () => {
         const spy = jasmine.createSpy('spy');
         new Dom(el).one('this contains space', spy);
         window['Coveo']['$'](el).trigger('thiscontainsspace');
         window['Coveo']['$'](el).trigger('thiscontainsspace');
         window['Coveo']['$'](el).trigger('thiscontainsspace');
         expect(spy).toHaveBeenCalledTimes(1);
-        expect(spy).not.toHaveBeenCalledTimes(3);
       });
 
-      it('using off should work properly', () => {
+      it('using "off" should work properly', () => {
         const spy = jasmine.createSpy('spy');
         new Dom(el).on('click', spy);
         new Dom(el).off('click', spy);
@@ -665,7 +645,7 @@ export function DomTests() {
         expect(spy).not.toHaveBeenCalled();
       });
 
-      it('using trigger should work properly', () => {
+      it('using "trigger" should work properly', () => {
         const spy = jasmine.createSpy('spy');
         new Dom(el).on('click', spy);
         new Dom(el).trigger('click');
@@ -677,7 +657,7 @@ export function DomTests() {
         expect(spy2).toHaveBeenCalledWith(jasmine.any(jQuery.Event), { bar: 'baz' });
       });
 
-      it('using trigger with non alpha numeric character should work properly', () => {
+      it('using "trigger" with non alpha numeric character should work properly', () => {
         const spy = jasmine.createSpy('spy');
         window['Coveo']['$'](el).on('thiscontainsspace', spy);
         new Dom(el).trigger('this contains space');

--- a/test/utils/DomTest.ts
+++ b/test/utils/DomTest.ts
@@ -6,41 +6,41 @@ import { Simulate } from '../Simulate';
 interface IJQuery {
   Event: any;
 }
-declare var jQuery: IJQuery;
+declare const jQuery: IJQuery;
 
 export function DomTests() {
   describe('Dom', () => {
-    var el: HTMLElement;
+    let el: HTMLElement;
 
-    beforeEach(function() {
+    beforeEach(() => {
       el = document.createElement('div');
       registerCustomMatcher();
     });
 
-    afterEach(function() {
+    afterEach(() => {
       el = undefined;
     });
 
-    describe('without jquery', function() {
-      beforeEach(function() {
+    describe('without jquery', () => {
+      beforeEach(() => {
         // we want to test the basic event, not jquery one
         Simulate.removeJQuery();
       });
 
-      afterEach(function() {
+      afterEach(() => {
         Simulate.removeJQuery();
       });
 
-      it('insert after should work properly', function() {
-        var parent = document.createElement('div');
-        var sibling = document.createElement('div');
+      it('insert after should work properly', () => {
+        const parent = document.createElement('div');
+        const sibling = document.createElement('div');
         parent.appendChild(sibling);
         expect(sibling.nextSibling).toBeNull();
         new Dom(el).insertAfter(sibling);
         expect(sibling.nextSibling).toBe(el);
         expect(sibling.previousSibling).toBeNull();
 
-        var anotherSibling = document.createElement('div');
+        const anotherSibling = document.createElement('div');
         parent.appendChild(anotherSibling);
         expect(el.nextSibling).toBe(anotherSibling);
         new Dom(el).insertAfter(anotherSibling);
@@ -48,16 +48,16 @@ export function DomTests() {
         expect(el.previousSibling).toBe(anotherSibling);
       });
 
-      it('insert before should work properly', function() {
-        var parent = document.createElement('div');
-        var sibling = document.createElement('div');
+      it('insert before should work properly', () => {
+        const parent = document.createElement('div');
+        const sibling = document.createElement('div');
         parent.appendChild(sibling);
         expect(sibling.nextSibling).toBeNull();
         new Dom(el).insertBefore(sibling);
         expect(sibling.nextSibling).toBeNull();
         expect(sibling.previousSibling).toBe(el);
 
-        var anotherSibling = document.createElement('div');
+        const anotherSibling = document.createElement('div');
         parent.appendChild(anotherSibling);
         expect(anotherSibling.nextSibling).toBeNull();
         expect(anotherSibling.previousSibling).toBe(sibling);
@@ -66,11 +66,11 @@ export function DomTests() {
         expect(el.previousSibling).toBe(sibling);
       });
 
-      it('replace should work properly', function() {
-        var other = document.createElement('div');
-        var sibling = document.createElement('div');
-        var otherSibling = document.createElement('div');
-        var parent = document.createElement('div');
+      it('replace should work properly', () => {
+        const other = document.createElement('div');
+        const sibling = document.createElement('div');
+        const otherSibling = document.createElement('div');
+        const parent = document.createElement('div');
         parent.appendChild(sibling);
         parent.appendChild(el);
         parent.appendChild(otherSibling);
@@ -86,34 +86,34 @@ export function DomTests() {
         expect(other.nextSibling).toBe(otherSibling);
       });
 
-      describe('prepend', function() {
-        it('should work properly', function() {
-          var firstChild = document.createElement('div');
+      describe('prepend', () => {
+        it('should work properly', () => {
+          const firstChild = document.createElement('div');
           el.appendChild(firstChild);
           expect(el.firstChild).toBe(firstChild);
 
-          var toPrepend = document.createElement('div');
+          const toPrepend = document.createElement('div');
           new Dom(el).prepend(toPrepend);
           expect(el.firstChild).toBe(toPrepend);
           expect(toPrepend.nextSibling).toBe(firstChild);
         });
 
-        it('should work even if there if parent element is empty', function() {
-          var parent = $$('div');
-          var toPrepend = $$('span', { className: 'foo' }).el;
+        it('should work even if there if parent element is empty', () => {
+          const parent = $$('div');
+          const toPrepend = $$('span', { className: 'foo' }).el;
           parent.prepend(toPrepend);
           expect(parent.el.firstChild).toBe(toPrepend);
         });
 
-        it('should work even if parent element contains text', function() {
-          var parent = $$('div', {}, 'thisissometext');
-          var toPrepend = $$('span', { className: 'foo' }).el;
+        it('should work even if parent element contains text', () => {
+          const parent = $$('div', {}, 'thisissometext');
+          const toPrepend = $$('span', { className: 'foo' }).el;
           parent.prepend(toPrepend);
           expect(parent.el.firstChild).toBe(toPrepend);
         });
       });
 
-      it('should give the correct text content', function() {
+      it('should give the correct text content', () => {
         el.innerHTML = '<div>this is the content</div>';
         expect(new Dom(el).text()).toEqual('this is the content');
         el = document.createElement('div');
@@ -121,8 +121,8 @@ export function DomTests() {
         expect(new Dom(el).text()).toEqual('this is the content');
       });
 
-      it('should allow to set the text content', function() {
-        var dom = new Dom(el).text('this is the content');
+      it('should allow to set the text content', () => {
+        let dom = new Dom(el).text('this is the content');
         expect(el.innerHTML).toEqual('this is the content');
 
         /// Setting HTML content as text should still work
@@ -131,9 +131,9 @@ export function DomTests() {
         expect(el.childNodes[0].nodeValue).toEqual('<div>this is the content</div>');
       });
 
-      describe('createElement', function() {
-        it('should properly create a single HTMLElement', function() {
-          var elem = Dom.createElement(
+      describe('createElement', () => {
+        it('should properly create a single HTMLElement', () => {
+          const elem = Dom.createElement(
             'div',
             {
               id: 'heidi',
@@ -149,8 +149,8 @@ export function DomTests() {
           expect(elem.innerHTML).toEqual('foobar2000');
         });
 
-        it("should properly create nested HTMLElement's", function() {
-          var elem = Dom.createElement(
+        it("should properly create nested HTMLElement's", () => {
+          const elem = Dom.createElement(
             'header',
             undefined,
             Dom.createElement('div', undefined, Dom.createElement('span', undefined, 'foo'))
@@ -162,8 +162,8 @@ export function DomTests() {
         });
       });
 
-      it('should find a child using a query selector', function() {
-        var toFind = document.createElement('div');
+      it('should find a child using a query selector', () => {
+        let toFind = document.createElement('div');
         toFind.className = 'qwerty';
         el.appendChild(toFind);
         expect(new Dom(el).find('.qwerty')).toBe(toFind);
@@ -181,7 +181,7 @@ export function DomTests() {
         expect(new Dom(el).find('#qwerty')).toBe(toFind);
 
         el = document.createElement('div');
-        var inner = document.createElement('div');
+        const inner = document.createElement('div');
         toFind = document.createElement('div');
         toFind.id = 'qwerty';
         inner.appendChild(toFind);
@@ -189,10 +189,10 @@ export function DomTests() {
         expect(new Dom(el).find('#qwerty')).toBe(toFind);
       });
 
-      it('should find all child using a query selector', function() {
-        var toFind = document.createElement('div');
+      it('should find all child using a query selector', () => {
+        const toFind = document.createElement('div');
         toFind.className = 'qwerty';
-        var toFind2 = document.createElement('div');
+        const toFind2 = document.createElement('div');
         toFind2.className = 'qwerty notqwerty';
         el.appendChild(toFind);
         el.appendChild(toFind2);
@@ -200,10 +200,10 @@ export function DomTests() {
         expect(new Dom(el).findAll('.qwerty')).toContain(toFind2);
       });
 
-      it('using findClass should find the child element', function() {
-        var toFind = document.createElement('div');
+      it('using findClass should find the child element', () => {
+        const toFind = document.createElement('div');
         toFind.className = 'qwerty';
-        var toFind2 = document.createElement('div');
+        const toFind2 = document.createElement('div');
         toFind2.className = 'qwerty notqwerty';
         toFind2.id = 'shouldNotBeFound';
         el.appendChild(toFind);
@@ -213,7 +213,7 @@ export function DomTests() {
         expect(new Dom(el).findClass('shouldNotBeFound').length).toBe(0);
       });
 
-      it('using addClass should work properly', function() {
+      it('using addClass should work properly', () => {
         el.className = 'qwerty';
         new Dom(el).addClass('notqwerty');
         expect(el.className).toBe('qwerty notqwerty');
@@ -232,7 +232,7 @@ export function DomTests() {
         expect(el.className).toBe('a b c');
       });
 
-      it('using removeClass should work properly', function() {
+      it('using removeClass should work properly', () => {
         el.className = 'qwerty';
         new Dom(el).removeClass('qwerty');
         expect(el.className).toBe('');
@@ -257,7 +257,7 @@ export function DomTests() {
         expect(el.className).toBe('popoqwerty notqwerty');
       });
 
-      it('using getClass should return the correct array with all classes', function() {
+      it('using getClass should return the correct array with all classes', () => {
         el.className = 'qwerty';
         expect(new Dom(el).getClass()).toContain('qwerty');
 
@@ -267,7 +267,7 @@ export function DomTests() {
         expect(new Dom(el).getClass()).toContain('notqwerty');
       });
 
-      it('using hasClass should return properly', function() {
+      it('using hasClass should return properly', () => {
         el.className = 'qwerty';
         expect(new Dom(el).hasClass('qwerty')).toBe(true);
 
@@ -294,9 +294,9 @@ export function DomTests() {
         expect(new Dom(el).hasClass('qwerty')).toBe(false);
       });
 
-      it('using toggleClass without switch should work properly', function() {
+      it('using toggleClass without switch should work properly', () => {
         el.className = 'qwerty';
-        var domEl = new Dom(el);
+        let domEl = new Dom(el);
         domEl.toggleClass('qwerty');
         expect(domEl.hasClass('qwerty')).toBe(false);
 
@@ -306,8 +306,8 @@ export function DomTests() {
         expect(domEl.hasClass('foobar2000')).toBe(true);
       });
 
-      it('using toggleClass with switch should work properly', function() {
-        var domEl = new Dom(el);
+      it('using toggleClass with switch should work properly', () => {
+        let domEl = new Dom(el);
         domEl.toggleClass('qwerty', false);
         expect(domEl.hasClass('qwerty')).toBe(false);
 
@@ -317,8 +317,8 @@ export function DomTests() {
         expect(domEl.hasClass('foobar2000')).toBe(true);
       });
 
-      it('using detach should work properly', function() {
-        var parent = document.createElement('div');
+      it('using detach should work properly', () => {
+        const parent = document.createElement('div');
         parent.appendChild(el);
         expect(parent.children).toContain(el);
 
@@ -326,15 +326,15 @@ export function DomTests() {
         expect(parent.children).not.toContain(el);
       });
 
-      it('using on should work properly', function() {
-        var spy = jasmine.createSpy('spy');
+      it('using on should work properly', () => {
+        const spy = jasmine.createSpy('spy');
         new Dom(el).on('click', spy);
         el.click();
         expect(spy).toHaveBeenCalled();
 
-        var spy2 = jasmine.createSpy('spy2');
+        const spy2 = jasmine.createSpy('spy2');
         new Dom(el).on('foo', spy2);
-        var event = new CustomEvent('foo', {
+        const event = new CustomEvent('foo', {
           detail: {
             lorem: 'ipsum'
           }
@@ -343,9 +343,9 @@ export function DomTests() {
         el.dispatchEvent(event);
         expect(spy2).toHaveBeenCalledWith(event, event.detail);
 
-        var spy3 = jasmine.createSpy('spy3');
+        const spy3 = jasmine.createSpy('spy3');
         new Dom(el).on(['1', '2', '3'], spy3);
-        var events = ['1', '2', '3'].map(evt => {
+        const events = ['1', '2', '3'].map(evt => {
           return new CustomEvent(evt);
         });
         events.forEach(evt => {
@@ -354,8 +354,8 @@ export function DomTests() {
         expect(spy3).toHaveBeenCalledTimes(3);
       });
 
-      it('using one should work properly', function() {
-        var spy = jasmine.createSpy('spy');
+      it('using one should work properly', () => {
+        const spy = jasmine.createSpy('spy');
         new Dom(el).one('click', spy);
         el.click();
         el.click();
@@ -365,16 +365,16 @@ export function DomTests() {
         expect(spy).not.toHaveBeenCalledTimes(3);
       });
 
-      it('using off should work properly', function() {
-        var spy = jasmine.createSpy('spy');
+      it('using off should work properly', () => {
+        const spy = jasmine.createSpy('spy');
         new Dom(el).on('click', spy);
         new Dom(el).off('click', spy);
         el.click();
         expect(spy).not.toHaveBeenCalled();
 
-        var spy2 = jasmine.createSpy('spy2');
+        const spy2 = jasmine.createSpy('spy2');
         new Dom(el).on(['1', '2', '3'], spy2);
-        var events = ['1', '2', '3'].map(evt => {
+        const events = ['1', '2', '3'].map(evt => {
           return new CustomEvent(evt);
         });
         new Dom(el).off(['1', '2', '3'], spy2);
@@ -384,20 +384,76 @@ export function DomTests() {
         expect(spy).not.toHaveBeenCalled();
       });
 
-      it('using trigger should work properly', function() {
+      it('using trigger should work properly', () => {
         registerCustomMatcher();
-        var spy = jasmine.createSpy('spy');
+        const spy = jasmine.createSpy('spy');
         new Dom(el).on('click', spy);
         new Dom(el).trigger('click');
         expect(spy).toHaveBeenCalled();
 
-        var spy2 = jasmine.createSpy('spy2');
+        const spy2 = jasmine.createSpy('spy2');
         new Dom(el).on('foo', spy2);
         new Dom(el).trigger('foo', { bar: 'baz' });
         expect(spy2).eventHandlerToHaveBeenCalledWith({ bar: 'baz' });
       });
 
-      it('using isEmpty should work properly', function() {
+      it('using on with a non alpha numeric character should work properly', () => {
+        const spy = jasmine.createSpy('spy');
+        new Dom(el).on('this contains space', spy);
+        const event = new CustomEvent('thiscontainsspace', {
+          detail: {
+            lorem: 'ipsum'
+          }
+        });
+
+        el.dispatchEvent(event);
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+
+      it('using one with multiple non alpha numeric character events should work properly', () => {
+        const spy = jasmine.createSpy('spy');
+        new Dom(el).on(['this contains space', 'this:contains space too'], spy);
+        const event = new CustomEvent('thiscontainsspace', {
+          detail: {
+            lorem: 'ipsum'
+          }
+        });
+        const event2 = new CustomEvent('this:containsspacetoo', {
+          detail: {
+            lorem: 'ipsum'
+          }
+        });
+
+        el.dispatchEvent(event);
+        el.dispatchEvent(event2);
+        expect(spy).toHaveBeenCalledTimes(2);
+      });
+
+      it('using one with a non alpha numeric character should work properly', () => {
+        const spy = jasmine.createSpy('spy');
+        new Dom(el).one('this contains space', spy);
+        const event = new CustomEvent('thiscontainsspace', {
+          detail: {
+            lorem: 'ipsum'
+          }
+        });
+
+        el.dispatchEvent(event);
+        el.dispatchEvent(event);
+        el.dispatchEvent(event);
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).not.toHaveBeenCalledTimes(3);
+      });
+
+      it('using trigger with a non alpha numeric character should work properly', () => {
+        const spy = jasmine.createSpy('spy');
+        el.addEventListener('thiscontainsspace', spy);
+
+        new Dom(el).trigger('this contains space');
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+
+      it('using isEmpty should work properly', () => {
         expect(new Dom(el).isEmpty()).toBe(true);
         el.appendChild(document.createElement('div'));
         expect(new Dom(el).isEmpty()).toBe(false);
@@ -407,20 +463,20 @@ export function DomTests() {
         expect(new Dom(el).isEmpty()).toBe(true);
       });
 
-      it('should find ancestor element using closest', function() {
-        var root = document.createElement('div');
+      it('should find ancestor element using closest', () => {
+        const root = document.createElement('div');
         root.className = 'findme';
         root.appendChild(el);
         expect(new Dom(el).closest('findme')).toBe(root);
       });
 
-      it('should find the first ancestor element using parent', function() {
-        let root = document.createElement('div');
-        let parentOne = $$('div', { className: 'foo' });
-        let parentTwo = $$('div', { className: 'foo' });
-        let parentThree = $$('div', { className: 'foo' });
+      it('should find the first ancestor element using parent', () => {
+        const root = document.createElement('div');
+        const parentOne = $$('div', { className: 'foo' });
+        const parentTwo = $$('div', { className: 'foo' });
+        const parentThree = $$('div', { className: 'foo' });
 
-        let child = $$('div');
+        const child = $$('div');
 
         root.appendChild(parentOne.el);
         parentOne.append(parentTwo.el);
@@ -430,18 +486,18 @@ export function DomTests() {
         expect(child.parent('foo')).toEqual(parentThree.el);
       });
 
-      it('should not throw if there are no parent element using parent', function() {
-        let root = $$('div');
+      it('should not throw if there are no parent element using parent', () => {
+        const root = $$('div');
         expect(() => root.parent('bar')).not.toThrow();
       });
 
-      it('should return undefined if there is no match using parent', function() {
-        let root = document.createElement('div');
-        let parentOne = $$('div', { className: 'foo' });
-        let parentTwo = $$('div', { className: 'foo' });
-        let parentThree = $$('div', { className: 'foo' });
+      it('should return undefined if there is no match using parent', () => {
+        const root = document.createElement('div');
+        const parentOne = $$('div', { className: 'foo' });
+        const parentTwo = $$('div', { className: 'foo' });
+        const parentThree = $$('div', { className: 'foo' });
 
-        let child = $$('div');
+        const child = $$('div');
 
         root.appendChild(parentOne.el);
         parentOne.append(parentTwo.el);
@@ -451,13 +507,13 @@ export function DomTests() {
         expect(child.parent('bar')).toBeUndefined();
       });
 
-      it('should find all ancestor elements using parents', function() {
-        let root = document.createElement('div');
-        let parentOne = $$('div', { className: 'foo' });
-        let parentTwo = $$('div', { className: 'foo' });
-        let parentThree = $$('div', { className: 'foo' });
+      it('should find all ancestor elements using parents', () => {
+        const root = document.createElement('div');
+        const parentOne = $$('div', { className: 'foo' });
+        const parentTwo = $$('div', { className: 'foo' });
+        const parentThree = $$('div', { className: 'foo' });
 
-        let child = $$('div');
+        const child = $$('div');
 
         root.appendChild(parentOne.el);
         parentOne.append(parentTwo.el);
@@ -467,13 +523,13 @@ export function DomTests() {
         expect(child.parents('foo')).toEqual([parentThree.el, parentTwo.el, parentOne.el]);
       });
 
-      it('should return empty array if there is no match using parents', function() {
-        let root = document.createElement('div');
-        let parentOne = $$('div', { className: 'foo' });
-        let parentTwo = $$('div', { className: 'foo' });
-        let parentThree = $$('div', { className: 'foo' });
+      it('should return empty array if there is no match using parents', () => {
+        const root = document.createElement('div');
+        const parentOne = $$('div', { className: 'foo' });
+        const parentTwo = $$('div', { className: 'foo' });
+        const parentThree = $$('div', { className: 'foo' });
 
-        let child = $$('div');
+        const child = $$('div');
 
         root.appendChild(parentOne.el);
         parentOne.append(parentTwo.el);
@@ -483,12 +539,12 @@ export function DomTests() {
         expect(child.parents('bar')).toEqual([]);
       });
 
-      it('should not fail if there is no parent element using parents', function() {
-        let root = $$('div');
+      it('should not fail if there is no parent element using parents', () => {
+        const root = $$('div');
         expect(() => root.parents('bar')).not.toThrow();
       });
 
-      it('should be able to tell if an element matches a selector', function() {
+      it('should be able to tell if an element matches a selector', () => {
         el = document.createElement('div');
         el.className = 'foo bar foobar';
         el.setAttribute('id', 'batman');
@@ -508,9 +564,9 @@ export function DomTests() {
         expect(new Dom(el).is('input')).toBe(false);
       });
 
-      it('should be able to empty an element', function() {
-        var append1 = document.createElement('div');
-        var append2 = document.createElement('div');
+      it('should be able to empty an element', () => {
+        const append1 = document.createElement('div');
+        const append2 = document.createElement('div');
         el.appendChild(append1);
         el.appendChild(append2);
         expect(append1.parentElement).toBe(el);
@@ -521,23 +577,23 @@ export function DomTests() {
       });
     });
 
-    describe('with jquery', function() {
-      beforeEach(function() {
+    describe('with jquery', () => {
+      beforeEach(() => {
         // we want to test the basic event, not jquery one
         Simulate.addJQuery();
       });
 
-      afterEach(function() {
+      afterEach(() => {
         Simulate.removeJQuery();
       });
 
-      it('using on should work properly', function() {
-        var spy = jasmine.createSpy('spy');
+      it('using on should work properly', () => {
+        const spy = jasmine.createSpy('spy');
         new Dom(el).on('click', spy);
         el.click();
         expect(spy).toHaveBeenCalled();
 
-        var spy2 = jasmine.createSpy('spy2');
+        const spy2 = jasmine.createSpy('spy2');
         new Dom(el).on('foo', spy2);
         new Dom(el).trigger('foo', {
           detail: {
@@ -554,9 +610,9 @@ export function DomTests() {
           })
         );
 
-        var spy3 = jasmine.createSpy('spy3');
+        const spy3 = jasmine.createSpy('spy3');
         new Dom(el).on(['1', '2', '3'], spy3);
-        var events = ['1', '2', '3'].map(evt => {
+        const events = ['1', '2', '3'].map(evt => {
           return new CustomEvent(evt);
         });
         events.forEach(evt => {
@@ -565,8 +621,15 @@ export function DomTests() {
         expect(spy3).toHaveBeenCalledTimes(3);
       });
 
-      it('using one should work properly', function() {
-        var spy = jasmine.createSpy('spy');
+      it('using on with non alpha numeric character should work properly', () => {
+        const spy = jasmine.createSpy('spy');
+        new Dom(el).on('this contains space', spy);
+        window['Coveo']['$'](el).trigger('thiscontainsspace');
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+
+      it('using one should work properly', () => {
+        const spy = jasmine.createSpy('spy');
         new Dom(el).one('click', spy);
         el.click();
         el.click();
@@ -576,14 +639,24 @@ export function DomTests() {
         expect(spy).not.toHaveBeenCalledTimes(3);
       });
 
-      it('using off should work properly', function() {
-        var spy = jasmine.createSpy('spy');
+      it('using one with non alpha numeric character should work properly', () => {
+        const spy = jasmine.createSpy('spy');
+        new Dom(el).one('this contains space', spy);
+        window['Coveo']['$'](el).trigger('thiscontainsspace');
+        window['Coveo']['$'](el).trigger('thiscontainsspace');
+        window['Coveo']['$'](el).trigger('thiscontainsspace');
+        expect(spy).toHaveBeenCalledTimes(1);
+        expect(spy).not.toHaveBeenCalledTimes(3);
+      });
+
+      it('using off should work properly', () => {
+        const spy = jasmine.createSpy('spy');
         new Dom(el).on('click', spy);
         new Dom(el).off('click', spy);
         el.click();
         expect(spy).not.toHaveBeenCalled();
 
-        var spy2 = jasmine.createSpy('spy2');
+        const spy2 = jasmine.createSpy('spy2');
         new Dom(el).on(['1', '2', '3'], spy2);
         new Dom(el).off(['1', '2', '3'], spy2);
         ['1', '2', '3'].forEach(evt => {
@@ -592,16 +665,23 @@ export function DomTests() {
         expect(spy).not.toHaveBeenCalled();
       });
 
-      it('using trigger should work properly', function() {
-        var spy = jasmine.createSpy('spy');
+      it('using trigger should work properly', () => {
+        const spy = jasmine.createSpy('spy');
         new Dom(el).on('click', spy);
         new Dom(el).trigger('click');
         expect(spy).toHaveBeenCalled();
 
-        var spy2 = jasmine.createSpy('spy2');
+        const spy2 = jasmine.createSpy('spy2');
         new Dom(el).on('foo', spy2);
         new Dom(el).trigger('foo', { bar: 'baz' });
         expect(spy2).toHaveBeenCalledWith(jasmine.any(jQuery.Event), { bar: 'baz' });
+      });
+
+      it('using trigger with non alpha numeric character should work properly', () => {
+        const spy = jasmine.createSpy('spy');
+        window['Coveo']['$'](el).on('thiscontainsspace', spy);
+        new Dom(el).trigger('this contains space');
+        expect(spy).toHaveBeenCalledTimes(1);
       });
     });
   });


### PR DESCRIPTION
jQuery only accepts `[a-zA-Z0-9\:\_]` for custom events, so we need to modify event types that we launch internally to match those accepted by jQuery.

https://coveord.atlassian.net/browse/JSUI-1855





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)