### PR TITLE
less specific selector for after initialization display:inherit

### DIFF
--- a/sass/_FullSearchGrid.scss
+++ b/sass/_FullSearchGrid.scss
@@ -20,12 +20,6 @@ $page-width: 1000px;
       }
     }
   }
-  &.coveo-after-initialization {
-    > * {
-      display: inherit;
-      visibility: inherit;
-    }
-  }
   .coveo-search-section {
     max-width: $medium_screen_width + unquote('px');
     margin: 54px auto 47px auto;
@@ -88,6 +82,13 @@ $page-width: 1000px;
     .CoveoResultsPerPage {
       display: none;
     }
+  }
+}
+
+.coveo-after-initialization {
+  > * {
+    display: inherit;
+    visibility: inherit;
   }
 }
 


### PR DESCRIPTION
the SimpleFilter background had `display: inherit` so it covered the entire search page.

https://coveord.atlassian.net/browse/JSUI-1995





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)