### PR TITLE
IPosition changed to IGeolocationPosition

### DIFF
--- a/src/EventsModules.ts
+++ b/src/EventsModules.ts
@@ -2,6 +2,7 @@ export { AdvancedSearchEvents } from './events/AdvancedSearchEvents';
 export { AnalyticsEvents } from './events/AnalyticsEvents';
 export { BreadcrumbEvents } from './events/BreadcrumbEvents';
 export { DebugEvents } from './events/DebugEvents';
+export { DistanceEvents } from './events/DistanceEvents';
 export { InitializationEvents } from './events/InitializationEvents';
 export { OmniboxEvents } from './events/OmniboxEvents';
 export { PreferencesPanelEvents } from './events/PreferencesPanelEvents';

--- a/src/events/DistanceEvents.ts
+++ b/src/events/DistanceEvents.ts
@@ -1,8 +1,15 @@
+/**
+ * The `IGeolocationPosition` interface describes a geolocation position.
+ */
 export interface IGeolocationPosition {
   longitude: number;
   latitude: number;
 }
 
+/**
+ * The `IGeolocationPositionProvider` interface describes a class that can provide a
+ * geolocation position to the [`DistanceResources`]{@link DistanceResources} component.
+ */
 export interface IGeolocationPositionProvider {
   getPosition(): Promise<IGeolocationPosition>;
 }

