### PR TITLE
Always sort group by results by numerical value.

### DIFF
--- a/src/ui/FacetRange/FacetRange.ts
+++ b/src/ui/FacetRange/FacetRange.ts
@@ -176,21 +176,18 @@ export class FacetRange extends Facet implements IComponentBindings {
     this.facetQueryController = new FacetRangeQueryController(this);
   }
 
-  protected processNewGroupByResults(groupByResult: IGroupByResult) {
-    if (groupByResult != null) {
-      if (this.options.ranges == null && (!this.keepDisplayedValuesNextTime || this.values.hasSelectedOrExcludedValues())) {
-        this.keepDisplayedValuesNextTime = false;
-        groupByResult.values.sort((valueA, valueB) => {
-          const startEndA = valueA.value.split('..');
-          const startEndB = valueB.value.split('..');
-          if (this.options.dateField) {
-            return Date.parse(startEndA[0]) - Date.parse(startEndB[0]);
-          }
-          return Number(startEndA[0]) - Number(startEndB[0]);
-        });
-      }
+  protected processNewGroupByResults(groupByResults: IGroupByResult) {
+    if (groupByResults != null && this.options.ranges == null) {
+      groupByResults.values.sort((valueA, valueB) => {
+        const startEndA = valueA.value.split('..');
+        const startEndB = valueB.value.split('..');
+        if (this.options.dateField) {
+          return Date.parse(startEndA[0]) - Date.parse(startEndB[0]);
+        }
+        return Number(startEndA[0]) - Number(startEndB[0]);
+      });
     }
-    super.processNewGroupByResults(groupByResult);
+    super.processNewGroupByResults(groupByResults);
   }
 }
 Initialization.registerAutoCreateComponent(FacetRange);


### PR DESCRIPTION
This removes the special check on the "keepDisplayedValuesNextTime" property from the base Facet component.

This property is already handled correctly by the base facet component, thus making this check here un-necessary.

https://coveord.atlassian.net/browse/JSUI-1857





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)