### PR TITLE
Do not modify omnibox content on blur if last query matches exactly what is already inside the omnibox

### DIFF
--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -727,15 +727,31 @@ export class Omnibox extends Component {
       return this.magicBox.getText();
     }
 
-    let query = this.magicBox.getWordCompletion();
-    if (query == null && this.lastSuggestions != null && this.lastSuggestions.length > 0) {
-      const textSuggestion = _.find(this.lastSuggestions, (suggestion: IOmniboxSuggestion) => suggestion.text != null);
-      if (textSuggestion != null) {
-        query = textSuggestion.text;
-      }
+    const wordCompletion = this.magicBox.getWordCompletion();
+
+    if (wordCompletion != null) {
+      return wordCompletion;
     }
 
-    return query || this.magicBox.getText();
+    return this.magicBox.getWordCompletion() || this.getFirstSuggestion() || this.magicBox.getText();
+  }
+
+  private getFirstSuggestion() {
+    if (this.lastSuggestions == null) {
+      return '';
+    }
+
+    if (this.lastSuggestions.length <= 0) {
+      return '';
+    }
+
+    const textSuggestion = _.find(this.lastSuggestions, (suggestion: IOmniboxSuggestion) => suggestion.text != null);
+
+    if (textSuggestion == null) {
+      return '';
+    }
+
+    return textSuggestion.text;
   }
 
   public updateQueryState() {

--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -719,16 +719,22 @@ export class Omnibox extends Component {
   }
 
   private getQuery(searchAsYouType: boolean) {
-    let query: string;
-    if (searchAsYouType) {
-      query = this.magicBox.getWordCompletion();
-      if (query == null && this.lastSuggestions != null && this.lastSuggestions.length > 0) {
-        const textSuggestion = _.find(this.lastSuggestions, (suggestion: IOmniboxSuggestion) => suggestion.text != null);
-        if (textSuggestion != null) {
-          query = textSuggestion.text;
-        }
+    if (this.lastQuery == this.magicBox.getText()) {
+      return this.lastQuery;
+    }
+
+    if (!searchAsYouType) {
+      return this.magicBox.getText();
+    }
+
+    let query = this.magicBox.getWordCompletion();
+    if (query == null && this.lastSuggestions != null && this.lastSuggestions.length > 0) {
+      const textSuggestion = _.find(this.lastSuggestions, (suggestion: IOmniboxSuggestion) => suggestion.text != null);
+      if (textSuggestion != null) {
+        query = textSuggestion.text;
       }
     }
+
     return query || this.magicBox.getText();
   }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2085





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)