### PR TITLE
Provide a way to resolve pipeline context when no query is performed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ notifications:
     on_failure: always
 node_js:
 - 8.5.0
-cache:
-  directories:
-  - node_modules
 before_script:
 - npm install -g gulp
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
 before_script:
 - npm install -g gulp
 before_install:
-- npm install -g npm@5.4.1
+- npm install -g npm@5.5.1
 script:
 - source read.version.sh
 - echo $PACKAGE_JSON_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ notifications:
     on_failure: always
 node_js:
 - 8.5.0
+cache:
+  directories:
+  - node_modules
 before_script:
 - npm install -g gulp
 before_install:

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,7 +87,10 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@salesforce-ux/design-system/-/design-system-2.0.3.tgz",
       "integrity": "sha1-UgoFCpWiQ7er6b7RMb9iUU2v7KA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "fsevents": "1.1.2"
+      }
     },
     "@types/d3": {
       "version": "3.5.36",
@@ -117,9 +120,9 @@
       "dev": true
     },
     "@types/jasmine": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.6.0.tgz",
-      "integrity": "sha512-1ZZdFvYA5zARDXPj5+VF0bwDZWH/o0QQWJVDc5srdC/DngcCZXskR33eR/4PielGvBjLQpQOd6KiQbmtqVkeZA==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.6.2.tgz",
+      "integrity": "sha512-MycZLb931+dfAUzz27JeIOrvKjqyWUk27PhJzYWpIJ9nEyPi2bb1AOc/X9bvmvYnekpNrGNqYXwvoXMmpaeoCw==",
       "dev": true
     },
     "@types/pikaday": {
@@ -140,9 +143,9 @@
       }
     },
     "@types/underscore": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha512-DP70788BXjp9+CKArXOUlNkZaXa+rHonDpbqH3/74ez16dLL5z2/bMT37etbln5J+H9M07NbRUyduDIoTM2tnw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.4.tgz",
+      "integrity": "sha512-lYM1FJ9v+gxyeH13ty22qvl5Z/UPq1xCwmxZANqzPNRBddshb6Q6uOUeat2FcPNKRqVg2dunxDCEa5X9gmrqeQ==",
       "dev": true
     },
     "CSSselect": {
@@ -303,20 +306,20 @@
       }
     },
     "ajv": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-      "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.3.0.tgz",
+      "integrity": "sha1-RBT/dKUIecII7l/cgm4ywwNUnto=",
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
-        "json-schema-traverse": "0.3.1",
-        "json-stable-stringify": "1.0.1"
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "ajv-keywords": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.0.tgz",
-      "integrity": "sha1-opbhf3v658HOT34N5T0pyzIWLfA=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
       "dev": true
     },
     "align-text": {
@@ -536,9 +539,9 @@
       "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "asn1.js": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
-      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.2.tgz",
+      "integrity": "sha512-b/OsSjvWEo8Pi8H0zsDd2P6Uqo2TK2pH8gNLSJtNLM2Db0v2QaAZ0pBQJXVjAn4gBuugeVDr7s63ZogpUIwWDg==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -606,7 +609,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000744",
+        "caniuse-db": "1.0.30000757",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -822,9 +825,9 @@
       "dev": true
     },
     "browserify-aes": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.8.tgz",
-      "integrity": "sha512-WYCMOT/PtGTlpOKFht0YJFYcPy6pLCR98CtWfzK13zoynLlBMvAdEMSRGmgnJCw2M2j/5qxBkinZQFobieM8dQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
+      "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
       "dev": true,
       "requires": {
         "buffer-xor": "1.0.3",
@@ -841,7 +844,7 @@
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
       "dev": true,
       "requires": {
-        "browserify-aes": "1.0.8",
+        "browserify-aes": "1.1.1",
         "browserify-des": "1.0.0",
         "evp_bytestokey": "1.0.3"
       }
@@ -897,8 +900,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000744",
-        "electron-to-chromium": "1.3.24"
+        "caniuse-db": "1.0.30000757",
+        "electron-to-chromium": "1.3.27"
       }
     },
     "buffer": {
@@ -1001,15 +1004,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000744",
+        "caniuse-db": "1.0.30000757",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000744",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000744.tgz",
-      "integrity": "sha1-AHWP991fcTjTShVgjcz3Glllb/4=",
+      "version": "1.0.30000757",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000757.tgz",
+      "integrity": "sha1-+iOjgyE9hX9KHmo77hezJmhQTL8=",
       "dev": true
     },
     "caseless": {
@@ -1096,6 +1099,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -1258,7 +1262,7 @@
       "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
-        "q": "1.5.0"
+        "q": "1.5.1"
       }
     },
     "code-point-at": {
@@ -1359,9 +1363,9 @@
       "dev": true
     },
     "compressible": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
-      "integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.12.tgz",
+      "integrity": "sha1-xZpcmdt2dn6YdlAOJx72OzSTvWY=",
       "dev": true,
       "requires": {
         "mime-db": "1.30.0"
@@ -1375,7 +1379,7 @@
       "requires": {
         "accepts": "1.3.4",
         "bytes": "3.0.0",
-        "compressible": "2.0.11",
+        "compressible": "2.0.12",
         "debug": "2.6.9",
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
@@ -1480,13 +1484,19 @@
             "statuses": "1.3.1",
             "unpipe": "1.0.0"
           }
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
         }
       }
     },
     "connect-history-api-fallback": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
-      "integrity": "sha1-5R0X+PDvDbkKZP20feMFFVbp8Wk=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.4.0.tgz",
+      "integrity": "sha1-PbJPlz9LkjsOgvYZzg3wJBHKYj0=",
       "dev": true
     },
     "console-browserify": {
@@ -2081,7 +2091,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.35"
       }
     },
     "d3": {
@@ -2348,9 +2358,9 @@
       }
     },
     "date-fns": {
-      "version": "1.28.5",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.28.5.tgz",
-      "integrity": "sha1-JXz8RdMi30XvVlhmWWfuhBzXP68=",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
       "dev": true
     },
     "date-now": {
@@ -2780,9 +2790,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.24",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.24.tgz",
-      "integrity": "sha1-m3uIuwXOufoBahd4M8wt3jiPIbY=",
+      "version": "1.3.27",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz",
+      "integrity": "sha1-eOy4o5kGYYe7N07t412ccFZagD0=",
       "dev": true
     },
     "elegant-spinner": {
@@ -3014,23 +3024,23 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.30",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
-      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
+      "version": "0.10.35",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
+      "integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.1",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
+        "es5-ext": "0.10.35",
         "es6-symbol": "3.1.1"
       }
     },
@@ -3041,8 +3051,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -3069,8 +3079,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
       }
@@ -3082,7 +3092,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.35"
       }
     },
     "es6-weak-map": {
@@ -3092,8 +3102,8 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "es5-ext": "0.10.35",
+        "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
     },
@@ -3191,7 +3201,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "es5-ext": "0.10.35"
       }
     },
     "event-stream": {
@@ -3384,9 +3394,9 @@
       "dev": true
     },
     "express": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.1.tgz",
-      "integrity": "sha512-STB7LZ4N0L+81FJHGla2oboUHTk4PaN1RsOkoRh9OSeEKylvF5hwKYVX1xCLFaCT7MD0BNG/gX2WFMLqY6EMBw==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.2.tgz",
+      "integrity": "sha1-41xt/i1kt9ygpc1PIXgb4ymeB2w=",
       "dev": true,
       "requires": {
         "accepts": "1.3.4",
@@ -3426,6 +3436,12 @@
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
           "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
           "dev": true
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
         }
       }
     },
