### PR TITLE
Handle query pipeline overwriting results per page

### DIFF
--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -110,8 +110,8 @@ export class ResultsPerPage extends Component {
       this.options.choicesDisplayed.indexOf(resultsPerPage) != -1,
       'The specified number of results is not available in the options.'
     );
+    this.searchInterface.resultsPerPage = resultsPerPage;
     this.currentResultsPerPage = resultsPerPage;
-    this.queryController.options.resultsPerPage = this.currentResultsPerPage;
     this.usageAnalytics.logCustomEvent<IAnalyticsResultsPerPageMeta>(
       analyticCause,
       { currentResultsPerPage: this.currentResultsPerPage },
@@ -193,6 +193,14 @@ export class ResultsPerPage extends Component {
   }
 
   private handleQuerySuccess(data: IQuerySuccessEventArgs) {
+    if (this.searchInterface.isResultsPerPageModifiedByPipeline) {
+      this.logger.info('Results per page was modified by backend code (query pipeline). ResultsPerPage component will be hidden', this);
+      this.reset();
+      this.currentResultsPerPage = this.getInitialChoice();
+      this.searchInterface.resultsPerPage = this.currentResultsPerPage;
+      return;
+    }
+
     if (data.results.results.length != 0) {
       this.reset();
       this.render();

--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -414,9 +414,6 @@ export class SearchInterface extends RootComponent implements IComponentBindings
   };
 
   public static SMALL_INTERFACE_CLASS_NAME = 'coveo-small-search-interface';
-
-  private attachedComponents: { [type: string]: BaseComponent[] };
-
   public root: HTMLElement;
   public queryStateModel: QueryStateModel;
   public componentStateModel: ComponentStateModel;
@@ -429,6 +426,10 @@ export class SearchInterface extends RootComponent implements IComponentBindings
    * This is useful, amongst other, for {@link Facet}, {@link Tab} and {@link ResultList}
    */
   public responsiveComponents: ResponsiveComponents;
+  public isResultsPerPageModifiedByPipeline = false;
+
+  private attachedComponents: { [type: string]: BaseComponent[] };
+  private queryPipelineConfigurationForResultsPerPage: number;
 
   /**
    * Creates a new SearchInterface. Initialize various singletons for the interface (e.g., usage analytics, query
@@ -490,6 +491,23 @@ export class SearchInterface extends RootComponent implements IComponentBindings
     this.element.style.display = element.style.display || 'block';
     this.setupDebugInfo();
     this.responsiveComponents = new ResponsiveComponents();
+  }
+
+  public set resultsPerPage(resultsPerPage: number) {
+    this.options.resultsPerPage = this.queryController.options.resultsPerPage = resultsPerPage;
+  }
+
+  public get resultsPerPage() {
+    if (this.queryPipelineConfigurationForResultsPerPage != null && this.queryPipelineConfigurationForResultsPerPage != 0) {
+      return this.queryPipelineConfigurationForResultsPerPage;
+    }
+    if (this.queryController.options.resultsPerPage != null && this.queryController.options.resultsPerPage != 0) {
+      return this.queryController.options.resultsPerPage;
+    }
+    // Things would get weird if somehow the number of results per page was set to 0 or not available.
+    // Specially for the pager component. As such, we try to cover that corner case.
+    this.logger.warn('Results per page is incoherent in the search interface.', this);
+    return 10;
   }
 
   /**
@@ -815,9 +833,28 @@ export class SearchInterface extends RootComponent implements IComponentBindings
   private handleQuerySuccess(data: IQuerySuccessEventArgs) {
     const noResults = data.results.results.length == 0;
     this.toggleSectionState('coveo-no-results', noResults);
+    this.handlePossiblyModifiedNumberOfResultsInQueryPipeline(data);
     const resultsHeader = $$(this.element).find('.coveo-results-header');
     if (resultsHeader) {
       $$(resultsHeader).removeClass('coveo-query-error');
+    }
+  }
+
+  private handlePossiblyModifiedNumberOfResultsInQueryPipeline(data: IQuerySuccessEventArgs) {
+    if (!data || !data.query || !data.results) {
+      return;
+    }
+
+    const numberOfRequestedResults = data.query.numberOfResults;
+    const numberOfResultsActuallyReturned = data.results.results.length;
+    const moreResultsAvailable = data.results.totalCountFiltered > numberOfResultsActuallyReturned;
+
+    if (numberOfRequestedResults != numberOfResultsActuallyReturned && moreResultsAvailable) {
+      this.isResultsPerPageModifiedByPipeline = true;
+      this.queryPipelineConfigurationForResultsPerPage = numberOfResultsActuallyReturned;
+    } else {
+      this.isResultsPerPageModifiedByPipeline = false;
+      this.queryPipelineConfigurationForResultsPerPage = null;
     }
   }
 

--- a/test/MockEnvironment.ts
+++ b/test/MockEnvironment.ts
@@ -218,6 +218,7 @@ export function mockSearchInterface(): SearchInterface {
   m.options = {};
   m.options.originalOptionsObject = {};
   m.responsiveComponents = mockResponsiveComponents();
+  m.resultsPerPage = 10;
   return m;
 }
 

--- a/test/ui/ResultsPerPageTest.ts
+++ b/test/ui/ResultsPerPageTest.ts
@@ -7,26 +7,64 @@ import { FakeResults } from '../Fake';
 import { $$ } from '../../src/utils/Dom';
 
 export function ResultsPerPageTest() {
-  describe('ResultsPerPage', function() {
+  describe('ResultsPerPage', () => {
     let test: Mock.IBasicComponentSetup<ResultsPerPage>;
 
-    beforeEach(function() {
+    beforeEach(() => {
       test = Mock.basicComponentSetup<ResultsPerPage>(ResultsPerPage);
       test.env.queryController.options = {};
       test.env.queryController.options.resultsPerPage = 10;
     });
 
-    afterEach(function() {
+    afterEach(() => {
       test = null;
     });
 
-    it('should trigger a query when the number of results per page changes', function() {
+    it('should trigger a query when the number of results per page changes', () => {
       test.cmp.setResultsPerPage(50);
       expect(test.env.queryController.executeQuery).toHaveBeenCalled();
     });
 
-    describe('analytics', function() {
-      it('should log the proper event when changing the number of results per page', function() {
+    describe('should be able to activate and deactivate', () => {
+      const isActivated = (test: Mock.IBasicComponentSetup<ResultsPerPage>) => {
+        return $$(test.cmp.element).find('.coveo-results-per-page-no-results') == null;
+      };
+
+      it('if the results per page parameter is overwritten in the backend (query pipeline)', () => {
+        test.env.searchInterface.isResultsPerPageModifiedByPipeline = false;
+        Simulate.query(test.env);
+        expect(isActivated(test)).toBeTruthy();
+
+        test.env.searchInterface.isResultsPerPageModifiedByPipeline = true;
+        Simulate.query(test.env);
+        expect(isActivated(test)).toBeFalsy();
+      });
+
+      it('on query success and query error', () => {
+        Simulate.query(test.env);
+        expect(isActivated(test)).toBeTruthy();
+
+        Simulate.queryError(test.env);
+        expect(isActivated(test)).toBeFalsy();
+      });
+
+      it('when there are results and when there are no results', () => {
+        let results = FakeResults.createFakeResults(10);
+        Simulate.query(test.env, {
+          results
+        });
+        expect(isActivated(test)).toBeTruthy();
+
+        results = FakeResults.createFakeResults(0);
+        Simulate.query(test.env, {
+          results
+        });
+        expect(isActivated(test)).toBeFalsy();
+      });
+    });
+
+    describe('analytics', () => {
+      it('should log the proper event when changing the number of results per page', () => {
         test.cmp.setResultsPerPage(50);
         expect(test.env.usageAnalytics.logCustomEvent).toHaveBeenCalledWith(
           analyticsActionCauseList.pagerResize,
@@ -36,8 +74,8 @@ export function ResultsPerPageTest() {
       });
     });
 
-    describe('exposes options', function() {
-      it('choicesDisplayed allows to choose the number of results per page options', function() {
+    describe('exposes options', () => {
+      it('choicesDisplayed allows to choose the number of results per page options', () => {
         test = Mock.optionsComponentSetup<ResultsPerPage, IResultsPerPageOptions>(ResultsPerPage, {
           choicesDisplayed: [15, 25, 35, 75]
         });
@@ -48,7 +86,7 @@ export function ResultsPerPageTest() {
         expect(test.env.queryController.options.resultsPerPage).toBe(15);
       });
 
-      it('initialChoice allows to choose the first choice of the number of results per page options', function() {
+      it('initialChoice allows to choose the first choice of the number of results per page options', () => {
         test = Mock.optionsComponentSetup<ResultsPerPage, IResultsPerPageOptions>(ResultsPerPage, {
           initialChoice: 13,
           choicesDisplayed: [3, 5, 7, 13]
@@ -59,7 +97,7 @@ export function ResultsPerPageTest() {
         expect(test.env.queryController.options.resultsPerPage).toBe(13);
       });
 
-      it('initialChoice allows to be undefined to set the first of the choicesDisplayed as default', function() {
+      it('initialChoice allows to be undefined to set the first of the choicesDisplayed as default', () => {
         let firstChoice = 3;
         test = Mock.optionsComponentSetup<ResultsPerPage, IResultsPerPageOptions>(ResultsPerPage, {
           initialChoice: undefined,
@@ -71,7 +109,7 @@ export function ResultsPerPageTest() {
         expect(test.env.queryController.options.resultsPerPage).toBe(firstChoice);
       });
 
-      it('initialChoice set as a choice not displayed uses the first choice instead', function() {
+      it('initialChoice set as a choice not displayed uses the first choice instead', () => {
         let aChoiceNotDisplayed = 15;
         let firstChoice = 3;
         test = Mock.optionsComponentSetup<ResultsPerPage, IResultsPerPageOptions>(ResultsPerPage, {


### PR DESCRIPTION
Since it is possible to overwrite query parameters in the backend (query pipeline), pager/search interface/results per page component needs to adapt themselves properly.

https://coveord.atlassian.net/browse/JSUI-1974





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)