### PR TITLE
Change reachedEndOfResults to a dynamic value

### DIFF
--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -571,6 +571,7 @@ export class ResultList extends Component {
     this.hideWaitingAnimation();
     $$(this.options.resultContainer).empty();
     this.currentlyDisplayedResults = [];
+    this.reachedTheEndOfResults = true;
   }
 
   private handleQuerySuccess(data: IQuerySuccessEventArgs) {
@@ -579,11 +580,14 @@ export class ResultList extends Component {
     const results = data.results;
     this.logger.trace('Received query results from new query', results);
     this.hideWaitingAnimation();
+
     ResultList.resultCurrentlyBeingRendered = undefined;
+    this.reachedTheEndOfResults = data.query.numberOfResults > data.results.results.length;
+
     this.currentlyDisplayedResults = [];
     this.buildResults(data.results).then((elements: HTMLElement[]) => {
       this.renderResults(elements);
-      this.reachedTheEndOfResults = false;
+
       this.showOrHideElementsDependingOnState(true, this.currentlyDisplayedResults.length != 0);
 
       if (DeviceUtils.isMobileDevice() && this.options.mobileScrollContainer != undefined) {

--- a/test/ui/ResultListTest.ts
+++ b/test/ui/ResultListTest.ts
@@ -144,7 +144,14 @@ export function ResultListTest() {
     });
 
     it('should tell if there are more results to display after a successful query', done => {
-      Simulate.query(test.env);
+      const queryBuilder = new QueryBuilder();
+      queryBuilder.numberOfResults = 10;
+
+      Simulate.query(test.env, {
+        results: FakeResults.createFakeResults(10),
+        query: queryBuilder.build()
+      });
+
       Defer.defer(() => {
         expect(test.cmp.hasPotentiallyMoreResultsToDisplay()).toBeTruthy();
         done();
@@ -153,9 +160,14 @@ export function ResultListTest() {
 
     it('should tell if there are no more results to display after a successful query with a limited amount of results returned', done => {
       const results = FakeResults.createFakeResults(5);
+      const queryBuilder = new QueryBuilder();
+      queryBuilder.numberOfResults = 10;
+
       Simulate.query(test.env, {
-        results: results
+        results: results,
+        query: queryBuilder.build()
       });
+
       Defer.defer(() => {
         expect(test.cmp.hasPotentiallyMoreResultsToDisplay()).toBeFalsy();
         done();

--- a/test/ui/ResultListTest.ts
+++ b/test/ui/ResultListTest.ts
@@ -143,6 +143,25 @@ export function ResultListTest() {
       });
     });
 
+    it('should tell if there are more results to display after a successful query', done => {
+      Simulate.query(test.env);
+      Defer.defer(() => {
+        expect(test.cmp.hasPotentiallyMoreResultsToDisplay()).toBeTruthy();
+        done();
+      });
+    });
+
+    it('should tell if there are no more results to display after a successful query with a limited amount of results returned', done => {
+      const results = FakeResults.createFakeResults(5);
+      Simulate.query(test.env, {
+        results: results
+      });
+      Defer.defer(() => {
+        expect(test.cmp.hasPotentiallyMoreResultsToDisplay()).toBeFalsy();
+        done();
+      });
+    });
+
     it('should allow to return the currently displayed result', () => {
       expect(ResultList.resultCurrentlyBeingRendered).toBeNull();
       const data = FakeResults.createFakeResult();


### PR DESCRIPTION
This would cause problem when external/custom code would try to access this propery to determine if more results were available.

It was only getting calculated properly in infinite scrolling mode.

https://coveord.atlassian.net/browse/JSUI-1933



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)