@@ -3441,7 +3457,7 @@
       "dev": true,
       "requires": {
         "iconv-lite": "0.4.19",
-        "jschardet": "1.5.1",
+        "jschardet": "1.6.0",
         "tmp": "0.0.33"
       },
       "dependencies": {
@@ -3466,9 +3482,9 @@
       }
     },
     "extract-text-webpack-plugin": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.1.tgz",
-      "integrity": "sha512-zv0/Cg2mU8uMzeQQ3oyfJvZU4Iv/GbQYUIr/HU+8pZetT/0W3xj6XAbxoG4gsp8SbnYcFd4BOsCAZPl9NvplPw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-3.0.2.tgz",
+      "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
       "dev": true,
       "requires": {
         "async": "2.5.0",
@@ -3500,26 +3516,17 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.5.tgz",
-      "integrity": "sha1-maBnNbbqIOqbcF13ms/8yHz/BEA=",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
+      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
       "dev": true,
       "requires": {
         "concat-stream": "1.6.0",
-        "debug": "2.2.0",
+        "debug": "2.6.9",
         "mkdirp": "0.5.0",
         "yauzl": "2.4.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
-        },
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -3534,12 +3541,6 @@
           "requires": {
             "minimist": "0.0.8"
           }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         }
       }
     },
@@ -3562,6 +3563,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3691,6 +3697,14 @@
         "parseurl": "1.3.2",
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        }
       }
     },
     "find-index": {
@@ -3861,6 +3875,905 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+      "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "nan": "2.7.0",
+        "node-pre-gyp": "0.6.36"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true,
+          "dev": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true,
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true,
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true,
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true,
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.36",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true,
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true,
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -4779,7 +5692,7 @@
         "concat-stream": "1.6.0",
         "gulp-util": "3.0.8",
         "through2": "2.0.3",
-        "yazl": "2.4.2"
+        "yazl": "2.4.3"
       }
     },
     "gulplog": {
@@ -4803,9 +5716,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
         "async": "1.5.2",
@@ -4841,7 +5754,7 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.2.3",
+        "ajv": "5.3.0",
         "har-schema": "2.0.0"
       }
     },
@@ -4925,7 +5838,7 @@
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
         "hoek": "4.2.0",
-        "sntp": "2.0.2"
+        "sntp": "2.1.0"
       },
       "dependencies": {
         "hoek": {
@@ -5086,7 +5999,7 @@
         "depd": "1.1.1",
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
-        "statuses": "1.3.1"
+        "statuses": "1.4.0"
       }
     },
     "http-parser-js": {
@@ -5208,6 +6121,16 @@
       "integrity": "sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=",
       "dev": true
     },
+    "import-local": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-0.1.1.tgz",
+      "integrity": "sha1-sReVcqrNwRxqkQCftDDbyrX2aKg=",
+      "dev": true,
+      "requires": {
+        "pkg-dir": "2.0.0",
+        "resolve-cwd": "2.0.0"
+      }
+    },
     "imports-loader": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/imports-loader/-/imports-loader-0.7.1.tgz",
@@ -5289,7 +6212,7 @@
       "dev": true,
       "requires": {
         "ansi-escapes": "3.0.0",
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
         "cli-cursor": "2.1.0",
         "cli-width": "2.2.0",
         "external-editor": "2.0.5",
@@ -5326,14 +6249,14 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "cli-cursor": {
@@ -5405,9 +6328,9 @@
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -5480,9 +6403,9 @@
       }
     },
     "is-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
-      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -5826,7 +6749,7 @@
         "escodegen": "1.7.1",
         "esprima": "2.5.0",
         "fileset": "0.2.1",
-        "handlebars": "4.0.10",
+        "handlebars": "4.0.11",
         "js-yaml": "3.10.0",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
@@ -5950,7 +6873,7 @@
         "glob": "5.0.15",
         "istanbul": "0.3.22",
         "minimist": "1.2.0",
-        "q": "1.5.0"
+        "q": "1.5.1"
       },
       "dependencies": {
         "glob": {
@@ -6016,7 +6939,7 @@
       "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
       "dev": true,
       "requires": {
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
         "jest-get-type": "21.2.0",
         "leven": "2.1.0",
         "pretty-format": "21.2.1"
@@ -6032,14 +6955,14 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "has-flag": {
@@ -6049,9 +6972,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6066,7 +6989,7 @@
       "requires": {
         "hoek": "2.16.3",
         "isemail": "1.2.0",
-        "moment": "2.18.1",
+        "moment": "2.19.1",
         "topo": "1.1.0"
       }
     },
@@ -6111,9 +7034,9 @@
       "optional": true
     },
     "jschardet": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.5.1.tgz",
-      "integrity": "sha512-vE2hT1D0HLZCLLclfBSfkfTTedhVj0fubHpJBHKwwUWX0nSbhPAfk+SG9rTX95BYNmau8rGFfCeaT6T5OW1C2A==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-1.6.0.tgz",
+      "integrity": "sha512-xYuhvQ7I9PDJIGBWev9xm0+SMSed3ZDBAmvVjbFR1ZRLAF+vlXcQu6cRI9uAlj81rzikElRVteehwV7DuX2ZmQ==",
       "dev": true
     },
     "jsdom": {
@@ -6129,7 +7052,7 @@
         "cssom": "0.3.2",
         "cssstyle": "0.2.37",
         "escodegen": "1.9.0",
-        "nwmatcher": "1.4.2",
+        "nwmatcher": "1.4.3",
         "parse5": "1.5.1",
         "request": "2.83.0",
         "sax": "1.2.4",
@@ -6169,14 +7092,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -6211,11 +7126,6 @@
           "optional": true
         }
       }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
     "jsonpointer": {
       "version": "4.0.1",
@@ -6415,7 +7325,7 @@
             "escodegen": "1.8.1",
             "esprima": "2.7.3",
             "glob": "5.0.15",
-            "handlebars": "4.0.10",
+            "handlebars": "4.0.11",
             "js-yaml": "3.10.0",
             "mkdirp": "0.5.1",
             "nopt": "3.0.6",
@@ -6487,13 +7397,19 @@
       "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo=",
       "dev": true
     },
+    "killable": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.0.tgz",
+      "integrity": "sha1-2ouEvUfeU5WHj5XWTQLyRJ/gXms=",
+      "dev": true
+    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "1.1.6"
       }
     },
     "klaw": {
@@ -6583,17 +7499,18 @@
         "lodash.isstring": "4.0.1",
         "lodash.mapvalues": "4.6.0",
         "rechoir": "0.6.2",
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "lint-staged": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-4.2.3.tgz",
-      "integrity": "sha512-Ks1vMyVpp3ldeFDN9sIcHcFDh0v3X6Y6LOdT0Wl86/BSDM2R8PVcuFODkh0Dav7Ni/asUPKONfXRWZM9YO85IQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-4.3.0.tgz",
+      "integrity": "sha512-C/Zxslg0VRbsxwmCu977iIs+QyrmW2cyRCPUV5NDFYOH/jtRFHH8ch7ua2fH0voI/nVC3Tpg7DykfgMZySliKw==",
       "dev": true,
       "requires": {
         "app-root-path": "2.0.1",
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
+        "commander": "2.11.0",
         "cosmiconfig": "1.1.0",
         "execa": "0.8.0",
         "is-glob": "4.0.0",
@@ -6618,14 +7535,14 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "has-flag": {
@@ -6659,9 +7576,9 @@
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -6683,12 +7600,12 @@
         "is-stream": "1.1.0",
         "listr-silent-renderer": "1.1.1",
         "listr-update-renderer": "0.2.0",
-        "listr-verbose-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
         "log-symbols": "1.0.2",
         "log-update": "1.0.2",
         "ora": "0.2.3",
         "p-map": "1.2.0",
-        "rxjs": "5.4.3",
+        "rxjs": "5.5.2",
         "stream-to-observable": "0.1.0",
         "strip-ansi": "3.0.1"
       },
@@ -6744,14 +7661,14 @@
       }
     },
     "listr-verbose-renderer": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz",
