### PR TITLE
Remove many "shouldDisplayLabel" + use more precise icons

### DIFF
--- a/filetypes/common.json
+++ b/filetypes/common.json
@@ -141,7 +141,7 @@
       }
     },
     "txt": {
-      "icon": "salesforce-doctype-gdoc",
+      "icon": "salesforce-doctype-txt",
       "captions": {
         "en": "Text",
         "fr": "Texte",
@@ -166,11 +166,10 @@
         "tr": "Metin",
         "zh-cn": "文本",
         "zh-tw": "文本"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "zip": {
-      "icon": "salesforce-doctype-pack",
+      "icon": "salesforce-doctype-zip",
       "captions": {
         "en": "Zip File",
         "fr": "Fichier Zip",
@@ -195,8 +194,7 @@
         "tr": "Zip Dosyası",
         "zh-cn": "Zip 文件",
         "zh-tw": "Zip文件"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "oleFile": {
       "icon": "file",
@@ -280,8 +278,7 @@
         "tr": "PDF Dosyası",
         "zh-cn": "PDF 文件",
         "zh-tw": "PDF文件"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "swf": {
       "icon": "salesforce-doctype-flash",
@@ -312,7 +309,7 @@
       }
     },
     "xml": {
-      "icon": "salesforce-doctype-html",
+      "icon": "salesforce-doctype-xml",
       "captions": {
         "en": "XML File",
         "fr": "Fichier XML",
@@ -337,8 +334,7 @@
         "tr": "XML Dosyası",
         "zh-cn": "XML 文件",
         "zh-tw": "XML文件"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "vsd": {
       "icon": "salesforce-doctype-visio",
@@ -450,8 +446,7 @@
         "tr": "RSS beslemesi",
         "zh-cn": "RSS 源",
         "zh-tw": "RSS 訂閱"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "doc": {
       "icon": "salesforce-doctype-word",
@@ -479,8 +474,7 @@
         "tr": "Belge",
         "zh-cn": "文档",
         "zh-tw": "文檔"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "docx": {
       "icon": "salesforce-doctype-word",
@@ -508,8 +502,7 @@
         "tr": "Microsoft Word Belgesi",
         "zh-cn": "Microsoft Word 文档",
         "zh-tw": "Microsoft Word 文檔"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "xls": {
       "icon": "salesforce-doctype-excel",
@@ -537,8 +530,7 @@
         "tr": "Spreadsheet Belgesi",
         "zh-cn": "电子数据表文档",
         "zh-tw": "試算表文文件"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "ppt": {
       "icon": "salesforce-doctype-ppt",
@@ -566,8 +558,7 @@
         "tr": "Sunum Belgesi",
         "zh-cn": "演示文档",
         "zh-tw": "演示視窗"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "video": {
       "icon": "video",
@@ -735,8 +726,7 @@
         "tr": "Open Text Belgesi",
         "zh-cn": "打开文本文档",
         "zh-tw": "打開文本文檔"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "box": {
       "icon": "user",

--- a/filetypes/objectType.json
+++ b/filetypes/objectType.json
@@ -561,7 +561,7 @@
       }
     },
     "solution": {
-      "icon": "salesforce-standard-article",
+      "icon": "salesforce-standard-solution",
       "captions": {
         "en": "Solution",
         "fr": "Solution",
@@ -586,8 +586,7 @@
         "tr": "Çözüm",
         "zh-cn": "解决方案",
         "zh-tw": "解決方案"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "report": {
       "icon": "salesforce-standard-report",
@@ -622,8 +621,7 @@
         "tr": "Görev",
         "zh-cn": "任务",
         "zh-tw": "任務"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "user": {
       "icon": "user",
@@ -987,8 +985,7 @@
         "tr": "Satış Literatürü",
         "zh-cn": "销售说明书",
         "zh-tw": "銷售說明書"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "salesorder": {
       "icon": "salesforce-standard-orders",
@@ -1016,11 +1013,10 @@
         "tr": "Satış Siparişi",
         "zh-cn": "销售订单",
         "zh-tw": "銷售定單"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "service": {
-      "icon": "list",
+      "icon": "salesforce-standard-service-contract",
       "captions": {
         "en": "Service",
         "fr": "Service",
@@ -1045,11 +1041,10 @@
         "tr": "Servis",
         "zh-cn": "服务",
         "zh-tw": "服務"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "socialprofile": {
-      "icon": "user",
+      "icon": "salesforce-standard-social",
       "captions": {
         "en": "Social Profile",
         "fr": "Profil social",
@@ -1074,11 +1069,10 @@
         "tr": "Sosyal Profil",
         "zh-cn": "社会形象",
         "zh-tw": "社會形象"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "kbdocumentation": {
-      "icon": "salesforce-standard-article",
+      "icon": "salesforce-standard-knowledge",
       "captions": {
         "en": "Knowledge Document",
         "fr": "Article de Documentation",
@@ -1103,11 +1097,10 @@
         "tr": "Dokümantasyon",
         "zh-cn": "文件",
         "zh-tw": "檔編制"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "kbtechnicalarticle": {
-      "icon": "salesforce-standard-article",
+      "icon": "salesforce-standard-knowledge",
       "captions": {
         "en": "Technical Documentation",
         "fr": "Documentation Technique",
@@ -1132,11 +1125,10 @@
         "tr": "Dokümantasyon",
         "zh-cn": "文件",
         "zh-tw": "檔編制"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "kbsolution": {
-      "icon": "salesforce-standard-article",
+      "icon": "salesforce-standard-solution",
       "captions": {
         "en": "Solution",
         "fr": "Solution",
@@ -1161,11 +1153,10 @@
         "tr": "Çözüm",
         "zh-cn": "解决方案",
         "zh-tw": "解決方案"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "kbknowledgearticle": {
-      "icon": "salesforce-standard-article",
+      "icon": "salesforce-standard-knowledge",
       "captions": {
         "en": "Knowledge Article",
         "fr": "Article de base de connaissance",
@@ -1190,11 +1181,10 @@
         "tr": "Bilgi Makalesi",
         "zh-cn": "知识文章",
         "zh-tw": "知識文章"
-      },
-      "shouldDisplayLabel": true
+      }
     },
     "kbattachment": {
-      "icon": "salesforce-standard-article",
+      "icon": "salesforce-doctype-attachment",
       "captions": {
         "en": "Attachment",
         "fr": "Pièce jointe",


### PR DESCRIPTION
The "shouldDisplayLabel" property is used to signify that a label should be used in tandem with the icon, because the icon might be too "ambiguous".

Since we've recently added a ton of new icons, we can remove the label since we have many more icons than can now be more precise.

https://coveord.atlassian.net/browse/JSUI-2107





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)