### PR TITLE
Force list layout + adding some UT for this class

### DIFF
--- a/src/ui/OmniboxResultList/OmniboxResultList.ts
+++ b/src/ui/OmniboxResultList/OmniboxResultList.ts
@@ -15,14 +15,15 @@ import { IQueryResults } from '../../rest/QueryResults';
 import * as _ from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 import OmniboxModuleDefintion = require('../Omnibox/Omnibox');
-
-import 'styling/_OmniboxResultList';
 import { InitializationEvents } from '../../EventsModules';
 import { logSearchBoxSubmitEvent } from '../Analytics/SharedAnalyticsCalls';
+import { Logger } from '../../misc/Logger';
+
+import 'styling/_OmniboxResultList';
 
 export interface IOmniboxResultListOptions extends IResultListOptions {
   omniboxZIndex?: number;
-  onSelect?: (result: IQueryResult, resultElement: HTMLElement, omniboxObject: IPopulateOmniboxEventArgs) => void;
+  onSelect?: (result: IQueryResult, resultElement: HTMLElement, omniboxObject: IPopulateOmniboxEventArgs, event?: Event) => void;
   headerTitle?: string;
   queryOverride?: string;
 }
@@ -49,6 +50,24 @@ export interface IOmniboxResultListOptions extends IResultListOptions {
 export class OmniboxResultList extends ResultList implements IComponentBindings {
   static ID = 'OmniboxResultList';
 
+  /**
+   * Specifies a list a css class that should be ignored when the end user click result in the omnibox
+   *
+   * Any element that is specified here should normally be able to handle the standard click event.
+   *
+   * Any element that does not match this css class and that is clicked will trigger a redirection by the OmniboxResultList.
+   */
+  static elementsToIgnore = [
+    'coveo-field-table-toggle-caption',
+    'CoveoFollowItem',
+    'CoveoPrintableUri',
+    'CoveoQuickview',
+    'CoveoResultLink',
+    'CoveoResultRating',
+    'CoveoResultTagging',
+    'CoveoYouTubeThumbnail'
+  ];
+
   static doExport = () => {
     exportGlobally({
       OmniboxResultList: OmniboxResultList
@@ -60,6 +79,17 @@ export class OmniboxResultList extends ResultList implements IComponentBindings 
    * @componentOptions
    */
   static options: IOmniboxResultListOptions = {
+    layout: ComponentOptions.buildStringOption({
+      defaultValue: 'list',
+      postProcessing: optionSetByUser => {
+        if (optionSetByUser != 'list') {
+          const logger = new Logger(OmniboxResultList);
+          logger.warn(`Cannot apply layout ${optionSetByUser} on the OmniboxResultListComponent`);
+          logger.warn(`OmniboxResultList does not support any layout other than "list"`);
+        }
+        return 'list';
+      }
+    }),
     /**
      * Specifies the z-index at which to render the ResultList inside the Omnibox.
      *
@@ -163,15 +193,16 @@ export class OmniboxResultList extends ResultList implements IComponentBindings 
       return this.buildResult(result).then((resultElement: HTMLElement) => {
         $$(resultElement).addClass('coveo-omnibox-selectable');
         resultElement['no-text-suggestion'] = true;
-        $$(resultElement).on(['keyboardSelect', 'click'], () => {
-          this.options.onSelect.call(this, result, resultElement, this.lastOmniboxRequest.omniboxObject);
-        });
+
+        $$(resultElement).on(['keyboardSelect', 'click'], (e: Event) => this.handleOmniboxElementSelection(e, resultElement, result));
+
         return this.autoCreateComponentsInsideResult(resultElement, result).initResult.then(() => {
           builtResults.push(resultElement);
           return resultElement;
         });
       });
     });
+
     return Promise.all(builtPromises).then(() => {
       return builtResults;
     });
@@ -185,10 +216,10 @@ export class OmniboxResultList extends ResultList implements IComponentBindings 
    * @param append
    */
   public renderResults(resultsElement: HTMLElement[], append = false) {
+    $$(this.options.resultContainer).empty();
     if (this.lastOmniboxRequest) {
-      const content = $$('div').el;
       if (this.options.headerTitle) {
-        content.appendChild(
+        this.options.resultContainer.appendChild(
           $$(
             'div',
             { className: 'coveo-omnibox-result-list-header' },
@@ -198,14 +229,14 @@ export class OmniboxResultList extends ResultList implements IComponentBindings 
         );
       }
       _.each(resultsElement, (resultElement: HTMLElement) => {
-        content.appendChild(resultElement);
+        this.options.resultContainer.appendChild(resultElement);
         this.triggerNewResultDisplayed(Component.getResult(resultElement), resultElement);
       });
       this.triggerNewResultsDisplayed();
-      if ($$(content).findAll('.coveo-omnibox-selectable').length == 0) {
+      if ($$(this.options.resultContainer).findAll('.coveo-omnibox-selectable').length == 0) {
         this.lastOmniboxRequest.resolve({ element: null, zIndex: this.options.omniboxZIndex });
       } else {
-        this.lastOmniboxRequest.resolve({ element: content, zIndex: this.options.omniboxZIndex });
+        this.lastOmniboxRequest.resolve({ element: this.options.resultContainer, zIndex: this.options.omniboxZIndex });
       }
       return Promise.resolve(null);
     }
@@ -237,7 +268,37 @@ export class OmniboxResultList extends ResultList implements IComponentBindings 
     }
   }
 
-  private onRowSelection(result: IQueryResult, resultElement: HTMLElement, omniboxObject: IPopulateOmniboxEventArgs) {
+  private handleOmniboxElementSelection(e: Event, resultElement: HTMLElement, result: IQueryResult) {
+    if (e && e.target && this.otherComponentShouldHandleSelection(e, resultElement)) {
+      return;
+    }
+
+    if (this.lastOmniboxRequest) {
+      this.options.onSelect.call(this, result, resultElement, this.lastOmniboxRequest.omniboxObject, e);
+    }
+  }
+
+  private otherComponentShouldHandleSelection(e: Event, resultElement: HTMLElement) {
+    // Other components can "trap" the click event, and instead trigger the "standard" component behaviour.
+    // So, for example, if someones clicks the ResultLink directly, we want the result link code to execute to redirect to the result, and not the OmniboxResultList selection code.
+    // Same for Quickview, YouTubeThumbnail, etc.
+    let current = e.target as HTMLElement;
+    let otherComponentWillHandleClick = false;
+
+    while (current && current != resultElement) {
+      otherComponentWillHandleClick =
+        _.find(OmniboxResultList.elementsToIgnore, elementToIgnore => $$(current).hasClass(elementToIgnore)) != null;
+
+      if (otherComponentWillHandleClick) {
+        break;
+      }
+
+      current = current.parentElement;
+    }
+    return otherComponentWillHandleClick;
+  }
+
+  private onRowSelection(result: IQueryResult, resultElement: HTMLElement, omniboxObject: IPopulateOmniboxEventArgs, e: Event) {
     this.usageAnalytics.logClickEvent(
       analyticsActionCauseList.documentOpen,
       { author: Utils.getFieldValue(result, 'author') },

--- a/src/utils/Dom.ts
+++ b/src/utils/Dom.ts
@@ -393,8 +393,9 @@ export class Dom {
    */
   public getClass(): string[] {
     // SVG elements got a className property, but it's not a string, it's an object
-    if (this.el.className && this.el.className.match) {
-      return this.el.className.match(Dom.CLASS_NAME_REGEX) || [];
+    const className = this.getAttribute('class');
+    if (className && className.match) {
+      return className.match(Dom.CLASS_NAME_REGEX) || [];
     } else {
       return [];
     }

--- a/src/utils/Dom.ts
+++ b/src/utils/Dom.ts
@@ -392,7 +392,12 @@ export class Dom {
    * @returns {any|Array}
    */
   public getClass(): string[] {
-    return this.el.className.match(Dom.CLASS_NAME_REGEX) || [];
+    // SVG elements got a className property, but it's not a string, it's an object
+    if (this.el.className && this.el.className.match) {
+      return this.el.className.match(Dom.CLASS_NAME_REGEX) || [];
+    } else {
+      return [];
+    }
   }
 
   /**

--- a/test/Test.ts
+++ b/test/Test.ts
@@ -214,6 +214,9 @@ MatrixTest();
 import { OmniboxTest } from './ui/OmniboxTest';
 OmniboxTest();
 
+import { OmniboxResultListTest } from './ui/OmniboxResultListTest';
+OmniboxResultListTest();
+
 import { PagerTest } from './ui/PagerTest';
 PagerTest();
 

--- a/test/ui/OmniboxResultListTest.ts
+++ b/test/ui/OmniboxResultListTest.ts
@@ -1,0 +1,166 @@
+import * as Mock from '../MockEnvironment';
+import { OmniboxResultList, IOmniboxResultListOptions } from '../../src/ui/OmniboxResultList/OmniboxResultList';
+import { FakeResults } from '../Fake';
+import { $$ } from '../../src/utils/Dom';
+import { IQueryResults } from '../../src/rest/QueryResults';
+import { Simulate } from '../Simulate';
+import { Template } from '../../src/ui/Templates/Template';
+import { get } from '../../src/ui/Base/RegisteredNamedMethods';
+import { Quickview } from '../../src/ui/Quickview/Quickview';
+import { ResultLink } from '../../src/ui/ResultLink/ResultLink';
+
+export function OmniboxResultListTest() {
+  describe('OmniboxResultListTest', () => {
+    let test: Mock.IBasicComponentSetup<OmniboxResultList>;
+    let results: IQueryResults;
+
+    beforeEach(() => {
+      test = Mock.basicComponentSetup<OmniboxResultList>(OmniboxResultList);
+      results = FakeResults.createFakeResults();
+    });
+
+    it('should support building results', async done => {
+      const built = await test.cmp.buildResults(results);
+      expect(built.length).toEqual(results.results.length);
+      done();
+    });
+
+    it('should make all results selectable by the omnibox', async done => {
+      const built = await test.cmp.buildResults(results);
+      built.forEach(element => {
+        expect($$(element).hasClass('coveo-omnibox-selectable')).toBe(true);
+      });
+      done();
+    });
+
+    it('should set the no-result-suggestion propery on each result for the magicbox', async done => {
+      const built = await test.cmp.buildResults(results);
+      built.forEach(element => {
+        expect(element['no-text-suggestion']).toBeTruthy();
+      });
+      done();
+    });
+
+    describe('when selecting an element', () => {
+      let spyOnSelect: jasmine.Spy;
+
+      beforeEach(() => {
+        spyOnSelect = jasmine.createSpy('onClick');
+        test.cmp.options.onSelect = spyOnSelect;
+        Simulate.omnibox(test.env);
+      });
+
+      it('should call the onSelect option when clicking on each element of the result list', async done => {
+        const built = await test.cmp.buildResults(results);
+
+        built.forEach(element => {
+          $$(element).trigger('click');
+        });
+        expect(spyOnSelect).toHaveBeenCalledTimes(10);
+        done();
+      });
+
+      it('should call the onSelect option when doing keyboard selection on each element of the result list', async done => {
+        const built = await test.cmp.buildResults(results);
+        built.forEach(element => {
+          $$(element).trigger('keyboardSelect');
+        });
+        expect(spyOnSelect).toHaveBeenCalledTimes(10);
+        done();
+      });
+
+      describe('with a custom result template', () => {
+        const setupCustomTemplate = (templateContent: string) => {
+          const tmpl = new Template(() => templateContent);
+          tmpl.condition = () => true;
+          test.cmp.options.resultTemplate = tmpl;
+        };
+
+        it('should not trigger select event on a quickview', async done => {
+          const spyOnQuickviewOpen = jasmine.createSpy('openQuickview');
+
+          setupCustomTemplate(`
+          <div>
+          <span class='random-stuff'></span>
+          <div class='CoveoQuickview'></div>
+          </div>
+          `);
+
+          const built = await test.cmp.buildResults(results);
+
+          built.forEach(element => {
+            const quickview = $$(element).find('.CoveoQuickview');
+            (<Quickview>get(quickview)).open = spyOnQuickviewOpen;
+            $$(quickview).trigger('click');
+          });
+
+          expect(spyOnSelect).not.toHaveBeenCalled();
+          expect(spyOnQuickviewOpen).toHaveBeenCalledTimes(10);
+          done();
+        });
+
+        it('should not trigger select event on a result link', async done => {
+          const spyOnResultLinkOpen = jasmine.createSpy('openResultLink');
+          setupCustomTemplate(`
+          <div>
+          <span class='random-stuff'></span>
+          <div class='CoveoResultLink'></div>
+          </div>
+          `);
+
+          const built = await test.cmp.buildResults(results);
+
+          built.forEach(element => {
+            const resultLink = $$(element).find('.CoveoResultLink');
+            (<ResultLink>get(resultLink)).openLink = spyOnResultLinkOpen;
+            $$(resultLink).trigger('click');
+          });
+
+          expect(spyOnSelect).not.toHaveBeenCalled();
+          expect(spyOnResultLinkOpen).toHaveBeenCalledTimes(10);
+          done();
+        });
+
+        it('should trigger the standard on select event on a random element', async done => {
+          setupCustomTemplate(`
+          <div>
+          <span class='random-stuff'></span>
+          <div class='CoveoResultLink'></div>
+          </div>
+          `);
+
+          const built = await test.cmp.buildResults(results);
+
+          built.forEach(element => {
+            const randomStuff = $$(element).find('.random-stuff');
+            $$(randomStuff).trigger('click');
+          });
+
+          expect(spyOnSelect).toHaveBeenCalledTimes(10);
+          done();
+        });
+      });
+    });
+
+    describe('exposes options', () => {
+      it('layout should be forced to list', () => {
+        test = Mock.optionsComponentSetup<OmniboxResultList, IOmniboxResultListOptions>(OmniboxResultList, {
+          layout: 'card'
+        });
+        expect(test.cmp.options.layout).toEqual('list');
+      });
+
+      it('headerTitle should output a title', async done => {
+        test = Mock.optionsComponentSetup<OmniboxResultList, IOmniboxResultListOptions>(OmniboxResultList, {
+          headerTitle: 'My title'
+        });
+        Simulate.omnibox(test.env);
+        const built = await test.cmp.buildResults(results);
+        await test.cmp.renderResults(built);
+        const header = $$(test.cmp.options.resultContainer).find('.coveo-omnibox-result-list-header');
+        expect($$(header).text()).toEqual('My title');
+        done();
+      });
+    });
+  });
+}

--- a/test/ui/OmniboxResultListTest.ts
+++ b/test/ui/OmniboxResultListTest.ts
@@ -33,7 +33,7 @@ export function OmniboxResultListTest() {
       done();
     });
 
-    it('should set the no-result-suggestion propery on each result for the magicbox', async done => {
+    it('should set the no-text-suggestion property on each result for the magicbox', async done => {
       const built = await test.cmp.buildResults(results);
       built.forEach(element => {
         expect(element['no-text-suggestion']).toBeTruthy();
@@ -56,7 +56,7 @@ export function OmniboxResultListTest() {
         built.forEach(element => {
           $$(element).trigger('click');
         });
-        expect(spyOnSelect).toHaveBeenCalledTimes(10);
+        expect(spyOnSelect).toHaveBeenCalledTimes(results.results.length);
         done();
       });
 
@@ -65,7 +65,7 @@ export function OmniboxResultListTest() {
         built.forEach(element => {
           $$(element).trigger('keyboardSelect');
         });
-        expect(spyOnSelect).toHaveBeenCalledTimes(10);
+        expect(spyOnSelect).toHaveBeenCalledTimes(results.results.length);
         done();
       });
 
@@ -95,7 +95,7 @@ export function OmniboxResultListTest() {
           });
 
           expect(spyOnSelect).not.toHaveBeenCalled();
-          expect(spyOnQuickviewOpen).toHaveBeenCalledTimes(10);
+          expect(spyOnQuickviewOpen).toHaveBeenCalledTimes(results.results.length);
           done();
         });
 
@@ -117,7 +117,7 @@ export function OmniboxResultListTest() {
           });
 
           expect(spyOnSelect).not.toHaveBeenCalled();
-          expect(spyOnResultLinkOpen).toHaveBeenCalledTimes(10);
+          expect(spyOnResultLinkOpen).toHaveBeenCalledTimes(results.results.length);
           done();
         });
 
@@ -136,7 +136,7 @@ export function OmniboxResultListTest() {
             $$(randomStuff).trigger('click');
           });
 
-          expect(spyOnSelect).toHaveBeenCalledTimes(10);
+          expect(spyOnSelect).toHaveBeenCalledTimes(results.results.length);
           done();
         });
       });


### PR DESCRIPTION
Card layout is too weird in Omnibox result list, so this will force the component to use the standard list layout.

This also add a change to ignore some components in the result list to let them handle their own click event, as opposed to always redirect to an external page.

Add UT.

https://coveord.atlassian.net/browse/JSUI-1841



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)