-      "integrity": "sha1-RNwBuww0oDxXIVTU0Izemx3FYg8=",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
       "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "cli-cursor": "1.0.2",
-        "date-fns": "1.28.5",
+        "date-fns": "1.29.0",
         "figures": "1.7.0"
       }
     },
@@ -7302,7 +8219,7 @@
       "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.1.0"
+        "chalk": "2.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7315,14 +8232,14 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "has-flag": {
@@ -7332,9 +8249,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -7363,9 +8280,9 @@
       }
     },
     "loglevel": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.0.tgz",
-      "integrity": "sha512-OQ2jhWI5G2qsvO0UFNyCQWgKl/tFiwuPIXxELzACeUO2FqstN/R7mmL09+nhv6xOWVPPojQO1A90sCEoJSgBcQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.5.1.tgz",
+      "integrity": "sha1-GJB4yUq5BT7iFaCs2/JCROoPZQI=",
       "dev": true
     },
     "longest": {
@@ -7731,9 +8648,9 @@
       "integrity": "sha1-KBmktjuG1iYxRqZH8tYNfmVW5J0="
     },
     "moment": {
-      "version": "2.18.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.18.1.tgz",
-      "integrity": "sha1-w2GT3Tzhwu7SrbfIAtu8d6gbHA8="
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
+      "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc="
     },
     "ms": {
       "version": "2.0.0",
@@ -7952,12 +8869,12 @@
         "core-js": "2.5.1",
         "del": "3.0.0",
         "globby": "6.1.0",
-        "handlebars": "4.0.10",
+        "handlebars": "4.0.11",
         "inquirer": "3.3.0",
         "lodash.get": "4.4.2",
         "mkdirp": "0.5.1",
         "pify": "3.0.0",
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       },
       "dependencies": {
         "pify": {
@@ -8269,9 +9186,9 @@
       "dev": true
     },
     "nwmatcher": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.2.tgz",
-      "integrity": "sha512-QMkCGQFYp5p+zwU3INntLmz1HMfSx9dMVJMYKmE1yuSf/22Wjo6VPFa405mCLUuQn9lbQvH2DZN9lt10ZNvtAg==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
+      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw==",
       "dev": true,
       "optional": true
     },
@@ -8627,8 +9544,8 @@
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
       "dev": true,
       "requires": {
-        "asn1.js": "4.9.1",
-        "browserify-aes": "1.0.8",
+        "asn1.js": "4.9.2",
+        "browserify-aes": "1.1.1",
         "create-hash": "1.1.3",
         "evp_bytestokey": "1.0.3",
         "pbkdf2": "3.0.14"
@@ -8928,7 +9845,7 @@
       "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.6.1.tgz",
       "integrity": "sha512-B+pxVcSGuzLblMe4dnhCF3dnI2zkyj5GAqanGX9cVcOk90fp2ULo1OZFUPRXQXUE5tmcimnk1tPOFs8tUHQetQ==",
       "requires": {
-        "moment": "2.18.1"
+        "moment": "2.19.1"
       }
     },
     "pinkie": {
@@ -8948,6 +9865,26 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/pjs/-/pjs-5.1.1.tgz",
       "integrity": "sha1-nfxGc7sB3v/WkV+x3sdYJ6ukKr8="
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "2.1.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "2.0.0"
+          }
+        }
+      }
     },
     "plop": {
       "version": "1.9.0",
@@ -9191,7 +10128,7 @@
       "integrity": "sha1-thTJcgvmgW6u41+zpfqh26agXds=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.13"
+        "postcss": "6.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9204,14 +10141,14 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "has-flag": {
@@ -9221,14 +10158,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
-          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
-            "chalk": "2.1.0",
+            "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "source-map": {
@@ -9238,9 +10175,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -9255,7 +10192,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.13"
+        "postcss": "6.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9268,14 +10205,14 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "css-selector-tokenizer": {
@@ -9296,14 +10233,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
-          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
-            "chalk": "2.1.0",
+            "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "source-map": {
@@ -9313,9 +10250,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -9330,7 +10267,7 @@
       "dev": true,
       "requires": {
         "css-selector-tokenizer": "0.7.0",
-        "postcss": "6.0.13"
+        "postcss": "6.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9343,14 +10280,14 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "css-selector-tokenizer": {
@@ -9371,14 +10308,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
-          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
-            "chalk": "2.1.0",
+            "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "source-map": {
@@ -9388,9 +10325,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -9405,7 +10342,7 @@
       "dev": true,
       "requires": {
         "icss-replace-symbols": "1.1.0",
-        "postcss": "6.0.13"
+        "postcss": "6.0.14"
       },
       "dependencies": {
         "ansi-styles": {
@@ -9418,14 +10355,14 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "has-flag": {
@@ -9435,14 +10372,14 @@
           "dev": true
         },
         "postcss": {
-          "version": "6.0.13",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.13.tgz",
-          "integrity": "sha512-nHsrD1PPTMSJDfU+osVsLtPkSP9YGeoOz4FDLN4r1DW4N5vqL1J+gACzTQHsfwIiWG/0/nV4yCzjTMo1zD8U1g==",
+          "version": "6.0.14",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.14.tgz",
+          "integrity": "sha512-NJ1z0f+1offCgadPhz+DvGm5Mkci+mmV5BqD13S992o0Xk9eElxUfPPF+t2ksH5R/17gz4xVK8KWocUQ5o3Rog==",
           "dev": true,
           "requires": {
-            "chalk": "2.1.0",
+            "chalk": "2.3.0",
             "source-map": "0.6.1",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "source-map": {
@@ -9452,9 +10389,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -9727,7 +10664,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "extract-zip": "1.6.5",
+        "extract-zip": "1.6.6",
         "https-proxy-agent": "2.1.0",
         "mime": "1.4.1",
         "progress": "2.0.0",
@@ -9756,9 +10693,9 @@
       }
     },
     "q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qjobs": {
@@ -9833,7 +10770,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9844,7 +10781,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -9883,9 +10820,9 @@
       "dev": true
     },
     "rc": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-      "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.2.tgz",
+      "integrity": "sha1-2M6ctX6NZNnHut2YdsfDTL48cHc=",
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.4",
@@ -10028,7 +10965,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "1.5.0"
       }
     },
     "redent": {
@@ -10114,7 +11051,7 @@
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "requires": {
-        "rc": "1.2.1"
+        "rc": "1.2.2"
       }
     },
     "regjsgen": {
@@ -10260,7 +11197,7 @@
             "escodegen": "1.8.1",
             "esprima": "2.7.3",
             "glob": "5.0.15",
-            "handlebars": "4.0.10",
+            "handlebars": "4.0.11",
             "js-yaml": "3.10.0",
             "mkdirp": "0.5.1",
             "nopt": "3.0.6",
@@ -10476,12 +11413,21 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
+      }
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "3.0.0"
       }
     },
     "resolve-dir": {
@@ -10494,6 +11440,12 @@
         "global-modules": "0.2.3"
       }
     },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
@@ -10501,9 +11453,9 @@
       "dev": true
     },
     "resolve-url-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-2.1.0.tgz",
