### PR TITLE
Cheat on arrow svg alignment for simple filter

### DIFF
--- a/sass/_SimpleFilter.scss
+++ b/sass/_SimpleFilter.scss
@@ -68,6 +68,7 @@
   color: $color-greyish-teal-blue;
   @include display(flex);
   @include justify-content(center);
+  @include align-items(center);
   overflow: hidden;
   width: inherit;
   pointer-events: none;
@@ -75,6 +76,11 @@
   @include user-select(none);
   white-space: nowrap;
   height: 20px;
+}
+
+.coveo-simplefilter-toggle-svg-container {
+  @include display(flex);
+  padding-top: 2px;
 }
 
 .coveo-simplefilter-circle {

--- a/src/ui/SimpleFilter/SimpleFilter.ts
+++ b/src/ui/SimpleFilter/SimpleFilter.ts
@@ -383,7 +383,7 @@ export class SimpleFilter extends Component {
   }
 
   private buildSvgToggleUpIcon(): HTMLElement {
-    let svgIcon = $$('span', null, SVGIcons.icons.arrowDown).el;
+    let svgIcon = $$('span', { className: 'coveo-simplefilter-toggle-svg-container' }, SVGIcons.icons.arrowDown).el;
     SVGDom.addClassToSVGInContainer(svgIcon, 'coveo-simplefilter-toggle-down-svg');
     return svgIcon;
   }


### PR DESCRIPTION
I added a sneaky 2 px padding, looks better visually since arrow + text is kinda weird looking when they are actually center aligned together.

https://coveord.atlassian.net/browse/JSUI-1988





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)