### PR TITLE
Support logging analytics event on hash change in the URL

### DIFF
--- a/src/controllers/HistoryController.ts
+++ b/src/controllers/HistoryController.ts
@@ -196,6 +196,10 @@ export class HistoryController extends RootComponent {
   }
 
   private mapStateDifferenceToUsageAnalyticsCall(stateDifference: IStringMap<any>) {
+    // In this method, we want to only match a single analytics event for the current state change.
+    // Even though it's technically possible that many property changed at the same time since the last state,
+    // the backend UA service does not support multiple search cause for a single search event.
+    // So we find the first event that match (if any), by order of importance (query expression > sort > facet)
     if (QUERY_STATE_ATTRIBUTES.Q in stateDifference) {
       logSearchBoxSubmitEvent(this.usageAnalytics);
       return;

--- a/src/controllers/HistoryController.ts
+++ b/src/controllers/HistoryController.ts
@@ -10,16 +10,10 @@ import { Utils } from '../utils/Utils';
 import * as _ from 'underscore';
 import { IStringMap } from '../rest/GenericParam';
 import { QUERY_STATE_ATTRIBUTES } from '../models/QueryStateModel';
-import { state } from '../Lazy';
 import { IAnalyticsClient } from '../ui/Analytics/AnalyticsClient';
-import {
-  IAnalyticsNoMeta,
-  analyticsActionCauseList,
-  IAnalyticsResultsSortMeta,
-  IAnalyticsFacetMeta,
-  IAnalyticsActionCause
-} from '../ui/Analytics/AnalyticsActionListMeta';
+import { analyticsActionCauseList, IAnalyticsFacetMeta, IAnalyticsActionCause } from '../ui/Analytics/AnalyticsActionListMeta';
 import { logSearchBoxSubmitEvent, logSortEvent } from '../ui/Analytics/SharedAnalyticsCalls';
+import { Model } from '../models/Model';
 
 export interface IHistoryControllerEnvironment {
   model: QueryStateModel;
@@ -43,7 +37,7 @@ export class HistoryController extends RootComponent {
   private initialHashChange = false;
   private willUpdateHash: boolean = false;
   private hashchange: (...args: any[]) => void;
-  private lastState;
+  private lastState: IStringMap<any>;
   private hashUtilsModule: typeof HashUtils;
 
   /**
@@ -63,7 +57,7 @@ export class HistoryController extends RootComponent {
       this.lastState = this.model.getAttributes();
     });
 
-    $$(this.element).on(this.model.getEventName(QueryStateModel.eventTypes.all), () => {
+    $$(this.element).on(this.model.getEventName(Model.eventTypes.all), () => {
       this.logger.trace('Query model changed. Update hash');
       this.updateHashFromModel();
     });

--- a/src/controllers/HistoryController.ts
+++ b/src/controllers/HistoryController.ts
@@ -85,10 +85,6 @@ export class HistoryController extends RootComponent {
     return this.hashUtilsModule ? this.hashUtilsModule : HashUtils;
   }
 
-  public set window(win: Window) {
-    this.environment.window = win;
-  }
-
   public get window() {
     return this.environment.window;
   }
@@ -241,9 +237,9 @@ export class HistoryController extends RootComponent {
     const valueRemoved = currentValue.length < lastValue.length;
     let valueModified;
     if (valueRemoved) {
-      valueModified = _.difference(lastValue, currentValue);
+      valueModified = _.first(_.difference(lastValue, currentValue));
     } else {
-      valueModified = _.difference(currentValue, lastValue);
+      valueModified = _.first(_.difference(currentValue, lastValue));
     }
 
     if (matchForInclusion) {

--- a/src/controllers/HistoryController.ts
+++ b/src/controllers/HistoryController.ts
@@ -1,6 +1,6 @@
 import { Assert } from '../misc/Assert';
 import { QueryController } from '../controllers/QueryController';
-import { Model } from '../models/Model';
+import { QueryStateModel } from '../models/QueryStateModel';
 import { InitializationEvents } from '../events/InitializationEvents';
 import { $$ } from '../utils/Dom';
 import { HashUtils } from '../utils/HashUtils';
@@ -8,6 +8,25 @@ import { Defer } from '../misc/Defer';
 import { RootComponent } from '../ui/Base/RootComponent';
 import { Utils } from '../utils/Utils';
 import * as _ from 'underscore';
+import { IStringMap } from '../rest/GenericParam';
+import { QUERY_STATE_ATTRIBUTES } from '../models/QueryStateModel';
+import { state } from '../Lazy';
+import { IAnalyticsClient } from '../ui/Analytics/AnalyticsClient';
+import {
+  IAnalyticsNoMeta,
+  analyticsActionCauseList,
+  IAnalyticsResultsSortMeta,
+  IAnalyticsFacetMeta,
+  IAnalyticsActionCause
+} from '../ui/Analytics/AnalyticsActionListMeta';
+import { logSearchBoxSubmitEvent, logSortEvent } from '../ui/Analytics/SharedAnalyticsCalls';
+
+export interface IHistoryControllerEnvironment {
+  model: QueryStateModel;
+  window: Window;
+  queryController: QueryController;
+  usageAnalytics: IAnalyticsClient;
+}
 
 /**
  * This component is instantiated automatically by the framework on the root if the {@link SearchInterface}.<br/>
@@ -24,42 +43,66 @@ export class HistoryController extends RootComponent {
   private initialHashChange = false;
   private willUpdateHash: boolean = false;
   private hashchange: (...args: any[]) => void;
+  private lastState;
+  private hashUtilsModule: typeof HashUtils;
 
   /**
-   * Create a new history controller
+   * Create a new HistoryController
    * @param element
-   * @param windoh For mock / test purposes.
-   * @param model
-   * @param queryController
-   * @param hashUtilsModule For mock / test purposes.
+   * @param environment
    */
-  constructor(
-    element: HTMLElement,
-    public windoh: Window,
-    public model: Model,
-    public queryController: QueryController,
-    private hashUtils: typeof HashUtils = HashUtils
-  ) {
+  constructor(public element: HTMLElement, private environment: IHistoryControllerEnvironment) {
     super(element, HistoryController.ID);
 
-    this.windoh = this.windoh || window;
     Assert.exists(this.model);
     Assert.exists(this.queryController);
 
     $$(this.element).on(InitializationEvents.restoreHistoryState, () => {
       this.logger.trace('Restore history state. Update model');
       this.updateModelFromHash();
+      this.lastState = this.model.getAttributes();
     });
 
-    $$(this.element).on(this.model.getEventName(Model.eventTypes.all), () => {
+    $$(this.element).on(this.model.getEventName(QueryStateModel.eventTypes.all), () => {
       this.logger.trace('Query model changed. Update hash');
       this.updateHashFromModel();
     });
+
     this.hashchange = () => {
       this.handleHashChange();
+      this.lastState = this.model.getAttributes();
     };
-    this.windoh.addEventListener('hashchange', this.hashchange);
+
+    this.window.addEventListener('hashchange', this.hashchange);
     $$(this.element).on(InitializationEvents.nuke, () => this.handleNuke());
+  }
+
+  public set hashUtils(hashUtils: typeof HashUtils) {
+    this.hashUtilsModule = hashUtils;
+  }
+
+  public get hashUtils() {
+    return this.hashUtilsModule ? this.hashUtilsModule : HashUtils;
+  }
+
+  public set window(win: Window) {
+    this.environment.window = win;
+  }
+
+  public get window() {
+    return this.environment.window;
+  }
+
+  public get model() {
+    return this.environment.model;
+  }
+
+  public get queryController() {
+    return this.environment.queryController;
+  }
+
+  public get usageAnalytics() {
+    return this.environment.usageAnalytics;
   }
 
   /**
@@ -69,25 +112,31 @@ export class HistoryController extends RootComponent {
   public setHashValues(values: {}) {
     this.logger.trace('Update history hash');
 
-    let hash = '#' + this.hashUtils.encodeValues(values);
-    this.ignoreNextHashChange = this.windoh.location.hash != hash;
+    const hash = '#' + this.hashUtils.encodeValues(values);
+    this.ignoreNextHashChange = this.window.location.hash != hash;
 
     this.logger.trace('ignoreNextHashChange', this.ignoreNextHashChange);
     this.logger.trace('initialHashChange', this.initialHashChange);
-    this.logger.trace('from', this.windoh.location.hash, 'to', hash);
+    this.logger.trace('from', this.window.location.hash, 'to', hash);
 
     if (this.initialHashChange) {
       this.initialHashChange = false;
-      this.windoh.location.replace(hash);
+      this.window.location.replace(hash);
       this.logger.trace('History hash modified', hash);
     } else if (this.ignoreNextHashChange) {
-      this.windoh.location.hash = hash;
+      this.window.location.hash = hash;
       this.logger.trace('History hash created', hash);
     }
   }
 
+  public debugInfo() {
+    return {
+      state: this.model.getAttributes()
+    };
+  }
+
   private handleNuke() {
-    this.windoh.removeEventListener('hashchange', this.hashchange);
+    this.window.removeEventListener('hashchange', this.hashchange);
   }
 
   private handleHashChange() {
@@ -99,9 +148,12 @@ export class HistoryController extends RootComponent {
       return;
     }
 
-    let diff = this.updateModelFromHash();
-
-    if (_.difference(diff, HistoryController.attributesThatDoNotTriggerQuery).length > 0) {
+    const attributesThatGotApplied = this.updateModelFromHash();
+    if (_.difference(attributesThatGotApplied, HistoryController.attributesThatDoNotTriggerQuery).length > 0) {
+      if (this.lastState) {
+        const differenceWithLastState = Utils.differenceBetweenObjects(this.model.getAttributes(), this.lastState);
+        this.mapStateDifferenceToUsageAnalyticsCall(differenceWithLastState);
+      }
       this.queryController.executeQuery();
     }
   }
@@ -111,7 +163,7 @@ export class HistoryController extends RootComponent {
 
     if (!this.willUpdateHash) {
       Defer.defer(() => {
-        let attributes = this.model.getAttributes();
+        const attributes = this.model.getAttributes();
         this.setHashValues(attributes);
         this.logger.debug('Saving state to hash', attributes);
         this.willUpdateHash = false;
@@ -123,10 +175,10 @@ export class HistoryController extends RootComponent {
   private updateModelFromHash() {
     this.logger.trace('History hash -> model');
 
-    let toSet: { [key: string]: any } = {};
-    let diff: string[] = [];
+    const toSet: { [key: string]: any } = {};
+    const diff: string[] = [];
     _.each(<_.Dictionary<any>>this.model.attributes, (value, key?, obj?) => {
-      let valToSet = this.getHashValue(key);
+      const valToSet = this.getHashValue(key);
       toSet[key] = valToSet;
       if (this.model.get(key) != valToSet) {
         diff.push(key);
@@ -141,7 +193,7 @@ export class HistoryController extends RootComponent {
     Assert.isNonEmptyString(key);
     let value;
     try {
-      value = this.hashUtils.getValue(key, this.hashUtils.getHash(this.windoh));
+      value = this.hashUtils.getValue(key, this.hashUtils.getHash(this.window));
     } catch (error) {
       this.logger.error(`Could not parse parameter ${key} from URI`);
     }
@@ -153,9 +205,79 @@ export class HistoryController extends RootComponent {
     return value;
   }
 
-  public debugInfo() {
-    return {
-      state: this.model.getAttributes()
-    };
+  private mapStateDifferenceToUsageAnalyticsCall(stateDifference: IStringMap<any>) {
+    if (QUERY_STATE_ATTRIBUTES.Q in stateDifference) {
+      logSearchBoxSubmitEvent(this.usageAnalytics);
+      return;
+    } else if (QUERY_STATE_ATTRIBUTES.SORT in stateDifference) {
+      logSortEvent(this.usageAnalytics, stateDifference[QUERY_STATE_ATTRIBUTES.SORT]);
+      return;
+    } else {
+      // Facet id are not known at compilation time, so we iterate on all keys,
+      // and try to determine if at least one is linked to a facet selection or exclusion.
+      _.keys(stateDifference).forEach(key => {
+        const facetInfo = this.extractFacetInfoFromStateDifference(key);
+        if (facetInfo) {
+          this.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(facetInfo.actionCause, {
+            facetId: facetInfo.fieldName,
+            facetTitle: facetInfo.fieldName,
+            facetValue: facetInfo.valueModified
+          });
+        }
+      });
+    }
+  }
+
+  private extractFacetInfoFromStateDifference(key: string) {
+    const regexForFacetInclusion = /f:(?!.*:not)(.*)/;
+    const matchForInclusion = regexForFacetInclusion.exec(key);
+
+    const regexForFacetExclusion = /f:(.*):not/;
+    const matchForExclusion = regexForFacetExclusion.exec(key);
+
+    const currentValue = this.model.get(key) || [];
+    const lastValue = this.lastState[key] || [];
+
+    const valueRemoved = currentValue.length < lastValue.length;
+    let valueModified;
+    if (valueRemoved) {
+      valueModified = _.difference(lastValue, currentValue);
+    } else {
+      valueModified = _.difference(currentValue, lastValue);
+    }
+
+    if (matchForInclusion) {
+      const fieldName = matchForInclusion[1];
+      let actionCause: IAnalyticsActionCause;
+      if (valueRemoved) {
+        actionCause = analyticsActionCauseList.facetDeselect;
+      } else {
+        actionCause = analyticsActionCauseList.facetSelect;
+      }
+
+      return {
+        fieldName,
+        actionCause,
+        valueModified
+      };
+    }
+
+    if (matchForExclusion) {
+      const fieldName = matchForExclusion[1];
+      let actionCause: IAnalyticsActionCause;
+      if (valueRemoved) {
+        actionCause = analyticsActionCauseList.facetUnexclude;
+      } else {
+        actionCause = analyticsActionCauseList.facetExclude;
+      }
+
+      return {
+        fieldName,
+        actionCause,
+        valueModified
+      };
+    }
+
+    return null;
   }
 }

--- a/src/models/Model.ts
+++ b/src/models/Model.ts
@@ -239,23 +239,6 @@ export class Model extends BaseComponent {
     return this.eventNameSpace + ':' + event;
   }
 
-  public differenceWith(attributes: IStringMap<any>) {
-    const difference: IStringMap<any> = {};
-
-    const addDiff = (anObject: IStringMap<any>) => {
-      for (const key in anObject) {
-        if (anObject[key] != this.getAttributes()[key] && difference[key] == null) {
-          difference[key] = this.getAttributes()[key];
-        }
-      }
-    };
-
-    addDiff(this.getAttributes());
-    addDiff(attributes);
-
-    return difference;
-  }
-
   private attributesHasChangedEvent() {
     $$(this.element).trigger(this.getEventName(Model.eventTypes.change), this.createAttributesChangedArgument());
   }

--- a/src/models/Model.ts
+++ b/src/models/Model.ts
@@ -3,6 +3,7 @@ import { Assert } from '../misc/Assert';
 import { Utils } from '../utils/Utils';
 import { BaseComponent } from '../ui/Base/BaseComponent';
 import * as _ from 'underscore';
+import { IStringMap } from '../rest/GenericParam';
 
 export const MODEL_EVENTS = {
   PREPROCESS: 'preprocess',
@@ -41,8 +42,8 @@ export class Model extends BaseComponent {
    * The attributes contained in this model.</br>
    * Normally, you should not set attributes directly on this property, as this would prevent required events from being triggered.
    */
-  public attributes: { [key: string]: any };
-  public defaultAttributes: { [key: string]: any };
+  public attributes: IStringMap<any>;
+  public defaultAttributes: IStringMap<any>;
   private eventNameSpace;
 
   /**
@@ -236,6 +237,23 @@ export class Model extends BaseComponent {
    */
   public getEventName(event: string) {
     return this.eventNameSpace + ':' + event;
+  }
+
+  public differenceWith(attributes: IStringMap<any>) {
+    const difference: IStringMap<any> = {};
+
+    const addDiff = (anObject: IStringMap<any>) => {
+      for (const key in anObject) {
+        if (anObject[key] != this.getAttributes()[key] && difference[key] == null) {
+          difference[key] = this.getAttributes()[key];
+        }
+      }
+    };
+
+    addDiff(this.getAttributes());
+    addDiff(attributes);
+
+    return difference;
   }
 
   private attributesHasChangedEvent() {

--- a/src/ui/Analytics/SharedAnalyticsCalls.ts
+++ b/src/ui/Analytics/SharedAnalyticsCalls.ts
@@ -1,11 +1,5 @@
 import { IAnalyticsClient } from './AnalyticsClient';
-import {
-  analyticsActionCauseList,
-  IAnalyticsNoMeta,
-  IAnalyticsResultsSortMeta,
-  IAnalyticsPagerMeta,
-  IAnalyticsActionCause
-} from './AnalyticsActionListMeta';
+import { analyticsActionCauseList, IAnalyticsNoMeta, IAnalyticsResultsSortMeta } from './AnalyticsActionListMeta';
 
 export function logSearchBoxSubmitEvent(client: IAnalyticsClient) {
   client.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.searchboxSubmit, {});

--- a/src/ui/Analytics/SharedAnalyticsCalls.ts
+++ b/src/ui/Analytics/SharedAnalyticsCalls.ts
@@ -1,0 +1,18 @@
+import { IAnalyticsClient } from './AnalyticsClient';
+import {
+  analyticsActionCauseList,
+  IAnalyticsNoMeta,
+  IAnalyticsResultsSortMeta,
+  IAnalyticsPagerMeta,
+  IAnalyticsActionCause
+} from './AnalyticsActionListMeta';
+
+export function logSearchBoxSubmitEvent(client: IAnalyticsClient) {
+  client.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.searchboxSubmit, {});
+}
+
+export function logSortEvent(client: IAnalyticsClient, resultsSortBy: string) {
+  client.logSearchEvent<IAnalyticsResultsSortMeta>(analyticsActionCauseList.resultsSort, {
+    resultsSortBy
+  });
+}

--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -279,6 +279,7 @@ export class Omnibox extends Component {
     this.triggerNewQuery(false, () => {
       logSearchBoxSubmitEvent(this.usageAnalytics);
     });
+    this.magicBox.blur();
   }
 
   /**
@@ -425,14 +426,7 @@ export class Omnibox extends Component {
     if (this.options.placeholder) {
       (<HTMLInputElement>this.magicBox.element.querySelector('input')).placeholder = this.options.placeholder;
     }
-    this.magicBox.onsubmit = () => {
-      this.magicBox.clearSuggestion();
-      this.updateQueryState();
-      this.triggerNewQuery(false, () => {
-        logSearchBoxSubmitEvent(this.usageAnalytics);
-      });
-      this.magicBox.blur();
-    };
+    this.magicBox.onsubmit = () => this.submit();
 
     this.magicBox.onselect = (suggestion: IOmniboxSuggestion) => {
       const index = _.indexOf(this.lastSuggestions, suggestion);

--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -33,6 +33,7 @@ import { StandaloneSearchInterface } from '../SearchInterface/SearchInterface';
 import * as _ from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 import 'styling/_Omnibox';
+import { logSearchBoxSubmitEvent } from '../Analytics/SharedAnalyticsCalls';
 
 export interface IOmniboxSuggestion extends Coveo.MagicBox.Suggestion {
   executableConfidence?: number;
@@ -276,7 +277,7 @@ export class Omnibox extends Component {
     this.magicBox.clearSuggestion();
     this.updateQueryState();
     this.triggerNewQuery(false, () => {
-      this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.searchboxSubmit, {});
+      logSearchBoxSubmitEvent(this.usageAnalytics);
     });
   }
 
@@ -428,7 +429,7 @@ export class Omnibox extends Component {
       this.magicBox.clearSuggestion();
       this.updateQueryState();
       this.triggerNewQuery(false, () => {
-        this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.searchboxSubmit, {});
+        logSearchBoxSubmitEvent(this.usageAnalytics);
       });
       this.magicBox.blur();
     };

--- a/src/ui/OmniboxResultList/OmniboxResultList.ts
+++ b/src/ui/OmniboxResultList/OmniboxResultList.ts
@@ -18,6 +18,7 @@ import OmniboxModuleDefintion = require('../Omnibox/Omnibox');
 
 import 'styling/_OmniboxResultList';
 import { InitializationEvents } from '../../EventsModules';
+import { logSearchBoxSubmitEvent } from '../Analytics/SharedAnalyticsCalls';
 
 export interface IOmniboxResultListOptions extends IResultListOptions {
   omniboxZIndex?: number;
@@ -145,7 +146,7 @@ export class OmniboxResultList extends ResultList implements IComponentBindings 
         const omnibox = <OmniboxModuleDefintion.Omnibox>Component.get(omniboxElement);
         const magicBox = omnibox.magicBox;
         magicBox.onsubmit = () => {
-          this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.searchboxSubmit, {});
+          logSearchBoxSubmitEvent(this.usageAnalytics);
           this.queryController.executeQuery();
         };
       });

--- a/src/ui/Sort/Sort.ts
+++ b/src/ui/Sort/Sort.ts
@@ -9,7 +9,6 @@ import { IAttributesChangedEventArg, MODEL_EVENTS } from '../../models/Model';
 import { QueryStateModel, QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
 import { QueryEvents, IQuerySuccessEventArgs, IBuildingQueryEventArgs } from '../../events/QueryEvents';
 import { Initialization } from '../Base/Initialization';
-import { analyticsActionCauseList, IAnalyticsResultsSortMeta } from '../Analytics/AnalyticsActionListMeta';
 import { KeyboardUtils, KEYBOARD } from '../../utils/KeyboardUtils';
 import { IQueryErrorEventArgs } from '../../events/QueryEvents';
 import * as _ from 'underscore';

--- a/src/ui/Sort/Sort.ts
+++ b/src/ui/Sort/Sort.ts
@@ -18,6 +18,7 @@ import { exportGlobally } from '../../GlobalExports';
 import 'styling/_Sort';
 import { SVGIcons } from '../../utils/SVGIcons';
 import { SVGDom } from '../../utils/SVGDom';
+import { logSortEvent } from '../Analytics/SharedAnalyticsCalls';
 
 export interface ISortOptions {
   sortCriteria?: SortCriteria[];
@@ -223,10 +224,7 @@ export class Sort extends Component {
     this.select();
     if (oldCriteria != this.currentCriteria) {
       this.queryController.deferExecuteQuery({
-        beforeExecuteQuery: () =>
-          this.usageAnalytics.logSearchEvent<IAnalyticsResultsSortMeta>(analyticsActionCauseList.resultsSort, {
-            resultsSortBy: this.currentCriteria.sort + this.currentCriteria.direction
-          })
+        beforeExecuteQuery: () => logSortEvent(this.usageAnalytics, this.currentCriteria.sort + this.currentCriteria.direction)
       });
     }
   }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -378,10 +378,10 @@ export class Utils {
     return firstArray;
   }
 
-  static differenceBetweenObjects(firstObject: IStringMap<any>, secondObject: IStringMap<any>) {
-    const difference: IStringMap<any> = {};
+  static differenceBetweenObjects<T>(firstObject: IStringMap<T>, secondObject: IStringMap<T>) {
+    const difference: IStringMap<T> = {};
 
-    const addDiff = (first: IStringMap<any>, second: IStringMap<any>) => {
+    const addDiff = (first: IStringMap<T>, second: IStringMap<T>) => {
       for (const key in first) {
         if (first[key] != second[key] && difference[key] == null) {
           difference[key] = first[key];

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -383,7 +383,7 @@ export class Utils {
 
     const addDiff = (first: IStringMap<T>, second: IStringMap<T>) => {
       for (const key in first) {
-        if (first[key] != second[key] && difference[key] == null) {
+        if (first[key] !== second[key] && difference[key] == null) {
           difference[key] = first[key];
         }
       }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -1,5 +1,6 @@
 import { IQueryResult } from '../rest/QueryResult';
 import * as _ from 'underscore';
+import { IStringMap } from '../rest/GenericParam';
 
 const isCoveoFieldRegex = /^@[a-zA-Z0-9_\.]+$/;
 
@@ -375,5 +376,21 @@ export class Utils {
       firstArray = firstArray.concat(diff);
     }
     return firstArray;
+  }
+
+  static differenceBetweenObjects(firstObject: IStringMap<any>, secondObject: IStringMap<any>) {
+    const difference: IStringMap<any> = {};
+
+    const addDiff = (first: IStringMap<any>, second: IStringMap<any>) => {
+      for (const key in first) {
+        if (first[key] != second[key] && difference[key] == null) {
+          difference[key] = first[key];
+        }
+      }
+    };
+
+    addDiff(firstObject, secondObject);
+    addDiff(secondObject, firstObject);
+    return difference;
   }
 }

--- a/test/controllers/HistoryControllerTest.ts
+++ b/test/controllers/HistoryControllerTest.ts
@@ -4,27 +4,29 @@ import * as Mock from '../MockEnvironment';
 import { $$ } from '../../src/utils/Dom';
 import { Defer } from '../../src/misc/Defer';
 import _ = require('underscore');
+import { analyticsActionCauseList, IAnalyticsResultsSortMeta, IAnalyticsFacetMeta } from '../../src/ui/Analytics/AnalyticsActionListMeta';
 
 export function HistoryControllerTest() {
-  describe('HistoryController', function() {
-    var historyController: HistoryController;
-    var env: Mock.IMockEnvironment;
+  describe('HistoryController', () => {
+    let historyController: HistoryController;
+    let env: Mock.IMockEnvironment;
 
-    beforeEach(function() {
+    beforeEach(() => {
       env = new Mock.MockEnvironmentBuilder().withLiveQueryStateModel().build();
-      historyController = new HistoryController(env.root, Mock.mockWindow(), env.queryStateModel, env.queryController);
+      historyController = new HistoryController(env.root, {
+        model: env.queryStateModel,
+        queryController: env.queryController,
+        usageAnalytics: env.usageAnalytics,
+        window: Mock.mockWindow()
+      });
     });
 
-    afterEach(function() {
+    afterEach(() => {
       historyController = null;
       env = null;
     });
 
-    it('should listen to hashchange event', function() {
-      expect(historyController.windoh.addEventListener).toHaveBeenCalledWith('hashchange', jasmine.any(Function));
-    });
-
-    it('should set the query state model representation on all event in the hash', function() {
+    it('should set the query state model representation on all event in the hash', () => {
       env.queryStateModel.attributes = {
         a: 'a',
         b: 'b',
@@ -41,29 +43,132 @@ export function HistoryControllerTest() {
 
       $$(historyController.element).trigger('state:all');
       Defer.flush();
-      expect(historyController.windoh.location.hash).toBe('#c=notDefault&d=[1,2,3]');
+      expect(historyController.window.location.hash).toBe('#c=notDefault&d=[1,2,3]');
     });
 
-    it('keeps parsing hash values after one fails to parse', () => {
-      let threwError = false;
-      let hashUtils = jasmine.createSpyObj('hashUtils', ['getValue', 'getHash']);
-      env.queryStateModel.attributes = {
-        a: 1,
-        b: 2,
-        c: 3
-      };
+    it('should listen to hashchange event', () => {
+      expect(historyController.window.addEventListener).toHaveBeenCalledWith('hashchange', jasmine.any(Function));
+    });
 
-      hashUtils.getValue.and.callFake(() => {
-        if (!threwError) {
-          threwError = true;
-          throw new Error();
-        }
+    describe('with a fake HashUtilsModule', () => {
+      let fakeHashUtils;
+      beforeEach(() => {
+        fakeHashUtils = {} as any;
+        fakeHashUtils.getValue = jasmine.createSpy('getValue');
+        fakeHashUtils.getHash = jasmine.createSpy('getHash').and.callFake(() => Mock.mockWindow().location.hash);
+        fakeHashUtils.encodeValues = jasmine.createSpy('encodeValues');
+        historyController.hashUtils = fakeHashUtils;
       });
-      historyController = new HistoryController(env.root, Mock.mockWindow(), env.queryStateModel, env.queryController, hashUtils);
 
-      $$(env.root).trigger(InitializationEvents.restoreHistoryState);
+      it('keeps parsing hash values after one fails to parse', () => {
+        let threwError = false;
+        env.queryStateModel.attributes = {
+          a: 1,
+          b: 2,
+          c: 3
+        };
 
-      expect(hashUtils.getValue).toHaveBeenCalledTimes(_.size(env.queryStateModel.attributes));
+        const throwsAnError = () => {
+          if (!threwError) {
+            threwError = true;
+            throw new Error();
+          }
+        };
+
+        historyController.hashUtils.getValue = jasmine.createSpy('getValue').and.callFake(throwsAnError);
+
+        $$(env.root).trigger(InitializationEvents.restoreHistoryState);
+
+        expect(historyController.hashUtils.getValue).toHaveBeenCalledTimes(_.size(env.queryStateModel.attributes));
+      });
+
+      describe('when logging analytics event', () => {
+        beforeEach(() => {
+          historyController = new HistoryController(env.root, {
+            model: env.queryStateModel,
+            queryController: env.queryController,
+            usageAnalytics: env.usageAnalytics,
+            window: window
+          });
+          historyController.hashUtils = fakeHashUtils;
+          $$(historyController.element).trigger(InitializationEvents.restoreHistoryState);
+        });
+
+        afterEach(() => {
+          window.location.hash = '';
+        });
+
+        const simulateHashModule = (key, value) => {
+          historyController.hashUtils.getValue = jasmine.createSpy('getValue').and.callFake((valueNeeded: string) => {
+            if (valueNeeded == key) {
+              return value;
+            }
+            return undefined;
+          });
+        };
+
+        it('should log an analytics event when q changes', () => {
+          simulateHashModule('q', 'foo');
+          window.dispatchEvent(new Event('hashchange'));
+          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.searchboxSubmit, {});
+        });
+
+        it('should log an analytics event when sort changes', () => {
+          simulateHashModule('sort', 'date ascending');
+          window.dispatchEvent(new Event('hashchange'));
+          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.resultsSort, {
+            resultsSortBy: 'date ascending'
+          } as IAnalyticsResultsSortMeta);
+        });
+
+        it('should log an analytics event when a facet changes to select a value', () => {
+          historyController.model.registerNewAttribute('f:@foo', []);
+          simulateHashModule('f:@foo', ['bar']);
+          window.dispatchEvent(new Event('hashchange'));
+          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.facetSelect, {
+            facetId: '@foo',
+            facetTitle: '@foo',
+            facetValue: 'bar'
+          } as IAnalyticsFacetMeta);
+        });
+
+        it('should log an analytics event when a facet changes to deselect a value', () => {
+          historyController.model.registerNewAttribute('f:@foo', []);
+          simulateHashModule('f:@foo', ['bar']);
+          window.dispatchEvent(new Event('hashchange'));
+          simulateHashModule('f:@foo', []);
+          window.dispatchEvent(new Event('hashchange'));
+          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.facetDeselect, {
+            facetId: '@foo',
+            facetTitle: '@foo',
+            facetValue: 'bar'
+          } as IAnalyticsFacetMeta);
+        });
+
+        it('should log an analytics event when a facet changes to exclude a value', () => {
+          historyController.model.registerNewAttribute('f:@foo:not', []);
+          simulateHashModule('f:@foo:not', ['bar']);
+          window.dispatchEvent(new Event('hashchange'));
+          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.facetExclude, {
+            facetId: '@foo',
+            facetTitle: '@foo',
+            facetValue: 'bar'
+          } as IAnalyticsFacetMeta);
+        });
+
+        it('should log an analytics event when a facet changes to unexclude a value', () => {
+          historyController.model.registerNewAttribute('f:@foo:not', []);
+          simulateHashModule('f:@foo:not', ['bar']);
+          window.dispatchEvent(new Event('hashchange'));
+          simulateHashModule('f:@foo:not', []);
+          window.dispatchEvent(new Event('hashchange'));
+          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.facetUnexclude, {
+            facetId: '@foo',
+            facetTitle: '@foo',
+            facetValue: 'bar'
+          } as IAnalyticsFacetMeta);
+        });
+      });
     });
   });
 }

--- a/test/controllers/HistoryControllerTest.ts
+++ b/test/controllers/HistoryControllerTest.ts
@@ -4,7 +4,12 @@ import * as Mock from '../MockEnvironment';
 import { $$ } from '../../src/utils/Dom';
 import { Defer } from '../../src/misc/Defer';
 import _ = require('underscore');
-import { analyticsActionCauseList, IAnalyticsResultsSortMeta, IAnalyticsFacetMeta } from '../../src/ui/Analytics/AnalyticsActionListMeta';
+import {
+  analyticsActionCauseList,
+  IAnalyticsResultsSortMeta,
+  IAnalyticsFacetMeta,
+  IAnalyticsActionCause
+} from '../../src/ui/Analytics/AnalyticsActionListMeta';
 
 export function HistoryControllerTest() {
   describe('HistoryController', () => {
@@ -107,6 +112,14 @@ export function HistoryControllerTest() {
           });
         };
 
+        const assertFacetAnalyticsCall = (cause: IAnalyticsActionCause) => {
+          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(cause, {
+            facetId: '@foo',
+            facetTitle: '@foo',
+            facetValue: 'bar'
+          } as IAnalyticsFacetMeta);
+        };
+
         it('should log an analytics event when q changes', () => {
           simulateHashModule('q', 'foo');
           window.dispatchEvent(new Event('hashchange'));
@@ -125,11 +138,7 @@ export function HistoryControllerTest() {
           historyController.model.registerNewAttribute('f:@foo', []);
           simulateHashModule('f:@foo', ['bar']);
           window.dispatchEvent(new Event('hashchange'));
-          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.facetSelect, {
-            facetId: '@foo',
-            facetTitle: '@foo',
-            facetValue: 'bar'
-          } as IAnalyticsFacetMeta);
+          assertFacetAnalyticsCall(analyticsActionCauseList.facetSelect);
         });
 
         it('should log an analytics event when a facet changes to deselect a value', () => {
@@ -138,22 +147,14 @@ export function HistoryControllerTest() {
           window.dispatchEvent(new Event('hashchange'));
           simulateHashModule('f:@foo', []);
           window.dispatchEvent(new Event('hashchange'));
-          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.facetDeselect, {
-            facetId: '@foo',
-            facetTitle: '@foo',
-            facetValue: 'bar'
-          } as IAnalyticsFacetMeta);
+          assertFacetAnalyticsCall(analyticsActionCauseList.facetDeselect);
         });
 
         it('should log an analytics event when a facet changes to exclude a value', () => {
           historyController.model.registerNewAttribute('f:@foo:not', []);
           simulateHashModule('f:@foo:not', ['bar']);
           window.dispatchEvent(new Event('hashchange'));
-          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.facetExclude, {
-            facetId: '@foo',
-            facetTitle: '@foo',
-            facetValue: 'bar'
-          } as IAnalyticsFacetMeta);
+          assertFacetAnalyticsCall(analyticsActionCauseList.facetExclude);
         });
 
         it('should log an analytics event when a facet changes to unexclude a value', () => {
@@ -162,11 +163,7 @@ export function HistoryControllerTest() {
           window.dispatchEvent(new Event('hashchange'));
           simulateHashModule('f:@foo:not', []);
           window.dispatchEvent(new Event('hashchange'));
-          expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.facetUnexclude, {
-            facetId: '@foo',
-            facetTitle: '@foo',
-            facetValue: 'bar'
-          } as IAnalyticsFacetMeta);
+          assertFacetAnalyticsCall(analyticsActionCauseList.facetUnexclude);
         });
       });
     });


### PR DESCRIPTION
If the url hash gets modified (either manually, or with custom javascript code), we will now try to detect those change and log the corresponding analytics event.

https://coveord.atlassian.net/browse/JSUI-1810


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)