-      "integrity": "sha1-J8lcwWpDU5I/29wtuvXu8iIyxHc=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-2.2.0.tgz",
+      "integrity": "sha512-ivEo27PgDKAm3Iwzh/ObwcDrKT2O25xWBIQX6HJVVfaxYWNNW6euPMmMFzpQUZo03+iv2TloBgffEk1ULnEPdg==",
       "dev": true,
       "requires": {
         "adjust-sourcemap-loader": "1.1.0",
@@ -10661,9 +11613,9 @@
       }
     },
     "rxjs": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
-      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.2.tgz",
+      "integrity": "sha512-oRYoIKWBU3Ic37fLA5VJu31VqQO4bWubRntcHSJ+cwaDQBwdnZ9x4zmhJfm/nFQ2E82/I4loSioHnACamrKGgA==",
       "dev": true,
       "requires": {
         "symbol-observable": "1.0.4"
@@ -10779,7 +11731,7 @@
       "integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
       "dev": true,
       "requires": {
-        "ajv": "5.2.3"
+        "ajv": "5.3.0"
       }
     },
     "script-loader": {
@@ -10866,6 +11818,14 @@
         "on-finished": "2.3.0",
         "range-parser": "1.2.0",
         "statuses": "1.3.1"
+      },
+      "dependencies": {
+        "statuses": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+          "dev": true
+        }
       }
     },
     "sentence-case": {
@@ -10963,7 +11923,7 @@
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "lazy-cache": {
@@ -11135,9 +12095,9 @@
       }
     },
     "sntp": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-      "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "4.2.0"
       },
@@ -11306,7 +12266,7 @@
         "faye-websocket": "0.11.1",
         "inherits": "2.0.3",
         "json3": "3.3.2",
-        "url-parse": "1.1.9"
+        "url-parse": "1.2.0"
       },
       "dependencies": {
         "faye-websocket": {
@@ -11482,9 +12442,9 @@
       "dev": true
     },
     "statuses": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
       "dev": true
     },
     "stdout-stream": {
@@ -12189,7 +13149,7 @@
       "integrity": "sha512-8t3bu2FcEkXb+D4L+Cn8qiK2E2C6Ms4/GQChvz6IMbVurcFHLXrhW4EMtfaol1a1ASQACZGDUGit4NHnX9g7hQ==",
       "dev": true,
       "requires": {
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
         "enhanced-resolve": "3.4.1",
         "loader-utils": "1.1.0",
         "semver": "5.4.1"
@@ -12205,14 +13165,14 @@
           }
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "has-flag": {
@@ -12239,9 +13199,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -12389,7 +13349,7 @@
     },
     "typedoc": {
       "version": "https://github.com/coveord/typedoc/tarball/master",
-      "integrity": "sha1-ibG3ZGwC6JiBVcEi1pQ+ZQvvY2c=",
+      "integrity": "sha1-n5Lm4ls2BF2+dpMee0ViiIpRQeY=",
       "dev": true,
       "requires": {
         "fs-extra": "0.26.7",
@@ -12485,9 +13445,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
-      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
+      "integrity": "sha1-7znN6ierrAtQAkLWcmq5DgyEZjE=",
       "dev": true
     },
     "uglify-js": {
@@ -12709,9 +13669,9 @@
       }
     },
     "url-parse": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
-      "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.2.0.tgz",
+      "integrity": "sha512-DT1XbYAfmQP65M/mE6OALxmXzZ/z1+e5zk2TcSKe/KiYbNGZxgtttzC0mR/sjopbpOXcbniq7eIKmocJnUWlEw==",
       "dev": true,
       "requires": {
         "querystringify": "1.0.0",
@@ -12952,15 +13912,15 @@
       "optional": true
     },
     "webpack": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.6.0.tgz",
-      "integrity": "sha512-OsHT3D0W0KmPPh60tC7asNnOmST6bKTiR90UyEdT9QYoaJ4OYN4Gg7WK1k3VxHK07ZoiYWPsKvlS/gAjwL/vRA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
+      "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
+        "acorn": "5.2.1",
         "acorn-dynamic-import": "2.0.2",
-        "ajv": "5.2.3",
-        "ajv-keywords": "2.1.0",
+        "ajv": "5.3.0",
+        "ajv-keywords": "2.1.1",
         "async": "2.5.0",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
@@ -12973,7 +13933,7 @@
         "mkdirp": "0.5.1",
         "node-libs-browser": "2.0.0",
         "source-map": "0.5.7",
-        "supports-color": "4.4.0",
+        "supports-color": "4.5.0",
         "tapable": "0.2.8",
         "uglifyjs-webpack-plugin": "0.4.6",
         "watchpack": "1.4.0",
@@ -12982,9 +13942,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
-          "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
+          "integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w==",
           "dev": true
         },
         "ansi-regex": {
@@ -13166,9 +14126,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -13234,9 +14194,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.1.tgz",
-      "integrity": "sha512-qFKs4Wg6JI6FkAQ6WFqeDCCxXEBLsDHkqJB3f9tmlqx8C68Y9vQWwcaMT4Q9H8WF32Q6QUNmgK4qQkdHfXvj/g==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.9.4.tgz",
+      "integrity": "sha512-thrqC0EQEoSjXeYgP6pUXcUCZ+LNrKsDPn+mItLnn5VyyNZOJKd06hUP5vqkYwL8nWWXsii0loSF9NHNccT6ow==",
       "dev": true,
       "requires": {
         "ansi-html": "0.0.7",
@@ -13244,14 +14204,17 @@
         "bonjour": "3.5.0",
         "chokidar": "1.7.0",
         "compression": "1.7.1",
-        "connect-history-api-fallback": "1.3.0",
+        "connect-history-api-fallback": "1.4.0",
+        "debug": "3.1.0",
         "del": "3.0.0",
-        "express": "4.16.1",
+        "express": "4.16.2",
         "html-entities": "1.2.1",
         "http-proxy-middleware": "0.17.4",
+        "import-local": "0.1.1",
         "internal-ip": "1.2.0",
         "ip": "1.1.5",
-        "loglevel": "1.5.0",
+        "killable": "1.0.0",
+        "loglevel": "1.5.1",
         "opn": "5.1.0",
         "portfinder": "1.0.13",
         "selfsigned": "1.10.1",
@@ -13260,7 +14223,7 @@
         "sockjs-client": "1.1.4",
         "spdy": "3.4.7",
         "strip-ansi": "3.0.1",
-        "supports-color": "4.4.0",
+        "supports-color": "4.5.0",
         "webpack-dev-middleware": "1.12.0",
         "yargs": "6.6.0"
       },
@@ -13282,6 +14245,15 @@
             "wrap-ansi": "2.1.0"
           }
         },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "has-flag": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
@@ -13289,9 +14261,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -13617,9 +14589,9 @@
       }
     },
     "yazl": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.2.tgz",
