### PR TITLE
Refactor URL manipulation into a single unified module

### DIFF
--- a/src/UtilsModules.ts
+++ b/src/UtilsModules.ts
@@ -18,3 +18,4 @@ export { StreamHighlightUtils } from './utils/StreamHighlightUtils';
 export { StringUtils } from './utils/StringUtils';
 export { TimeSpan } from './utils/TimeSpanUtils';
 export { Utils } from './utils/Utils';
+export { UrlUtils } from './utils/UrlUtils';

--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -29,6 +29,7 @@ import { BaseComponent } from '../ui/Base/BaseComponent';
 import { ModalBox } from '../ExternalModulesShim';
 import { history } from 'coveo.analytics';
 import * as _ from 'underscore';
+import { UrlUtils } from '../utils/UrlUtils';
 
 /**
  * Possible options when performing a query with the query controller
@@ -495,7 +496,7 @@ export class QueryController extends RootComponent {
   }
 
   private getPipelineInUrl() {
-    return QueryUtils.getUrlParameter('pipeline');
+    return UrlUtils.getUrlParameter('pipeline');
   }
 
   private cancelAnyCurrentPendingQuery() {

--- a/src/rest/AnalyticsEndpoint.ts
+++ b/src/rest/AnalyticsEndpoint.ts
@@ -94,7 +94,7 @@ export class AnalyticsEndpoint {
 
   private sendToService<D, R>(data: D, path: string, paramName: string): Promise<R> {
     const versionToCall = AnalyticsEndpoint.CUSTOM_ANALYTICS_VERSION || AnalyticsEndpoint.DEFAULT_ANALYTICS_VERSION;
-    const url = UrlUtils.normalizeAsString({
+    const urlNormalized = UrlUtils.normalizeAsParts({
       paths: [this.options.serviceUrl, '/rest/', versionToCall, '/analytics/', path],
       query: {
         org: this.organization,
@@ -109,9 +109,9 @@ export class AnalyticsEndpoint {
         .call<R>({
           errorsAsSuccess: false,
           method: 'POST',
-          queryString: [],
+          queryString: urlNormalized.queryNormalized,
           requestData: data,
-          url: url,
+          url: urlNormalized.path,
           responseType: 'text',
           requestDataType: 'application/json'
         })

--- a/src/rest/AnalyticsEndpoint.ts
+++ b/src/rest/AnalyticsEndpoint.ts
@@ -168,11 +168,13 @@ export class AnalyticsEndpoint {
   }
 
   private buildAnalyticsUrl(path: string) {
-    return (
-      this.options.serviceUrl +
-      '/rest/' +
-      (AnalyticsEndpoint.CUSTOM_ANALYTICS_VERSION || AnalyticsEndpoint.DEFAULT_ANALYTICS_VERSION) +
-      path
-    );
+    return UrlUtils.normalizeAsString({
+      paths: [
+        this.options.serviceUrl,
+        '/rest/',
+        AnalyticsEndpoint.CUSTOM_ANALYTICS_VERSION || AnalyticsEndpoint.DEFAULT_ANALYTICS_VERSION,
+        path
+      ]
+    });
   }
 }

--- a/src/rest/EndpointCaller.ts
+++ b/src/rest/EndpointCaller.ts
@@ -6,6 +6,7 @@ import { DeviceUtils } from '../utils/DeviceUtils';
 import { Utils } from '../utils/Utils';
 import { JQueryUtils } from '../utils/JQueryutils';
 import * as _ from 'underscore';
+import { UrlUtils } from '../utils/UrlUtils';
 
 declare const XDomainRequest;
 
@@ -481,12 +482,11 @@ export class EndpointCaller {
     error(queryError);
   }
 
-  private combineUrlAndQueryString(url: String, queryString: string[]): string {
-    let questionMark = '?';
-    if (url.match(/\?$/)) {
-      questionMark = '';
-    }
-    return url + (queryString.length > 0 ? questionMark + queryString.join('&') : '');
+  private combineUrlAndQueryString(url: string, queryString: string[]): string {
+    return UrlUtils.normalizeAsString({
+      paths: [url],
+      queryAsString: queryString
+    });
   }
 
   private isXDomainRequestSupported(): boolean {

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -693,7 +693,7 @@ export class SearchEndpoint implements ISearchEndpoint {
       ...callParams,
       requestData: {
         ...callParams.requestData,
-        ratingRequest
+        ...ratingRequest
       }
     };
     return this.performOneCall<any>(callParams, callOptions).then(() => {

--- a/src/utils/QueryUtils.ts
+++ b/src/utils/QueryUtils.ts
@@ -203,21 +203,6 @@ export class QueryUtils {
     return '(NOT ' + filter + ')';
   }
 
-  static mergeQueryString(url: string, queryString: string) {
-    let queryStringPosition = url.indexOf('?');
-    if (queryStringPosition != -1) {
-      url += '&' + queryString;
-    } else {
-      url += '?' + queryString;
-    }
-    return url;
-  }
-
-  static mergePath(url: string, path: string) {
-    let urlSplit = url.split('?');
-    return urlSplit[0] + path + '?' + (urlSplit[1] || '');
-  }
-
   public static setPropertyOnResults(results: IQueryResults, property: string, value: any, afterOneLoop?: () => any) {
     _.each(results.results, (result: IQueryResult) => {
       QueryUtils.setPropertyOnResult(result, property, value);
@@ -233,15 +218,6 @@ export class QueryUtils {
     if (!Utils.isNullOrUndefined(result.parentResult)) {
       result.parentResult[property] = value;
     }
-  }
-
-  // http://stackoverflow.com/a/11582513
-  public static getUrlParameter(name: string): string {
-    return (
-      decodeURIComponent(
-        (new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search) || [, ''])[1].replace(/\+/g, '%20')
-      ) || null
-    );
   }
 
   public static isStratusAgnosticField(fieldToVerify: string, fieldToMatch: string): boolean {

--- a/src/utils/UrlUtils.ts
+++ b/src/utils/UrlUtils.ts
@@ -1,0 +1,151 @@
+import { isArray, pairs, Dictionary, compact } from 'underscore';
+import { Utils } from './Utils';
+
+export interface IUrlNormalize {
+  paths: string[] | string;
+  queryAsString?: string[] | string;
+  hashAsString?: string[] | string;
+  query?: Dictionary<string>;
+  hash?: Dictionary<string>;
+}
+
+export class UrlUtils {
+  public static getUrlParameter(name: string): string {
+    return (
+      decodeURIComponent(
+        (new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search) || [, ''])[1].replace(/\+/g, '%20')
+      ) || null
+    );
+  }
+
+  public static normalizeAsString(toNormalize: IUrlNormalize): string {
+    const { queryNormalized, hashNormalized, path } = this.normalizeAsParts(toNormalize);
+
+    return `${path}${this.addToUrlIfNotEmpty(queryNormalized, '&', '?')}${this.addToUrlIfNotEmpty(hashNormalized, '&', '#')}`;
+  }
+
+  public static normalizeAsParts(toNormalize: IUrlNormalize) {
+    const pathsNormalized = this.normalizePaths(toNormalize);
+    const queryNormalized = this.normalizeQueryString(toNormalize);
+    const hashNormalized = this.normalizeHash(toNormalize);
+
+    return {
+      pathsNormalized,
+      queryNormalized,
+      hashNormalized,
+      path: this.addToUrlIfNotEmpty(pathsNormalized, '/', '')
+    };
+  }
+
+  private static normalizePaths(toNormalize: IUrlNormalize) {
+    return this.toArray(toNormalize.paths).map(path => {
+      if (Utils.isNonEmptyString(path)) {
+        let treatedPath = this.removeAtEnd('/', path);
+        treatedPath = this.removeAtStart('/', treatedPath);
+        return treatedPath;
+      }
+      return '';
+    });
+  }
+
+  private static normalizeQueryString(toNormalize: IUrlNormalize) {
+    let queryNormalized: string[] = [];
+
+    if (toNormalize.queryAsString) {
+      queryNormalized = queryNormalized.concat(
+        this.toArray(toNormalize.queryAsString).map(query => {
+          ['?', '&'].forEach(problematicChar => {
+            query = this.removeAtStart(problematicChar, query);
+            query = this.removeAtEnd(problematicChar, query);
+          });
+          return query;
+        })
+      );
+    }
+
+    if (toNormalize.query) {
+      const paired: string[][] = pairs(toNormalize.query);
+      queryNormalized = queryNormalized.concat(
+        paired.map(pair => {
+          const [key, value] = pair;
+          if (!Utils.isNullOrUndefined(value)) {
+            return [key, Utils.safeEncodeURIComponent(value)].join('=');
+          }
+          return '';
+        })
+      );
+    }
+
+    return queryNormalized;
+  }
+
+  private static normalizeHash(toNormalize: IUrlNormalize) {
+    let hashNormalized: string[] = [];
+
+    if (toNormalize.hashAsString) {
+      hashNormalized = hashNormalized.concat(
+        this.toArray(toNormalize.hashAsString).map(hash => {
+          ['#', '&'].forEach(problematicChar => {
+            hash = this.removeAtStart(problematicChar, hash);
+            hash = this.removeAtEnd(problematicChar, hash);
+          });
+          return hash;
+        })
+      );
+    }
+
+    if (toNormalize.hash) {
+      const paired: string[][] = pairs(toNormalize.hash);
+      hashNormalized = hashNormalized.concat(
+        paired.map(pair => {
+          const [key, value] = pair;
+          if (Utils.isNonEmptyString(value)) {
+            return [key, Utils.safeEncodeURIComponent(value)].join('=');
+          }
+          return '';
+        })
+      );
+    }
+    return hashNormalized;
+  }
+
+  private static addToUrlIfNotEmpty(toAdd: string[], joinWith: string, leadWith: string) {
+    if (Utils.isNonEmptyArray(toAdd)) {
+      return `${leadWith}${compact(toAdd).join(joinWith)}`;
+    }
+    return '';
+  }
+
+  private static startsWith(searchString: string, targetString: string) {
+    return targetString.charAt(0) == searchString;
+  }
+
+  private static endsWith(searchString: string, targetString: string) {
+    return targetString.charAt(targetString.length - 1) == searchString;
+  }
+
+  private static removeAtEnd(searchString: string, targetString: string) {
+    while (this.endsWith(searchString, targetString)) {
+      targetString = targetString.slice(0, targetString.length - searchString.length);
+    }
+
+    return targetString;
+  }
+
+  private static removeAtStart(searchString: string, targetString: string) {
+    while (this.startsWith(searchString, targetString)) {
+      targetString = targetString.slice(searchString.length);
+    }
+    return targetString;
+  }
+
+  private static toArray(parameter: string | string[]): string[] {
+    let ret: string[];
+    if (!isArray(parameter)) {
+      ret = [parameter];
+    } else {
+      ret = parameter;
+    }
+    return ret;
+  }
+}

--- a/test/Test.ts
+++ b/test/Test.ts
@@ -492,3 +492,6 @@ SimpleFilterTest();
 
 import { DeviceUtilsTest } from './utils/DeviceUtilsTest';
 DeviceUtilsTest();
+
+import { UrlUtilsTest } from './utils/UrlUtilsTest';
+UrlUtilsTest();

--- a/test/rest/SearchEndpointTest.ts
+++ b/test/rest/SearchEndpointTest.ts
@@ -12,6 +12,7 @@ import { IQuerySuggestResponse } from '../../src/rest/QuerySuggest';
 import { ISubscription } from '../../src/rest/Subscription';
 import { AjaxError } from '../../src/rest/AjaxError';
 import _ = require('underscore');
+import { Utils } from '../../src/utils/Utils';
 
 export function SearchEndpointTest() {
   describe('SearchEndpoint', () => {
@@ -64,7 +65,9 @@ export function SearchEndpointTest() {
 
       it('should not map it to organizationId', () => {
         const fakeResult = FakeResults.createFakeResult();
-        expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toBe(ep.getBaseUri() + '/html?workgroup=myOrgId&uniqueId=' + fakeResult.uniqueId);
+        expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toContain(
+          ep.getBaseUri() + '/html?workgroup=myOrgId&uniqueId=' + fakeResult.uniqueId
+        );
       });
     });
 
@@ -86,7 +89,7 @@ export function SearchEndpointTest() {
 
       it('should not map it to workgroup', () => {
         const fakeResult = FakeResults.createFakeResult();
-        expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toBe(
+        expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toContain(
           ep.getBaseUri() + '/html?organizationId=myOrgId&uniqueId=' + fakeResult.uniqueId
         );
       });
@@ -108,7 +111,9 @@ export function SearchEndpointTest() {
 
       it('will add it in the query string', () => {
         const fakeResult = FakeResults.createFakeResult();
-        expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toBe(ep.getBaseUri() + '/html?access_token=token&uniqueId=' + fakeResult.uniqueId);
+        expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toContain(
+          ep.getBaseUri() + '/html?access_token=token&uniqueId=' + fakeResult.uniqueId
+        );
       });
     });
 
@@ -155,7 +160,7 @@ export function SearchEndpointTest() {
       it('allow to get an export to excel link', () => {
         const qbuilder = new QueryBuilder();
         qbuilder.expression.add('batman');
-        expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain(ep.getBaseUri() + '/?');
+        expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain(ep.getBaseUri() + '?');
         expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain('organizationId=myOrgId');
         expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain('potatoe=mashed');
         expect(ep.getExportToExcelLink(qbuilder.build(), 56)).toContain('q=batman');
@@ -232,7 +237,7 @@ export function SearchEndpointTest() {
           qbuilder.numberOfResults = 153;
           qbuilder.enableCollaborativeRating = true;
           const promiseSuccess = ep.search(qbuilder.build());
-          expect(jasmine.Ajax.requests.mostRecent().url).toContain(ep.getBaseUri() + '/?');
+          expect(jasmine.Ajax.requests.mostRecent().url).toContain(ep.getBaseUri() + '?');
           expect(jasmine.Ajax.requests.mostRecent().url).toContain('organizationId=myOrgId');
           expect(jasmine.Ajax.requests.mostRecent().url).toContain('potatoe=mashed');
           expect(jasmine.Ajax.requests.mostRecent().params).toContain('q=batman');
@@ -278,7 +283,7 @@ export function SearchEndpointTest() {
           const promiseSuccess = ep.getRawDataStream(fakeResult.uniqueId, '$Thumbnail');
           expect(jasmine.Ajax.requests.mostRecent().url).toContain(ep.getBaseUri() + '/datastream?');
           expect(jasmine.Ajax.requests.mostRecent().url).toContain('uniqueId=' + fakeResult.uniqueId);
-          expect(jasmine.Ajax.requests.mostRecent().url).toContain('dataStream=$Thumbnail');
+          expect(jasmine.Ajax.requests.mostRecent().url).toContain(`dataStream=${Utils.safeEncodeURIComponent('$Thumbnail')}`);
           expect(jasmine.Ajax.requests.mostRecent().url).toContain('organizationId=myOrgId');
           expect(jasmine.Ajax.requests.mostRecent().url).toContain('potatoe=mashed');
           expect(jasmine.Ajax.requests.mostRecent().method).toBe('GET');

--- a/test/rest/SearchEndpointTest.ts
+++ b/test/rest/SearchEndpointTest.ts
@@ -65,9 +65,11 @@ export function SearchEndpointTest() {
 
       it('should not map it to organizationId', () => {
         const fakeResult = FakeResults.createFakeResult();
-        expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toContain(
-          ep.getBaseUri() + '/html?workgroup=myOrgId&uniqueId=' + fakeResult.uniqueId
-        );
+        const viewAsHtmlUri = ep.getViewAsHtmlUri(fakeResult.uniqueId);
+        expect(viewAsHtmlUri).toContain(ep.getBaseUri());
+        expect(viewAsHtmlUri).toContain('/html');
+        expect(viewAsHtmlUri).toContain('workgroup=myOrgId');
+        expect(viewAsHtmlUri).toContain(`uniqueId=${fakeResult.uniqueId}`);
       });
     });
 
@@ -89,9 +91,11 @@ export function SearchEndpointTest() {
 
       it('should not map it to workgroup', () => {
         const fakeResult = FakeResults.createFakeResult();
-        expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toContain(
-          ep.getBaseUri() + '/html?organizationId=myOrgId&uniqueId=' + fakeResult.uniqueId
-        );
+        const viewAsHtmlUri = ep.getViewAsHtmlUri(fakeResult.uniqueId);
+        expect(viewAsHtmlUri).toContain(ep.getBaseUri());
+        expect(viewAsHtmlUri).toContain('/html');
+        expect(viewAsHtmlUri).toContain('organizationId=myOrgId');
+        expect(viewAsHtmlUri).toContain(`uniqueId=${fakeResult.uniqueId}`);
       });
     });
 
@@ -111,9 +115,9 @@ export function SearchEndpointTest() {
 
       it('will add it in the query string', () => {
         const fakeResult = FakeResults.createFakeResult();
-        expect(ep.getViewAsHtmlUri(fakeResult.uniqueId)).toContain(
-          ep.getBaseUri() + '/html?access_token=token&uniqueId=' + fakeResult.uniqueId
-        );
+        const viewAsHtmlUri = ep.getViewAsHtmlUri(fakeResult.uniqueId);
+        expect(viewAsHtmlUri).toContain(ep.getBaseUri());
+        expect(viewAsHtmlUri).toContain('access_token=token');
       });
     });
 

--- a/test/rest/SearchEndpointTest.ts
+++ b/test/rest/SearchEndpointTest.ts
@@ -492,6 +492,8 @@ export function SearchEndpointTest() {
           expect(jasmine.Ajax.requests.mostRecent().url).toContain('potatoe=mashed');
 
           expect(jasmine.Ajax.requests.mostRecent().method).toBe('POST');
+          expect(jasmine.Ajax.requests.mostRecent().params).toContain('rating=Best');
+          expect(jasmine.Ajax.requests.mostRecent().params).toContain('uniqueId=' + fakeResult.uniqueId);
 
           promiseSuccess
             .then((response: boolean) => {

--- a/test/utils/UrlUtilsTest.ts
+++ b/test/utils/UrlUtilsTest.ts
@@ -1,0 +1,111 @@
+import { UrlUtils } from '../../src/utils/UrlUtils';
+import { Utils } from '../Test';
+
+export function UrlUtilsTest() {
+  describe('UrlUtils', () => {
+    it('should support combining multiple paths with trailing slash', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/', 'b/', 'c//', 'd///']
+      });
+      expect(url).toBe('https://a.com/b/c/d');
+    });
+
+    it('should support combining multiple paths with leading slash', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/', '/b', '//c', '///d']
+      });
+      expect(url).toBe('https://a.com/b/c/d');
+    });
+
+    it('should support passing in query string as an array of strings', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        queryAsString: ['123=4', '456=7']
+      });
+      expect(url).toBe('https://a.com?123=4&456=7');
+    });
+
+    it('should support passing in query string as a dictionnary', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        query: {
+          123: 4,
+          456: 7
+        }
+      });
+      expect(url).toBe('https://a.com?123=4&456=7');
+    });
+
+    it('should use both query string as an array of strings and a dictionnary', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        queryAsString: ['123=4', '456=7'],
+        query: {
+          abc: 'd',
+          efg: 'h'
+        }
+      });
+      expect(url).toBe('https://a.com?123=4&456=7&abc=d&efg=h');
+    });
+
+    it('should remove duplicates query string parameters', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        queryAsString: ['123=4', '456=7', '123=4'],
+        query: {
+          abc: 'd',
+          efg: 'h',
+          123: 4
+        }
+      });
+      expect(url).toBe('https://a.com?123=4&456=7&abc=d&efg=h');
+    });
+
+    it('should url encode query string parameters', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        queryAsString: ['123=4 56'],
+        query: {
+          abc: '&def'
+        }
+      });
+      expect(url).toBe(`https://a.com?123=4${Utils.safeEncodeURIComponent(' ')}56&abc=${Utils.safeEncodeURIComponent('&')}def`);
+    });
+
+    it('should not double url encode query string parameters', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        queryAsString: [`123=4${Utils.safeEncodeURIComponent(' ')}56`],
+        query: {
+          abc: `${Utils.safeEncodeURIComponent('&')}def`
+        }
+      });
+      expect(url).toBe(`https://a.com?123=4${Utils.safeEncodeURIComponent(' ')}56&abc=${Utils.safeEncodeURIComponent('&')}def`);
+    });
+
+    it('should remove incoherent "?" character', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/?'],
+        queryAsString: ['?123=4', '456?=7', '123=4'],
+        query: {
+          'abc?': 'd',
+          '?efg': 'h?',
+          123: 4
+        }
+      });
+      expect(url).toBe(`https://a.com?123=4&456=7&abc=d&efg=h${Utils.safeEncodeURIComponent('?')}`);
+    });
+
+    it('should remove incoherent "=" character', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com'],
+        queryAsString: ['=123=4'],
+        query: {
+          '=abc': 'd',
+          'efg=': 'h'
+        }
+      });
+      expect(url).toBe(`https://a.com?123=4&abc=d&efg=h`);
+    });
+  });
+}


### PR DESCRIPTION
There was many different places using different piece of code to build valid URL, and they were inconsistent, and some had some bugs where we'd end up with trailing slash in url, or duplication with query string parameters.

This creates an `UrlUtils` module which allows to normalize urls building.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)