### PR TITLE
Fix some issues in the playground + some refactor

### DIFF
--- a/docs/playground/src/Playground.ts
+++ b/docs/playground/src/Playground.ts
@@ -1,12 +1,12 @@
-import {$$, Dom} from "../../../src/utils/Dom";
-import {SearchEndpoint} from "../../../src/rest/SearchEndpoint";
-import {IComponentPlaygroundConfiguration, PlaygroundConfiguration} from "./PlaygroundConfiguration";
-import {QueryEvents, IBuildingQueryEventArgs} from "../../../src/events/QueryEvents";
+import { $$, Dom } from '../../../src/utils/Dom';
+import { SearchEndpoint } from '../../../src/rest/SearchEndpoint';
+import { IComponentPlaygroundConfiguration, PlaygroundConfiguration } from './PlaygroundConfiguration';
+import { QueryEvents, IBuildingQueryEventArgs } from '../../../src/events/QueryEvents';
 import { setLanguageAfterPageLoaded } from '../../../src/strings/DefaultLanguage';
 setLanguageAfterPageLoaded();
 
-declare var Coveo;
-declare var $;
+declare const Coveo;
+declare const $;
 
 export class Playground {
   private componentContainer: Dom;
@@ -15,7 +15,7 @@ export class Playground {
   private initialized = false;
 
   constructor(public body: HTMLBodyElement) {
-    let previewContainer = $$(document.body).find('.preview-container');
+    const previewContainer = $$(document.body).find('.preview-container');
     if (this.isComponentPage() && this.shouldInitialize()) {
       this.initializePreview();
     } else {
@@ -32,17 +32,24 @@ export class Playground {
   }
 
   public shouldInitialize() {
-    let name = this.getComponentName();
-    let configuration = this.getConfiguration();
+    const name = this.getComponentName();
+    const configuration = this.getConfiguration();
     return name && configuration && configuration.show;
   }
 
   public isComponentPage() {
-    return $$(this.getTitle()).text().toLowerCase().indexOf('coveo component') != -1;
+    return (
+      $$(this.getTitle())
+        .text()
+        .toLowerCase()
+        .indexOf('coveo component') != -1
+    );
   }
 
   public getComponentName() {
-    let match = $$(this.getTitle()).text().match(/([a-zA-Z]+)$/);
+    const match = $$(this.getTitle())
+      .text()
+      .match(/([a-zA-Z]+)$/);
     if (match) {
       return match[1];
     }
@@ -58,7 +65,7 @@ export class Playground {
   public show() {
     this.showButton.hide();
     this.hideButton.show();
-    $(this.componentContainer.el).slideDown(undefined, ()=> {
+    $(this.componentContainer.el).slideDown(undefined, () => {
       if (!this.initialized) {
         this.initializeComponent();
       }
@@ -66,24 +73,23 @@ export class Playground {
   }
 
   public initializeComponent() {
-    let configuration = this.getConfiguration();
+    const configuration = this.getConfiguration();
     SearchEndpoint.configureSampleEndpointV2();
-    let searchInterface = this.getSearchInterface();
+    const searchInterface = this.getSearchInterface();
     this.componentContainer.append(searchInterface.el);
     Coveo.SearchEndpoint.endpoints['default'] = SearchEndpoint.endpoints['default'];
-    let initOptions = this.getInitConfig();
+    const initOptions = this.getInitConfig();
     Coveo.init(searchInterface.el, initOptions);
     this.initialized = true;
-    if(this.getConfiguration().toExecute) {
+    if (this.getConfiguration().toExecute) {
       this.getConfiguration().toExecute();
     }
     this.triggerQuery(configuration, searchInterface.el);
-
   }
 
   public getInitConfig() {
-    let initOptions = {};
-    let configuration = this.getConfiguration();
+    const initOptions = {};
+    const configuration = this.getConfiguration();
     initOptions[this.getComponentName()] = configuration.options;
     initOptions['SearchInterface'] = PlaygroundConfiguration['SearchInterface'].options;
     if (configuration.isResultComponent) {
@@ -93,11 +99,10 @@ export class Playground {
   }
 
   public getSearchInterface(): Dom {
-    let searchInterface = $$('div', {
-      className: 'CoveoSearchInterface',
-      'data-design': 'new'
+    const searchInterface = $$('div', {
+      className: 'CoveoSearchInterface'
     });
-    let configuration = this.getConfiguration();
+    const configuration = this.getConfiguration();
     if (configuration.isResultComponent) {
       this.insertElementIntoResultList(searchInterface);
     } else {
@@ -107,17 +112,17 @@ export class Playground {
   }
 
   public initializePreview() {
-    let previewContainer = $$(document.body).find('.preview-container');
-    this.showButton = $$('button', {className: 'preview-toggle'}, `Show a live example of ${this.getComponentName()}`);
-    this.hideButton = $$('button', {className: 'preview-toggle'}, 'Hide example');
-    this.componentContainer = $$('div', {className: 'component-container'});
+    const previewContainer = $$(document.body).find('.preview-container');
+    this.showButton = $$('button', { className: 'preview-toggle' }, `Show a live example of ${this.getComponentName()}`);
+    this.hideButton = $$('button', { className: 'preview-toggle' }, 'Hide example');
+    this.componentContainer = $$('div', { className: 'component-container' });
     this.componentContainer.hide();
     this.hideButton.hide();
-    this.showButton.on('click', ()=> {
+    this.showButton.on('click', () => {
       this.show();
     });
 
-    this.hideButton.on('click', ()=> {
+    this.hideButton.on('click', () => {
       this.hide();
     });
     previewContainer.appendChild(this.showButton.el);
@@ -126,12 +131,12 @@ export class Playground {
   }
 
   public insertElementIntoResultList(searchInterface: Dom) {
-    let resultListElement = $$('div', {className: 'CoveoResultList'});
-    let scriptElement = $$('script', {
+    const resultListElement = $$('div', { className: 'CoveoResultList' });
+    const scriptElement = $$('script', {
       type: 'text/underscore',
       className: 'result-template'
     });
-    let resultContainer = $$('div');
+    const resultContainer = $$('div');
     resultContainer.el.innerHTML = this.getComponentElement().el.outerHTML;
     scriptElement.el.innerHTML = resultContainer.el.outerHTML;
     resultListElement.append(scriptElement.el);
@@ -146,13 +151,12 @@ export class Playground {
     if (this.getConfiguration().element) {
       return this.getConfiguration().element;
     }
-    return $$('div', {className: `Coveo${Coveo[this.getComponentName()].ID}`});
-
+    return $$('div', { className: `Coveo${Coveo[this.getComponentName()].ID}` });
   }
 
   public triggerQuery(configuration: IComponentPlaygroundConfiguration, searchInterface: HTMLElement) {
     if (configuration.basicExpression || configuration.advancedExpression) {
-      $$(searchInterface).on(QueryEvents.buildingQuery, (e: Event, args: IBuildingQueryEventArgs)=> {
+      $$(searchInterface).on(QueryEvents.buildingQuery, (e: Event, args: IBuildingQueryEventArgs) => {
         if (configuration.basicExpression) {
           args.queryBuilder.expression.add(configuration.basicExpression);
         }
@@ -160,12 +164,20 @@ export class Playground {
           args.queryBuilder.advancedExpression.add(configuration.advancedExpression);
         }
       });
-      let messageAboutBasic = configuration.basicExpression ? `the basic query expression is "<span class='preview-info-emphasis'>${configuration.basicExpression}"</span>` : '';
-      let messageAboutAdvanced = configuration.advancedExpression ? `the advanced query expression is "<span class='preview-info-emphasis'>${configuration.advancedExpression}"</span>` : '';
+      let messageAboutBasic = configuration.basicExpression
+        ? `the basic query expression is "<span class='preview-info-emphasis'>${configuration.basicExpression}"</span>`
+        : '';
+      const messageAboutAdvanced = configuration.advancedExpression
+        ? `the advanced query expression is "<span class='preview-info-emphasis'>${configuration.advancedExpression}"</span>`
+        : '';
       if (configuration.basicExpression && configuration.advancedExpression) {
         messageAboutBasic += ' and ';
       }
-      let messageAboutQuery = $$('div', {className: 'preview-info'}, `Currently showing an example where ${messageAboutBasic}${messageAboutAdvanced}.`)
+      const messageAboutQuery = $$(
+        'div',
+        { className: 'preview-info' },
+        `Currently showing an example where ${messageAboutBasic}${messageAboutAdvanced}.`
+      );
 
       $$(searchInterface).prepend(messageAboutQuery.el);
     }

--- a/docs/playground/src/PlaygroundConfiguration.ts
+++ b/docs/playground/src/PlaygroundConfiguration.ts
@@ -2,6 +2,7 @@ import { IStringMap } from '../../../src/rest/GenericParam';
 import { $$, Dom } from '../../../src/utils/Dom';
 import { SearchEndpoint } from '../../../src/rest/SearchEndpoint';
 import { SearchSectionBuilder } from './SearchSectionBuilder';
+import { SectionBuilder } from './SectionBuilder';
 export interface IComponentPlaygroundConfiguration {
   show: boolean; // should we show a preview for this component. False is assumed if not specified.
   isResultComponent?: boolean; // is this component supposed to be inserted inside a result template ? False is assumed if not specified
@@ -12,7 +13,7 @@ export interface IComponentPlaygroundConfiguration {
   toExecute?: Function;
 }
 
-declare var Coveo;
+declare const Coveo;
 
 const getComponentContainerElement = () => {
   return $$(document.body).find('.component-container');
@@ -74,11 +75,28 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   Tab: {
     show: true,
-    element: $$(
-      'div',
-      { className: 'coveo-tab-section' },
-      `<div class="CoveoTab" data-caption="All content" data-id="All"></div><div class="CoveoTab" data-caption="YouTube videos" data-id="YouTube"></div><div class="CoveoTab" data-caption="Google Drive" data-id="GoogleDrive"></div><div class="CoveoTab" data-caption="Emails" data-id="Emails"></div><div class="CoveoTab" data-caption="Salesforce content" data-id="Salesforce"></div>`
-    )
+    element: new SectionBuilder($$('div', { className: 'coveo-tab-section' }))
+      .withComponent('CoveoTab', {
+        'data-caption': 'All content',
+        'data-id': 'All'
+      })
+      .withComponent('CoveoTab', {
+        'data-caption': 'YouTube videos',
+        'data-id': 'YouTube'
+      })
+      .withComponent('CoveoTab', {
+        'data-caption': 'Google Drive',
+        'data-id': 'GoogleDrive'
+      })
+      .withComponent('CoveoTab', {
+        'data-caption': 'Emails',
+        'data-id': 'Emails'
+      })
+      .withComponent('CoveoTab', {
+        'data-caption': 'Salesforce content',
+        'data-id': 'Salesforce'
+      })
+      .build()
   },
   FacetSlider: {
     show: true,
@@ -103,11 +121,14 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   Breadcrumb: {
     show: true,
-    element: $$(
-      'div',
-      undefined,
-      `<div class="CoveoBreadcrumb"></div><p>Interact with the facet to modify the breadcrumb</p><div class="CoveoFacet" data-field="@objecttype" data-title="Type"></div>`
-    )
+    element: new SectionBuilder()
+      .withComponent('CoveoBreadcrumb')
+      .withDomElement($$('p', {}, 'Interact with the facet to modify the breadcrumb'))
+      .withComponent('CoveoFacet', {
+        'data-field': '@objecttype',
+        'data-title': 'Type'
+      })
+      .build()
   },
   DidYouMean: {
     show: true,
@@ -184,20 +205,20 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
       minimizedByDefault: false
     },
     isResultComponent: true,
-    advancedExpression: '@source=="Dropbox - coveodocumentationsamples@gmail.com"',
-    element: $$(
-      'div',
-      undefined,
-      `<table class="CoveoFieldTable">
-            <tbody>
-             <tr data-field="@size" data-caption="Document size" data-helper="size">
-              </tr>
-              <tr data-field="@source" data-caption="Source">
-              </tr>
-              <tr data-field="@date" data-caption="Date" date-helper="dateTime"></tr>
-            </tbody>
-          </table>`
-    )
+    advancedExpression: '@connectortype==DropboxCrawler AND @objecttype==File',
+    element: new SectionBuilder()
+      .withDomElement(
+        $$(
+          'table',
+          { className: 'CoveoFieldTable' },
+          `<tbody>
+    <tr data-field="@size" data-caption="Document size" data-helper="size"></tr>
+     <tr data-field="@source" data-caption="Source"></tr>
+     <tr data-field="@date" data-caption="Date" date-helper="dateTime"></tr>
+   </tbody>`
+        )
+      )
+      .build()
   },
   FieldValue: {
     show: true,
@@ -208,19 +229,6 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
     isResultComponent: true,
     advancedExpression: '@date'
   },
-  FollowItem: {
-    show: true,
-    isResultComponent: true,
-    element: $$(
-      'div',
-      undefined,
-      `<div class="CoveoSearchAlerts"></div><a class="CoveoResultLink"></a><span class="CoveoFollowItem"></span>`
-    ),
-    basicExpression: 'technology',
-    toExecute: () => {
-      setMinHeightOnSearchInterface('300px');
-    }
-  },
   HiddenQuery: {
     show: true,
     options: {
@@ -228,10 +236,15 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
     },
     toExecute: () => {
       const searchInterface = getSearchInterfaceElement();
-      Coveo.state(searchInterface, 'hd', 'This is the filter description');
-      Coveo.state(searchInterface, 'hq', '@uri');
+      Coveo.$$(searchInterface).on('afterInitialization', () => {
+        Coveo.state(searchInterface, 'hd', 'This is the filter description');
+        Coveo.state(searchInterface, 'hq', '@uri');
+      });
     },
-    element: $$('div', undefined, `<div class="CoveoBreadcrumb"></div><div class="CoveoHiddenQuery"></div>`)
+    element: new SectionBuilder()
+      .withComponent('CoveoBreadcrumb')
+      .withComponent('CoveoHiddenQuery')
+      .build()
   },
   HierarchicalFacet: {
     show: true,
@@ -267,7 +280,7 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
       computedFieldFormat: 'n0 bytes',
       columnLabels: ['PDF', 'YouTube Videos', 'Excel documents']
     },
-    element: $$('div', undefined, `<div class="CoveoBreadcrumb"></div><div class="CoveoMatrix"></div>`)
+    element: new SectionBuilder().withComponent('CoveoMatrix').build()
   },
   OmniboxResultList: {
     show: true,
@@ -284,7 +297,18 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
               className: 'result-template',
               type: 'text/underscore'
             },
-            "<div><span class='CoveoIcon' data-small='true' data-with-label='false' style='display:inline-block; vertical-align:middle; margin-right:5px;'></span><a class='CoveoResultLink'></a></div>"
+            new SectionBuilder()
+              .withComponent(
+                'CoveoIcon',
+                {
+                  'data-small': 'true',
+                  'data-with-label': 'false',
+                  style: 'display:inline-block; vertical-align:middle; margin-right:5px;'
+                },
+                'span'
+              )
+              .withComponent('CoveoResultLink', {}, 'a')
+              .build()
           )
         )
       )
@@ -416,19 +440,40 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   SimpleFilter: {
     show: true,
-    element: $$(
-      'div',
-      undefined,
-      `<div class="CoveoSimpleFilter" data-field="@filetype" data-title="File Type"></div><div class="CoveoResultList"></div>`
-    )
+    options: {
+      field: '@filetype',
+      title: 'File Type'
+    },
+    element: new SectionBuilder()
+      .withComponent('CoveoSimpleFilter')
+      .withComponent('CoveoResultList')
+      .build()
   },
   Sort: {
     show: true,
-    element: $$(
-      'div',
-      undefined,
-      `<div class="coveo-sort-section"><span class="CoveoSort" data-sort-criteria="relevancy" data-caption="Relevance"></span><span class="CoveoSort" data-sort-criteria="date descending,date ascending" data-caption="Date"></span></div><div class="CoveoResultList"></div>`
-    ),
+    element: new SectionBuilder()
+      .withDomElement(
+        new SectionBuilder($$('div', { className: 'coveo-sort-section' }))
+          .withComponent(
+            'CoveoSort',
+            {
+              'data-sort-criteria': 'relevancy',
+              'data-caption': 'relevancy'
+            },
+            'span'
+          )
+          .withComponent(
+            'CoveoSort',
+            {
+              'data-sort-criteria': 'date descending,date ascending',
+              'data-caption': 'Date'
+            },
+            'span'
+          )
+          .build()
+      )
+      .withComponent('CoveoResultList')
+      .build(),
     toExecute: () => {
       getSearchInterfaceElement().style.padding = '20px';
       $$(getSearchInterfaceElement()).on('buildingQuery', function(e, args) {

--- a/docs/playground/src/PlaygroundConfiguration.ts
+++ b/docs/playground/src/PlaygroundConfiguration.ts
@@ -241,9 +241,11 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
     },
     toExecute: () => {
       // `@hierarchicfield` does not exist in the sample Coveo Cloud V2 organization.
-      $$(document.body).on('newQuery', function(e, args) {
+      $$(getSearchInterfaceElement()).on('newQuery', function(e, args) {
         SearchEndpoint.configureSampleEndpoint();
-        Coveo.get($$(document.body).find('.CoveoHierarchicalFacet')).queryController.setEndpoint(SearchEndpoint.endpoints['default']);
+        Coveo.get($$(getSearchInterfaceElement()).find('.CoveoHierarchicalFacet')).queryController.setEndpoint(
+          SearchEndpoint.endpoints['default']
+        );
       });
     },
     advancedExpression: '@hierarchicfield'
@@ -282,16 +284,17 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
               className: 'result-template',
               type: 'text/underscore'
             },
-            "<div><a class='CoveoResultLink'></a></div>"
+            "<div><span class='CoveoIcon' data-small='true' data-with-label='false' style='display:inline-block; vertical-align:middle; margin-right:5px;'></span><a class='CoveoResultLink'></a></div>"
           )
         )
       )
+      .withoutQuerySuggest()
       .build(),
     options: {
       headerTitle: ''
     },
     toExecute: () => {
-      setMinHeightOnSearchInterface('300px');
+      setMinHeightOnSearchInterface('500px');
       getSearchInterfaceInstance().options.resultsPerPage = 5;
     }
   },
@@ -303,11 +306,18 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   PreferencesPanel: {
     show: true,
-    element: $$(
-      'div',
-      undefined,
-      `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"><div class="CoveoResultsPreferences"></div><div class="CoveoResultsFiltersPreferences"></div></div>`
-    ),
+    element: new SearchSectionBuilder()
+      .withDomElement(
+        $$(
+          'div',
+          {
+            className: 'CoveoPreferencesPanel'
+          },
+          $$('div', { className: 'CoveoResultsPreferences' }),
+          $$('div', { className: 'CoveoResultsFiltersPreferences' })
+        )
+      )
+      .build(),
     toExecute: () => {
       setMinHeightOnSearchInterface('300px');
     }
@@ -348,11 +358,17 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   ResultsFiltersPreferences: {
     show: true,
-    element: $$(
-      'div',
-      undefined,
-      `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"><div class="CoveoResultsFiltersPreferences"></div></div>`
-    ),
+    element: new SearchSectionBuilder()
+      .withDomElement(
+        $$(
+          'div',
+          {
+            className: 'CoveoPreferencesPanel'
+          },
+          $$('div', { className: 'CoveoResultsFiltersPreferences' })
+        )
+      )
+      .build(),
     toExecute: () => {
       setMinHeightOnSearchInterface('300px');
     }
@@ -364,41 +380,36 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
     }
   },
   ResultsPreferences: {
-    element: $$(
-      'div',
-      undefined,
-      `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"><div class="CoveoResultsPreferences"></div></div>`
-    ),
+    element: new SearchSectionBuilder()
+      .withDomElement(
+        $$(
+          'div',
+          {
+            className: 'CoveoPreferencesPanel'
+          },
+          $$('div', { className: 'CoveoResultsPreferences' })
+        )
+      )
+      .build(),
     show: true,
-    toExecute: () => {
-      setMinHeightOnSearchInterface('300px');
-    }
-  },
-  SearchAlerts: {
-    show: true,
-    element: $$(
-      'div',
-      undefined,
-      `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoSearchAlerts"></div>`
-    ),
     toExecute: () => {
       setMinHeightOnSearchInterface('300px');
     }
   },
   Settings: {
     show: true,
-    element: $$(
-      'div',
-      undefined,
-      `<div class="coveo-search-section"><div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"></div><div class="CoveoShareQuery"></div><div class="CoveoExportToExcel"></div></div>`
-    ),
+    element: new SearchSectionBuilder()
+      .withComponent('CoveoShareQuery')
+      .withComponent('CoveoExportToExcel')
+      .withComponent('CoveoAdvancedSearch')
+      .build(),
     toExecute: () => {
       setMinHeightOnSearchInterface('300px');
     }
   },
   ShareQuery: {
     show: true,
-    element: $$('div', undefined, `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoShareQuery"></div>`),
+    element: new SearchSectionBuilder().withComponent('CoveoShareQuery').build(),
     toExecute: () => {
       setMinHeightOnSearchInterface('300px');
     }
@@ -420,7 +431,7 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
     ),
     toExecute: () => {
       getSearchInterfaceElement().style.padding = '20px';
-      $$(document.body).on('buildingQuery', function(e, args) {
+      $$(getSearchInterfaceElement()).on('buildingQuery', function(e, args) {
         args.queryBuilder.numberOfResults = 3;
       });
     }
@@ -437,11 +448,7 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   AdvancedSearch: {
     show: true,
-    element: $$(
-      'div',
-      undefined,
-      `<div class="coveo-search-section"><div class="CoveoSettings"></div><div class="CoveoSearchbox"></div></div><div class="CoveoAdvancedSearch"></div>`
-    ),
+    element: new SearchSectionBuilder().withComponent('CoveoAdvancedSearch').build(),
     toExecute: () => {
       setMinHeightOnSearchInterface('300px');
     }

--- a/docs/playground/src/PlaygroundConfiguration.ts
+++ b/docs/playground/src/PlaygroundConfiguration.ts
@@ -1,7 +1,7 @@
-import {IStringMap} from "../../../src/rest/GenericParam";
-import {$$, Dom} from "../../../src/utils/Dom";
-import {SearchEndpoint} from "../../../src/rest/SearchEndpoint";
-
+import { IStringMap } from '../../../src/rest/GenericParam';
+import { $$, Dom } from '../../../src/utils/Dom';
+import { SearchEndpoint } from '../../../src/rest/SearchEndpoint';
+import { SearchSectionBuilder } from './SearchSectionBuilder';
 export interface IComponentPlaygroundConfiguration {
   show: boolean; // should we show a preview for this component. False is assumed if not specified.
   isResultComponent?: boolean; // is this component supposed to be inserted inside a result template ? False is assumed if not specified
@@ -13,6 +13,22 @@ export interface IComponentPlaygroundConfiguration {
 }
 
 declare var Coveo;
+
+const getComponentContainerElement = () => {
+  return $$(document.body).find('.component-container');
+};
+
+const getSearchInterfaceElement = () => {
+  return $$(getComponentContainerElement()).find('.CoveoSearchInterface');
+};
+
+const getSearchInterfaceInstance = () => {
+  return Coveo.get(getSearchInterfaceElement(), Coveo.SearchInterface);
+};
+
+const setMinHeightOnSearchInterface = (minHeight: string) => {
+  getSearchInterfaceElement().style.minHeight = minHeight;
+};
 
 export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfiguration> = {
   SearchInterface: {
@@ -58,7 +74,11 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   Tab: {
     show: true,
-    element: $$('div', {className: 'coveo-tab-section'}, `<div class="CoveoTab" data-caption="All content" data-id="All"></div><div class="CoveoTab" data-caption="YouTube videos" data-id="YouTube"></div><div class="CoveoTab" data-caption="Google Drive" data-id="GoogleDrive"></div><div class="CoveoTab" data-caption="Emails" data-id="Emails"></div><div class="CoveoTab" data-caption="Salesforce content" data-id="Salesforce"></div>`)
+    element: $$(
+      'div',
+      { className: 'coveo-tab-section' },
+      `<div class="CoveoTab" data-caption="All content" data-id="All"></div><div class="CoveoTab" data-caption="YouTube videos" data-id="YouTube"></div><div class="CoveoTab" data-caption="Google Drive" data-id="GoogleDrive"></div><div class="CoveoTab" data-caption="Emails" data-id="Emails"></div><div class="CoveoTab" data-caption="Salesforce content" data-id="Salesforce"></div>`
+    )
   },
   FacetSlider: {
     show: true,
@@ -83,24 +103,28 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   Breadcrumb: {
     show: true,
-    element: $$('div', undefined, `<div class="CoveoBreadcrumb"></div><p>Interact with the facet to modify the breadcrumb</p><div class="CoveoFacet" data-field="@objecttype" data-title="Type"></div>`)
+    element: $$(
+      'div',
+      undefined,
+      `<div class="CoveoBreadcrumb"></div><p>Interact with the facet to modify the breadcrumb</p><div class="CoveoFacet" data-field="@objecttype" data-title="Type"></div>`
+    )
   },
   DidYouMean: {
     show: true,
     basicExpression: 'testt',
-    element: $$('div', undefined, `<div class="CoveoDidYouMean"></div><div class='CoveoSearchbox'></div>`)
+    element: new SearchSectionBuilder().withComponent('CoveoDidYouMean').build()
   },
   ErrorReport: {
     show: true,
-    toExecute: ()=> {
+    toExecute: () => {
       Coveo['SearchEndpoint'].endpoints['default'].options.accessToken = 'invalid';
     }
   },
   ExportToExcel: {
     show: true,
-    element: $$('div', undefined, `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoExportToExcel"></div>`),
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.minHeight = '300px';
+    element: new SearchSectionBuilder().withComponent('CoveoExportToExcel').build(),
+    toExecute: () => {
+      setMinHeightOnSearchInterface('300px');
     }
   },
   FacetRange: {
@@ -108,26 +132,29 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
     options: {
       field: '@size',
       title: 'Documents size',
-      ranges: [{
-        start: 0,
-        end: 100,
-        label: "0 - 100 KB",
-        endInclusive: false
-      }, {
-        start: 100,
-        end: 200,
-        label: "100 - 200 KB",
-        endInclusive: false
-      }, {
-        start: 200,
-        end: 300,
-        label: "200 - 300 KB",
-        endInclusive: false
-      },
+      ranges: [
+        {
+          start: 0,
+          end: 100,
+          label: '0 - 100 KB',
+          endInclusive: false
+        },
+        {
+          start: 100,
+          end: 200,
+          label: '100 - 200 KB',
+          endInclusive: false
+        },
+        {
+          start: 200,
+          end: 300,
+          label: '200 - 300 KB',
+          endInclusive: false
+        },
         {
           start: 300,
           end: 400,
-          label: "300 - 400 KB",
+          label: '300 - 400 KB',
           endInclusive: false
         }
       ],
@@ -136,12 +163,19 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   FieldSuggestions: {
     options: {
-      field: '@author'
+      field: '@author',
+      headerTitle: 'Authors'
     },
     show: true,
-    element: $$('div', undefined, `<div class='preview-info'>Showing suggestions on the field <span class='preview-info-emphasis'>@author</span></div><div class="CoveoSearchbox" data-enable-omnibox="true"></div><div class="CoveoFieldSuggestions"></div>`),
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.minHeight = '500px';
+    element: new SearchSectionBuilder()
+      .withDomElement(
+        $$('div', { className: 'preview-info' }, "Showing suggestions on the field <span class='preview-info-emphasis'>@author</span>")
+      )
+      .withComponent('CoveoFieldSuggestions')
+      .withoutQuerySuggest()
+      .build(),
+    toExecute: () => {
+      setMinHeightOnSearchInterface('500px');
     }
   },
   FieldTable: {
@@ -151,8 +185,10 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
     },
     isResultComponent: true,
     advancedExpression: '@source=="Dropbox - coveodocumentationsamples@gmail.com"',
-    element: $$('div', undefined,
-        `<table class="CoveoFieldTable">
+    element: $$(
+      'div',
+      undefined,
+      `<table class="CoveoFieldTable">
             <tbody>
              <tr data-field="@size" data-caption="Document size" data-helper="size">
               </tr>
@@ -160,7 +196,8 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
               </tr>
               <tr data-field="@date" data-caption="Date" date-helper="dateTime"></tr>
             </tbody>
-          </table>`)
+          </table>`
+    )
   },
   FieldValue: {
     show: true,
@@ -174,10 +211,14 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   FollowItem: {
     show: true,
     isResultComponent: true,
-    element: $$('div', undefined, `<div class="CoveoSearchAlerts"></div><a class="CoveoResultLink"></a><span class="CoveoFollowItem"></span>`),
+    element: $$(
+      'div',
+      undefined,
+      `<div class="CoveoSearchAlerts"></div><a class="CoveoResultLink"></a><span class="CoveoFollowItem"></span>`
+    ),
     basicExpression: 'technology',
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.minHeight = '300px';
+    toExecute: () => {
+      setMinHeightOnSearchInterface('300px');
     }
   },
   HiddenQuery: {
@@ -185,8 +226,8 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
     options: {
       title: 'This is the filter title'
     },
-    toExecute: ()=> {
-      let searchInterface = $$(document.body).find('.component-container .CoveoSearchInterface');
+    toExecute: () => {
+      const searchInterface = getSearchInterfaceElement();
       Coveo.state(searchInterface, 'hd', 'This is the filter description');
       Coveo.state(searchInterface, 'hq', '@uri');
     },
@@ -198,18 +239,19 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
       field: '@hierarchicfield',
       title: 'Hierarchical Facet with random values'
     },
-    toExecute: ()=> {  // `@hierarchicfield` does not exist in the sample Coveo Cloud V2 organization.
+    toExecute: () => {
+      // `@hierarchicfield` does not exist in the sample Coveo Cloud V2 organization.
       $$(document.body).on('newQuery', function(e, args) {
         SearchEndpoint.configureSampleEndpoint();
-        Coveo.get($$(document.body).find(".CoveoHierarchicalFacet")).queryController.setEndpoint(SearchEndpoint.endpoints['default']);
+        Coveo.get($$(document.body).find('.CoveoHierarchicalFacet')).queryController.setEndpoint(SearchEndpoint.endpoints['default']);
       });
     },
-    advancedExpression: "@hierarchicfield"
+    advancedExpression: '@hierarchicfield'
   },
   Logo: {
     show: true,
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.padding = '20px';
+    toExecute: () => {
+      getSearchInterfaceElement().style.padding = '20px';
     }
   },
   Matrix: {
@@ -227,25 +269,47 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   OmniboxResultList: {
     show: true,
-    element: $$('div', undefined, `<div class="CoveoSearchbox" data-enable-omnibox="true" data-inline="true"></div><div class="CoveoOmniboxResultList"><script class="result-template" type="text/x-underscore"><div><a class='CoveoResultLink'></a></div></script></div>`),
+    element: new SearchSectionBuilder()
+      .withDomElement(
+        $$(
+          'div',
+          {
+            className: 'CoveoOmniboxResultList'
+          },
+          $$(
+            'script',
+            {
+              className: 'result-template',
+              type: 'text/underscore'
+            },
+            "<div><a class='CoveoResultLink'></a></div>"
+          )
+        )
+      )
+      .build(),
     options: {
       headerTitle: ''
     },
-    toExecute: ()=> {
-      Coveo.get($$(document.body).find('.CoveoSearchInterface'), Coveo.SearchInterface).options.resultsPerPage = 5;
+    toExecute: () => {
+      setMinHeightOnSearchInterface('300px');
+      getSearchInterfaceInstance().options.resultsPerPage = 5;
     }
   },
   Pager: {
     show: true,
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.padding = '20px';
+    toExecute: () => {
+      getSearchInterfaceElement().style.padding = '20px';
     }
   },
   PreferencesPanel: {
     show: true,
-    element: $$('div', undefined, `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"><div class="CoveoResultsPreferences"></div><div class="CoveoResultsFiltersPreferences"></div></div>`),
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.minHeight = '300px';
+    element: $$(
+      'div',
+      undefined,
+      `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"><div class="CoveoResultsPreferences"></div><div class="CoveoResultsFiltersPreferences"></div></div>`
+    ),
+    toExecute: () => {
+      setMinHeightOnSearchInterface('300px');
     }
   },
   PrintableUri: {
@@ -278,60 +342,84 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   ResultRating: {
     show: true,
     isResultComponent: true,
-    toExecute: ()=> {
-      Coveo.get($$(document.body).find('.CoveoSearchInterface'), Coveo.SearchInterface).options.enableCollaborativeRating = true;
+    toExecute: () => {
+      getSearchInterfaceInstance().options.enableCollaborativeRating = true;
     }
   },
   ResultsFiltersPreferences: {
     show: true,
-    element: $$('div', undefined, `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"><div class="CoveoResultsFiltersPreferences"></div></div>`),
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.minHeight = '300px';
+    element: $$(
+      'div',
+      undefined,
+      `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"><div class="CoveoResultsFiltersPreferences"></div></div>`
+    ),
+    toExecute: () => {
+      setMinHeightOnSearchInterface('300px');
     }
   },
   ResultsPerPage: {
     show: true,
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.padding = '20px';
+    toExecute: () => {
+      getSearchInterfaceElement().style.padding = '20px';
     }
   },
   ResultsPreferences: {
-    element: $$('div', undefined, `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"><div class="CoveoResultsPreferences"></div></div>`),
+    element: $$(
+      'div',
+      undefined,
+      `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"><div class="CoveoResultsPreferences"></div></div>`
+    ),
     show: true,
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.minHeight = '300px';
+    toExecute: () => {
+      setMinHeightOnSearchInterface('300px');
     }
   },
   SearchAlerts: {
     show: true,
-    element: $$('div', undefined, `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoSearchAlerts"></div>`),
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.minHeight = '300px';
+    element: $$(
+      'div',
+      undefined,
+      `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoSearchAlerts"></div>`
+    ),
+    toExecute: () => {
+      setMinHeightOnSearchInterface('300px');
     }
   },
   Settings: {
     show: true,
-    element: $$('div', undefined, `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"></div><div class="CoveoShareQuery"></div><div class="CoveoExportToExcel"></div>`),
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.minHeight = '300px';
+    element: $$(
+      'div',
+      undefined,
+      `<div class="coveo-search-section"><div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoPreferencesPanel"></div><div class="CoveoShareQuery"></div><div class="CoveoExportToExcel"></div></div>`
+    ),
+    toExecute: () => {
+      setMinHeightOnSearchInterface('300px');
     }
   },
   ShareQuery: {
     show: true,
     element: $$('div', undefined, `<div class="CoveoSettings"></div><div class="CoveoSearchbox"></div><div class="CoveoShareQuery"></div>`),
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.minHeight = '300px';
+    toExecute: () => {
+      setMinHeightOnSearchInterface('300px');
     }
   },
   SimpleFilter: {
     show: true,
-    element: $$('div', undefined, `<div class="CoveoSimpleFilter" data-field="@filetype" data-title="File Type"></div><div class="CoveoResultList"></div>`),
+    element: $$(
+      'div',
+      undefined,
+      `<div class="CoveoSimpleFilter" data-field="@filetype" data-title="File Type"></div><div class="CoveoResultList"></div>`
+    )
   },
   Sort: {
     show: true,
-    element: $$('div', undefined, `<div class="coveo-sort-section"><span class="CoveoSort" data-sort-criteria="relevancy" data-caption="Relevance"></span><span class="CoveoSort" data-sort-criteria="date descending,date ascending" data-caption="Date"></span></div><div class="CoveoResultList"></div>`),
-    toExecute: ()=> {
-      $$(document.body).find('.preview-container .CoveoSearchInterface').style.padding = '20px';
+    element: $$(
+      'div',
+      undefined,
+      `<div class="coveo-sort-section"><span class="CoveoSort" data-sort-criteria="relevancy" data-caption="Relevance"></span><span class="CoveoSort" data-sort-criteria="date descending,date ascending" data-caption="Date"></span></div><div class="CoveoResultList"></div>`
+    ),
+    toExecute: () => {
+      getSearchInterfaceElement().style.padding = '20px';
       $$(document.body).on('buildingQuery', function(e, args) {
         args.queryBuilder.numberOfResults = 3;
       });
@@ -349,9 +437,13 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   },
   AdvancedSearch: {
     show: true,
-    element: $$('div', undefined, `<div class="coveo-search-section"><div class="CoveoSettings"></div><div class="CoveoSearchbox"></div></div><div class="CoveoAdvancedSearch"></div>`),
-    toExecute: ()=> {
-      $$(document.body).find('.CoveoSearchInterface').style.minHeight = '300px';
+    element: $$(
+      'div',
+      undefined,
+      `<div class="coveo-search-section"><div class="CoveoSettings"></div><div class="CoveoSearchbox"></div></div><div class="CoveoAdvancedSearch"></div>`
+    ),
+    toExecute: () => {
+      setMinHeightOnSearchInterface('300px');
     }
   }
-}
+};

--- a/docs/playground/src/SearchSectionBuilder.ts
+++ b/docs/playground/src/SearchSectionBuilder.ts
@@ -1,17 +1,20 @@
 import { $$, Dom } from '../../../src/utils/Dom';
+import { SectionBuilder } from './SectionBuilder';
 
-export class SearchSectionBuilder {
-  public section: Dom;
+export class SearchSectionBuilder extends SectionBuilder {
   public searchbox: Dom;
   public settings: Dom;
 
   private enableOmnibox = true;
   private enableQuerySuggest = true;
 
-  constructor() {
-    this.section = $$('div', {
+  constructor(
+    sectionParameter = $$('div', {
       className: 'coveo-search-section'
-    });
+    })
+  ) {
+    super();
+    this.section = sectionParameter;
 
     this.searchbox = $$('div', {
       className: 'CoveoSearchbox'
@@ -45,19 +48,10 @@ export class SearchSectionBuilder {
     return this;
   }
 
-  public withComponent(component: string) {
-    this.section.append($$('div', { className: component }).el);
-    return this;
-  }
-
-  public withDomElement(dom: Dom) {
-    this.section.append(dom.el);
-    return this;
-  }
-
   public build() {
+    const built = super.build();
     this.searchbox.setAttribute('data-enable-omnibox', this.enableOmnibox.toString());
     this.searchbox.setAttribute('data-enable-query-suggest-addon', this.enableQuerySuggest.toString());
-    return this.section;
+    return built;
   }
 }

--- a/docs/playground/src/SearchSectionBuilder.ts
+++ b/docs/playground/src/SearchSectionBuilder.ts
@@ -1,0 +1,63 @@
+import { $$, Dom } from '../../../src/utils/Dom';
+
+export class SearchSectionBuilder {
+  public section: Dom;
+  public searchbox: Dom;
+  public settings: Dom;
+
+  private enableOmnibox = true;
+  private enableQuerySuggest = true;
+
+  constructor() {
+    this.section = $$('div', {
+      className: 'coveo-search-section'
+    });
+
+    this.searchbox = $$('div', {
+      className: 'CoveoSearchbox'
+    });
+
+    this.settings = $$('div', {
+      className: 'CoveoSettings'
+    });
+
+    this.section.append(this.settings.el);
+    this.section.append(this.searchbox.el);
+  }
+
+  public withOmnibox() {
+    this.enableOmnibox = true;
+    return this;
+  }
+
+  public withoutOmnibox() {
+    this.enableOmnibox = false;
+    return this;
+  }
+
+  public withQuerySuggest() {
+    this.enableQuerySuggest = true;
+    return this;
+  }
+
+  public withoutQuerySuggest() {
+    this.enableQuerySuggest = false;
+    return this;
+  }
+
+  public withComponent(component: string) {
+    this.section.append($$('div', { className: component }).el);
+    return this;
+  }
+
+  public withDomElement(dom: Dom) {
+    this.section.append(dom.el);
+    return this;
+  }
+
+  public build() {
+    this.searchbox.setAttribute('data-enable-omnibox', this.enableOmnibox.toString());
+    this.searchbox.setAttribute('data-enable-query-suggest-addon', this.enableQuerySuggest.toString());
+    return this.section;
+  }
+}

--- a/docs/playground/src/SectionBuilder.ts
+++ b/docs/playground/src/SectionBuilder.ts
@@ -1,0 +1,20 @@
+import { $$, Dom } from '../../../src/utils/Dom';
+import { IStringMap } from '../../../src/rest/GenericParam';
+
+export class SectionBuilder {
+  constructor(public section = $$('div')) {}
+
+  public withComponent(component: string, props: IStringMap<any> = {}, markupTag = 'div') {
+    this.section.append($$(markupTag, { className: component, ...props }).el);
+    return this;
+  }
+
+  public withDomElement(dom: Dom) {
+    this.section.append(dom.el);
+    return this;
+  }
+
+  public build() {
+    return this.section;
+  }
+}

--- a/webpack.playground.config.js
+++ b/webpack.playground.config.js
@@ -1,90 +1,14 @@
 'use strict';
-const _ = require('underscore');
-const minimize = process.argv.indexOf('minimize') !== -1;
-const webpack = require('webpack');
-const path = require('path');
-const production = process.env.NODE_ENV === 'production';
-const globalizePath = __dirname + '/lib/globalize/globalize.min.js';
-
-module.exports = {
-  entry: {
-    'playground': ['./docs/playground/src/Index.ts'],
-  },
-  output: {
-    path: require('path').resolve('./docs/theme/assets/gen/js'),
-    filename: '[name].js',
-    libraryTarget: 'var',
-    library: 'playground',
-    devtoolModuleFilenameTemplate: '[resource-path]'
-  },
-  resolve: {
-    extensions: ['.ts', '.js', '.scss'],
-    alias: {
-      'l10n': __dirname + '/lib/l10n/l10n.min.js',
-      'globalize': globalizePath,
-      'modal-box': __dirname + '/node_modules/modal-box/bin/ModalBox.min.js',
-      'magic-box': __dirname + '/node_modules/coveomagicbox/bin/MagicBox.min.js',
-      'default-language': __dirname + '/src/strings/DefaultLanguage.js',
-      'jQuery': __dirname + '/test/lib/jquery.js',
-      'styling': __dirname + '/sass'
-    },
-    modules: ['node_modules', path.resolve(__dirname, '../bin/image/css')]
-  },
-  plugins : [new webpack.DefinePlugin({
-    DISABLE_LOGGER: minimize
-  })],
-  devtool: 'source-map',
-  module: {
-    rules: [{
-      test: /underscore-min.js/,
-      use: [{
-        loader: 'string-replace-loader',
-        options: {
-          search: '//# sourceMappingURL=underscore-min.map',
-          replace: ''
-        }
-      }]
-    }, {
-      test: require.resolve(globalizePath),
-      use: [{
-        loader: 'expose-loader?Globalize'
-      }]
-    }, {
-      test: /jquery.js/,
-      use: [{
-        loader: 'string-replace-loader',
-        options: {
-          search: '//@ sourceMappingURL=jquery.min.map',
-          replace: ''
-        }
-      }]
-    }, {
-      test: /promise|es6-promise/,
-      use: [{
-        loader: 'string-replace-loader',
-        options: {
-          search: '//# sourceMappingURL=es6-promise.map',
-          replace: ''
-        }
-      }]
-    }, {
-      test: /coveo\.analytics\/dist\/.*\.js/,
-      use: [{
-        loader: 'string-replace-loader',
-        options: {
-          search: '(?!\n).*\.map',
-          flags: 'g',
-          replace: ''
-        }
-      }]
-    }, {
-      test: /\.ts$/,
-      use: [{
-        loader: 'ts-loader'
-      }]
-    }, {
-      test: /\.scss/,
-      use: [{loader: 'null-loader'}]
-    }]
-  }
+const baseConfig = require('./webpack.config');
+baseConfig.entry = {
+  playground: ['./docs/playground/src/Index.ts']
 };
+baseConfig.output = {
+  path: require('path').resolve('./docs/theme/assets/gen/js'),
+  filename: '[name].js',
+  libraryTarget: 'var',
+  library: 'playground',
+  devtoolModuleFilenameTemplate: '[resource-path]'
+};
+
+module.exports = baseConfig;


### PR DESCRIPTION
The "playground" is the section that appear in the documentation where you can see a "Live example of ${component name}".

eg : https://coveo.github.io/search-ui/components/facet.html

Pretty much every component need some kind of configuration to be displayed in a manner that make sense or where people consulting the documentation understand properly what the component does exactly. 

This PR add a small utility classes to create standard "sections".

https://coveord.atlassian.net/browse/JSUI-1850


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)