### PR TITLE
Refactor Access Token renewal for Analytics + Search Endpoint

### DIFF
--- a/src/rest/AccessToken.ts
+++ b/src/rest/AccessToken.ts
@@ -5,7 +5,7 @@ import { debounce } from 'underscore';
 export type onRenew = (newToken: string) => void;
 
 export enum ACCESS_TOKEN_ERRORS {
-  NO_RENEW_FUNCTIONS = 'NO_RENEW_FUNCTIONS',
+  NO_RENEW_FUNCTION = 'NO_RENEW_FUNCTION',
   REPEATED_FAILURES = 'REPEATED_FAILURES'
 }
 
@@ -47,7 +47,7 @@ export class AccessToken {
           this.logger.error('There is most probably an authentication error, or a bad implementation of the custom renew function');
           this.logger.error('Inspect the developer console of your browser to find out the root cause');
           break;
-        case ACCESS_TOKEN_ERRORS.NO_RENEW_FUNCTIONS:
+        case ACCESS_TOKEN_ERRORS.NO_RENEW_FUNCTION:
           this.logger.error(`AccessToken tried to renew, but no function is configured on initialization to provide acess token renewal`);
           this.logger.error('The option name is renewAccessToken on the SearchEndpoint class');
           break;
@@ -67,7 +67,7 @@ export class AccessToken {
 
   private verifyRenewSetup() {
     if (this.renew == null) {
-      throw new Error(ACCESS_TOKEN_ERRORS.NO_RENEW_FUNCTIONS);
+      throw new Error(ACCESS_TOKEN_ERRORS.NO_RENEW_FUNCTION);
     }
     if (this.triedRenewals >= 5) {
       throw new Error(ACCESS_TOKEN_ERRORS.REPEATED_FAILURES);

--- a/src/rest/AccessToken.ts
+++ b/src/rest/AccessToken.ts
@@ -2,7 +2,7 @@ import { IErrorResponse } from './EndpointCaller';
 import { Logger } from '../misc/Logger';
 import { debounce } from 'underscore';
 
-export type onRenew = (newToken: string) => void;
+export type onTokenRefreshed = (newToken: string) => void;
 
 export enum ACCESS_TOKEN_ERRORS {
   NO_RENEW_FUNCTION = 'NO_RENEW_FUNCTION',
@@ -10,7 +10,7 @@ export enum ACCESS_TOKEN_ERRORS {
 }
 
 export class AccessToken {
-  private subscribers: onRenew[] = [];
+  private subscribers: onTokenRefreshed[] = [];
   private logger: Logger = new Logger(this);
   private triedRenewals: number = 0;
   private resetRenewalTriesAfterDelay;
@@ -26,7 +26,7 @@ export class AccessToken {
   }
 
   public isExpired(error: IErrorResponse) {
-    return error != null && error.statusCode != null && error.statusCode == 419;
+    return error != null && error.statusCode === 419;
   }
 
   public async doRenew(onError?: (error: Error) => void): Promise<Boolean> {
@@ -61,8 +61,8 @@ export class AccessToken {
     }
   }
 
-  public afterRenew(afterRenew: onRenew) {
-    this.subscribers.push(afterRenew);
+  public subscribeToRenewal(onTokenRefreshed: onTokenRefreshed) {
+    this.subscribers.push(onTokenRefreshed);
   }
 
   private verifyRenewSetup() {

--- a/src/rest/AccessToken.ts
+++ b/src/rest/AccessToken.ts
@@ -1,0 +1,80 @@
+import { IErrorResponse } from './EndpointCaller';
+import { Logger } from '../misc/Logger';
+import { debounce } from 'underscore';
+
+export type onRenew = (newToken: string) => void;
+
+export class AccessToken {
+  private subscribers: onRenew[] = [];
+  private logger: Logger = new Logger(this);
+  private stopAllRenewalAttempt = false;
+  private triedRenewals: number = 0;
+  private resetRenewalTriesAfterDelay;
+
+  constructor(public token: string, public renew?: () => Promise<string>) {
+    this.resetRenewalTriesAfterDelay = debounce(
+      () => {
+        this.triedRenewals = 0;
+      },
+      500,
+      false
+    );
+  }
+
+  public isExpired(error: IErrorResponse) {
+    return true;
+    //return this.canDoRenew() && error != null && error.statusCode != null && error.statusCode == 419;
+  }
+
+  public async doRenew(onError?: (error: Error) => void): Promise<Boolean> {
+    this.triedRenewals++;
+    this.resetRenewalTriesAfterDelay();
+
+    if (!this.canDoRenew()) {
+      return false;
+    }
+
+    try {
+      this.logger.info('Renewing expired access token');
+      this.token = await this.renew();
+      this.logger.info('Access token renewed', this.token);
+      this.subscribers.forEach(subscriber => subscriber(this.token));
+      return true;
+    } catch (error) {
+      this.logger.error('Failed to renew access token', error);
+
+      if (onError) {
+        onError(error);
+      } else {
+        throw error;
+      }
+
+      return false;
+    }
+  }
+
+  public afterRenew(afterRenew: onRenew) {
+    if (this.canDoRenew()) {
+      this.subscribers.push(afterRenew);
+    }
+  }
+
+  public canDoRenew() {
+    if (this.stopAllRenewalAttempt) {
+      return false;
+    }
+
+    if (this.renew == null) {
+      this.logger.error(`AccessToken tried to renew, but no function is configured on initialization to provide acess token renewal`);
+      return false;
+    }
+    if (this.triedRenewals >= 5) {
+      this.stopAllRenewalAttempt = true;
+      this.logger.error('AccessToken tried to renew itself extremely fast in a short period of time');
+      this.logger.error('There is most probably an authentication error, or a bad implementation of the custom renew function');
+      this.logger.error('Inspect the developer console of your browser to find out the root cause');
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/rest/AnalyticsEndpoint.ts
+++ b/src/rest/AnalyticsEndpoint.ts
@@ -15,9 +15,10 @@ import { ISuccessResponse } from '../rest/EndpointCaller';
 import { IStringMap } from '../rest/GenericParam';
 import * as _ from 'underscore';
 import { Utils } from '../utils/Utils';
+import { AccessToken } from './AccessToken';
 
 export interface IAnalyticsEndpointOptions {
-  token: string;
+  accessToken: AccessToken;
   serviceUrl: string;
   organization: string;
 }
@@ -39,9 +40,10 @@ export class AnalyticsEndpoint {
   constructor(public options: IAnalyticsEndpointOptions) {
     this.logger = new Logger(this);
 
-    var endpointCallerOptions: IEndpointCallerOptions = {
-      accessToken: this.options.token && this.options.token != '' ? this.options.token : null
+    const endpointCallerOptions: IEndpointCallerOptions = {
+      accessToken: this.options.accessToken.token
     };
+
     this.endpointCaller = new EndpointCaller(endpointCallerOptions);
     this.organization = options.organization;
   }
@@ -55,7 +57,7 @@ export class AnalyticsEndpoint {
       if (this.getCurrentVisitId()) {
         resolve(this.getCurrentVisitId());
       } else {
-        var url = this.buildAnalyticsUrl('/analytics/visit');
+        const url = this.buildAnalyticsUrl('/analytics/visit');
         this.getFromService<IAPIAnalyticsVisitResponseRest>(url, {})
           .then((response: IAPIAnalyticsVisitResponseRest) => {
             this.visitId = response.id;
@@ -88,53 +90,65 @@ export class AnalyticsEndpoint {
   }
 
   public getTopQueries(params: ITopQueries): Promise<string[]> {
-    var url = this.buildAnalyticsUrl('/stats/topQueries');
+    const url = this.buildAnalyticsUrl('/stats/topQueries');
     return this.getFromService<string[]>(url, params);
   }
 
-  private sendToService<D, R>(data: D, path: string, paramName: string): Promise<R> {
-    var url = QueryUtils.mergePath(
+  private async sendToService<D, R>(data: D, path: string, paramName: string): Promise<R> {
+    // We use pendingRequest because we don't want to have 2 request to analytics at the same time.
+    // Otherwise the cookie visitId won't be set correctly.
+    if (AnalyticsEndpoint.pendingRequest != null) {
+      try {
+        await AnalyticsEndpoint.pendingRequest;
+      } finally {
+        return this.sendToService<D, R>(data, path, paramName);
+      }
+    }
+
+    const url = QueryUtils.mergePath(
       this.options.serviceUrl,
       '/rest/' + (AnalyticsEndpoint.CUSTOM_ANALYTICS_VERSION || AnalyticsEndpoint.DEFAULT_ANALYTICS_VERSION) + '/analytics/' + path
     );
-    var queryString = [];
+    const queryString = [];
 
     if (this.organization) {
       queryString.push('org=' + this.organization);
     }
+
     if (Cookie.get('visitorId')) {
       queryString.push('visitor=' + Utils.safeEncodeURIComponent(Cookie.get('visitorId')));
     }
 
-    // We use pendingRequest because we don't want to have 2 request to analytics at the same time.
-    // Otherwise the cookie visitId won't be set correctly.
-    if (AnalyticsEndpoint.pendingRequest == null) {
-      AnalyticsEndpoint.pendingRequest = this.endpointCaller
-        .call<R>({
-          errorsAsSuccess: false,
-          method: 'POST',
-          queryString: queryString,
-          requestData: data,
-          url: url,
-          responseType: 'text',
-          requestDataType: 'application/json'
-        })
-        .then((res: ISuccessResponse<R>) => {
-          return this.handleAnalyticsEventResponse(<any>res.data);
-        })
-        .finally(() => {
-          AnalyticsEndpoint.pendingRequest = null;
-        });
-      return AnalyticsEndpoint.pendingRequest;
-    } else {
-      return AnalyticsEndpoint.pendingRequest.finally(() => {
-        return this.sendToService<D, R>(data, path, paramName);
-      });
+    AnalyticsEndpoint.pendingRequest = this.endpointCaller.call<R>({
+      errorsAsSuccess: false,
+      method: 'POST',
+      queryString: queryString,
+      requestData: data,
+      url: url,
+      responseType: 'text',
+      requestDataType: 'application/json'
+    });
+
+    try {
+      const results = await AnalyticsEndpoint.pendingRequest;
+      this.handleAnalyticsEventResponse(results.data);
+    } catch (error) {
+      if (this.options.accessToken.isExpired(error)) {
+        AnalyticsEndpoint.pendingRequest = null;
+        const successfullyRenewed = await this.options.accessToken.doRenew();
+        if (successfullyRenewed) {
+          return this.sendToService<D, R>(data, path, paramName);
+        }
+      }
+    } finally {
+      AnalyticsEndpoint.pendingRequest = null;
     }
+
+    return AnalyticsEndpoint.pendingRequest;
   }
 
   private getFromService<T>(url: string, params: IStringMap<string>): Promise<T> {
-    var paramsToSend = this.options.token && this.options.token != '' ? _.extend({ access_token: this.options.token }, params) : params;
+    const paramsToSend = { ...params, access_token: this.options.accessToken.token };
     return this.endpointCaller
       .call<T>({
         errorsAsSuccess: false,
@@ -150,8 +164,8 @@ export class AnalyticsEndpoint {
   }
 
   private handleAnalyticsEventResponse(response: IAPIAnalyticsEventResponse | IAPIAnalyticsSearchEventsResponse) {
-    var visitId: string;
-    var visitorId: string;
+    let visitId: string;
+    let visitorId: string;
 
     if (response['visitId']) {
       visitId = response['visitId'];

--- a/src/rest/EndpointCaller.ts
+++ b/src/rest/EndpointCaller.ts
@@ -224,6 +224,7 @@ export class EndpointCaller {
       method: params.method
     };
     requestInfo.headers = this.buildRequestHeaders(requestInfo);
+
     if (_.isFunction(this.options.requestModifier)) {
       requestInfo = this.options.requestModifier(requestInfo);
     }

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -223,7 +223,7 @@ export class SearchEndpoint implements ISearchEndpoint {
     this.options = <ISearchEndpointOptions>_.extend({}, defaultOptions, options);
 
     this.accessToken = new AccessToken(this.options.accessToken, this.options.renewAccessToken);
-    this.accessToken.afterRenew(() => this.createEndpointCaller());
+    this.accessToken.subscribeToRenewal(() => this.createEndpointCaller());
 
     // Forward any debug=1 query argument to the REST API to ease debugging
     if (SearchEndpoint.isDebugArgumentPresent()) {

--- a/src/ui/Analytics/Analytics.ts
+++ b/src/ui/Analytics/Analytics.ts
@@ -21,6 +21,7 @@ import * as _ from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 import { PendingSearchEvent } from './PendingSearchEvent';
 import { PendingSearchAsYouTypeSearchEvent } from './PendingSearchAsYouTypeSearchEvent';
+import { AccessToken } from '../../rest/AccessToken';
 
 export interface IAnalyticsOptions {
   user?: string;
@@ -33,6 +34,7 @@ export interface IAnalyticsOptions {
   splitTestRunVersion?: string;
   sendToCloud?: boolean;
   organization?: string;
+  renewAccessToken?: () => Promise<string>;
 }
 
 /**
@@ -165,6 +167,8 @@ export class Analytics extends Component {
    */
   public client: IAnalyticsClient;
 
+  private accessToken: AccessToken;
+
   /**
    * Creates a new `Analytics` component. Creates the [`AnalyticsClient`]{@link IAnalyticsClient}.
    * @param element The HTMLElement on which the component will be instantiated.
@@ -176,7 +180,20 @@ export class Analytics extends Component {
     super(element, Analytics.ID, bindings);
     this.options = ComponentOptions.initComponentOptions(element, Analytics, options);
 
-    this.retrieveInfoFromDefaultSearchEndpoint();
+    this.setupAccessToken();
+
+    if (this.accessToken == null) {
+      this.logger.error(`Analytics component could not resolve any access token`);
+      this.logger.error(
+        `Either provide a analytics token : data-option-token="an-authentication-token" on the Analytics element, or configure a default SearchEndpoint`,
+        this.element
+      );
+      return;
+    } else {
+      this.options.token = this.accessToken.token;
+      this.accessToken.afterRenew(newToken => (this.client.endpoint.endpointCaller.options.accessToken = newToken));
+    }
+
     this.initializeAnalyticsClient();
     Assert.exists(this.client);
 
@@ -327,7 +344,7 @@ export class Analytics extends Component {
 
   protected initializeAnalyticsEndpoint(): AnalyticsEndpoint {
     return new AnalyticsEndpoint({
-      token: this.options.token,
+      accessToken: this.accessToken,
       serviceUrl: this.options.endpoint,
       organization: this.options.organization
     });
@@ -381,10 +398,29 @@ export class Analytics extends Component {
     }
   }
 
-  private retrieveInfoFromDefaultSearchEndpoint() {
-    let defaultEndpoint = SearchEndpoint.endpoints['default'];
-    if (this.options.token == null && defaultEndpoint) {
-      this.options.token = defaultEndpoint.options.accessToken;
+  private setupAccessToken() {
+    this.trySetupAccessTokenFromOptions();
+    if (this.accessToken == null) {
+      this.trySetupAccessTokenFromDefaultSearchEndpoint();
+    }
+  }
+
+  private trySetupAccessTokenFromOptions() {
+    if (this.options.token != null) {
+      this.accessToken = new AccessToken(this.options.token, this.options.renewAccessToken);
+    }
+  }
+
+  private trySetupAccessTokenFromDefaultSearchEndpoint() {
+    const defaultEndpoint = SearchEndpoint.endpoints['default'];
+    if (defaultEndpoint) {
+      this.accessToken = defaultEndpoint.accessToken;
+
+      this.options.token = defaultEndpoint.accessToken.token;
+      defaultEndpoint.accessToken.afterRenew(newToken => {
+        this.options.token = newToken;
+        this.initializeAnalyticsClient();
+      });
     }
 
     if (!this.options.organization && defaultEndpoint) {

--- a/src/ui/Analytics/Analytics.ts
+++ b/src/ui/Analytics/Analytics.ts
@@ -191,7 +191,7 @@ export class Analytics extends Component {
       return;
     } else {
       this.options.token = this.accessToken.token;
-      this.accessToken.afterRenew(newToken => (this.client.endpoint.endpointCaller.options.accessToken = newToken));
+      this.accessToken.subscribeToRenewal(newToken => (this.client.endpoint.endpointCaller.options.accessToken = newToken));
     }
 
     this.initializeAnalyticsClient();
@@ -417,7 +417,7 @@ export class Analytics extends Component {
       this.accessToken = defaultEndpoint.accessToken;
 
       this.options.token = defaultEndpoint.accessToken.token;
-      defaultEndpoint.accessToken.afterRenew(newToken => {
+      defaultEndpoint.accessToken.subscribeToRenewal(newToken => {
         this.options.token = newToken;
         this.initializeAnalyticsClient();
       });

--- a/src/ui/Analytics/AnalyticsClient.ts
+++ b/src/ui/Analytics/AnalyticsClient.ts
@@ -3,6 +3,7 @@ import { IAPIAnalyticsEventResponse } from '../../rest/APIAnalyticsEventResponse
 import { IQueryResult } from '../../rest/QueryResult';
 import { ITopQueries } from '../../rest/TopQueries';
 import { PendingSearchEvent } from './PendingSearchEvent';
+import { AnalyticsEndpoint } from '../../rest/AnalyticsEndpoint';
 
 /**
  * The `IAnalyticsClient` interface describes an analytics client that can log events to, or return information from the
@@ -12,6 +13,7 @@ import { PendingSearchEvent } from './PendingSearchEvent';
  */
 export interface IAnalyticsClient {
   isContextual: boolean;
+  endpoint: AnalyticsEndpoint;
 
   /**
    * Indicates whether there is an [`Analytics`]{@link Analytics} component in the search page. Returns `true` if an

--- a/src/ui/Analytics/MultiAnalyticsClient.ts
+++ b/src/ui/Analytics/MultiAnalyticsClient.ts
@@ -5,10 +5,11 @@ import { IQueryResult } from '../../rest/QueryResult';
 import { ITopQueries } from '../../rest/TopQueries';
 import { IAPIAnalyticsEventResponse } from '../../rest/APIAnalyticsEventResponse';
 import * as _ from 'underscore';
+import { AnalyticsEndpoint } from '../../rest/AnalyticsEndpoint';
 
 export class MultiAnalyticsClient implements IAnalyticsClient {
   public isContextual = false;
-  public endpoint = _.first(this.analyticsClients).endpoint;
+  public endpoint: AnalyticsEndpoint = _.first(this.analyticsClients).endpoint;
 
   constructor(private analyticsClients: IAnalyticsClient[] = []) {}
 

--- a/src/ui/Analytics/MultiAnalyticsClient.ts
+++ b/src/ui/Analytics/MultiAnalyticsClient.ts
@@ -8,6 +8,7 @@ import * as _ from 'underscore';
 
 export class MultiAnalyticsClient implements IAnalyticsClient {
   public isContextual = false;
+  public endpoint = _.first(this.analyticsClients).endpoint;
 
   constructor(private analyticsClients: IAnalyticsClient[] = []) {}
 

--- a/src/ui/Analytics/NoopAnalyticsClient.ts
+++ b/src/ui/Analytics/NoopAnalyticsClient.ts
@@ -7,7 +7,7 @@ import { IStringMap } from '../../rest/GenericParam';
 
 export class NoopAnalyticsClient implements IAnalyticsClient {
   public isContextual: boolean = false;
-
+  public endpoint = null;
   private currentEventCause: string;
   private currentEventMeta: IStringMap<any>;
 

--- a/test/Test.ts
+++ b/test/Test.ts
@@ -492,3 +492,6 @@ SimpleFilterTest();
 
 import { DeviceUtilsTest } from './utils/DeviceUtilsTest';
 DeviceUtilsTest();
+
+import { AccessTokenTest } from './rest/AccessTokenTest';
+AccessTokenTest();

--- a/test/rest/AccessTokenTest.ts
+++ b/test/rest/AccessTokenTest.ts
@@ -23,13 +23,28 @@ export function AccessTokenTest() {
       done();
     });
 
-    it('should behave correctly when there is a renew function', async done => {
-      const renew = jasmine.createSpy('spy').and.returnValue(Promise.resolve('nuevo tokeno'));
-      token = new AccessToken('el accesso tokeno', renew as any);
-      const renewSuccessful = await token.doRenew();
-      expect(renew).toHaveBeenCalled();
-      expect(renewSuccessful).toBeTruthy();
-      done();
+    describe('with a valid renew function', () => {
+      let renew: jasmine.Spy;
+
+      beforeEach(() => {
+        renew = jasmine.createSpy('spy').and.returnValue(Promise.resolve('nuevo tokeno')) as any;
+        token = new AccessToken('el accesso tokeno', renew as any);
+      });
+
+      it('should return a success on renew', async done => {
+        const renewSuccessful = await token.doRenew();
+        expect(renew).toHaveBeenCalled();
+        expect(renewSuccessful).toBeTruthy();
+        done();
+      });
+
+      it('should call subscribers', async done => {
+        const subscriber = jasmine.createSpy('subscriber');
+        token.afterRenew(subscriber);
+        await token.doRenew();
+        expect(subscriber).toHaveBeenCalledWith('nuevo tokeno');
+        done();
+      });
     });
 
     describe('with an error callback on renew', () => {

--- a/test/rest/AccessTokenTest.ts
+++ b/test/rest/AccessTokenTest.ts
@@ -17,7 +17,7 @@ export function AccessTokenTest() {
       expect(token.isExpired({ statusCode: 500 })).toBeFalsy();
     });
 
-    it('should behave correctly if there is no renew function', async done => {
+    it('should properly return that the renew was not successful if there is no renew function', async done => {
       const renewSuccessful = await token.doRenew();
       expect(renewSuccessful).toBeFalsy();
       done();
@@ -40,7 +40,7 @@ export function AccessTokenTest() {
 
       it('should call subscribers', async done => {
         const subscriber = jasmine.createSpy('subscriber');
-        token.afterRenew(subscriber);
+        token.subscribeToRenewal(subscriber);
         await token.doRenew();
         expect(subscriber).toHaveBeenCalledWith('nuevo tokeno');
         done();

--- a/test/ui/AnalyticsEndpointTest.ts
+++ b/test/ui/AnalyticsEndpointTest.ts
@@ -132,15 +132,19 @@ export function AnalyticsEndpointTest() {
           return e;
         })
         .then(() => done());
-      expect(jasmine.Ajax.requests.mostRecent().url).toContain('/topQueries');
-      expect(jasmine.Ajax.requests.mostRecent().url).toContain('org=organization');
-      expect(jasmine.Ajax.requests.mostRecent().url).toContain('access_token=token');
-      expect(jasmine.Ajax.requests.mostRecent().url).toContain('pageSize=10');
-      expect(jasmine.Ajax.requests.mostRecent().url).toContain('queryText=foobar');
 
-      expect(jasmine.Ajax.requests.mostRecent().method).toBe('GET');
+      const mostRecentRequest = jasmine.Ajax.requests.mostRecent();
+      const mostRecentUrl = mostRecentRequest.url;
 
-      jasmine.Ajax.requests.mostRecent().respondWith({
+      expect(mostRecentUrl).toContain('/topQueries');
+      expect(mostRecentUrl).toContain('org=organization');
+      expect(mostRecentUrl).toContain('access_token=token');
+      expect(mostRecentUrl).toContain('pageSize=10');
+      expect(mostRecentUrl).toContain('queryText=foobar');
+
+      expect(mostRecentRequest.method).toBe('GET');
+
+      mostRecentRequest.respondWith({
         status: 200,
         response: ['foo', 'bar', 'foobar']
       });

--- a/test/ui/AnalyticsEndpointTest.ts
+++ b/test/ui/AnalyticsEndpointTest.ts
@@ -3,6 +3,7 @@ import { IErrorResponse } from '../../src/rest/EndpointCaller';
 import { FakeResults } from '../Fake';
 import { IAPIAnalyticsSearchEventsResponse } from '../../src/rest/APIAnalyticsSearchEventsResponse';
 import { IAPIAnalyticsEventResponse } from '../../src/rest/APIAnalyticsEventResponse';
+import { AccessToken } from '../../src/rest/AccessToken';
 export function AnalyticsEndpointTest() {
   function buildUrl(endpoint: AnalyticsEndpoint, path: string) {
     return endpoint.options.serviceUrl + '/rest/' + AnalyticsEndpoint.DEFAULT_ANALYTICS_VERSION + path;
@@ -14,7 +15,7 @@ export function AnalyticsEndpointTest() {
     beforeEach(() => {
       endpoint = new AnalyticsEndpoint({
         serviceUrl: 'foo.com',
-        token: 'token',
+        accessToken: new AccessToken('token'),
         organization: 'organization'
       });
       jasmine.Ajax.install();
@@ -131,11 +132,14 @@ export function AnalyticsEndpointTest() {
           return e;
         })
         .then(() => done());
+      expect(jasmine.Ajax.requests.mostRecent().url).toContain('/topQueries');
+      expect(jasmine.Ajax.requests.mostRecent().url).toContain('org=organization');
+      expect(jasmine.Ajax.requests.mostRecent().url).toContain('access_token=token');
+      expect(jasmine.Ajax.requests.mostRecent().url).toContain('pageSize=10');
+      expect(jasmine.Ajax.requests.mostRecent().url).toContain('queryText=foobar');
 
-      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
-        buildUrl(endpoint, '/stats/topQueries?org=organization&access_token=token&pageSize=10&queryText=foobar')
-      );
       expect(jasmine.Ajax.requests.mostRecent().method).toBe('GET');
+
       jasmine.Ajax.requests.mostRecent().respondWith({
         status: 200,
         response: ['foo', 'bar', 'foobar']

--- a/test/ui/AnalyticsTest.ts
+++ b/test/ui/AnalyticsTest.ts
@@ -10,6 +10,18 @@ import { MultiAnalyticsClient } from '../../src/ui/Analytics/MultiAnalyticsClien
 
 export function AnalyticsTest() {
   describe('Analytics', () => {
+    beforeEach(() => {
+      SearchEndpoint.endpoints['default'] = new SearchEndpoint({
+        accessToken: 'some token',
+        queryStringArguments: { workgroup: 'organization' },
+        restUri: 'some/uri'
+      });
+    });
+
+    afterEach(() => {
+      SearchEndpoint.endpoints['default'] = null;
+    });
+
     describe('with default setup', () => {
       let test: Mock.IBasicComponentSetup<Analytics>;
       beforeEach(() => {
@@ -21,7 +33,6 @@ export function AnalyticsTest() {
         test = Mock.basicComponentSetup<Analytics>(Analytics);
       });
       afterEach(() => {
-        SearchEndpoint.endpoints['default'] = null;
         test = null;
       });
 

--- a/test/ui/PendingSearchAsYouTypeSearchEventTest.ts
+++ b/test/ui/PendingSearchAsYouTypeSearchEventTest.ts
@@ -7,6 +7,7 @@ import { QueryEvents } from '../../src/events/QueryEvents';
 import { $$ } from '../../src/utils/Dom';
 import { QueryBuilder } from '../../src/ui/Base/QueryBuilder';
 import { Defer } from '../../src/MiscModules';
+import { AccessToken } from '../../src/rest/AccessToken';
 
 export function PendingSearchAsYouTypeSearchEventTest() {
   describe('PendingSearchAsYouTypeSearchEvent', () => {
@@ -19,7 +20,7 @@ export function PendingSearchAsYouTypeSearchEventTest() {
       root = document.createElement('div');
       searchInterface = new SearchInterface(root);
       endpoint = new AnalyticsEndpoint({
-        token: 'token',
+        accessToken: new AccessToken('token'),
         serviceUrl: 'serviceUrl',
         organization: 'organization'
       });

--- a/test/ui/SearchInterfaceTest.ts
+++ b/test/ui/SearchInterfaceTest.ts
@@ -67,13 +67,15 @@ export function SearchInterfaceTest() {
     });
 
     describe('usage analytics', () => {
-      let searchInterfaceDiv: HTMLDivElement;
-      let analyticsDiv: HTMLDivElement;
+      let searchInterfaceDiv: HTMLElement;
+      let analyticsDiv: HTMLElement;
 
       beforeEach(() => {
-        searchInterfaceDiv = document.createElement('div');
-        analyticsDiv = document.createElement('div');
-        analyticsDiv.className = 'CoveoAnalytics';
+        searchInterfaceDiv = $$('div').el;
+        analyticsDiv = $$('div', {
+          className: 'CoveoAnalytics',
+          'data-token': 'el-tokeno'
+        }).el;
       });
 
       afterEach(() => {
@@ -83,6 +85,7 @@ export function SearchInterfaceTest() {
 
       it('should initialize if found inside the root', () => {
         searchInterfaceDiv.appendChild(analyticsDiv);
+        analyticsDiv.setAttribute('data-token', 'el-tokeno');
         const searchInterface = new SearchInterface(searchInterfaceDiv);
         expect(searchInterface.usageAnalytics instanceof Coveo['LiveAnalyticsClient']).toBe(true);
       });


### PR DESCRIPTION
Search Endpoint + Analytics are both using search token by default to authenticate. Search token expires after 12 hours. There was a renewal mechanism in place for search endpoint which was not properly propagated to the analytics components.

This PR refactor "access token" options, which were plain string, to an actual AccessToken class which encapsulate the renewal mechanism a bit more, as well as providing way to subscribe to renewal events.

https://coveord.atlassian.net/browse/JSUI-1945

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)