### PR TITLE
Added a check to getAttributeFromAlias to not check without an alias.

### DIFF
--- a/src/ui/Base/ComponentOptions.ts
+++ b/src/ui/Base/ComponentOptions.ts
@@ -909,8 +909,11 @@ export class ComponentOptions {
         }
       });
       return attributeFound;
+    }
+    if (option.alias) {
+      return element.getAttribute(ComponentOptions.attrNameFromName(option.alias));
     } else {
-      return element.getAttribute(ComponentOptions.attrNameFromName(<string>option.alias));
+      return undefined;
     }
   }
 }


### PR DESCRIPTION
If the `option.alias` doesn't exist, simply return `undefined` this is the normal behavior of doing a `getAttribute()` with an `undefined` or `null` parameter according to the w3 specification and behavior in browser.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)