### PR TITLE
Remove all no-wrap for result-cell containing the ResultLink in default templates

### DIFF
--- a/templates/All/Default.html
+++ b/templates/All/Default.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Chatter/Chatter.html
+++ b/templates/Chatter/Chatter.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top; padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align: top; font-size: 16px;">
+      <div class="coveo-result-cell" style="vertical-align: top; font-size: 16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Confluence/Confluence.html
+++ b/templates/Confluence/Confluence.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Dropbox/Dropbox.html
+++ b/templates/Dropbox/Dropbox.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Email/EmailThread.html
+++ b/templates/Email/EmailThread.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/GoogleDrive/GoogleDrive.html
+++ b/templates/GoogleDrive/GoogleDrive.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Jira/Jira.html
+++ b/templates/Jira/Jira.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
         <span class="CoveoText" data-value=" - "></span>
         <a class="CoveoResultLink" data-title-template="${raw.jikey}"></a>

--- a/templates/Lithium/LithiumThread.html
+++ b/templates/Lithium/LithiumThread.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/RSS/RSS.html
+++ b/templates/RSS/RSS.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Salesforce/Salesforce.html
+++ b/templates/Salesforce/Salesforce.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/SalesforceCase/SalesforceCase.html
+++ b/templates/SalesforceCase/SalesforceCase.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink" data-title-template="${title} - ${raw.sfcasenumber}"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/SalesforceCase/SalesforceCaseComment.html
+++ b/templates/SalesforceCase/SalesforceCaseComment.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top; padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align: top; font-size: 16px;">
+      <div class="coveo-result-cell" style="vertical-align: top; font-size: 16px;">
         <a class="CoveoResultLink" data-title-template="# ${raw.sfcasecasenumber}"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/SharePoint/SharePoint.html
+++ b/templates/SharePoint/SharePoint.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/SharePoint/SharePointList.html
+++ b/templates/SharePoint/SharePointList.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:80px;text-align:right;font-size:12px">

--- a/templates/YouTube/YouTubeVideo.html
+++ b/templates/YouTube/YouTubeVideo.html
@@ -6,7 +6,7 @@
     </div>
     <div class="coveo-result-cell" >
       <div class="coveo-result-row">
-        <div class="coveo-result-cell coveo-no-wrap" style="font-size:16px">
+        <div class="coveo-result-cell" style="font-size:16px">
           <a class="CoveoResultLink">
           </a>
         </div>


### PR DESCRIPTION
The ResultLink is arguably the most important part of the result, it should be displayed in full.

https://coveord.atlassian.net/browse/JSUI-1862





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)