### PR TITLE
Some css tweaks for IE11 with result header

### DIFF
--- a/sass/_FullSearchGrid.scss
+++ b/sass/_FullSearchGrid.scss
@@ -99,15 +99,20 @@ $page-width: 1000px;
   display: inline-block;
   font-size: $font-size-smaller;
   margin-right: auto;
+  @include flex(auto);
 }
 .coveo-result-layout-section {
   @include display(flex);
+  @include flex(auto);
+  @include flex-shrink(0);
   &.coveo-result-layout-hidden {
     display: none;
   }
 }
 .coveo-sort-section {
   @include display(flex);
+  @include flex(auto);
+  @include flex-shrink(0);
 }
 
 .coveo-results-header > *:not(:first-child) {

--- a/sass/_ResultLayout.scss
+++ b/sass/_ResultLayout.scss
@@ -14,6 +14,7 @@
 
   .coveo-icon {
     margin-right: 5px;
+    min-width: 14px;
   }
   &.coveo-hidden {
     display: none;


### PR DESCRIPTION
This forces the "layout" and "sort" section to not shrink so as to not get all cramped up.

The summary section can be shrinked since it's text that can wrap when we need more space.

https://coveord.atlassian.net/browse/JSUI-1864





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)