### PR TITLE
Add handler to close on document click for Facet Settings

### DIFF
--- a/src/ui/Facet/FacetSettings.ts
+++ b/src/ui/Facet/FacetSettings.ts
@@ -30,13 +30,13 @@ export interface IFacetState {
  */
 export class FacetSettings extends FacetSort {
   public loadedFromSettings: { [attribute: string]: any };
-  public settingsPopup: HTMLElement;
+  private settingsPopup: HTMLElement;
 
   private facetStateLocalStorage: LocalStorageUtils<IFacetState>;
   private includedStateAttribute: string;
   private excludedStateAttribute: string;
   private operatorStateAttribute: string;
-  public settingsButton: HTMLElement;
+  private settingsButton: HTMLElement;
   private directionSection: HTMLElement[];
   private saveStateSection: HTMLElement;
   private clearStateSection: HTMLElement;
@@ -447,7 +447,7 @@ export class FacetSettings extends FacetSort {
     let closeTimeout: number;
     $$(this.settingsButton).on('click', (e: Event) => this.handleClickSettingsButtons(e, sortSection));
 
-    const mouseLeave = e => {
+    const mouseLeave = () => {
       closeTimeout = window.setTimeout(() => {
         this.close();
       }, 300);

--- a/test/ui/FacetSettingsTest.ts
+++ b/test/ui/FacetSettingsTest.ts
@@ -119,7 +119,7 @@ export function FacetSettingsTest() {
       facetSettings = new FacetSettings(['score', 'alphaascending', 'alphadescending'], facet);
       facetSettings.build();
       facetSettings.open();
-      let ascendingSection = $$(facetSettings.settingsPopup).find('.coveo-facet-settings-item[data-direction="ascending"]');
+      const ascendingSection = $$(facetSettings.settingsPopup).find('.coveo-facet-settings-item[data-direction="ascending"]');
       expect($$(ascendingSection).hasClass('coveo-selected')).toBe(false);
       $$(facetSettings.getSortItem('alphaascending')).trigger('click');
       expect($$(ascendingSection).hasClass('coveo-selected')).toBe(true);
@@ -129,10 +129,39 @@ export function FacetSettingsTest() {
       facetSettings = new FacetSettings(['alphaascending', 'alphadescending', 'score'], facet);
       facetSettings.build();
       facetSettings.open();
-      let ascendingSection = $$(facetSettings.settingsPopup).find('.coveo-facet-settings-item[data-direction="ascending"]');
+      const ascendingSection = $$(facetSettings.settingsPopup).find('.coveo-facet-settings-item[data-direction="ascending"]');
       expect($$(ascendingSection).hasClass('coveo-selected')).toBe(true);
       $$(facetSettings.getSortItem('score')).trigger('click');
       expect($$(ascendingSection).hasClass('coveo-selected')).toBe(false);
+    });
+
+    describe('when closing the popup', () => {
+      beforeEach(() => {
+        facetSettings = new FacetSettings(['foo', 'bar'], facet);
+        spyOn(facetSettings, 'close');
+        facetSettings.build();
+        facetSettings.open();
+      });
+
+      it('should close the after a delay on mouseleave', done => {
+        $$(facetSettings.button).trigger('mouseleave');
+        setTimeout(() => {
+          expect(facetSettings.close).toHaveBeenCalled();
+          done();
+        }, 400);
+      });
+
+      it('should not close if there is a mouseenter following a mouseleave', done => {
+        $$(facetSettings.button).trigger('mouseleave');
+        setTimeout(() => {
+          $$(facetSettings.button).trigger('mouseenter');
+        }, 50);
+
+        setTimeout(() => {
+          expect(facetSettings.close).not.toHaveBeenCalled();
+          done();
+        }, 400);
+      });
     });
   });
 }


### PR DESCRIPTION
Since on mobile, mouseleave and mouseenter do not exist.

I did not add a test for document on click, because it's very hard to test for.

https://coveord.atlassian.net/browse/JSUI-1942





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)