-      "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
+      "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
       "dev": true,
       "requires": {
         "buffer-crc32": "0.2.13"

--- a/src/rest/Query.ts
+++ b/src/rest/Query.ts
@@ -1,6 +1,7 @@
 import { IQueryFunction } from './QueryFunction';
 import { IRankingFunction } from './RankingFunction';
 import { IGroupByRequest } from './GroupByRequest';
+import { Context } from '../ui/PipelineContext/PipelineGlobalExports';
 
 /**
  * The IQuery interface describes a query that can be performed on the Coveo REST Search API.
@@ -202,7 +203,7 @@ export interface IQuery {
   /**
    * The context is a map of key_value that can be used in the Query pipeline in the Coveo platform.<br/>
    */
-  context?: { [name: string]: any };
+  context?: Context;
 
   /**
    * The actions history represents the past actions a user made and is used by the Coveo Machine Learning service to

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -929,7 +929,7 @@ export class SearchEndpoint implements ISearchEndpoint {
         } else {
           valueEncoded = encodeURIComponent(value);
         }
-        queryString.push('context[' + key + ']=' + valueEncoded);
+        queryString.push(`context[${encodeURIComponent(key)}]=${valueEncoded}`);
       });
 
       if (queryObject.fieldsToInclude) {

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -923,13 +923,13 @@ export class SearchEndpoint implements ISearchEndpoint {
       });
 
       _.each(queryObject.context, (value, key) => {
-        let valueEncoded;
+        let encodedValue: string;
         if (_.isArray(value)) {
-          valueEncoded = encodeURIComponent(_.map(value, v => encodeURIComponent(v)).join(','));
+          encodedValue = encodeURIComponent(_.map(value, v => encodeURIComponent(v)).join(','));
         } else {
-          valueEncoded = encodeURIComponent(value);
+          encodedValue = encodeURIComponent(value);
         }
-        queryString.push(`context[${encodeURIComponent(key)}]=${valueEncoded}`);
+        queryString.push(`context[${encodeURIComponent(key)}]=${encodedValue}`);
       });
 
       if (queryObject.fieldsToInclude) {

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -923,7 +923,13 @@ export class SearchEndpoint implements ISearchEndpoint {
       });
 
       _.each(queryObject.context, (value, key) => {
-        queryString.push('context[' + key + ']=' + encodeURIComponent(value));
+        let valueEncoded;
+        if (_.isArray(value)) {
+          valueEncoded = encodeURIComponent(_.map(value, v => encodeURIComponent(v)).join(','));
+        } else {
+          valueEncoded = encodeURIComponent(value);
+        }
+        queryString.push('context[' + key + ']=' + valueEncoded);
       });
 
       if (queryObject.fieldsToInclude) {

--- a/src/ui/Analytics/PendingSearchAsYouTypeSearchEvent.ts
+++ b/src/ui/Analytics/PendingSearchAsYouTypeSearchEvent.ts
@@ -34,7 +34,7 @@ export class PendingSearchAsYouTypeSearchEvent extends PendingSearchEvent {
     // For example, DidYouMean would be wrong in that case.
     const eventTarget: HTMLElement = <HTMLElement>e.target;
     const searchInterface = <SearchInterface>Component.get(eventTarget, SearchInterface);
-    this.modifyQueryContent = searchInterface.queryStateModel.get(QueryStateModel.attributesEnum.q);
+    this.modifyQueryContent(searchInterface.queryStateModel.get(QueryStateModel.attributesEnum.q));
     this.beforeResolve = new Promise(resolve => {
       this.toSendRightNow = () => {
         if (!this.isCancelledOrFinished()) {

--- a/src/ui/Analytics/PendingSearchAsYouTypeSearchEvent.ts
+++ b/src/ui/Analytics/PendingSearchAsYouTypeSearchEvent.ts
@@ -34,7 +34,7 @@ export class PendingSearchAsYouTypeSearchEvent extends PendingSearchEvent {
     // For example, DidYouMean would be wrong in that case.
     const eventTarget: HTMLElement = <HTMLElement>e.target;
     const searchInterface = <SearchInterface>Component.get(eventTarget, SearchInterface);
-    this.modifiedQueryContent = searchInterface.queryStateModel.get(QueryStateModel.attributesEnum.q);
+    this.modifyQueryContent = searchInterface.queryStateModel.get(QueryStateModel.attributesEnum.q);
     this.beforeResolve = new Promise(resolve => {
       this.toSendRightNow = () => {
         if (!this.isCancelledOrFinished()) {
@@ -73,7 +73,7 @@ export class PendingSearchAsYouTypeSearchEvent extends PendingSearchEvent {
     this.templateSearchEvent.actionType = newCause.type;
   }
 
-  public set modifiedQueryContent(query: string) {
+  public modifyQueryContent(query: string) {
     this.queryContent = query;
   }
 

--- a/src/ui/Omnibox/QuerySuggestAddon.ts
+++ b/src/ui/Omnibox/QuerySuggestAddon.ts
@@ -78,7 +78,7 @@ export class QuerySuggestAddon {
     let searchHub = this.omnibox.getBindings().componentOptionsModel.get(ComponentOptionsModel.attributesEnum.searchHub);
     let pipeline = this.omnibox.getBindings().searchInterface.options.pipeline;
     let enableWordCompletion = this.omnibox.options.enableSearchAsYouType;
-    let context = this.omnibox.getBindings().queryController.getLastQuery().context;
+    let context = this.omnibox.getBindings().searchInterface.getQueryContext();
 
     if (locale) {
       payload.locale = locale;

--- a/src/ui/PipelineContext/PipelineContext.ts
+++ b/src/ui/PipelineContext/PipelineContext.ts
@@ -7,9 +7,9 @@ import { $$ } from '../../utils/Dom';
 import { Initialization } from '../Base/Initialization';
 import * as _ from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
+import { Context, IPipelineContextProvider } from './PipelineGlobalExports';
 
-export var context: any;
-declare var Coveo;
+declare const Coveo;
 
 export interface IPipelineContextOptions {}
 
@@ -22,12 +22,14 @@ export interface IPipelineContextOptions {}
  * This can be any arbitrary information that you can use to contextualize the query and help Coveo improve relevance by returning results tailored to a specific context.
  *
  * This component is meant to be configured using a script tag, with a JSON content.
+ * 
+ * The values can be either a `string` or an array of `string`.
  *
  * ```
  * <script class='CoveoPipelineContext' type='text/context'>
  *   {
- *      "foo" : "bar"
- *      "foobar" : "{foo, bar}"
+ *      "foo" : "bar",
+ *      "foobar" : ["foo", "bar"]
  *   }
  * </script>
  * ```
@@ -44,63 +46,97 @@ export interface IPipelineContextOptions {}
  * Using this component as opposed to JavaScript code means you will be able to leverage the interface editor.
  *
  * Regardless of if you use this component or JavaScript to add context, both will add the needed data in the [Query.Context]{@link IQuery.context} parameter.
+ * 
+ * **Note:**
+ * 
+ * Using this component also ensures that the framework will be able to properly determine the context in all corner cases, including when using a Standalone Search box ({@link initSearchbox}) displaying query suggestions.
+ * 
+ * If this component is not used in those cases, the context won't be able to be resolved and leveraged properly in the [Query Pipeline](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=108).
+ * 
  */
-export class PipelineContext extends Component {
+export class PipelineContext extends Component implements IPipelineContextProvider {
   static ID = 'PipelineContext';
   static CURRENT_URL = 'CurrentUrl';
 
   static doExport = () => {
     exportGlobally({
-      PipelineContext: PipelineContext,
-      context: context
+      PipelineContext: PipelineContext
     });
   };
 
-  private content: { [id: string]: string | Array<string> };
+  private contextContent: Context = {};
 
   public constructor(public element: HTMLElement, public options?: IPipelineContextOptions, public bindings?: IComponentBindings) {
     super(element, PipelineContext.ID, bindings);
     this.options = ComponentOptions.initComponentOptions(element, PipelineContext, options);
-
-    if (this.element.tagName.toLowerCase() == 'script') {
-      try {
-        // Content can be HTML encoded for special char ({!})
-        this.content = JSON.parse(Utils.decodeHTMLEntities($$(this.element).text()));
-      } catch (e) {
-        try {
-          this.content = JSON.parse($$(this.element).text());
-        } catch (e) {
-          return;
-        }
-      }
-    }
+    this.setContext(
+      $$(this.element)
+        .text()
+        .trim()
+    );
     this.bind.onRootElement(QueryEvents.buildingQuery, (args: IBuildingQueryEventArgs) => this.handleBuildingQuery(args));
   }
 
   /**
+   * Set a new context, replacing any value previously set.
+   * 
+   * @param newContext The new context to set, which can be directly passed as a JSON, or as a stringified JSON.
+   */
+  public setContext(newContext: string | Context) {
+    if (_.isString(newContext)) {
+      const contextParsed = this.tryParseContextFromString(newContext);
+      this.contextContent = contextParsed;
+    } else {
+      this.contextContent = newContext;
+    }
+  }
+
+  /**
+   * Return the current context
+   */
+  public getContext(): Context {
+    const keys = this.getContextKeys();
+    return _.object(keys, _.map(keys, key => this.getContextValue(key)));
+  }
+
+  /**
+   * Set a value for a context, replacing the old value if it was already available.
+   * @param contextKey
+   * @param contextValue 
+   */
+  public setContextValue(contextKey: string, contextValue: string | string[]) {
+    this.contextContent[contextKey] = contextValue;
+  }
+
+  /**
    * Return all the context keys configured for context.
-   * @returns {string[]|Array}
+   * @returns {string[]}
    */
   public getContextKeys(): string[] {
-    return this.content ? _.keys(this.content) : [];
+    return _.keys(this.contextContent);
   }
 
   /**
    * Get the context value associated to the given key.
+   * 
+   * If the global variable Coveo.context contains the requested key, this method will return the value contained in Coveo.context instead of the one contained internally.
+   * 
+   * This is especially useful in a Coveo for Salesforce context, where context values can be extracted from a backend service.
    * @param key
    * @returns {string}
    */
   public getContextValue(key: string): string | string[] {
-    const contextValue = this.content[key];
+    const contextValue = this.contextContent[key];
     if (_.isArray(contextValue)) {
       const contextValues = [];
-      _.each(this.content[key], value => {
+      _.each(this.contextContent[key], value => {
         contextValues.push(this.getModifiedData(value));
       });
       return contextValues;
     } else if (_.isString(contextValue)) {
       return this.getModifiedData(contextValue);
     }
+    return undefined;
   }
 
   private handleBuildingQuery(args: IBuildingQueryEventArgs) {
@@ -110,12 +146,38 @@ export class PipelineContext extends Component {
     });
   }
 
-  // We need to modify the data to escape special salesforce characters. eg: {! }
+  private tryParseContextFromString(contextAsString: string): Context {
+    if (_.isEmpty(contextAsString)) {
+      return {};
+    }
+    try {
+      // Context could be HTML encoded (eg: Coveo for Salesforce)
+      return JSON.parse(Utils.decodeHTMLEntities(contextAsString));
+    } catch (e) {
+      try {
+        return JSON.parse(contextAsString);
+      } catch (e) {
+        this.logger.error(`Error while trying to parse context from the PipelineContext component`, e);
+        return null;
+      }
+    }
+  }
+
   private getModifiedData(value: string) {
+    /* We need to modify the data to escape special salesforce characters. eg: {! }
+     If we find the matching value in the global Coveo.context variable, we return that one instead of the one present locally.
+     So, concretely, the component could contain : 
+     {
+       "productName" : "{! productValueFromSalesforce }"
+     }
+
+     This means that in those case, we would try to access Coveo.context.productValueFromSalesforce (which would in theory be a "real" product value from salesforce, and not a placeholder/variable)
+    */
     return value.replace(/\{\!([^\}]+)\}/g, (all: string, contextKey: string) => {
-      if (Coveo.context != null && contextKey in Coveo.context) {
-        return Coveo.context[contextKey];
-      } else if (contextKey == PipelineContext.CURRENT_URL) {
+      const trimmedKey = contextKey.trim();
+      if (Coveo.context != null && trimmedKey in Coveo.context) {
+        return Coveo.context[trimmedKey];
+      } else if (trimmedKey == PipelineContext.CURRENT_URL) {
         return window.location.href;
       }
       return '';

--- a/src/ui/PipelineContext/PipelineContext.ts
+++ b/src/ui/PipelineContext/PipelineContext.ts
@@ -49,9 +49,9 @@ export interface IPipelineContextOptions {}
  * 
  * **Note:**
  * 
- * Using this component also ensures that the framework will be able to properly determine the context in all corner cases, including when using a Standalone Search box ({@link initSearchbox}) displaying query suggestions.
+ * This component also ensures that the framework properly determines the context in all corner cases, including when a standalone search box ([initSearchbox]{@link initSearchbox}) is displaying query suggestions.
  * 
- * If this component is not used in those cases, the context won't be able to be resolved and leveraged properly in the [Query Pipeline](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=108).
+ * In most cases, if you do not use this component, the context will not be resolved and leveraged properly in the query pipeline (see [What Is a Query Pipeline?](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=252)).
  * 
  */
 export class PipelineContext extends Component implements IPipelineContextProvider {
@@ -92,7 +92,7 @@ export class PipelineContext extends Component implements IPipelineContextProvid
   }
 
   /**
-   * Return the current context
+   * Returns the current context
    */
   public getContext(): Context {
     const keys = this.getContextKeys();
@@ -100,7 +100,7 @@ export class PipelineContext extends Component implements IPipelineContextProvid
   }
 
   /**
-   * Set a value for a context, replacing the old value if it was already available.
+   * Sets a value for a context key, replacing the previous value if applicable.
    * @param contextKey
    * @param contextValue 
    */
@@ -136,7 +136,7 @@ export class PipelineContext extends Component implements IPipelineContextProvid
     } else if (_.isString(contextValue)) {
       return this.getModifiedData(contextValue);
     }
-    return undefined;
+    return '';
   }
 
   private handleBuildingQuery(args: IBuildingQueryEventArgs) {
@@ -175,7 +175,7 @@ export class PipelineContext extends Component implements IPipelineContextProvid
     */
     return value.replace(/\{\!([^\}]+)\}/g, (all: string, contextKey: string) => {
       const trimmedKey = contextKey.trim();
-      if (Coveo.context != null && trimmedKey in Coveo.context) {
+      if (Coveo.context && trimmedKey in Coveo.context) {
         return Coveo.context[trimmedKey];
       } else if (trimmedKey == PipelineContext.CURRENT_URL) {
         return window.location.href;

--- a/src/ui/PipelineContext/PipelineGlobalExports.ts
+++ b/src/ui/PipelineContext/PipelineGlobalExports.ts
@@ -1,0 +1,7 @@
+import { IStringMap } from '../../rest/GenericParam';
+
+export type Context = IStringMap<string | string[]>;
+
+export interface IPipelineContextProvider {
+  getContext: () => Context;
+}

--- a/src/ui/PipelineContext/PipelineGlobalExports.ts
+++ b/src/ui/PipelineContext/PipelineGlobalExports.ts
@@ -1,5 +1,8 @@
 import { IStringMap } from '../../rest/GenericParam';
 
+/**
+ * A context, as returned by {@link SearchInterface.getQueryContext} or {@link PipelineContext.getContext}
+ */
 export type Context = IStringMap<string | string[]>;
 
 export interface IPipelineContextProvider {

--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -516,21 +516,21 @@ export class SearchInterface extends RootComponent implements IComponentBindings
   }
 
   /**
-   * Get the Query context for the current Search Interface.
+   * Gets the query context for the current search interface.
    * 
    * If the search interface has performed at least one query, it will try to resolve the context from the last query sent to the Coveo Search API.
    * 
    * If the search interface has not performed a query yet, it will try to resolve the context from any avaiable {@link PipelineContext} component.
    * 
-   * If there are multiple {@link PipelineContext} component available, it will merge all context values together.
+   * If multiple {@link PipelineContext} components are available, it will merge all context values together.
    * 
    * **Note:**
-   * It is not recommended to have multiple PipelineContext component, especially if you have duplicate context key in each one.
+   * Having multiple PipelineContext components in the same search interface is not recommended, especially if some context keys are repeated across those components.
    * 
    * If no context is found, returns `undefined`
    */
   public getQueryContext(): Context {
-    let ret: Context = undefined;
+    let ret: Context;
 
     const lastQuery = this.queryController.getLastQuery();
     if (lastQuery.context) {

--- a/test/rest/SearchEndpointTest.ts
+++ b/test/rest/SearchEndpointTest.ts
@@ -14,16 +14,16 @@ import { AjaxError } from '../../src/rest/AjaxError';
 import _ = require('underscore');
 
 export function SearchEndpointTest() {
-  describe('SearchEndpoint', function() {
-    beforeEach(function() {
+  describe('SearchEndpoint', () => {
+    beforeEach(() => {
       SearchEndpoint.endpoints = {};
     });
 
-    afterEach(function() {
+    afterEach(() => {
       SearchEndpoint.endpoints = {};
     });
 
-    it('allow to setup easily a search endpoint to point to a sample endpoint', function() {
+    it('allow to setup easily a search endpoint to point to a sample endpoint', () => {
       SearchEndpoint.configureSampleEndpoint();
       const ep: SearchEndpoint = SearchEndpoint.endpoints['default'];
       expect(ep).toBeDefined();
@@ -31,7 +31,7 @@ export function SearchEndpointTest() {
       expect(ep.options.restUri).toBeDefined();
     });
 
-    it('allow to setup easily a cloud endpoint', function() {
+    it('allow to setup easily a cloud endpoint', () => {
       SearchEndpoint.configureCloudEndpoint('foo', 'bar');
       const ep: SearchEndpoint = SearchEndpoint.endpoints['default'];
       expect(ep).toBeDefined();
@@ -39,17 +39,17 @@ export function SearchEndpointTest() {
       expect(ep.options.queryStringArguments['organizationId']).toBe('foo');
     });
 
-    it('allow to setup easily a on prem endpoint', function() {
+    it('allow to setup easily a on prem endpoint', () => {
       SearchEndpoint.configureOnPremiseEndpoint('foo.com');
       const ep: SearchEndpoint = SearchEndpoint.endpoints['default'];
       expect(ep).toBeDefined();
       expect(ep.options.restUri).toBe('foo.com');
     });
 
-    describe('with a workgroup argument', function() {
+    describe('with a workgroup argument', () => {
       let ep: SearchEndpoint;
 
-      beforeEach(function() {
+      beforeEach(() => {
         ep = new SearchEndpoint({
           restUri: 'foo/rest/search',
           queryStringArguments: {
@@ -58,20 +58,20 @@ export function SearchEndpointTest() {
         });
       });
 
-      afterEach(function() {
+      afterEach(() => {
         ep = null;
       });
 
-      it('should not map it to organizationId', function() {
+      it('should not map it to organizationId', () => {
         const fakeResult = FakeResults.createFakeResult();
         expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toBe(ep.getBaseUri() + '/html?workgroup=myOrgId&uniqueId=' + fakeResult.uniqueId);
       });
     });
 
-    describe('with an orgaganizationId argument', function() {
+    describe('with an orgaganizationId argument', () => {
       let ep: SearchEndpoint;
 
-      beforeEach(function() {
+      beforeEach(() => {
         ep = new SearchEndpoint({
           restUri: 'foo/rest/search',
           queryStringArguments: {
@@ -80,11 +80,11 @@ export function SearchEndpointTest() {
         });
       });
 
-      afterEach(function() {
+      afterEach(() => {
         ep = null;
       });
 
-      it('should not map it to workgroup', function() {
+      it('should not map it to workgroup', () => {
         const fakeResult = FakeResults.createFakeResult();
         expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toBe(
           ep.getBaseUri() + '/html?organizationId=myOrgId&uniqueId=' + fakeResult.uniqueId
@@ -92,17 +92,17 @@ export function SearchEndpointTest() {
       });
     });
 
-    describe('with a search token argument', function() {
+    describe('with a search token argument', () => {
       let ep: SearchEndpoint;
 
-      beforeEach(function() {
+      beforeEach(() => {
         ep = new SearchEndpoint({
           restUri: 'foo/rest/search',
           accessToken: 'token'
         });
       });
 
-      afterEach(function() {
+      afterEach(() => {
         ep = null;
       });
 
@@ -112,10 +112,10 @@ export function SearchEndpointTest() {
       });
     });
 
-    describe('with a basic setup', function() {
+    describe('with a basic setup', () => {
       let ep: SearchEndpoint;
 
-      beforeEach(function() {
+      beforeEach(() => {
         ep = new SearchEndpoint({
           restUri: 'foo/rest/search',
           accessToken: 'token',
@@ -126,15 +126,15 @@ export function SearchEndpointTest() {
         });
       });
 
-      afterEach(function() {
+      afterEach(() => {
         ep = null;
       });
 
-      it('allow to get the base uri', function() {
+      it('allow to get the base uri', () => {
         expect(ep.getBaseUri()).toBe('foo/rest/search/v2');
       });
 
-      it('allow to get the auth provider uri', function() {
+      it('allow to get the auth provider uri', () => {
         expect(ep.getAuthenticationProviderUri('ad')).toContain(ep.getBaseUri() + '/login/ad?');
         expect(ep.getAuthenticationProviderUri('ad')).toContain('organizationId=myOrgId');
         expect(ep.getAuthenticationProviderUri('ad')).toContain('potatoe=mashed');
@@ -148,11 +148,11 @@ export function SearchEndpointTest() {
         expect(ep.getAuthenticationProviderUri('troll', undefined, 'msg')).toContain('message=msg');
       });
 
-      it('allow to check if endpoint is jsonp', function() {
+      it('allow to check if endpoint is jsonp', () => {
         expect(ep.isJsonp()).toBe(false);
       });
 
-      it('allow to get an export to excel link', function() {
+      it('allow to get an export to excel link', () => {
         const qbuilder = new QueryBuilder();
         qbuilder.expression.add('batman');
         expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain(ep.getBaseUri() + '/?');
@@ -163,7 +163,43 @@ export function SearchEndpointTest() {
         expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain('format=xlsx');
       });
 
-      it('allow to get an uri to view as datastream', function() {
+      it('allow to get an export to excel link with a context', () => {
+        const qbuilder = new QueryBuilder();
+        qbuilder.addContext({
+          foo: 'bar'
+        });
+        expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain('context[foo]=bar');
+      });
+
+      it('allow to get an export to excel link with context encoded', () => {
+        const qbuilder = new QueryBuilder();
+        qbuilder.addContext({
+          'foo bar': 'buzz bazz'
+        });
+        expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain(
+          `context[foo${encodeURIComponent(' ')}bar]=buzz${encodeURIComponent(' ')}bazz`
+        );
+      });
+
+      it('allow to get an export to excel link with a context array', () => {
+        const qbuilder = new QueryBuilder();
+        qbuilder.addContext({
+          foo: ['buzz', 'bazz']
+        });
+        expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain(`context[foo]=buzz${encodeURIComponent(',')}bazz`);
+      });
+
+      it('allow to get an export to excel link with a context with multiple values', () => {
+        const qbuilder = new QueryBuilder();
+        qbuilder.addContext({
+          foo: 'bar',
+          bazz: 'buzz'
+        });
+        expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain('context[foo]=bar');
+        expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain('context[bazz]=buzz');
+      });
+
+      it('allow to get an uri to view as datastream', () => {
         const fakeResult = FakeResults.createFakeResult();
         expect(ep.getViewAsDatastreamUri(fakeResult.uniqueId, '$Thumbnail')).toContain(ep.getBaseUri() + '/datastream?');
         expect(ep.getViewAsDatastreamUri(fakeResult.uniqueId, '$Thumbnail')).toContain('organizationId=myOrgId');
@@ -172,7 +208,7 @@ export function SearchEndpointTest() {
         expect(ep.getViewAsDatastreamUri(fakeResult.uniqueId, '$Thumbnail')).toContain('dataStream=' + encodeURIComponent('$Thumbnail'));
       });
 
-      it('allow to get an uri to view as html', function() {
+      it('allow to get an uri to view as html', () => {
         const fakeResult = FakeResults.createFakeResult();
         expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toContain(ep.getBaseUri() + '/html?');
         expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toContain('organizationId=myOrgId');
@@ -180,12 +216,12 @@ export function SearchEndpointTest() {
         expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toContain('uniqueId=' + fakeResult.uniqueId);
       });
 
-      describe('will execute requests on the search api', function() {
-        beforeEach(function() {
+      describe('will execute requests on the search api', () => {
+        beforeEach(() => {
           jasmine.Ajax.install();
         });
 
-        afterEach(function() {
+        afterEach(() => {
           jasmine.Ajax.uninstall();
           ep.reset();
         });
@@ -680,7 +716,7 @@ export function SearchEndpointTest() {
           });
         });
 
-        it('request can be modified', function() {
+        it('request can be modified', () => {
           ep.setRequestModifier((requestInfo: IRequestInfo<any>) => {
             requestInfo.headers['Potato'] = 'OmgPotatoes';
             return requestInfo;

--- a/test/ui/PipelineContextTest.ts
+++ b/test/ui/PipelineContextTest.ts
@@ -24,7 +24,7 @@ export function PipelineContextText() {
       });
 
       describe('when it contains valid JSON context', () => {
-        let context = {
+        const context = {
           qwerty: 'azerty',
           'a key': 'a value',
           'another key': ['multiple', 'values', 'in', 'array']
@@ -37,7 +37,7 @@ export function PipelineContextText() {
         });
 
         it('should add the JSON content in the query', () => {
-          let simulation = Simulate.query(test.env);
+          const simulation = Simulate.query(test.env);
           expect(simulation.queryBuilder.build().context).toEqual(
             jasmine.objectContaining({
               qwerty: 'azerty',
@@ -54,18 +54,75 @@ export function PipelineContextText() {
         it('should return the context value', () => {
           expect(test.cmp.getContextValue('qwerty')).toBe('azerty');
         });
+
+        it('should support setting a new context', () => {
+          test.cmp.setContext({ abc: 'def', hij: ['klm', 'nop'] });
+          expect(test.cmp.getContextKeys()).toEqual(jasmine.arrayContaining(['abc', 'hij']));
+        });
+
+        it('should support setting a single context value', () => {
+          test.cmp.setContextValue('popo', 'qwerty');
+          test.cmp.setContextValue('123', ['456', '789']);
+          expect(test.cmp.getContextValue('popo')).toEqual('qwerty');
+          expect(test.cmp.getContextValue('123')).toEqual(['456', '789']);
+        });
+
+        describe('with a global Coveo.context variable', () => {
+          beforeEach(() => {
+            Coveo['context'] = {};
+            Coveo['context']['productName'] = 'ACME 2000 ULTIMATE EDITION';
+            Coveo['context']['userRole'] = 'SYS ADMIN';
+          });
+
+          afterEach(() => {
+            Coveo['context'] = null;
+          });
+
+          it('should support transforming context values', () => {
+            test.cmp.setContextValue('someKey', '{!productName}');
+            expect(test.cmp.getContextValue('someKey')).toEqual('ACME 2000 ULTIMATE EDITION');
+          });
+
+          it('should support transforming context values and trim if needed', () => {
+            test.cmp.setContextValue('someKey', '{!  productName   }');
+            expect(test.cmp.getContextValue('someKey')).toEqual('ACME 2000 ULTIMATE EDITION');
+          });
+
+          it("should support transforming context values when it's from an array", () => {
+            test.cmp.setContextValue('someKey', ['foo', '{!productName}', '{!userRole}']);
+            expect(test.cmp.getContextValue('someKey')).toEqual(['foo', 'ACME 2000 ULTIMATE EDITION', 'SYS ADMIN']);
+          });
+
+          it('should transform the whole context when requesting the context as a whole object', () => {
+            test.cmp.setContext({
+              someKey: '{!productName}',
+              anotherKey: ['{!userRole}', 'foo', 'bar']
+            });
+            expect(test.cmp.getContext()).toEqual(
+              jasmine.objectContaining({
+                someKey: 'ACME 2000 ULTIMATE EDITION',
+                anotherKey: ['SYS ADMIN', 'foo', 'bar']
+              })
+            );
+          });
+
+          it('should support passing a special context syntax without a global variable value, and returns an empty string', () => {
+            test.cmp.setContextValue('someKey', '{!doesNothing}');
+            expect(test.cmp.getContextValue('someKey')).toEqual('');
+          });
+        });
       });
 
       it('should add JSON content in the query if it HTML encoded', () => {
-        let context = {
+        const context = {
           qwerty: 'azerty'
         };
-        let encoded = Utils.encodeHTMLEntities(JSON.stringify(context));
+        const encoded = Utils.encodeHTMLEntities(JSON.stringify(context));
         $$(scriptTag).text(encoded);
 
         test = Mock.advancedComponentSetup<PipelineContext>(PipelineContext, new Mock.AdvancedComponentSetupOptions(scriptTag));
 
-        let simulation = Simulate.query(test.env);
+        const simulation = Simulate.query(test.env);
         expect(simulation.queryBuilder.build().context).toEqual(
           jasmine.objectContaining({
             qwerty: 'azerty'

--- a/test/ui/PipelineContextTest.ts
+++ b/test/ui/PipelineContextTest.ts
@@ -62,8 +62,12 @@ export function PipelineContextText() {
 
         it('should support setting a single context value', () => {
           test.cmp.setContextValue('popo', 'qwerty');
-          test.cmp.setContextValue('123', ['456', '789']);
           expect(test.cmp.getContextValue('popo')).toEqual('qwerty');
+        });
+
+        it('should support setting a single context value as an array', () => {
+          test.cmp.setContextValue('123', ['456', '789']);
+
           expect(test.cmp.getContextValue('123')).toEqual(['456', '789']);
         });
 

--- a/test/ui/QuerySuggestAddonTest.ts
+++ b/test/ui/QuerySuggestAddonTest.ts
@@ -84,9 +84,9 @@ export function QuerySuggestAddonTest() {
       });
 
       it('with the context', () => {
-        queryController.getLastQuery = () => {
+        searchInterface.getQueryContext = () => {
           return <any>{
-            context: 'a context'
+            'context key': 'context value'
           };
         };
 
@@ -94,7 +94,7 @@ export function QuerySuggestAddonTest() {
         querySuggest.getSuggestion();
         expect(endpoint.getQuerySuggest).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            context: 'a context'
+            context: { 'context key': 'context value' }
           })
         );
       });


### PR DESCRIPTION
The pipeline context would normally get resolved from the last query (when we are doing the call for the query suggest).

In some cases, we want to be able to provide the context without having performed any query.

This adds a logic in `SearchInterface` to `getQueryContext()`.

The search interface will return the last query context, if available.

If not available, instead it will try to resolve any `PipelineContext` component, and query them to retrieve the context.

This also adds a couple of utility method on the `PipelineContext` component to set and get the context.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)