### PR TITLE
Add a flag to block query in simple filter when clearing breadcrumb

### DIFF
--- a/src/ui/SimpleFilter/SimpleFilter.ts
+++ b/src/ui/SimpleFilter/SimpleFilter.ts
@@ -127,6 +127,7 @@ export class SimpleFilter extends Component {
   private groupByRequestValues: string[] = [];
   private isSticky: boolean = false;
   private groupByBuilder: SimpleFilterValues;
+  private shouldTriggerQuery = true;
 
   /**
    * Creates a new `SimpleFilter` component. Binds multiple query events as well.
@@ -326,7 +327,9 @@ export class SimpleFilter extends Component {
       simpleFilterSelectedValue: checkbox.label,
       simpleFilterField: <string>this.options.field
     });
-    this.queryController.executeQuery();
+    if (this.shouldTriggerQuery) {
+      this.queryController.executeQuery();
+    }
   }
 
   private createCheckbox(label: string) {
@@ -439,11 +442,11 @@ export class SimpleFilter extends Component {
   }
 
   private handleClearBreadcrumb() {
-    this.usageAnalytics.logSearchEvent<IAnalyticsSimpleFilterMeta>(analyticsActionCauseList.simpleFilterClearAll, {
-      simpleFilterTitle: this.options.title,
-      simpleFilterField: <string>this.options.field
-    });
+    // Bit of a hack with that flag, but essentially we want "clear breadcrumb" to be a global, unique event.
+    // Not something that will log a special event for SimpleFilter (or any component)
+    this.shouldTriggerQuery = false;
     this.resetSimpleFilter();
+    this.shouldTriggerQuery = true;
   }
 
   private handleQuerySuccess(data: IQuerySuccessEventArgs) {


### PR DESCRIPTION
Not the cleanest fix, but it's pretty "surgical". 

Refactoring to handle checkbox selection depending on the user action would be much more involved and risky, so a simple flag seems the simplest approach.


https://coveord.atlassian.net/browse/JSUI-2014





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)