### PR TITLE
Add a dedicated initialization function for results element

### DIFF
--- a/src/ui/Backdrop/Backdrop.ts
+++ b/src/ui/Backdrop/Backdrop.ts
@@ -1,10 +1,9 @@
 import { Component } from '../Base/Component';
 import { ComponentOptions, IFieldOption } from '../Base/ComponentOptions';
 import { IComponentBindings } from '../Base/ComponentBindings';
-import { Initialization, IInitializationParameters } from '../Base/Initialization';
+import { Initialization } from '../Base/Initialization';
 import { IResultsComponentBindings } from '../Base/ResultsComponentBindings';
 import { IQueryResult } from '../../rest/QueryResult';
-import * as _ from 'underscore';
 import { Utils } from '../../utils/Utils';
 import { exportGlobally } from '../../GlobalExports';
 import { YouTubeThumbnail, IYouTubeThumbnailOptions } from '../YouTube/YouTubeThumbnail';
@@ -112,18 +111,7 @@ export class Backdrop extends Component {
     this.element.style.background = background;
     this.element.style.backgroundSize = 'cover';
 
-    // Initialize components inside
-    let initOptions = this.searchInterface.options.originalOptionsObject;
-    let resultComponentBindings: IResultsComponentBindings = _.extend({}, this.getBindings(), {
-      resultElement: element
-    });
-    let initParameters: IInitializationParameters = {
-      options: _.extend({}, { initOptions: { ResultLink: options } }, initOptions),
-      bindings: resultComponentBindings,
-      result: result
-    };
-    Initialization.automaticallyCreateComponentsInside(this.element, initParameters);
-
+    Initialization.automaticallyCreateComponentsInsideResult(element, result);
     this.configureSpecialBackdropActions();
   }
 

