### PR TITLE
Fix definitions for typescript 1.x

### DIFF
--- a/gulpTasks/definition.js
+++ b/gulpTasks/definition.js
@@ -6,12 +6,13 @@ const runsequence = require('run-sequence');
 const footer = require('gulp-footer');
 const shell = require('gulp-shell');
 
-gulp.task('definitions', function (done) {
+gulp.task('definitions', function(done) {
   runsequence('externalDefs', 'internalDefs', 'cleanDefs', 'validateDefs', done);
 });
 
-gulp.task('cleanDefs', function () {
-  return gulp.src('bin/ts/CoveoJsSearch.d.ts')
+gulp.task('cleanDefs', function() {
+  return (gulp
+      .src('bin/ts/CoveoJsSearch.d.ts')
       .pipe(replace(/import.*$/gm, ''))
       .pipe(replace(/(declare module )(.*)( {$)/gm, '$1Coveo$3'))
       .pipe(replace(/export =.+;$/gm, ''))
@@ -25,48 +26,56 @@ gulp.task('cleanDefs', function () {
       .pipe(replace(/ensureDom: Function;\n\s*options\?: any;/gm, 'ensureDom: Function;\n\t\toptions: any;'))
       .pipe(replace(/^(\s*const\s\w+\s)(=\s\w+);$/gm, '$1: any;'))
       .pipe(replace(/:\s?.*ModuleDefinition\./gm, ': ')) // Assume that types that end with ModuleDefinition were imported using the import type only syntax
-                                                         // and stripping ModuleDefinition will refer to the correct type.
+      // and stripping ModuleDefinition will refer to the correct type.
       .pipe(replace(/\n\t(?:const|let|var)\s.*;/gm, ''))
-      .pipe(gulp.dest('bin/ts/'));
+      .pipe(replace(/readonly/gm, ''))
+      .pipe(gulp.dest('bin/ts/')) );
 });
 
-gulp.task('externalDefs', function () {
-  return gulp.src([
-    './node_modules/@types/underscore/index.d.ts',
-    './lib/es6-promise/index.d.ts',
-    './lib/modal-box/index.d.ts',
-    './lib/magic-box/index.d.ts',
-    './node_modules/@types/d3/index.d.ts',
-    './lib/globalize/index.d.ts',
-    './lib/jstimezonedetect/index.d.ts',
-    './lib/coveoanalytics/index.d.ts'
-      ])
-      .pipe(concat('Externals.d.ts'))
-      .pipe(replace(/import.*$/gm, ''))
-      .pipe(replace(/(declare module )(.*)( {$)/gm, '$1$2$3'))
-      .pipe(replace(/export as namespace .*;$/gm, ''))
-      .pipe(replace(/export =.+;$/gm, ''))
-      .pipe(replace(/export .+ from .+$/gm, ''))
-      .pipe(replace(/export (?:default )?(.*)$/gm, '$1'))
-      .pipe(replace(/private .+;$/gm, ''))
-      .pipe(replace(/\t[A-Za-z]+;$/gm, ''))
-      .pipe(replace(/\n\t\s*(\n\t\s*)/g, '$1'))
-      .pipe(replace(/never/gm, 'void'))
-      .pipe(replace(/undefined/g, 'any'))
-      .pipe(gulp.dest('./bin/ts'));
+gulp.task('externalDefs', function() {
+  return gulp
+    .src([
+      './node_modules/@types/underscore/index.d.ts',
+      './lib/es6-promise/index.d.ts',
+      './lib/modal-box/index.d.ts',
+      './lib/magic-box/index.d.ts',
+      './node_modules/@types/d3/index.d.ts',
+      './lib/globalize/index.d.ts',
+      './lib/jstimezonedetect/index.d.ts',
+      './lib/coveoanalytics/index.d.ts'
+    ])
+    .pipe(concat('Externals.d.ts'))
+    .pipe(replace(/import.*$/gm, ''))
+    .pipe(replace(/(declare module )(.*)( {$)/gm, '$1$2$3'))
+    .pipe(replace(/export as namespace .*;$/gm, ''))
+    .pipe(replace(/export =.+;$/gm, ''))
+    .pipe(replace(/export .+ from .+$/gm, ''))
+    .pipe(replace(/export (?:default )?(.*)$/gm, '$1'))
+    .pipe(replace(/private .+;$/gm, ''))
+    .pipe(replace(/\t[A-Za-z]+;$/gm, ''))
+    .pipe(replace(/\n\t\s*(\n\t\s*)/g, '$1'))
+    .pipe(replace(/never/gm, 'void'))
+    .pipe(replace(/undefined/g, 'any'))
+    .pipe(gulp.dest('./bin/ts'));
 });
 
-gulp.task('internalDefs', function () {
+gulp.task('internalDefs', function() {
   return require('dts-generator').default({
     name: 'Coveo',
     project: './',
     out: 'bin/ts/CoveoJsSearch.d.ts',
     externs: ['Externals.d.ts'],
     verbose: true,
-    exclude: ['lib/**/*.d.ts', 'node_modules/**/*.d.ts', 'typings/**/*.d.ts', 'src/*.ts', 'bin/**/*.d.ts', 'test/lib/**/*.d.ts', 'test/Test.ts']
+    exclude: [
+      'lib/**/*.d.ts',
+      'node_modules/**/*.d.ts',
+      'typings/**/*.d.ts',
+      'src/*.ts',
+      'bin/**/*.d.ts',
+      'test/lib/**/*.d.ts',
+      'test/Test.ts'
+    ]
   });
-})
+});
 
-gulp.task('validateDefs', shell.task([
-  'node node_modules/typescript/bin/tsc --noEmit ./bin/ts/CoveoJsSearch.d.ts'
-]))
+gulp.task('validateDefs', shell.task(['node node_modules/typescript/bin/tsc --noEmit ./bin/ts/CoveoJsSearch.d.ts']));

--- a/src/ui/SimpleFilter/SimpleFilterValues.ts
+++ b/src/ui/SimpleFilter/SimpleFilterValues.ts
@@ -4,12 +4,7 @@ import { ComponentOptions, IFieldOption } from '../Base/ComponentOptions';
 import * as _ from 'underscore';
 import { IGroupByRequest } from '../../rest/GroupByRequest';
 import { QueryBuilder } from '../Base/QueryBuilder';
-import { SimpleFilter } from './SimpleFilter';
-
-export interface ISimpleFilterOptions {
-  field: IFieldOption;
-  maximumNumberOfValues: number;
-}
+import { SimpleFilter, ISimpleFilterOptions } from './SimpleFilter';
 
 export class SimpleFilterValues {
   private groupByRequestValues: string[] = [];


### PR DESCRIPTION
The generated definition as "one single big module" should still be typescript 1.x compatible (readonly is a modifier that is only valid for typescript 2.x)

https://coveord.atlassian.net/browse/JSUI-1873





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)