### PR TITLE
correctly hide recommendation component

### DIFF
--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -201,7 +201,6 @@ export class Recommendation extends SearchInterface implements IComponentBinding
   public historyStore: CoveoAnalytics.HistoryStore;
 
   private mainInterfaceQuery: IQuerySuccessEventArgs;
-  private displayStyle: string;
 
   /**
    * Creates a new Recommendation component.
@@ -213,6 +212,7 @@ export class Recommendation extends SearchInterface implements IComponentBinding
    */
   constructor(public element: HTMLElement, public options: IRecommendationOptions = {}, public analyticsOptions = {}, _window = window) {
     super(element, ComponentOptions.initComponentOptions(element, Recommendation, options), analyticsOptions, _window);
+    this.element.style.display = '';
     if (!this.options.id) {
       this.generateDefaultId();
     }
@@ -236,8 +236,6 @@ export class Recommendation extends SearchInterface implements IComponentBinding
       // When the recommendation component is "standalone", we add additional safeguard against bad config.
       this.ensureCurrentPageViewExistsInStore();
     }
-
-    this.displayStyle = this.element.style.display;
     ResponsiveRecommendation.init(this.root, this, options);
   }
 
@@ -256,11 +254,11 @@ export class Recommendation extends SearchInterface implements IComponentBinding
   }
 
   public hide(): void {
-    $$(this.element).hide();
+    $$(this.element).addClass('coveo-hidden');
   }
 
   public show(): void {
-    this.element.style.display = this.displayStyle;
+    $$(this.element).removeClass('coveo-hidden');
   }
 
   private ensureCurrentPageViewExistsInStore() {

--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -139,7 +139,7 @@ export class Recommendation extends SearchInterface implements IComponentBinding
     /**
      * Specifies whether to hide the Recommendations component if no result or recommendation is available.
      *
-     * Default value is `false`.
+     * Default value is `true`.
      */
     hideIfNoResults: ComponentOptions.buildBooleanOption({ defaultValue: true }),
     autoTriggerQuery: ComponentOptions.buildBooleanOption({
@@ -201,6 +201,7 @@ export class Recommendation extends SearchInterface implements IComponentBinding
   public historyStore: CoveoAnalytics.HistoryStore;
 
   private mainInterfaceQuery: IQuerySuccessEventArgs;
+  private displayStyle: string;
 
   /**
    * Creates a new Recommendation component.
@@ -235,6 +236,8 @@ export class Recommendation extends SearchInterface implements IComponentBinding
       // When the recommendation component is "standalone", we add additional safeguard against bad config.
       this.ensureCurrentPageViewExistsInStore();
     }
+
+    this.displayStyle = this.element.style.display;
     ResponsiveRecommendation.init(this.root, this, options);
   }
 
@@ -253,11 +256,11 @@ export class Recommendation extends SearchInterface implements IComponentBinding
   }
 
   public hide(): void {
-    $$(this.element).addClass('coveo-hidden');
+    $$(this.element).hide();
   }
 
   public show(): void {
-    $$(this.element).removeClass('coveo-hidden');
+    this.element.style.display = this.displayStyle;
   }
 
   private ensureCurrentPageViewExistsInStore() {

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -76,13 +76,17 @@ export function RecommendationTest() {
     });
 
     describe('when propaging events', () => {
+      let recommendation: Recommendation;
       beforeEach(() => {
         mainSearchInterface.cmp.element.appendChild(test.cmp.element);
+        const div = $$('div').el;
+        new Mock.MockEnvironmentBuilder().withRoot(div);
+        recommendation = new Recommendation(div, options);
       });
 
       function addListenEventSpy(attributeName) {
         const spy = jasmine.createSpy('spy');
-        const eventName = test.cmp.getBindings().queryStateModel.getEventName(Model.eventTypes.change + attributeName);
+        const eventName = recommendation.getBindings().queryStateModel.getEventName(Model.eventTypes.change + attributeName);
         const mainSearchInterfaceContainer = $$('div');
         mainSearchInterfaceContainer.on(eventName, () => {
           spy();

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -21,7 +21,7 @@ export function RecommendationTest() {
     let store: CoveoAnalytics.HistoryStore;
 
     const isHidden = (test: Mock.IBasicComponentSetup<Recommendation>): boolean => {
-      return $$(test.cmp.element).css('display') == 'none';
+      return $$(test.cmp.element).hasClass('coveo-hidden');
     };
 
     beforeEach(() => {

--- a/test/ui/RecommendationTest.ts
+++ b/test/ui/RecommendationTest.ts
@@ -21,7 +21,7 @@ export function RecommendationTest() {
     let store: CoveoAnalytics.HistoryStore;
 
     const isHidden = (test: Mock.IBasicComponentSetup<Recommendation>): boolean => {
-      return test.cmp.element.classList.contains('coveo-hidden');
+      return $$(test.cmp.element).css('display') == 'none';
     };
 
     beforeEach(() => {


### PR DESCRIPTION
The hide-if-no-results option on the recommendation component broke because of this change https://github.com/coveo/search-ui/pull/741/files#diff-1fd33db2e97b1b3b50602c19e35c19efR490.

The inline style was override the `coveo-hidden` class so I went back to something similar to the old behaviour we had when hiding/showing the recommendation component.

https://coveord.atlassian.net/browse/JSUI-2011





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)