--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -395,7 +395,6 @@ export class Initialization {
   /**
    * Scan the element and all its children for known components. Initialize every known component found.
    *
-   * NB : This
    * @param element
    * @param initParameters
    * @param ignore

--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -19,6 +19,7 @@ import * as _ from 'underscore';
 import { IStringMap } from '../../rest/GenericParam';
 import { get, state } from './RegisteredNamedMethods';
 import { InitializationHelper } from './InitializationHelper';
+import { IResultsComponentBindings } from './ResultsComponentBindings';
 
 /**
  * Represent the initialization parameters required to init a new component.
@@ -369,7 +370,32 @@ export class Initialization {
   }
 
   /**
+   * Scan the result element and all its children for known components. Initialize every known result component found.
+   *
+   * See also : {@link Initialization.automaticallyCreateComponentsInside}.
+   * @param resultElement The root element to scan for known components
+   * @param result The result which needs to be passed to each result component constructor.
+   * @param optionsToInject A set of options to inject for the components found inside the resultElement. These options will be merged with any options passed during the "init" call of the search interface.
+   */
+  public static automaticallyCreateComponentsInsideResult(
+    resultElement: HTMLElement,
+    result: IQueryResult,
+    optionsToInject = {}
+  ): IInitResult {
+    const options = { ...{ initOptions: optionsToInject }, ...result.searchInterface.options.originalOptionsObject };
+    const bindings: IResultsComponentBindings = { ...result.searchInterface.getBindings(), resultElement };
+    const initParameters: IInitializationParameters = {
+      options,
+      bindings,
+      result
+    };
+    return Initialization.automaticallyCreateComponentsInside(resultElement, initParameters);
+  }
+
+  /**
    * Scan the element and all its children for known components. Initialize every known component found.
+   *
+   * NB : This
    * @param element
    * @param initParameters
    * @param ignore
@@ -701,11 +727,7 @@ export class LazyInitialization {
   public static buildErrorCallback(chunkName: string, resolve: Function) {
     return error => {
       LazyInitialization.logger.warn(
-        `Cannot load chunk for ${
-          chunkName
-        }. You may need to configure the paths of the resources using Coveo.configureResourceRoot. Current path is ${
-          __webpack_public_path__
-        }.`
+        `Cannot load chunk for ${chunkName}. You may need to configure the paths of the resources using Coveo.configureResourceRoot. Current path is ${__webpack_public_path__}.`
       );
       resolve(() => {});
     };

--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -3,7 +3,6 @@ import { TableTemplate } from '../Templates/TableTemplate';
 import { DefaultResultTemplate } from '../Templates/DefaultResultTemplate';
 import { Component } from '../Base/Component';
 import { IComponentBindings } from '../Base/ComponentBindings';
-import { IResultsComponentBindings } from '../Base/ResultsComponentBindings';
 import { ComponentOptions, IFieldOption } from '../Base/ComponentOptions';
 import { IQueryResult } from '../../rest/QueryResult';
 import { IQueryResults } from '../../rest/QueryResults';
@@ -21,7 +20,7 @@ import { QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
 import { QueryUtils } from '../../utils/QueryUtils';
 import { $$, Win, Doc } from '../../utils/Dom';
 import { analyticsActionCauseList, IAnalyticsNoMeta } from '../Analytics/AnalyticsActionListMeta';
-import { Initialization, IInitializationParameters, IInitResult } from '../Base/Initialization';
+import { Initialization, IInitResult } from '../Base/Initialization';
 import { Defer } from '../../misc/Defer';
 import { DeviceUtils } from '../../utils/DeviceUtils';
 import { ResultListEvents, IDisplayedNewResultEventArgs, IChangeLayoutEventArgs } from '../../events/ResultListEvents';
@@ -538,17 +537,7 @@ export class ResultList extends Component {
 
   protected autoCreateComponentsInsideResult(element: HTMLElement, result: IQueryResult): IInitResult {
     Assert.exists(element);
-
-    const initOptions = this.searchInterface.options.originalOptionsObject;
-    const resultComponentBindings: IResultsComponentBindings = _.extend({}, this.getBindings(), {
-      resultElement: element
-    });
-    const initParameters: IInitializationParameters = {
-      options: initOptions,
-      bindings: resultComponentBindings,
-      result: result
-    };
-    return Initialization.automaticallyCreateComponentsInside(element, initParameters);
+    return Initialization.automaticallyCreateComponentsInsideResult(element, result);
   }
 
   protected triggerNewResultDisplayed(result: IQueryResult, resultElement: HTMLElement) {

--- a/src/ui/YouTube/YouTubeThumbnail.ts
+++ b/src/ui/YouTube/YouTubeThumbnail.ts
@@ -3,11 +3,10 @@ import { ComponentOptions } from '../Base/ComponentOptions';
 import { IResultsComponentBindings } from '../Base/ResultsComponentBindings';
 import { IQueryResult } from '../../rest/QueryResult';
 import { ResultLink } from '../ResultLink/ResultLink';
-import { Initialization, IInitializationParameters } from '../Base/Initialization';
+import { Initialization } from '../Base/Initialization';
 import { DomUtils } from '../../utils/DomUtils';
 import { $$, Dom } from '../../utils/Dom';
 import { ModalBox as ModalBoxModule } from '../../ExternalModulesShim';
-import * as _ from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 import { get } from '../Base/RegisteredNamedMethods';
 import { SVGIcons } from '../../utils/SVGIcons';
@@ -111,22 +110,9 @@ export class YouTubeThumbnail extends Component {
 
     $$(this.element).append(this.resultLink.el);
 
-    if (this.options.embed) {
-      this.options = _.extend(this.options, {
-        onClick: () => this.openYoutubeIframe()
-      });
-    }
-
-    let initOptions = this.searchInterface.options.originalOptionsObject;
-    let resultComponentBindings: IResultsComponentBindings = _.extend({}, this.getBindings(), {
-      resultElement: element
+    Initialization.automaticallyCreateComponentsInsideResult(element, result, {
+      ResultLink: this.options.embed ? { onClick: () => this.openYoutubeIframe() } : null
     });
-    let initParameters: IInitializationParameters = {
-      options: _.extend({}, { initOptions: { ResultLink: options } }, initOptions),
-      bindings: resultComponentBindings,
-      result: result
-    };
-    Initialization.automaticallyCreateComponentsInside(element, initParameters);
   }
 
   /**

--- a/src/utils/DomUtils.ts
+++ b/src/utils/DomUtils.ts
@@ -8,6 +8,7 @@ import { SVGIcons } from './SVGIcons';
 import { load } from '../ui/Base/RegisteredNamedMethods';
 import { Logger } from '../misc/Logger';
 import { IComponentBindings } from '../ui/Base/ComponentBindings';
+import { Initialization } from '../Core';
 export class DomUtils {
   static getPopUpCloseButton(captionForClose: string, captionForReminder: string): string {
     let container = document.createElement('span');
@@ -109,7 +110,8 @@ export class DomUtils {
 
     load(toLoad)
       .then(() => {
-        new Coveo[toLoad](clickableLinkElement.el, undefined, bindings, resultForResultLink);
+        clickableLinkElement.addClass(`Coveo${toLoad}`);
+        return Initialization.automaticallyCreateComponentsInsideResult(clickableLinkElement.el, resultForResultLink);
       })
       .catch(err => {
         const logger = new Logger(this);

--- a/test/MockEnvironment.ts
+++ b/test/MockEnvironment.ts
@@ -107,6 +107,7 @@ export class MockEnvironmentBuilder {
     this.searchInterface.componentStateModel = this.componentStateModel;
     this.searchInterface.componentOptionsModel = this.componentOptionsModel;
     this.searchInterface.element = this.root;
+    this.searchInterface.getBindings = () => this.getBindings() as any;
 
     if (!this.searchEndpoint) {
       this.searchEndpoint = mockSearchEndpoint();
@@ -219,6 +220,9 @@ export function mockSearchInterface(): SearchInterface {
   m.options.originalOptionsObject = {};
   m.responsiveComponents = mockResponsiveComponents();
   m.resultsPerPage = 10;
+  m.getBindings = () => {
+    return new MockEnvironmentBuilder().build() as any;
+  };
   return m;
 }
 

--- a/test/ui/InitializationTest.ts
+++ b/test/ui/InitializationTest.ts
@@ -14,6 +14,9 @@ import { NoopComponent } from '../../src/ui/NoopComponent/NoopComponent';
 import { state } from '../../src/ui/Base/RegisteredNamedMethods';
 import { get } from '../../src/UIBaseModules';
 import { QueryController } from '../../src/controllers/QueryController';
+import { FakeResults } from '../Fake';
+import { IQueryResult } from '../../src/rest/QueryResult';
+import { ResultLink } from '../../src/ui/ResultLink/ResultLink';
 declare const $;
 
 export function InitializationTest() {
@@ -285,6 +288,31 @@ export function InitializationTest() {
       });
       expect(Component.get(queryBox) instanceof Querybox).toBe(true);
       expect(Component.get(queryBox) instanceof ResultList).toBe(false);
+    });
+
+    describe('when inside a result element', () => {
+      let result: IQueryResult;
+      let resultLink: HTMLElement;
+
+      beforeEach(() => {
+        result = FakeResults.createFakeResult();
+        result.searchInterface = new Mock.MockEnvironmentBuilder().build().searchInterface;
+        resultLink = $$('a', { className: 'CoveoResultLink' }).el;
+      });
+
+      it('allow to automaticallyCreateComponentInsideResult', () => {
+        expect(Component.get(resultLink) instanceof ResultLink).toBe(false);
+        Initialization.automaticallyCreateComponentsInsideResult(resultLink, result);
+        expect(Component.get(resultLink) instanceof ResultLink).toBe(true);
+      });
+
+      it('allows to automaticallyCreateComponentInsideResult with additional options', () => {
+        Initialization.automaticallyCreateComponentsInsideResult(resultLink, result, {
+          ResultLink: { alwaysOpenInNewWindow: true }
+        });
+        const resultLinkComponent = Component.get(resultLink) as ResultLink;
+        expect(resultLinkComponent.options.alwaysOpenInNewWindow).toBeTruthy();
+      });
     });
 
     it('allow to monkeyPatchComponentMethod', () => {


### PR DESCRIPTION
The initial problem was for "QuickviewHeader", which was directly calling the component constructor, without properly resolving the initialization option for ResultLink.

Since it's a pattern that is used in a couple of different place, I decided to add an helper method for that in Initialization module.

https://coveord.atlassian.net/browse/JSUI-2022





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)