### PR TITLE
Fix extend deep when merging arrays of HTML elements

### DIFF
--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -272,7 +272,7 @@ export class Utils {
       _.each(src, (e, i, obj) => {
         if (typeof target[i] === 'undefined') {
           toReturn[i] = <any>e;
-        } else if (typeof e === 'object') {
+        } else if (typeof e === 'object' && !_.isElement(e)) {
           toReturn[i] = Utils.extendDeep(target[i], e);
         } else {
           if (target.indexOf(e) === -1) {
@@ -281,7 +281,7 @@ export class Utils {
         }
       });
     } else {
-      if (target && typeof target === 'object') {
+      if (target && typeof target === 'object' && !_.isElement(target)) {
         _.each(_.keys(target), key => {
           toReturn[key] = target[key];
         });

--- a/test/utils/UtilsTest.ts
+++ b/test/utils/UtilsTest.ts
@@ -2,19 +2,59 @@ import { Utils } from '../../src/utils/Utils';
 
 export function UtilsTest() {
   describe('Utils', () => {
-    it('safeEncodeURIComponent should support null values', () => {
-      expect(Utils.safeEncodeURIComponent(null)).toEqual(encodeURIComponent('null'));
+    describe('safeEncodeURIComponent', () => {
+      it('should support null values', () => {
+        expect(Utils.safeEncodeURIComponent(null)).toEqual(encodeURIComponent('null'));
+      });
+
+      it('should return the standard value for standard string', () => {
+        expect(Utils.safeEncodeURIComponent('The quick brown fox over the lazy dog')).toEqual(
+          encodeURIComponent('The quick brown fox over the lazy dog')
+        );
+      });
+
+      it('should not throw when encoding weird unicode strings as opposed to the standard function', () => {
+        expect(() => encodeURIComponent('\uD800')).toThrow();
+        expect(() => Utils.safeEncodeURIComponent('\uD800')).not.toThrow();
+      });
     });
 
-    it('safeEncodeURIComponent should return the standard value for standard string', () => {
-      expect(Utils.safeEncodeURIComponent('The quick brown fox over the lazy dog')).toEqual(
-        encodeURIComponent('The quick brown fox over the lazy dog')
-      );
-    });
+    describe('extendDeep', () => {
+      const nonExistingValue = 'value1';
+      const existingValue = 'value2';
 
-    it('safeEncodeURIComponent should not throw when encoding weird unicode strings as opposed to the standard function', () => {
-      expect(() => encodeURIComponent('\uD800')).toThrow();
-      expect(() => Utils.safeEncodeURIComponent('\uD800')).not.toThrow();
+      it('should add new key in target', () => {
+        const result = Utils.extendDeep({ existingValue }, { nonExistingValue });
+        expect(result).toEqual({
+          nonExistingValue,
+          existingValue
+        });
+      });
+
+      it('should override the value of an existing key in target', () => {
+        const newValue = 'bloup';
+
+        const result = Utils.extendDeep({ existingValue }, { existingValue: newValue });
+        expect(result).toEqual({
+          existingValue: newValue
+        });
+      });
+
+      it('should merge two arrays with simple values', () => {
+        const result = Utils.extendDeep({ existingValue: [nonExistingValue] }, { existingValue: [existingValue] });
+        expect(result).toEqual({
+          existingValue: [nonExistingValue, existingValue]
+        });
+      });
+
+      it('should merge two arrays with HTML element values', () => {
+        const existingElement = document.createElement('div');
+        const nonExistingElement = document.createElement('div');
+        const result = Utils.extendDeep({ existingValue: [existingElement] }, { existingValue: [nonExistingElement] });
+        expect(result).toEqual({
+          existingValue: [existingElement, nonExistingElement]
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
When merging two arrays containing HTML elements, the element would be detected as an `object`. The merge would try to read its keys and merge the values just like a normal JS object.

This fixes the issue by considering an HTML element as a simple value instead of an object. It is covered by the `should merge two arrays with HTML element values` test.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)