### PR TITLE
Add missing path in generated documentation URL

### DIFF
--- a/docs/theme/partials/member.sources.hbs
+++ b/docs/theme/partials/member.sources.hbs
@@ -13,7 +13,7 @@
             {{#each sources}}
                 {{#if url}}
                   <li>Defined in
-                    <a href="https://github.com/coveo/search-ui/tree/master/{{fileName}}#L{{line}}">{{fileName}}
+                    <a href="https://github.com/coveo/search-ui/tree/master/src/{{fileName}}#L{{line}}">{{fileName}}
                       :{{line}}</a></li>
                 {{else}}
                     <li>Defined in <a href="{{relativeURL "/media/"}}{{fileName}}">{{fileName}}:{{line}}</a></li>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2049





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)