### PR TITLE
Added note in `childFiled` and `parentField` options

### DIFF
--- a/src/ui/Folding/Folding.ts
+++ b/src/ui/Folding/Folding.ts
@@ -85,12 +85,20 @@ export class Folding extends Component {
     /**
      * Specifies the field that determines whether a certain result is a child of another top result.
      *
+     * **Note:**
+     * > In the index, the values of the corresponding field must contain alphanumerical characters only. Using a
+     * > `childField` whose values contain non-indexable characters (such as underscores) will fail.
+     *
      * Default value is `@topparentid`.
      */
     childField: ComponentOptions.buildFieldOption({ defaultValue: '@topparentid' }),
 
     /**
      * Specifies the field that determines whether a certain result is a top result containing other child results.
+     *
+     * **Note:**
+     * > In the index, the values of the corresponding field must contain alphanumerical characters only. Using a
+     * > `parentField` whose values contain non-indexable characters (such as underscores) will fail.
      *
      * Default value is `@containsattachment`.
      */

--- a/src/ui/Folding/Folding.ts
+++ b/src/ui/Folding/Folding.ts
@@ -87,7 +87,7 @@ export class Folding extends Component {
      *
      * **Note:**
      * > In the index, the values of the corresponding field must contain alphanumerical characters only. Using a
-     * > `childField` whose values contain non-indexable characters (such as underscores) will fail.
+     * > `childField` whose values contain non-indexable characters (such as underscores) will make folding fail.
      *
      * Default value is `@topparentid`.
      */
@@ -98,7 +98,7 @@ export class Folding extends Component {
      *
      * **Note:**
      * > In the index, the values of the corresponding field must contain alphanumerical characters only. Using a
-     * > `parentField` whose values contain non-indexable characters (such as underscores) will fail.
+     * > `parentField` whose values contain non-indexable characters (such as underscores) will make folding fail.
      *
      * Default value is `@containsattachment`.
      */


### PR DESCRIPTION
To indicate that the values of those fields in the index should only contain alphanumerical characters.





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)