### PR TITLE
properly prevent model events from bubbling from the Recommendation c…

### DIFF
--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -286,10 +286,10 @@ export class Recommendation extends SearchInterface implements IComponentBinding
     // add a mechanism that waits for the full search interface to be correctly initialized
     // then, set the needed values on the component options model.
     let searchInterfaceComponent = <SearchInterface>get(this.options.mainSearchInterface, SearchInterface);
-    let alreadyInitialized = searchInterfaceComponent != null;
+    const alreadyInitialized = searchInterfaceComponent != null;
 
-    let onceInitialized = () => {
-      let mainSearchInterfaceOptionsModel = <ComponentOptionsModel>searchInterfaceComponent.getBindings().componentOptionsModel;
+    const onceInitialized = () => {
+      const mainSearchInterfaceOptionsModel = <ComponentOptionsModel>searchInterfaceComponent.getBindings().componentOptionsModel;
       this.componentOptionsModel.setMultiple(mainSearchInterfaceOptionsModel.getAttributes());
       $$(this.options.mainSearchInterface).on(this.componentOptionsModel.getEventName(MODEL_EVENTS.ALL), () => {
         this.componentOptionsModel.setMultiple(mainSearchInterfaceOptionsModel.getAttributes());
@@ -387,16 +387,19 @@ export class Recommendation extends SearchInterface implements IComponentBinding
       return event;
     }
   ) {
-    for (let event in eventType) {
+    for (const event in eventType) {
       $$(this.root).on(eventName(event), (e: Event) => e.stopPropagation());
     }
   }
 
   private getAllModelEvents() {
-    let events = {};
+    const events = {};
+    const queryStateModel = this.getBindings().queryStateModel;
     _.each(_.values(Model.eventTypes), event => {
+      const eventName = queryStateModel.getEventName(event);
+      events[eventName] = eventName;
       _.each(_.values(QUERY_STATE_ATTRIBUTES), attribute => {
-        let eventName = this.getBindings().queryStateModel.getEventName(event + attribute);
+        const eventName = this.queryStateModel.getEventName(event + attribute);
         events[eventName] = eventName;
       });
     });

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -79,13 +79,20 @@ export function RecommendationTest() {
       beforeEach(() => {
         mainSearchInterface.cmp.element.appendChild(test.cmp.element);
       });
-      it('should prevent model events with atttributes from bubbling', () => {
-        const mainSearchInterfaceContainer = $$('div');
-        const eventName = test.cmp.getBindings().queryStateModel.getEventName(Model.eventTypes.change + QUERY_STATE_ATTRIBUTES.Q);
+
+      function addListenEventSpy(attributeName) {
         const spy = jasmine.createSpy('spy');
+        const eventName = test.cmp.getBindings().queryStateModel.getEventName(Model.eventTypes.change + attributeName);
+        const mainSearchInterfaceContainer = $$('div');
         mainSearchInterfaceContainer.on(eventName, () => {
           spy();
         });
+        return { spy, eventName };
+      }
+
+      it('should prevent model events with atttributes from bubbling', () => {
+        const attributeName = QUERY_STATE_ATTRIBUTES.Q;
+        const { spy, eventName } = addListenEventSpy(attributeName);
 
         $$(test.cmp.element).trigger(eventName);
 
@@ -93,12 +100,7 @@ export function RecommendationTest() {
       });
 
       it('should prevent model events without attributes from bubbling', () => {
-        const mainSearchInterfaceContainer = $$('div', mainSearchInterface.cmp.element);
-        const eventName = test.cmp.getBindings().queryStateModel.getEventName(Model.eventTypes.change);
-        const spy = jasmine.createSpy('spy');
-        mainSearchInterfaceContainer.on(eventName, () => {
-          spy();
-        });
+        const { spy, eventName } = addListenEventSpy('');
 
         $$(test.cmp.element).trigger(eventName);
 

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -7,6 +7,9 @@ import { Simulate } from '../Simulate';
 import { QueryBuilder } from '../../src/ui/Base/QueryBuilder';
 import { FakeResults } from '../Fake';
 import _ = require('underscore');
+import { Model } from '../../src/models/Model';
+import { QUERY_STATE_ATTRIBUTES } from '../../src/models/QueryStateModel';
+import { $$ } from '../../src/utils/Dom';
 
 export function RecommendationTest() {
   describe('Recommendation', () => {
@@ -22,7 +25,7 @@ export function RecommendationTest() {
     };
 
     beforeEach(() => {
-      mainSearchInterface = Mock.basicSearchInterfaceSetup(SearchInterface);
+      mainSearchInterface = Mock.basicSearchInterfaceSetup<SearchInterface>(SearchInterface);
       options = {
         mainSearchInterface: mainSearchInterface.env.root,
         userContext: {
@@ -70,6 +73,37 @@ export function RecommendationTest() {
       expect(mainSearchInterface.cmp.componentOptionsModel.getAttributes).toHaveBeenCalled();
       mainSearchInterface.cmp.componentOptionsModel.setMultiple({ resultLink: { alwaysOpenInNewWindow: true } });
       expect(mainSearchInterface.cmp.componentOptionsModel.getAttributes).toHaveBeenCalled();
+    });
+
+    describe('when propaging events', () => {
+      beforeEach(() => {
+        mainSearchInterface.cmp.element.appendChild(test.cmp.element);
+      });
+      it('should prevent model events with atttributes from bubbling', () => {
+        const mainSearchInterfaceContainer = $$('div');
+        const eventName = test.cmp.getBindings().queryStateModel.getEventName(Model.eventTypes.change + QUERY_STATE_ATTRIBUTES.Q);
+        const spy = jasmine.createSpy('spy');
+        mainSearchInterfaceContainer.on(eventName, () => {
+          spy();
+        });
+
+        $$(test.cmp.element).trigger(eventName);
+
+        expect(spy).not.toHaveBeenCalled();
+      });
+
+      it('should prevent model events without attributes from bubbling', () => {
+        const mainSearchInterfaceContainer = $$('div', mainSearchInterface.cmp.element);
+        const eventName = test.cmp.getBindings().queryStateModel.getEventName(Model.eventTypes.change);
+        const spy = jasmine.createSpy('spy');
+        mainSearchInterfaceContainer.on(eventName, () => {
+          spy();
+        });
+
+        $$(test.cmp.element).trigger(eventName);
+
+        expect(spy).not.toHaveBeenCalled();
+      });
     });
 
     describe('when the mainInterface triggered a query', () => {


### PR DESCRIPTION
This caused a search interface with history enabled and a recommendation component to reset the hash to default values on load.

Not all model events name are followed by the attribute name.
https://coveord.atlassian.net/browse/JSUI-1994





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)