--- a/src/events/DistanceEvents.ts
+++ b/src/events/DistanceEvents.ts
@@ -1,10 +1,10 @@
-export interface IPosition {
+export interface IGeolocationPosition {
   longitude: number;
   latitude: number;
 }
 
-export interface IPositionProvider {
-  getPosition(): Promise<IPosition>;
+export interface IGeolocationPositionProvider {
+  getPosition(): Promise<IGeolocationPosition>;
 }
 
 /**
@@ -15,7 +15,7 @@ export interface IResolvingPositionEventArgs {
   /**
    * The array of providers that can provide a position. The first provider that can resolve the position will be used.
    */
-  providers: IPositionProvider[];
+  providers: IGeolocationPositionProvider[];
 }
 
 /**
@@ -26,7 +26,7 @@ export interface IPositionResolvedEventArgs {
   /**
    * The position that was resolved.
    */
-  position: IPosition;
+  position: IGeolocationPosition;
 }
 
 /**

--- a/src/events/DistanceEvents.ts
+++ b/src/events/DistanceEvents.ts
@@ -1,5 +1,6 @@
 /**
- * The `IGeolocationPosition` interface describes a geolocation position.
+ * The `IGeolocationPosition` interface describes a geolocation position
+ * usable by the [DistanceResources]{@link DistanceResources} component.
  */
 export interface IGeolocationPosition {
   longitude: number;
@@ -7,8 +8,8 @@ export interface IGeolocationPosition {
 }
 
 /**
- * The `IGeolocationPositionProvider` interface describes a class that can provide a
- * geolocation position to the [`DistanceResources`]{@link DistanceResources} component.
+ * The `IGeolocationPositionProvider` interface describes an object with a method that can provide
+ * a geolocation position to the [DistanceResources]{@link DistanceResources} component.
  */
 export interface IGeolocationPositionProvider {
   getPosition(): Promise<IGeolocationPosition>;

--- a/src/ui/Distance/DistanceResources.ts
+++ b/src/ui/Distance/DistanceResources.ts
@@ -2,8 +2,8 @@ import { $$ } from '../../utils/Dom';
 import {
   DistanceEvents,
   IResolvingPositionEventArgs,
-  IPosition,
-  IPositionProvider,
+  IGeolocationPosition,
+  IGeolocationPositionProvider,
   IPositionResolvedEventArgs
 } from '../../events/DistanceEvents';
 
@@ -53,7 +53,7 @@ export class DistanceResources extends Component {
   };
   private latitude: number;
   private longitude: number;
-  private lastPositionRequest: Promise<IPosition | void>;
+  private lastPositionRequest: Promise<IGeolocationPosition | void>;
   private isFirstPositionResolved = false;
   private pendingSearchEventOnCancellation: PendingSearchEvent;
 
@@ -238,9 +238,9 @@ export class DistanceResources extends Component {
   /**
    * Returns a promise of the last position resolved using the registered position providers.
    *
-   * @returns {Promise<IPosition>} A promise of the last resolved position value.
+   * @returns {Promise<IGeolocationPosition>} A promise of the last resolved position value.
    */
-  public getLastPositionRequest(): Promise<IPosition> {
+  public getLastPositionRequest(): Promise<IGeolocationPosition> {
     return this.lastPositionRequest || Promise.reject('No position request was executed yet.');
   }
 
@@ -287,8 +287,8 @@ export class DistanceResources extends Component {
       });
   }
 
-  private getProvidersFromOptions(): IPositionProvider[] {
-    const providers: IPositionProvider[] = [];
+  private getProvidersFromOptions(): IGeolocationPositionProvider[] {
+    const providers: IGeolocationPositionProvider[] = [];
 
     if (this.options.useNavigator) {
       providers.push(new NavigatorPositionProvider());
@@ -305,8 +305,8 @@ export class DistanceResources extends Component {
     return providers;
   }
 
-  private tryGetPositionFromProviders(providers: IPositionProvider[]): Promise<IPosition> {
-    return new Promise<IPosition>((resolve, reject) => {
+  private tryGetPositionFromProviders(providers: IGeolocationPositionProvider[]): Promise<IGeolocationPosition> {
+    return new Promise<IGeolocationPosition>((resolve, reject) => {
       const tryNextProvider = () => {
         if (providers.length > 0) {
           const provider = providers.shift();

--- a/src/ui/Distance/GoogleApiPositionProvider.ts
+++ b/src/ui/Distance/GoogleApiPositionProvider.ts
@@ -1,5 +1,5 @@
 import { EndpointCaller } from '../../rest/EndpointCaller';
-import { IPosition, IPositionProvider } from '../../events/DistanceEvents';
+import { IGeolocationPosition, IGeolocationPositionProvider } from '../../events/DistanceEvents';
 
 const GOOGLE_MAP_BASE_URL = 'https://www.googleapis.com/geolocation/v1/geolocate';
 
@@ -19,10 +19,10 @@ interface IGeolocationResponseLocation {
  * [`googleApiKey`]{@link DistanceResources.options.googleApiKey} option is set to a valid  Google Maps Geolocation API
  * key.
  */
-export class GoogleApiPositionProvider implements IPositionProvider {
+export class GoogleApiPositionProvider implements IGeolocationPositionProvider {
   constructor(private googleApiKey: string) {}
 
-  public getPosition(): Promise<IPosition> {
+  public getPosition(): Promise<IGeolocationPosition> {
     return new EndpointCaller()
       .call<IGeolocationResponse>({
         errorsAsSuccess: false,

--- a/src/ui/Distance/NavigatorPositionProvider.ts
+++ b/src/ui/Distance/NavigatorPositionProvider.ts
@@ -1,4 +1,4 @@
-import { IPositionProvider, IPosition } from '../../events/DistanceEvents';
+import { IGeolocationPositionProvider, IGeolocationPosition } from '../../events/DistanceEvents';
 
 /**
  * The `NavigatorPositionProvider` class uses the current web browser to provide the position of the end user to
@@ -8,9 +8,9 @@ import { IPositionProvider, IPosition } from '../../events/DistanceEvents';
  * **Note:**
  * > Recent web browsers typically require a site to be in HTTPS to enable their geolocation service.
  */
-export class NavigatorPositionProvider implements IPositionProvider {
-  public getPosition(): Promise<IPosition> {
-    return new Promise<IPosition>((resolve, reject) => {
+export class NavigatorPositionProvider implements IGeolocationPositionProvider {
+  public getPosition(): Promise<IGeolocationPosition> {
+    return new Promise<IGeolocationPosition>((resolve, reject) => {
       navigator.geolocation.getCurrentPosition(
         position => {
           resolve({

--- a/src/ui/Distance/StaticPositionProvider.ts
+++ b/src/ui/Distance/StaticPositionProvider.ts
@@ -1,13 +1,13 @@
-import { IPositionProvider, IPosition } from '../../events/DistanceEvents';
+import { IGeolocationPositionProvider, IGeolocationPosition } from '../../events/DistanceEvents';
 
 /**
  * The `StaticPositionProvider` class provides a static end user position to a
  * [`DistanceResources`]{@link DistanceResources} component.
  */
-export class StaticPositionProvider implements IPositionProvider {
+export class StaticPositionProvider implements IGeolocationPositionProvider {
   constructor(private latitude: number, private longitude: number) {}
 
-  public getPosition(): Promise<IPosition> {
+  public getPosition(): Promise<IGeolocationPosition> {
     return Promise.resolve({
       longitude: this.longitude,
       latitude: this.latitude

--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -12,7 +12,7 @@ import { IAnalyticsFacetMeta, analyticsActionCauseList } from '../Analytics/Anal
 import { IEndpointError } from '../../rest/EndpointError';
 import { Component } from '../Base/Component';
 import { DomUtils } from '../../utils/DomUtils';
-import { PopupUtils, HorizontalAlignment, VerticalAlignment } from '../../utils/PopupUtils';
+import { PopupUtils, PopupHorizontalAlignment, PopupVerticalAlignment } from '../../utils/PopupUtils';
 import { l } from '../../strings/Strings';
 import { Assert } from '../../misc/Assert';
 import { KEYBOARD } from '../../utils/KeyboardUtils';
@@ -98,15 +98,15 @@ export class FacetSearch {
         }
         EventsUtils.addPrefixedEvent(this.search, 'AnimationEnd', evt => {
           PopupUtils.positionPopup(this.searchResults, nextTo, this.root, {
-            horizontal: HorizontalAlignment.CENTER,
-            vertical: VerticalAlignment.BOTTOM
+            horizontal: PopupHorizontalAlignment.CENTER,
+            vertical: PopupVerticalAlignment.BOTTOM
           });
           EventsUtils.removePrefixedEvent(this.search, 'AnimationEnd', this);
         });
       } else {
         PopupUtils.positionPopup(this.searchResults, nextTo, this.root, {
-          horizontal: HorizontalAlignment.CENTER,
-          vertical: VerticalAlignment.BOTTOM
+          horizontal: PopupHorizontalAlignment.CENTER,
+          vertical: PopupVerticalAlignment.BOTTOM
         });
       }
     }

--- a/src/ui/Facet/FacetSettings.ts
+++ b/src/ui/Facet/FacetSettings.ts
@@ -8,7 +8,7 @@ import { l } from '../../strings/Strings';
 import { QueryStateModel } from '../../models/QueryStateModel';
 import { IAnalyticsFacetMeta, analyticsActionCauseList } from '../Analytics/AnalyticsActionListMeta';
 import { DeviceUtils } from '../../utils/DeviceUtils';
-import { PopupUtils, HorizontalAlignment, VerticalAlignment } from '../../utils/PopupUtils';
+import { PopupUtils, PopupHorizontalAlignment, PopupVerticalAlignment } from '../../utils/PopupUtils';
 import * as _ from 'underscore';
 import 'styling/_FacetSettings';
 import { SVGIcons } from '../../utils/SVGIcons';
@@ -513,8 +513,8 @@ export class FacetSettings extends FacetSort {
   }
 
   private getPopupAlignment() {
-    const alignmentHorizontal = DeviceUtils.isMobileDevice() ? HorizontalAlignment.CENTER : HorizontalAlignment.INNERLEFT;
-    const alignmentVertical = VerticalAlignment.BOTTOM;
+    const alignmentHorizontal = DeviceUtils.isMobileDevice() ? PopupHorizontalAlignment.CENTER : PopupHorizontalAlignment.INNERLEFT;
+    const alignmentVertical = PopupVerticalAlignment.BOTTOM;
     return {
       horizontal: alignmentHorizontal,
       vertical: alignmentVertical

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent.ts
@@ -1,5 +1,5 @@
 import { $$, Dom } from '../../../utils/Dom';
-import { PopupUtils, HorizontalAlignment, VerticalAlignment } from '../../../utils/PopupUtils';
+import { PopupUtils, PopupHorizontalAlignment, PopupVerticalAlignment } from '../../../utils/PopupUtils';
 import { ResponsiveComponentsManager } from '../ResponsiveComponentsManager';
 
 export interface IResponsiveDropdownContent {
@@ -41,7 +41,7 @@ export class ResponsiveDropdownContent implements IResponsiveDropdownContent {
       this.element.el,
       $$(this.coveoRoot.find(`.${ResponsiveComponentsManager.DROPDOWN_HEADER_WRAPPER_CSS_CLASS}`)).el,
       this.coveoRoot.el,
-      { horizontal: HorizontalAlignment.INNERRIGHT, vertical: VerticalAlignment.BOTTOM, verticalOffset: 15 },
+      { horizontal: PopupHorizontalAlignment.INNERRIGHT, vertical: PopupVerticalAlignment.BOTTOM, verticalOffset: 15 },
       this.coveoRoot.el
     );
   }

--- a/src/ui/ResponsiveComponents/ResponsiveTabs.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveTabs.ts
@@ -1,6 +1,6 @@
 import { $$, Dom } from '../../utils/Dom';
 import { InitializationEvents } from '../../events/InitializationEvents';
-import { PopupUtils, HorizontalAlignment, VerticalAlignment } from '../../utils/PopupUtils';
+import { PopupUtils, PopupHorizontalAlignment, PopupVerticalAlignment } from '../../utils/PopupUtils';
 import { EventsUtils } from '../../utils/EventsUtils';
 import { Utils } from '../../utils/Utils';
 import { Logger } from '../../misc/Logger';
@@ -353,7 +353,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
       this.dropdownContent.el,
       this.dropdownHeader.el,
       this.coveoRoot.el,
-      { horizontal: HorizontalAlignment.INNERRIGHT, vertical: VerticalAlignment.BOTTOM },
+      { horizontal: PopupHorizontalAlignment.INNERRIGHT, vertical: PopupVerticalAlignment.BOTTOM },
       this.coveoRoot.el
     );
   }

--- a/src/ui/SearchAlerts/SearchAlertsMessage.ts
+++ b/src/ui/SearchAlerts/SearchAlertsMessage.ts
@@ -9,7 +9,7 @@ import {
 } from '../../events/SearchAlertEvents';
 import { QueryEvents } from '../../events/QueryEvents';
 import { ISubscriptionItemRequest, SUBSCRIPTION_TYPE, ISubscriptionQueryRequest } from '../../rest/Subscription';
-import { PopupUtils, HorizontalAlignment, VerticalAlignment } from '../../utils/PopupUtils';
+import { PopupUtils, PopupHorizontalAlignment, PopupVerticalAlignment } from '../../utils/PopupUtils';
 import { l } from '../../strings/Strings';
 import { $$, Dom } from '../../utils/Dom';
 import * as _ from 'underscore';
@@ -128,8 +128,8 @@ export class SearchAlertsMessage extends Component {
       dom.el,
       this.root,
       {
-        horizontal: HorizontalAlignment.INNERLEFT,
-        vertical: VerticalAlignment.BOTTOM,
+        horizontal: PopupHorizontalAlignment.INNERLEFT,
+        vertical: PopupVerticalAlignment.BOTTOM,
         verticalOffset: 12,
         horizontalClip: true
       },

--- a/src/ui/Settings/Settings.ts
+++ b/src/ui/Settings/Settings.ts
@@ -3,7 +3,7 @@ import { IComponentBindings } from '../Base/ComponentBindings';
 import { ComponentOptions } from '../Base/ComponentOptions';
 import { InitializationEvents } from '../../events/InitializationEvents';
 import { $$ } from '../../utils/Dom';
-import { PopupUtils, IPosition, HorizontalAlignment, VerticalAlignment } from '../../utils/PopupUtils';
+import { PopupUtils, IPopupPosition, PopupHorizontalAlignment, PopupVerticalAlignment } from '../../utils/PopupUtils';
 import { IMenuItem } from '../Menu/MenuItem';
 import { SettingsEvents } from '../../events/SettingsEvents';
 import { Initialization } from '../Base/Initialization';
@@ -159,10 +159,10 @@ export class Settings extends Component {
     clearTimeout(this.closeTimeout);
   }
 
-  private getPopupPositioning(): IPosition {
+  private getPopupPositioning(): IPopupPosition {
     return {
-      horizontal: HorizontalAlignment.INNERRIGHT,
-      vertical: VerticalAlignment.BOTTOM,
+      horizontal: PopupHorizontalAlignment.INNERRIGHT,
+      vertical: PopupVerticalAlignment.BOTTOM,
       verticalOffset: 8
     };
   }

--- a/src/utils/PopupUtils.ts
+++ b/src/utils/PopupUtils.ts
@@ -1,14 +1,14 @@
 import { $$, IOffset } from './Dom';
 
-export interface IPosition {
-  vertical: VerticalAlignment;
-  horizontal: HorizontalAlignment;
+export interface IPopupPosition {
+  vertical: PopupVerticalAlignment;
+  horizontal: PopupHorizontalAlignment;
   verticalOffset?: number;
   horizontalOffset?: number;
   horizontalClip?: boolean;
 }
 
-export enum VerticalAlignment {
+export enum PopupVerticalAlignment {
   TOP,
   MIDDLE,
   BOTTOM,
@@ -16,7 +16,7 @@ export enum VerticalAlignment {
   INNERBOTTOM
 }
 
-export enum HorizontalAlignment {
+export enum PopupHorizontalAlignment {
   LEFT,
   CENTER,
   RIGHT,
@@ -24,7 +24,7 @@ export enum HorizontalAlignment {
   INNERRIGHT
 }
 
-interface IElementBoundary {
+interface IPopupElementBoundary {
   top: number;
   left: number;
   right: number;
@@ -36,7 +36,7 @@ export class PopupUtils {
     popUp: HTMLElement,
     nextTo: HTMLElement,
     boundary: HTMLElement,
-    desiredPosition: IPosition,
+    desiredPosition: IPopupPosition,
     appendTo?: HTMLElement,
     checkForBoundary = 0
   ) {
@@ -74,25 +74,25 @@ export class PopupUtils {
     }
   }
 
-  private static finalAdjustement(popUpOffSet: IOffset, popUpPosition: IOffset, popUp: HTMLElement, desiredPosition: IPosition) {
+  private static finalAdjustement(popUpOffSet: IOffset, popUpPosition: IOffset, popUp: HTMLElement, desiredPosition: IPopupPosition) {
     let position = $$(popUp).position();
     popUp.style.top = position.top + desiredPosition.verticalOffset - (popUpOffSet.top - popUpPosition.top) + 'px';
     popUp.style.left = position.left + desiredPosition.horizontalOffset - (popUpOffSet.left - popUpPosition.left) + 'px';
   }
 
-  private static basicVerticalAlignment(popUpPosition: IOffset, popUp: HTMLElement, nextTo: HTMLElement, desiredPosition: IPosition) {
+  private static basicVerticalAlignment(popUpPosition: IOffset, popUp: HTMLElement, nextTo: HTMLElement, desiredPosition: IPopupPosition) {
     switch (desiredPosition.vertical) {
-      case VerticalAlignment.TOP:
+      case PopupVerticalAlignment.TOP:
         popUpPosition.top -= popUp.offsetHeight;
         break;
-      case VerticalAlignment.BOTTOM:
+      case PopupVerticalAlignment.BOTTOM:
         popUpPosition.top += nextTo.offsetHeight;
         break;
-      case VerticalAlignment.MIDDLE:
+      case PopupVerticalAlignment.MIDDLE:
         popUpPosition.top -= popUp.offsetHeight / 3;
-      case VerticalAlignment.INNERTOP:
+      case PopupVerticalAlignment.INNERTOP:
         break; // Nothing to do, it's the default alignment normally
-      case VerticalAlignment.INNERBOTTOM:
+      case PopupVerticalAlignment.INNERBOTTOM:
         popUpPosition.top -= popUp.offsetHeight - nextTo.offsetHeight;
         break;
       default:
@@ -100,20 +100,25 @@ export class PopupUtils {
     }
   }
 
-  private static basicHorizontalAlignment(popUpPosition: IOffset, popUp: HTMLElement, nextTo: HTMLElement, desiredPosition: IPosition) {
+  private static basicHorizontalAlignment(
+    popUpPosition: IOffset,
+    popUp: HTMLElement,
+    nextTo: HTMLElement,
+    desiredPosition: IPopupPosition
+  ) {
     switch (desiredPosition.horizontal) {
-      case HorizontalAlignment.LEFT:
+      case PopupHorizontalAlignment.LEFT:
         popUpPosition.left -= popUp.offsetWidth;
         break;
-      case HorizontalAlignment.RIGHT:
+      case PopupHorizontalAlignment.RIGHT:
         popUpPosition.left += nextTo.offsetWidth;
         break;
-      case HorizontalAlignment.CENTER:
+      case PopupHorizontalAlignment.CENTER:
         popUpPosition.left += PopupUtils.offSetToAlignCenter(popUp, nextTo);
         break;
-      case HorizontalAlignment.INNERLEFT:
+      case PopupHorizontalAlignment.INNERLEFT:
         break; // Nothing to do, it's the default alignment normally
-      case HorizontalAlignment.INNERRIGHT:
+      case PopupHorizontalAlignment.INNERRIGHT:
         popUpPosition.left -= popUp.offsetWidth - nextTo.offsetWidth;
         break;
       default:
@@ -121,19 +126,19 @@ export class PopupUtils {
     }
   }
 
-  private static alignInsideBoundary(oldPosition: IPosition, checkBoundary) {
+  private static alignInsideBoundary(oldPosition: IPopupPosition, checkBoundary) {
     let newDesiredPosition = oldPosition;
     if (checkBoundary.horizontal == 'left') {
-      newDesiredPosition.horizontal = HorizontalAlignment.RIGHT;
+      newDesiredPosition.horizontal = PopupHorizontalAlignment.RIGHT;
     }
     if (checkBoundary.horizontal == 'right') {
-      newDesiredPosition.horizontal = HorizontalAlignment.LEFT;
+      newDesiredPosition.horizontal = PopupHorizontalAlignment.LEFT;
     }
     if (checkBoundary.vertical == 'top') {
-      newDesiredPosition.vertical = VerticalAlignment.BOTTOM;
+      newDesiredPosition.vertical = PopupVerticalAlignment.BOTTOM;
     }
     if (checkBoundary.vertical == 'bottom') {
-      newDesiredPosition.vertical = VerticalAlignment.TOP;
+      newDesiredPosition.vertical = PopupVerticalAlignment.TOP;
     }
     return newDesiredPosition;
   }
@@ -160,7 +165,7 @@ export class PopupUtils {
     };
   }
 
-  private static checkForOutOfBoundary(popUpBoundary: IElementBoundary, boundary: IElementBoundary) {
+  private static checkForOutOfBoundary(popUpBoundary: IPopupElementBoundary, boundary: IPopupElementBoundary) {
     let ret = {
       vertical: 'ok',
       horizontal: 'ok'

--- a/test/ui/DistanceResourcesTest.ts
+++ b/test/ui/DistanceResourcesTest.ts
@@ -7,10 +7,10 @@ import { ISimulateQueryData } from '../Simulate';
 import { QueryStateModel } from '../../src/models/QueryStateModel';
 import { $$ } from '../../src/utils/Dom';
 import {
-  IPosition,
+  IGeolocationPosition,
   DistanceEvents,
   IResolvingPositionEventArgs,
-  IPositionProvider,
+  IGeolocationPositionProvider,
   IPositionResolvedEventArgs
 } from '../../src/events/DistanceEvents';
 import { InitializationEvents } from '../../src/EventsModules';
@@ -28,16 +28,16 @@ export function DistanceResourcesTest() {
     const longitudeField = 'longitude';
     const defaultUnitConversionFactor = 1000;
     const disabledComponentsClass = 'bloupbloup';
-    const aNicePlace = <IPosition>{ latitude: latitudeForANicePlace, longitude: longitudeForANicePlace };
+    const aNicePlace = <IGeolocationPosition>{ latitude: latitudeForANicePlace, longitude: longitudeForANicePlace };
     const expectedQueryFunctionForANicePlace = <IQueryFunction>{
       function: `dist(${latitudeField}, ${longitudeField}, ${latitudeForANicePlace}, ${longitudeForANicePlace})/${defaultUnitConversionFactor}`,
       fieldName: distanceField
     };
 
-    const aValidPositionProvider: IPositionProvider = {
+    const aValidPositionProvider: IGeolocationPositionProvider = {
       getPosition: () => Promise.resolve(aNicePlace)
     };
-    const badPositionProvider: IPositionProvider = {
+    const badPositionProvider: IGeolocationPositionProvider = {
       getPosition: () => Promise.reject(`Wow I'm so bad`)
     };
 
@@ -230,8 +230,8 @@ export function DistanceResourcesTest() {
     });
 
     describe('when two position providers are registered', () => {
-      const anotherProviderThatShouldNotBeUsed: IPositionProvider = {
-        getPosition: () => Promise.resolve(<IPosition>{ latitude: 0, longitude: 0 })
+      const anotherProviderThatShouldNotBeUsed: IGeolocationPositionProvider = {
+        getPosition: () => Promise.resolve(<IGeolocationPosition>{ latitude: 0, longitude: 0 })
       };
 
       beforeEach(() => {


### PR DESCRIPTION
It conflicts in the generated .d.ts with an existing `IPosition` in `PopupUtils`:

```
export interface IPosition {
  vertical: VerticalAlignment;
  horizontal: HorizontalAlignment;
  verticalOffset?: number;
  horizontalOffset?: number;
  horizontalClip?: boolean;
}
```

😢

It still generates a valid .d.ts, but it gives a warning that I need to implement `vertical` and `horizontal`  

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)