### PR TITLE
remove engine field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
     "zipForGitReleases": "gulp zip",
     "uploadCoverage": "gulp uploadCoverage"
   },
-  "engines": {
-    "node": "8.x"
-  },
   "lint-staged": {
     "*.{js,ts,json,scss}": ["prettier --write", "git add"]
   },


### PR DESCRIPTION
People installing our package never actually use node when interacting with our package. We originally had it only for heroku but it's not actually necessary.

https://coveord.atlassian.net/browse/JSUI-1929





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)