### PR TITLE
[DOC-2015] Fix "broken" links in docs

### DIFF
--- a/src/events/InitializationEvents.ts
+++ b/src/events/InitializationEvents.ts
@@ -15,7 +15,7 @@ export class InitializationEvents {
   public static beforeInitialization = 'beforeInitialization';
   /**
    * Triggered after the components are initialized (eg: After the constructor of each component is executed)
-   * but before their state is set from the hash portion of the URL (e.g., http://mysearchinterface#q=myQuery ).
+   * but before their state is set from the hash portion of the URL (e.g., `http://mysearchinterface#q=myQuery`).
    *
    * This is also before the first query is launched (if the {@link SearchInterface.options.autoTriggerQuery} is `true`).
    *
@@ -24,7 +24,7 @@ export class InitializationEvents {
    */
   public static afterComponentsInitialization = 'afterComponentsInitialization';
   /**
-   * Triggered right before the state from the URL (e.g., http://mysearchinterface#q=myQuery ) gets applied in the interface.
+   * Triggered right before the state from the URL (e.g., `http://mysearchinterface#q=myQuery`) gets applied in the interface.
    *
    * This will typically only be useful if the {@link SearchInterface.options.enableHistory} is set to `true`.
    *
@@ -35,7 +35,7 @@ export class InitializationEvents {
   /**
    * Triggered right after the UI is fully initialized.
    *
-   * Concretely this means that the constructor of each component has been executed, and that the state coming for the URL (e.g., http://mysearchinterface#q=myquery) has been applied.
+   * Concretely this means that the constructor of each component has been executed, and that the state coming for the URL (e.g., `http://mysearchinterface#q=myquery`) has been applied.
    *
    * It is triggered *before* the first query is launched, and if the {@link SearchInterface.options.autoTriggerQuery} is `true`.
    *

--- a/src/rest/Query.ts
+++ b/src/rest/Query.ts
@@ -69,7 +69,7 @@ export interface IQuery {
   /**
    * Whether to enable wildcards on the basic expression keywords.<br/>
    * This enables the wildcard features of the index. Coveo Platform will expand keywords containing wildcard characters to the possible matching keywords to broaden the query.<br/>
-   * See : https://onlinehelp.coveo.com/en/ces/7.0/user/using_wildcards_in_queries.htm<br/>
+   * See [Using Wildcards in Queries](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=359).<br/>
    * If not specified, this parameter defaults to false.
    */
   wildcards?: boolean;


### PR DESCRIPTION
- Enclose "fake" links between back-ticks so they don't get rendered as `a` tags
- Update external link to _Using Wildcards in Queries_ OH topic





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)