### PR TITLE
Put back export of TemplateHelpers

### DIFF
--- a/src/TemplatesModules.ts
+++ b/src/TemplatesModules.ts
@@ -1,3 +1,4 @@
+export { TemplateHelpers } from './ui/Templates/TemplateHelpers';
 export { TemplateCache } from './ui/Templates/TemplateCache';
 export { HtmlTemplate } from './ui/Templates/HtmlTemplate';
 export { UnderscoreTemplate } from './ui/Templates/UnderscoreTemplate';


### PR DESCRIPTION
Breaks *at runtime* if using 
```
import { TemplateHelpers } from "coveo-search-ui"; 
TemplateHelpers.anything()
```
while TypeScript is still compiling.

Change was done here: https://github.com/coveo/search-ui/pull/707/files#diff-17d3fb7a4319ae62917f4161770e4023L1

And breaks starting with 2.3826.0

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

JSUI-1980