### PR TITLE
Disable syntax highlights in search box when query syntax is disabled on the component

### DIFF
--- a/sass/_Searchbox.scss
+++ b/sass/_Searchbox.scss
@@ -1,6 +1,5 @@
 @import 'Variables';
 @import './mixins/mediaQuery';
-
 .CoveoSearchbox {
   &.coveo-inline {
     overflow: hidden;
@@ -15,7 +14,6 @@
     border-top-right-radius: $default-border-radius;
     border-bottom-right-radius: $default-border-radius;
   }
-
   .magic-box {
     @include defaultRoundedBorder();
     .magic-box-clear-svg {
@@ -59,5 +57,12 @@
         display: none;
       }
     }
+  }
+}
+
+.coveo-query-syntax-disabled {
+  &.magic-box .magic-box-input .magic-box-underlay span,
+  .magic-box-highlight-container {
+    display: none;
   }
 }

--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -245,6 +245,8 @@ export class Omnibox extends Component {
     const originalValueForQuerySyntax = this.options.enableQuerySyntax;
     this.options = _.extend({}, this.options, this.componentOptionsModel.get(ComponentOptionsModel.attributesEnum.searchBox));
 
+    $$(this.element).toggleClass('coveo-query-syntax-disabled', this.options.enableQuerySyntax == false);
+
     this.suggestionAddon = this.options.enableQuerySuggestAddon ? new QuerySuggestAddon(this) : new VoidQuerySuggestAddon();
     new OldOmniboxAddon(this);
     this.createMagicBox();

--- a/src/ui/Querybox/Querybox.ts
+++ b/src/ui/Querybox/Querybox.ts
@@ -257,6 +257,8 @@ export class Querybox extends Component {
     this.options = ComponentOptions.initComponentOptions(element, Querybox, options);
     this.options = _.extend({}, this.options, this.componentOptionsModel.get(ComponentOptionsModel.attributesEnum.searchBox));
 
+    $$(this.element).toggleClass('coveo-query-syntax-disabled', this.options.enableQuerySyntax == false);
+
     this.magicBox = MagicBox.create(
       element,
       new MagicBox.Grammar('Query', {

--- a/test/ui/OmniboxTest.ts
+++ b/test/ui/OmniboxTest.ts
@@ -62,6 +62,14 @@ export function OmniboxTest() {
         }, test.cmp.options.searchAsYouTypeDelay);
       });
 
+      it('enableQuerySyntax to false should add the correct class on the element', () => {
+        test = Mock.optionsComponentSetup<Omnibox, IOmniboxOptions>(Omnibox, {
+          enableQuerySyntax: false
+        });
+
+        expect($$(test.cmp.element).hasClass('coveo-query-syntax-disabled')).toBeTruthy();
+      });
+
       it('enableQuerySyntax should modify the enableQuerySyntax parameter', function() {
         test = Mock.optionsComponentSetup<Omnibox, IOmniboxOptions>(Omnibox, {
           enableQuerySyntax: false


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2109





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)