### PR TITLE
Rework UA logging for Quickview 

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "fastclick": "1.0.6",
     "jstimezonedetect": "^1.0.6",
     "latinize": "^0.4.0",
-    "modal-box": "2.0.x",
+    "modal-box": "^2.0.9",
     "pikaday": "^1.4.0",
     "underscore": "^1.8.3"
   }

--- a/src/ui/Quickview/QuickviewDocument.ts
+++ b/src/ui/Quickview/QuickviewDocument.ts
@@ -1,7 +1,6 @@
 import { Component } from '../Base/Component';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { ComponentOptions } from '../Base/ComponentOptions';
-import { analyticsActionCauseList } from '../Analytics/AnalyticsActionListMeta';
 import { IQueryResult } from '../../rest/QueryResult';
 import { Assert } from '../../misc/Assert';
 import { $$, Dom } from '../../utils/Dom';
@@ -105,20 +104,7 @@ export class QuickviewDocument extends Component {
 
   public open() {
     this.ensureDom();
-    let documentURL = $$(this.element).getAttribute('href');
-    if (documentURL == undefined || documentURL == '') {
-      documentURL = this.result.clickUri;
-    }
-    this.usageAnalytics.logClickEvent(
-      analyticsActionCauseList.documentQuickview,
-      {
-        author: Utils.getFieldValue(this.result, 'author'),
-        documentURL: documentURL,
-        documentTitle: this.result.title
-      },
-      this.result,
-      this.queryController.element
-    );
+
     const beforeLoad = new Date().getTime();
     const iframe = <HTMLIFrameElement>this.iframe.find('iframe');
     iframe.src = 'about:blank';

--- a/src/ui/Quickview/QuickviewFields.ts
+++ b/src/ui/Quickview/QuickviewFields.ts
@@ -4,7 +4,8 @@ const fields = [
   'urihash', // analytics
   'collection', // analytics
   'source', // analytics,
-  'author' // analytics
+  'author', // analytics,
+  'date' // used in header of the quickview
 ];
 
 export function registerFields() {

--- a/src/utils/DomUtils.ts
+++ b/src/utils/DomUtils.ts
@@ -1,12 +1,13 @@
 import { $$, Dom } from './Dom';
 import { IQueryResult } from '../rest/QueryResult';
-import { IResultsComponentBindings } from '../ui/Base/ResultsComponentBindings';
 import { DateUtils } from './DateUtils';
 import { FileTypes } from '../ui/Misc/FileTypes';
 import { Utils } from './Utils';
 import { StringUtils } from './StringUtils';
 import { SVGIcons } from './SVGIcons';
-
+import { load } from '../ui/Base/RegisteredNamedMethods';
+import { Logger } from '../misc/Logger';
+import { IComponentBindings } from '../ui/Base/ComponentBindings';
 export class DomUtils {
   static getPopUpCloseButton(captionForClose: string, captionForReminder: string): string {
     let container = document.createElement('span');
@@ -73,13 +74,17 @@ export class DomUtils {
     return header;
   }
 
-  static getQuickviewHeader(result: IQueryResult, options: { showDate: boolean; title: string }, bindings: IResultsComponentBindings): Dom {
+  static getQuickviewHeader(result: IQueryResult, options: { showDate: boolean; title: string }, bindings: IComponentBindings): Dom {
     let date = '';
     if (options.showDate) {
-      date = DateUtils.dateTimeToString(new Date(Utils.getFieldValue(result, 'date')));
+      const dateValueFromResult = Utils.getFieldValue(result, 'date');
+      if (dateValueFromResult) {
+        date = DateUtils.dateTimeToString(new Date(dateValueFromResult));
+      }
     }
-    let fileType = FileTypes.get(result);
-    let header = $$('div');
+    const fileType = FileTypes.get(result);
+    const header = $$('div');
+
     header.el.innerHTML = `<div class='coveo-quickview-right-header'>
         <span class='coveo-quickview-time'>${date}</span>
         <span class='coveo-quickview-close-button'>
@@ -88,14 +93,26 @@ export class DomUtils {
       </div>
       <div class='coveo-quickview-left-header'>
         <span class='coveo-quickview-icon coveo-small ${fileType.icon}'></span>
-        <a class='coveo-quickview-pop-up-reminder'> ${options.title || ''}</a>
       </div>`;
-    new Coveo[Coveo['Salesforce'] ? 'SalesforceResultLink' : 'ResultLink'](
-      header.find('.coveo-quickview-pop-up-reminder'),
-      undefined,
-      bindings,
-      result
-    );
+
+    const clickableLinkElement = $$('a', { className: 'coveo-quickview-pop-up-reminder' });
+
+    const toLoad = Coveo['Salesforce'] ? 'SalesforceResultLink' : 'ResultLink';
+
+    load(toLoad)
+      .then(() => {
+        new Coveo[toLoad](clickableLinkElement.el, undefined, bindings, { ...result, title: options.title });
+      })
+      .catch(err => {
+        const logger = new Logger(this);
+        logger.error(`Failed to load module ${toLoad} : ${err}`);
+        logger.info(`Fallback on displaying a non clickable header`);
+        clickableLinkElement.text(options.title);
+      })
+      .finally(() => {
+        $$(header.find('.coveo-quickview-left-header')).append(clickableLinkElement.el);
+      });
+
     return header;
   }
 

--- a/test/Test.ts
+++ b/test/Test.ts
@@ -454,6 +454,9 @@ ValueElementTest();
 import { PublicPathUtilsTest } from './utils/PublicPathUtilsTest';
 PublicPathUtilsTest();
 
+import { DomUtilsTest } from './utils/DomUtilsTest';
+DomUtilsTest();
+
 import { CheckboxTest } from './ui/CheckboxTest';
 CheckboxTest();
 

--- a/test/ui/QuickviewTest.ts
+++ b/test/ui/QuickviewTest.ts
@@ -6,6 +6,8 @@ import { Template } from '../../src/ui/Templates/Template';
 import { StringUtils } from '../../src/utils/StringUtils';
 import { Simulate } from '../Simulate';
 import { Defer } from '../../src/misc/Defer';
+import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
+import { Utils } from '../../src/UtilsModules';
 
 export function QuickviewTest() {
   describe('Quickview', () => {
@@ -41,6 +43,23 @@ export function QuickviewTest() {
       Defer.defer(() => {
         quickview.close();
         expect(modalBox.close).toHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('logs an analytics event on open', done => {
+      quickview.open();
+      Defer.defer(() => {
+        expect(quickview.usageAnalytics.logClickEvent).toHaveBeenCalledWith(
+          analyticsActionCauseList.documentQuickview,
+          {
+            author: Utils.getFieldValue(result, 'author'),
+            documentURL: result.clickUri,
+            documentTitle: result.title
+          },
+          result,
+          quickview.element
+        );
         done();
       });
     });

--- a/test/utils/DomUtilsTest.ts
+++ b/test/utils/DomUtilsTest.ts
@@ -1,0 +1,62 @@
+import { DomUtils } from '../../src/utils/DomUtils';
+import { FakeResults } from '../Fake';
+import { MockEnvironmentBuilder } from '../MockEnvironment';
+import { $$, load, get } from '../Test';
+import { IQueryResult } from '../../src/rest/QueryResult';
+import { LazyInitialization } from '../../src/ui/Base/Initialization';
+
+declare const Coveo;
+
+export function DomUtilsTest() {
+  describe('DomUtils', () => {
+    let fakeResult: IQueryResult;
+    let env: MockEnvironmentBuilder;
+
+    beforeEach(() => {
+      fakeResult = FakeResults.createFakeResult();
+      env = new MockEnvironmentBuilder().withResult(fakeResult);
+    });
+
+    it('should support creating a quickview header with the passed in title', async done => {
+      const header = DomUtils.getQuickviewHeader(fakeResult, { title: 'foo', showDate: true }, env.build());
+      await load('ResultLink');
+      const link = $$(header).find('.CoveoResultLink');
+      expect($$(get(link).element).text()).toEqual('foo');
+      done();
+    });
+
+    it('should display a date if requested', () => {
+      const header = DomUtils.getQuickviewHeader(fakeResult, { title: 'title', showDate: true }, env.build());
+      const time = $$(header).find('.coveo-quickview-time');
+      expect($$(time).text()).not.toBe('');
+    });
+
+    it('should not display a date if not requested', () => {
+      const header = DomUtils.getQuickviewHeader(fakeResult, { title: 'title', showDate: false }, env.build());
+      const time = $$(header).find('.coveo-quickview-time');
+      expect($$(time).text()).toBe('');
+    });
+
+    describe('with a salesforce namespace', () => {
+      let spy: jasmine.Spy;
+      beforeEach(() => {
+        Coveo.Salesforce = {};
+        spy = jasmine.createSpy('SalesforceResultLink');
+        Coveo.SalesforceResultLink = spy;
+        LazyInitialization.registerLazyComponent('SalesforceResultLink', () => Promise.resolve(spy as any));
+      });
+
+      afterEach(() => {
+        delete Coveo.Salesforce;
+        delete Coveo.SalesforceResultLink;
+      });
+
+      it('should try to load a salesforce result link', async done => {
+        DomUtils.getQuickviewHeader(fakeResult, { title: 'foo', showDate: true }, env.build());
+        await load('SalesforceResultLink');
+        expect(spy).toHaveBeenCalled();
+        done();
+      });
+    });
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4902,9 +4902,9 @@ mkdirp@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.5.tgz#de3e5f8961c88c787ee1368df849ac4413eca8d7"
 
-modal-box@2.0.x:
-  version "2.0.7"
-  resolved "https://registry.yarnpkg.com/modal-box/-/modal-box-2.0.7.tgz#2819a4b63b86d6263146a647f2d60d7e6556e49d"
+modal-box@^2.0.9:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/modal-box/-/modal-box-2.0.9.tgz#a773216728a55e0a075432c646e667e636c2880a"
 
 moment@2.14.*:
   version "2.14.1"
@@ -6060,11 +6060,11 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
 
-punycode@1.3.2:
+punycode@1.3.2, punycode@^1.2.4:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
 
-punycode@^1.2.4, punycode@^1.4.1:
+punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
@@ -6608,13 +6608,9 @@ sass-loader@^6.0:
     lodash.tail "^4.1.1"
     pify "^3.0.0"
 
-sax@1.2.1:
+sax@1.2.1, sax@>=0.6.0, sax@^1.1.4, sax@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
-
-sax@>=0.6.0, sax@^1.1.4, sax@~1.2.1:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 schema-utils@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Also include a couple of bugfixes for possibly undefined ResultLink component in lazy mode

This updaes the modalbox module to accept either an HTMLElement or a string for the title of the modal, instead of a only string.

https://coveord.atlassian.net/browse/JSUI-1877





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)