### PR TITLE
Remove any usage of query syntax in query override

### DIFF
--- a/src/controllers/FacetSliderQueryController.ts
+++ b/src/controllers/FacetSliderQueryController.ts
@@ -57,8 +57,9 @@ export class FacetSliderQueryController {
     if (!this.isAValidRangeResponse(args)) {
       const logger = new Logger(this);
       logger.error(
-        `Cannot instantiate FacetSlider for this field : ${this.facet.options
-          .field}. It needs to be configured as a numerical field in the index`
+        `Cannot instantiate FacetSlider for this field : ${
+          this.facet.options.field
+        }. It needs to be configured as a numerical field in the index`
       );
       logger.error(`Disabling the FacetSlider`, this.facet);
       this.facet.disable();
@@ -179,7 +180,7 @@ export class FacetSliderQueryController {
     // This will determine the full range of the query so that the X range of the slider is static
     this.groupByRequestForFullRange = queryBuilder.groupByRequests.length;
     const groupByRequestForFullRange = _.clone(basicGroupByRequestForSlider);
-    groupByRequestForFullRange.queryOverride = this.facet.options.queryOverride || '@uri';
+    groupByRequestForFullRange.advancedQueryOverride = this.facet.options.queryOverride || '@uri';
     delete groupByRequestForFullRange.constantQueryOverride;
     delete groupByRequestForFullRange.advancedQueryOverride;
 
@@ -192,10 +193,10 @@ export class FacetSliderQueryController {
       groupByRequest.queryOverride = queryOverrideObject.basic;
       groupByRequest.advancedQueryOverride = queryOverrideObject.advanced;
       groupByRequest.constantQueryOverride = queryOverrideObject.constant;
-      if (groupByRequest.queryOverride == undefined) {
-        groupByRequest.queryOverride = this.facet.options.queryOverride || '@uri';
+      if (groupByRequest.advancedQueryOverride == undefined) {
+        groupByRequest.advancedQueryOverride = this.facet.options.queryOverride || '@uri';
       } else {
-        groupByRequest.queryOverride += this.facet.options.queryOverride ? ' ' + this.facet.options.queryOverride : '';
+        groupByRequest.advancedQueryOverride += this.facet.options.queryOverride ? ' ' + this.facet.options.queryOverride : '';
       }
     } else if (this.facet.options.queryOverride != null) {
       const completeExpression = queryBuilder.computeCompleteExpression();

--- a/src/ui/Base/QueryBuilder.ts
+++ b/src/ui/Base/QueryBuilder.ts
@@ -369,14 +369,6 @@ export class QueryBuilder {
       this.constantExpression.build(),
       this.disjunctionExpression.build()
     );
-    /*const queryBuilderExpression = ;
-    return {
-      constant: ExpressionBuilder.mergeUsingOr(queryBuilderExpression.expressionBuilders.constantExpression, queryBuilderExpression.expressionBuilders.disjunctionExpression).build(),
-      basic: queryBuilderExpression.basic,
-      advanced: queryBuilderExpression.advanced,
-      full: queryBuilderExpression.full,
-      withoutConstant: ExpressionBuilder.mergeUsingOr(queryBuilderExpression.withoutConstant, queryBuilderExpression.)
-    }*/
   }
 
   /**

--- a/src/ui/Base/QueryBuilder.ts
+++ b/src/ui/Base/QueryBuilder.ts
@@ -3,34 +3,9 @@ import { IRankingFunction } from '../../rest/RankingFunction';
 import { IQueryFunction } from '../../rest/QueryFunction';
 import { IGroupByRequest } from '../../rest/GroupByRequest';
 import { IQuery } from '../../rest/Query';
+import { IQueryBuilderExpression } from './QueryBuilderExpression';
 import * as _ from 'underscore';
 import { Utils } from '../../utils/Utils';
-
-/**
- * Describe the expressions part of a QueryBuilder.
- */
-export interface IQueryBuilderExpression {
-  /**
-   * The whole expression
-   */
-  full?: string;
-  /**
-   * The full part, but without the constant.
-   */
-  withoutConstant?: string;
-  /**
-   * The constant part of the expression
-   */
-  constant?: string;
-  /**
-   * The basic part of the expression
-   */
-  basic?: string;
-  /**
-   * The advanced part of the expression
-   */
-  advanced?: string;
-}
 
 /**
  * The QueryBuilder is used to build a {@link IQuery} that will be able to be executed using the Search API.
@@ -440,7 +415,8 @@ export class QueryBuilder {
       withoutConstant: ExpressionBuilder.mergeUsingOr(withoutConstantAndExcept, this.disjunctionExpression).build(),
       basic: ExpressionBuilder.mergeUsingOr(basicAndExcept, this.disjunctionExpression).build(),
       advanced: ExpressionBuilder.mergeUsingOr(advancedAndExcept, this.disjunctionExpression).build(),
-      constant: ExpressionBuilder.mergeUsingOr(this.constantExpression, this.disjunctionExpression).build()
+      constant: ExpressionBuilder.mergeUsingOr(this.constantExpression, this.disjunctionExpression).build(),
+      disjunction: this.disjunctionExpression.build()
     };
   }
 

--- a/src/ui/Base/QueryBuilder.ts
+++ b/src/ui/Base/QueryBuilder.ts
@@ -3,7 +3,7 @@ import { IRankingFunction } from '../../rest/RankingFunction';
 import { IQueryFunction } from '../../rest/QueryFunction';
 import { IGroupByRequest } from '../../rest/GroupByRequest';
 import { IQuery } from '../../rest/Query';
-import { IQueryBuilderExpression } from './QueryBuilderExpression';
+import { QueryBuilderExpression } from './QueryBuilderExpression';
 import * as _ from 'underscore';
 import { Utils } from '../../utils/Utils';
 
@@ -362,19 +362,21 @@ export class QueryBuilder {
    * Return only the expression(s) part(s) of the query, as an object.
    * @returns {{full: string, withoutConstant: string, constant: string}}
    */
-  public computeCompleteExpressionParts(): IQueryBuilderExpression {
-    const withoutConstant = ExpressionBuilder.merge(this.expression, this.advancedExpression);
-
+  public computeCompleteExpressionParts(): any {
+    return new QueryBuilderExpression(
+      this.expression.build(),
+      this.advancedExpression.build(),
+      this.constantExpression.build(),
+      this.disjunctionExpression.build()
+    );
+    /*const queryBuilderExpression = ;
     return {
-      full: ExpressionBuilder.mergeUsingOr(
-        ExpressionBuilder.merge(withoutConstant, this.constantExpression),
-        this.disjunctionExpression
-      ).build(),
-      withoutConstant: ExpressionBuilder.mergeUsingOr(withoutConstant, this.disjunctionExpression).build(),
-      basic: ExpressionBuilder.mergeUsingOr(this.expression, this.disjunctionExpression).build(),
-      advanced: ExpressionBuilder.mergeUsingOr(this.advancedExpression, this.disjunctionExpression).build(),
-      constant: ExpressionBuilder.mergeUsingOr(this.constantExpression, this.disjunctionExpression).build()
-    };
+      constant: ExpressionBuilder.mergeUsingOr(queryBuilderExpression.expressionBuilders.constantExpression, queryBuilderExpression.expressionBuilders.disjunctionExpression).build(),
+      basic: queryBuilderExpression.basic,
+      advanced: queryBuilderExpression.advanced,
+      full: queryBuilderExpression.full,
+      withoutConstant: ExpressionBuilder.mergeUsingOr(queryBuilderExpression.withoutConstant, queryBuilderExpression.)
+    }*/
   }
 
   /**
@@ -395,29 +397,32 @@ export class QueryBuilder {
    * @param except
    * @returns {{full: string, withoutConstant: string, constant: string}}
    */
-  public computeCompleteExpressionPartsExcept(except: string): IQueryBuilderExpression {
+  public computeCompleteExpressionPartsExcept(except: string): QueryBuilderExpression {
     const withoutConstantAndExcept = ExpressionBuilder.merge(this.expression, this.advancedExpression);
     withoutConstantAndExcept.remove(except);
 
-    const basicAndExcept = new ExpressionBuilder();
-    basicAndExcept.fromExpressionBuilder(this.expression);
-    basicAndExcept.remove(except);
+    const basicWithoutException = new ExpressionBuilder();
+    basicWithoutException.fromExpressionBuilder(this.expression);
+    basicWithoutException.remove(except);
 
-    const advancedAndExcept = new ExpressionBuilder();
-    advancedAndExcept.fromExpressionBuilder(this.advancedExpression);
-    advancedAndExcept.remove(except);
+    const advancedWithoutException = new ExpressionBuilder();
+    advancedWithoutException.fromExpressionBuilder(this.advancedExpression);
+    advancedWithoutException.remove(except);
 
-    return {
-      full: ExpressionBuilder.mergeUsingOr(
-        ExpressionBuilder.merge(withoutConstantAndExcept, this.constantExpression),
-        this.disjunctionExpression
-      ).build(),
-      withoutConstant: ExpressionBuilder.mergeUsingOr(withoutConstantAndExcept, this.disjunctionExpression).build(),
-      basic: ExpressionBuilder.mergeUsingOr(basicAndExcept, this.disjunctionExpression).build(),
-      advanced: ExpressionBuilder.mergeUsingOr(advancedAndExcept, this.disjunctionExpression).build(),
-      constant: ExpressionBuilder.mergeUsingOr(this.constantExpression, this.disjunctionExpression).build(),
-      disjunction: this.disjunctionExpression.build()
-    };
+    const constantWithoutException = new ExpressionBuilder();
+    constantWithoutException.fromExpressionBuilder(this.constantExpression);
+    constantWithoutException.remove(except);
+
+    const disjunctionWithoutException = new ExpressionBuilder();
+    disjunctionWithoutException.fromExpressionBuilder(this.disjunctionExpression);
+    disjunctionWithoutException.remove(except);
+
+    return new QueryBuilderExpression(
+      basicWithoutException.build(),
+      advancedWithoutException.build(),
+      constantWithoutException.build(),
+      disjunctionWithoutException.build()
+    );
   }
 
   /**

--- a/src/ui/Base/QueryBuilderExpression.ts
+++ b/src/ui/Base/QueryBuilderExpression.ts
@@ -1,0 +1,101 @@
+import * as _ from 'underscore';
+import { ExpressionBuilder } from './ExpressionBuilder';
+import { Utils } from '../../UtilsModules';
+
+/**
+ * Describe the expressions part of a QueryBuilder.
+ */
+export interface IQueryBuilderExpression {
+  /**
+   * The whole expression
+   */
+  full?: string;
+  /**
+   * The full part, but without the constant.
+   */
+  withoutConstant?: string;
+  /**
+   * The constant part of the expression
+   */
+  constant?: string;
+  /**
+   * The basic part of the expression
+   */
+  basic?: string;
+  /**
+   * The advanced part of the expression
+   */
+  advanced?: string;
+  /**
+   * The disjunction part of the expression
+   */
+  disjunction?: string;
+}
+
+export class QueryBuilderExpression implements IQueryBuilderExpression {
+  public static isEmpty(queryBuilderExpression: QueryBuilderExpression | IQueryBuilderExpression) {
+    let expression: QueryBuilderExpression;
+    if (queryBuilderExpression instanceof QueryBuilderExpression) {
+      expression = queryBuilderExpression as QueryBuilderExpression;
+    } else {
+      expression = QueryBuilderExpression.fromQueryBuilderExpression(queryBuilderExpression as IQueryBuilderExpression);
+    }
+    const allNonEmptyValues = _.chain(expression)
+      .values()
+      .compact()
+      .value();
+
+    return _.isEmpty(allNonEmptyValues);
+  }
+
+  public static fromQueryBuilderExpression(queryBuilderExpression: IQueryBuilderExpression) {
+    return new QueryBuilderExpression(
+      queryBuilderExpression.basic,
+      queryBuilderExpression.advanced,
+      queryBuilderExpression.constant,
+      queryBuilderExpression.disjunction
+    );
+  }
+
+  public constructor(public basic: string, public advanced: string, public constant: string, public disjunction: string) {}
+
+  public get expressionBuilders() {
+    const addIfNotEmpty = (expression: ExpressionBuilder, value: string) => {
+      if (Utils.isNonEmptyString(value)) {
+        expression.add(value);
+      }
+    };
+
+    const basicExpression = new ExpressionBuilder();
+    addIfNotEmpty(basicExpression, this.basic);
+
+    const advancedExpression = new ExpressionBuilder();
+    addIfNotEmpty(advancedExpression, this.advanced);
+
+    const constantExpression = new ExpressionBuilder();
+    addIfNotEmpty(constantExpression, this.constant);
+
+    const disjunctionExpression = new ExpressionBuilder();
+    addIfNotEmpty(disjunctionExpression, this.disjunction);
+
+    return {
+      basicExpression,
+      advancedExpression,
+      constantExpression,
+      disjunctionExpression
+    };
+  }
+
+  public mergeWith(queryBuilderExpression: IQueryBuilderExpression) {
+    const otherExpression = QueryBuilderExpression.fromQueryBuilderExpression(queryBuilderExpression);
+    const otherBuilders = otherExpression.expressionBuilders;
+    const builders = this.expressionBuilders;
+
+    this.basic = ExpressionBuilder.merge(builders.basicExpression, otherBuilders.basicExpression).build();
+    this.advanced = ExpressionBuilder.merge(builders.advancedExpression, otherBuilders.advancedExpression).build();
+    this.constant = ExpressionBuilder.merge(builders.constantExpression, otherBuilders.constantExpression).build();
+    this.disjunction = ExpressionBuilder.merge(builders.disjunctionExpression, otherBuilders.disjunctionExpression).build();
+
+    return this;
+  }
+}

--- a/src/ui/Facet/FacetSearchParameters.ts
+++ b/src/ui/Facet/FacetSearchParameters.ts
@@ -57,15 +57,9 @@ export class FacetSearchParameters {
 
     let allowedValues;
     if (this.valueToSearch) {
-      allowedValues = typedByUser
-        .concat(this.alwaysInclude)
-        .concat(this.alwaysExclude)
+      allowedValues = typedByUser.concat(this.alwaysInclude).concat(this.alwaysExclude);
     } else {
-      allowedValues = _.compact(
-        typedByUser
-          .concat(this.alwaysInclude)
-          .concat(this.facet.options.allowedValues)
-      )
+      allowedValues = _.compact(typedByUser.concat(this.alwaysInclude).concat(this.facet.options.allowedValues));
     }
 
     let completeFacetWithStandardValues = this.completeFacetWithStandardValues;
@@ -108,13 +102,12 @@ export class FacetSearchParameters {
     // but arrange for the basic expression to adapt itself with no syntax block
     if (lastQuery.enableQuerySyntax) {
       lastQuery.q = this.facet.facetQueryController.basicExpressionToUseForFacetSearch;
+    } else if (Utils.isNonEmptyString(this.facet.facetQueryController.basicExpressionToUseForFacetSearch)) {
+      lastQuery.q = `<@- ${this.facet.facetQueryController.basicExpressionToUseForFacetSearch} -@>`;
     } else {
-      if (this.facet.facetQueryController.basicExpressionToUseForFacetSearch == '@uri') {
-        lastQuery.q = '';
-      } else {
-        lastQuery.q = `<@- ${this.facet.facetQueryController.basicExpressionToUseForFacetSearch} -@>`;
-      }
+      lastQuery.q = '';
     }
+
     lastQuery.enableQuerySyntax = true;
     lastQuery.cq = this.facet.facetQueryController.constantExpressionToUseForFacetSearch;
     lastQuery.aq = this.facet.facetQueryController.advancedExpressionToUseForFacetSearch;

--- a/test/controllers/FacetSliderQueryControllerTest.ts
+++ b/test/controllers/FacetSliderQueryControllerTest.ts
@@ -95,7 +95,7 @@ export function FacetSliderQueryControllerTest() {
           field: '@foo',
           generateAutomaticRanges: true,
           maximumNumberOfValues: 10,
-          queryOverride: '@uri',
+          advancedQueryOverride: '@uri',
           sortCriteria: 'nosort'
         })
       );
@@ -115,7 +115,7 @@ export function FacetSliderQueryControllerTest() {
           field: '@foo',
           generateAutomaticRanges: true,
           maximumNumberOfValues: 10,
-          queryOverride: 'my query override',
+          advancedQueryOverride: 'my query override',
           sortCriteria: 'nosort'
         })
       );

--- a/test/ui/FacetSearchParametersTest.ts
+++ b/test/ui/FacetSearchParametersTest.ts
@@ -148,7 +148,7 @@ export function FacetSearchParametersTest() {
           spy.and.returnValue(builder.build());
           const params = new FacetSearchParameters(mockFacet);
           expect(params.getQuery().enableQuerySyntax).toBe(true);
-          expect(params.getQuery().q).toBe('');
+          expect(params.getQuery().q).toBe('<@- @uri -@>');
           expect(params.getQuery().aq).toBe('@advanced');
           expect(params.getQuery().cq).toBe('@constant');
         });

--- a/test/ui/QueryBuilderTest.ts
+++ b/test/ui/QueryBuilderTest.ts
@@ -53,19 +53,20 @@ export function QueryBuilderTest() {
       });
 
       it('and computeCompleteExpressionParts', () => {
-        expect(queryBuilder.computeCompleteExpressionParts().constant).toBe('(constant) OR (disjunction)');
-        expect(queryBuilder.computeCompleteExpressionParts().withoutConstant).toBe('((basic) (advanced)) OR (disjunction)');
+        expect(queryBuilder.computeCompleteExpressionParts().constant).toBe('constant');
+        expect(queryBuilder.computeCompleteExpressionParts().withoutConstant).toBe('(basic) (advanced)');
         expect(queryBuilder.computeCompleteExpressionParts().full).toBe('((basic) (advanced) (constant)) OR (disjunction)');
       });
 
       it('and computeCompleteExpressionExcept', () => {
         expect(queryBuilder.computeCompleteExpressionExcept('advanced')).toBe('((basic) (constant)) OR (disjunction)');
         expect(queryBuilder.computeCompleteExpressionExcept('basic')).toBe('((advanced) (constant)) OR (disjunction)');
+        expect(queryBuilder.computeCompleteExpressionExcept('disjunction')).toBe('(basic) (advanced) (constant)');
       });
 
       it('and computeCompleteExpressionPartsExcept', () => {
-        expect(queryBuilder.computeCompleteExpressionPartsExcept('advanced').constant).toBe('(constant) OR (disjunction)');
-        expect(queryBuilder.computeCompleteExpressionPartsExcept('advanced').withoutConstant).toBe('(basic) OR (disjunction)');
+        expect(queryBuilder.computeCompleteExpressionPartsExcept('advanced').constant).toBe('constant');
+        expect(queryBuilder.computeCompleteExpressionPartsExcept('advanced').withoutConstant).toBe('basic');
         expect(queryBuilder.computeCompleteExpressionPartsExcept('advanced').full).toBe('((basic) (constant)) OR (disjunction)');
       });
     });


### PR DESCRIPTION
Some places were still passing in possible query syntax inside facet queries.

Re-factored the query builder expression part a bit to hopefully make the code a bit clearer.

https://github.com/coveo/search-ui/compare/JSUI-1946


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)