### PR TITLE
Add sftitle and sf_title to the ChatterPostAttachment JSUI-2119

### DIFF
--- a/src/ui/ChatterPostAttachment/ChatterPostAttachment.ts
+++ b/src/ui/ChatterPostAttachment/ChatterPostAttachment.ts
@@ -49,6 +49,10 @@ export class ChatterPostAttachment extends Component {
 
       if (!Utils.isNullOrUndefined(Utils.getFieldValue(result, 'sfcontentfilename'))) {
         linkElement.text(Utils.getFieldValue(result, 'sfcontentfilename'));
+      } else if (!Utils.isNullOrUndefined(Utils.getFieldValue(result, 'sftitle'))) {
+        linkElement.text(Utils.getFieldValue(result, 'sftitle'));
+      } else if (!Utils.isNullOrUndefined(Utils.getFieldValue(result, 'sf_title'))) {
+        linkElement.text(Utils.getFieldValue(result, 'sf_title'));
       } else {
         linkElement.text(l('ShowAttachment'));
       }

--- a/src/ui/ChatterPostAttachment/ChatterPostAttachment.ts
+++ b/src/ui/ChatterPostAttachment/ChatterPostAttachment.ts
@@ -48,11 +48,7 @@ export class ChatterPostAttachment extends Component {
       rootElement.append(linkElement.el);
 
       if (!Utils.isNullOrUndefined(Utils.getFieldValue(result, 'sfcontentfilename'))) {
-        linkElement.text(Utils.getFieldValue(result, 'sfcontentfilename'));
-      } else if (!Utils.isNullOrUndefined(Utils.getFieldValue(result, 'sftitle'))) {
-        linkElement.text(Utils.getFieldValue(result, 'sftitle'));
-      } else if (!Utils.isNullOrUndefined(Utils.getFieldValue(result, 'sf_title'))) {
-        linkElement.text(Utils.getFieldValue(result, 'sf_title'));
+        linkElement.text(Utils.getFieldValue(result, ['sfcontentfilename','sftitle','sf_title']));
       } else {
         linkElement.text(l('ShowAttachment'));
       }

--- a/src/ui/ChatterPostAttachment/ChatterPostAttachment.ts
+++ b/src/ui/ChatterPostAttachment/ChatterPostAttachment.ts
@@ -46,9 +46,8 @@ export class ChatterPostAttachment extends Component {
         )
       });
       rootElement.append(linkElement.el);
-
-      if (!Utils.isNullOrUndefined(Utils.getFieldValue(result, 'sfcontentfilename'))) {
-        linkElement.text(Utils.getFieldValue(result, ['sfcontentfilename','sftitle','sf_title']));
+      if (!Utils.isNullOrUndefined(Utils.getFieldValue(result, ['sfcontentfilename', 'sftitle', 'sf_title']))) {
+        linkElement.text(Utils.getFieldValue(result, ['sfcontentfilename', 'sftitle', 'sf_title']));
       } else {
         linkElement.text(l('ShowAttachment'));
       }

--- a/src/ui/ChatterPostAttachment/ChatterPostAttachment.ts
+++ b/src/ui/ChatterPostAttachment/ChatterPostAttachment.ts
@@ -46,8 +46,11 @@ export class ChatterPostAttachment extends Component {
         )
       });
       rootElement.append(linkElement.el);
-      if (!Utils.isNullOrUndefined(Utils.getFieldValue(result, ['sfcontentfilename', 'sftitle', 'sf_title']))) {
-        linkElement.text(Utils.getFieldValue(result, ['sfcontentfilename', 'sftitle', 'sf_title']));
+
+      const fieldValue = Utils.getFirstAvailableFieldValue(result, ['sfcontentfilename', 'sftitle', 'sf_title']);
+
+      if (!Utils.isNullOrUndefined(fieldValue)) {
+        linkElement.text(fieldValue);
       } else {
         linkElement.text(l('ShowAttachment'));
       }

--- a/src/ui/ChatterPostAttachment/ChatterPostAttachmentFields.ts
+++ b/src/ui/ChatterPostAttachment/ChatterPostAttachmentFields.ts
@@ -1,6 +1,6 @@
 import { Initialization } from '../Base/Initialization';
 
-const fields = ['sfcontentversionid', 'sffeeditemid', 'sfcontentfilename'];
+const fields = ['sfcontentversionid', 'sffeeditemid', 'sfcontentfilename', 'sftitle', 'sf_title'];
 
 export function registerFields() {
   Initialization.registerComponentFields('ChatterPostAttachment', fields);

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -199,16 +199,16 @@ export class Utils {
   /**
    * Get the value of a field.
    * If multiple names are provided the first result not null is returned.
-   * 
+   *
    * @param result a QueryResult in which to ge the fieldvalue.
    * @param name One or multiple fieldNames to get the value.
    */
-  static getFieldValue(result: IQueryResult, name: string|Array<string>): any {
-    if(Array.isArray(name)) {
+  static getFieldValue(result: IQueryResult, name: string | Array<string>): any {
+    if (Array.isArray(name)) {
       for (let i = 0; i < name.length; i++) {
-        const fieldValue = this.getFieldValue(result, name[i]);
-        if(fieldValue !== undefined) {
-          return fieldValue;
+        let value = this.getFieldValue(result, name[i]);
+        if (value !== undefined) {
+          return value;
         }
       }
       return undefined;
@@ -216,7 +216,7 @@ export class Utils {
       // Be as forgiving as possible about the field name, since we expect
       // user provided values.
       if (name == null) {
-      return undefined;
+        return undefined;
       }
       name = Utils.trim(name);
       if (name[0] == '@') {
@@ -248,7 +248,6 @@ export class Utils {
     }
   }
 
-  
   static throttle(func, wait, options: { leading?: boolean; trailing?: boolean } = {}, context?, args?) {
     let result;
     let timeout: number = null;

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -202,9 +202,9 @@ export class Utils {
    * @param result a QueryResult in which to ge the fieldvalue.
    * @param name One or multiple fieldNames to get the value.
    */
-  static getFirstAvailableFieldValue(result: IQueryResult, fieldNames: Array<String>): string | undefined {
+  static getFirstAvailableFieldValue(result: IQueryResult, fieldNames: Array<string>): string | undefined {
     for (let i = 0; i < fieldNames.length; i++) {
-      let value = Utils.getFieldValue(result, name[i]);
+      let value = Utils.getFieldValue(result, fieldNames[i]);
       if (value !== undefined) {
         return value;
       }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -197,55 +197,54 @@ export class Utils {
   }
 
   /**
-   * Get the value of a field.
-   * If multiple names are provided the first result not null is returned.
+   * Get the value of the first field from the array and defined in the result.
    *
    * @param result a QueryResult in which to ge the fieldvalue.
    * @param name One or multiple fieldNames to get the value.
    */
-  static getFieldValue(result: IQueryResult, name: string | Array<string>): any {
-    if (Array.isArray(name)) {
-      for (let i = 0; i < name.length; i++) {
-        let value = this.getFieldValue(result, name[i]);
-        if (value !== undefined) {
-          return value;
-        }
+  static getFirstAvailableFieldValue(result: IQueryResult, fieldNames: Array<String>): string | undefined {
+    for (let i = 0; i < fieldNames.length; i++) {
+      let value = Utils.getFieldValue(result, name[i]);
+      if (value !== undefined) {
+        return value;
       }
-      return undefined;
-    } else {
-      // Be as forgiving as possible about the field name, since we expect
-      // user provided values.
-      if (name == null) {
-        return undefined;
-      }
-      name = Utils.trim(name);
-      if (name[0] == '@') {
-        name = name.substr(1);
-      }
-      if (name == '') {
-        return undefined;
-      }
-
-      // At this point the name should be well formed
-      if (!Utils.isCoveoField('@' + name)) {
-        throw `Not a valid field : ${name}`;
-      }
-      // Handle namespace field values of the form sf.Foo.Bar
-      let parts = name.split('.').reverse();
-      let obj = result.raw;
-      while (parts.length > 1) {
-        obj = Utils.getCaseInsensitiveProperty(obj, parts.pop());
-        if (Utils.isUndefined(obj)) {
-          return undefined;
-        }
-      }
-      let value = Utils.getCaseInsensitiveProperty(obj, parts[0]);
-      // If still nothing, look at the root of the result
-      if (value == null) {
-        value = Utils.getCaseInsensitiveProperty(result, name);
-      }
-      return value;
     }
+    return undefined;
+  }
+
+  static getFieldValue(result: IQueryResult, name: string): any {
+    // Be as forgiving as possible about the field name, since we expect
+    // user provided values.
+    if (name == null) {
+      return undefined;
+    }
+    name = Utils.trim(name);
+    if (name[0] == '@') {
+      name = name.substr(1);
+    }
+    if (name == '') {
+      return undefined;
+    }
+
+    // At this point the name should be well formed
+    if (!Utils.isCoveoField('@' + name)) {
+      throw `Not a valid field : ${name}`;
+    }
+    // Handle namespace field values of the form sf.Foo.Bar
+    let parts = name.split('.').reverse();
+    let obj = result.raw;
+    while (parts.length > 1) {
+      obj = Utils.getCaseInsensitiveProperty(obj, parts.pop());
+      if (Utils.isUndefined(obj)) {
+        return undefined;
+      }
+    }
+    let value = Utils.getCaseInsensitiveProperty(obj, parts[0]);
+    // If still nothing, look at the root of the result
+    if (value == null) {
+      value = Utils.getCaseInsensitiveProperty(result, name);
+    }
+    return value;
   }
 
   static throttle(func, wait, options: { leading?: boolean; trailing?: boolean } = {}, context?, args?) {

--- a/test/Fake.ts
+++ b/test/Fake.ts
@@ -317,6 +317,8 @@ export class FakeResults {
     if (hasAttachment) {
       result.raw.coveochatterfeedtopics = 'PostAttachment';
       result.raw.sfcontentfilename = 'fileName';
+      result.raw.sftitle = 'fileName';
+      result.raw.sf_title = 'fileName';
       result.raw.sfcontentversionid = token;
     }
 

--- a/test/ui/ChatterPostAttachmentTest.ts
+++ b/test/ui/ChatterPostAttachmentTest.ts
@@ -24,7 +24,42 @@ export function ChatterPostAttachmentTest() {
           .getAttribute('href')
       ).toContain(ChatterUtils.buildURI(result.clickUri, result.raw.sffeeditemid, result.raw.sfcontentversionid));
     });
-
+    it('should use sfcontentfilename if present', () => {
+      let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
+      result.raw.sfcontentfilename = 'foo';
+      result.raw.sftitle = 'bar';
+      result.raw.sf_title = 'baz';
+      test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
+        ChatterPostAttachment,
+        <IChatterPostAttachmentOption>{},
+        result
+      );
+      expect($$($$(test.cmp.element).find('a')).text()).toContain(result.raw.sfcontentfilename);
+    });
+    it('should use sftitle if sfcontentfilename is not present', () => {
+      let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
+      result.raw.sfcontentfilename = 'foo';
+      result.raw.sftitle = 'bar';
+      result.raw.sf_title = 'baz';
+      test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
+        ChatterPostAttachment,
+        <IChatterPostAttachmentOption>{},
+        result
+      );
+      expect($$($$(test.cmp.element).find('a')).text()).toContain(result.raw.sftitle);
+    });
+    it('should use sf_title if sftitle and sfcontentfilename are not present', () => {
+      let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
+      result.raw.sfcontentfilename = 'foo';
+      result.raw.sftitle = 'bar';
+      result.raw.sf_title = 'baz';
+      test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
+        ChatterPostAttachment,
+        <IChatterPostAttachmentOption>{},
+        result
+      );
+      expect($$($$(test.cmp.element).find('a')).text()).toContain(result.raw.sf_title);
+    });
     it('should behave correctly with no filename but with a contentversionid', () => {
       let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
       result.raw.sfcontentfilename = undefined;

--- a/test/ui/ChatterPostAttachmentTest.ts
+++ b/test/ui/ChatterPostAttachmentTest.ts
@@ -5,10 +5,23 @@ import { IChatterPostAttachmentOption } from '../../src/ui/ChatterPostAttachment
 import { ChatterUtils } from '../../src/utils/ChatterUtils';
 import { $$ } from '../../src/utils/Dom';
 import { l } from '../../src/strings/Strings';
+import { IQueryResult } from '../../src/rest/QueryResult';
 
 export function ChatterPostAttachmentTest() {
   describe('ChatterPostAttachment', () => {
     let test: Mock.IBasicComponentSetup<ChatterPostAttachment>;
+    const generateResult = function(sfcontentfilename: string, sftitle: string, sf_title: string): IQueryResult {
+      let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
+      result.raw.sfcontentfilename = sfcontentfilename;
+      result.raw.sftitle = sftitle;
+      result.raw.sf_title = sf_title;
+      test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
+        ChatterPostAttachment,
+        <IChatterPostAttachmentOption>{},
+        result
+      );
+      return result;
+    };
 
     it('should behave correctly with no data', () => {
       let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
@@ -25,51 +38,20 @@ export function ChatterPostAttachmentTest() {
       ).toContain(ChatterUtils.buildURI(result.clickUri, result.raw.sffeeditemid, result.raw.sfcontentversionid));
     });
     it('should use sfcontentfilename if present', () => {
-      let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
-      result.raw.sfcontentfilename = 'foo';
-      result.raw.sftitle = 'bar';
-      result.raw.sf_title = 'baz';
-      test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
-        ChatterPostAttachment,
-        <IChatterPostAttachmentOption>{},
-        result
-      );
+      let result = generateResult('foo', 'bar', 'baz');
       expect($$($$(test.cmp.element).find('a')).text()).toContain(result.raw.sfcontentfilename);
     });
     it('should use sftitle if sfcontentfilename is not present', () => {
-      let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
-      result.raw.sfcontentfilename = undefined;
-      result.raw.sftitle = 'bar';
-      result.raw.sf_title = 'baz';
-      test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
-        ChatterPostAttachment,
-        <IChatterPostAttachmentOption>{},
-        result
-      );
+      let result = generateResult(undefined, 'bar', 'baz');
       expect($$($$(test.cmp.element).find('a')).text()).toContain(result.raw.sftitle);
     });
     it('should use sf_title if sftitle and sfcontentfilename are not present', () => {
-      let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
-      result.raw.sfcontentfilename = undefined;
-      result.raw.sftitle = undefined;
-      result.raw.sf_title = 'baz';
-      test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
-        ChatterPostAttachment,
-        <IChatterPostAttachmentOption>{},
-        result
-      );
+      let result;
+      generateResult(undefined, undefined, 'baz');
       expect($$($$(test.cmp.element).find('a')).text()).toContain(result.raw.sf_title);
     });
     it('should behave correctly with no filename but with a contentversionid', () => {
-      let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
-      result.raw.sfcontentfilename = undefined;
-      result.raw.sftitle = undefined;
-      result.raw.sf_title = undefined;
-      test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
-        ChatterPostAttachment,
-        <IChatterPostAttachmentOption>{},
-        result
-      );
+      let result = generateResult(undefined, undefined, undefined);
       expect($$($$(test.cmp.element).find('a')).text()).toContain(l('ShowAttachment'));
     });
   });

--- a/test/ui/ChatterPostAttachmentTest.ts
+++ b/test/ui/ChatterPostAttachmentTest.ts
@@ -28,6 +28,8 @@ export function ChatterPostAttachmentTest() {
     it('should behave correctly with no filename but with a contentversionid', () => {
       let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
       result.raw.sfcontentfilename = undefined;
+      result.raw.sftitle = undefined;
+      result.raw.sf_title = undefined;
       test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
         ChatterPostAttachment,
         <IChatterPostAttachmentOption>{},

--- a/test/ui/ChatterPostAttachmentTest.ts
+++ b/test/ui/ChatterPostAttachmentTest.ts
@@ -10,8 +10,9 @@ import { IQueryResult } from '../../src/rest/QueryResult';
 export function ChatterPostAttachmentTest() {
   describe('ChatterPostAttachment', () => {
     let test: Mock.IBasicComponentSetup<ChatterPostAttachment>;
-    const generateResult = function(sfcontentfilename: string, sftitle: string, sf_title: string): IQueryResult {
-      let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
+    let result: IQueryResult;
+    const generateResult = function(sfcontentfilename: string, sftitle: string, sf_title: string) {
+      result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
       result.raw.sfcontentfilename = sfcontentfilename;
       result.raw.sftitle = sftitle;
       result.raw.sf_title = sf_title;
@@ -20,11 +21,10 @@ export function ChatterPostAttachmentTest() {
         <IChatterPostAttachmentOption>{},
         result
       );
-      return result;
     };
 
     it('should behave correctly with no data', () => {
-      let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
+      result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
       test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
         ChatterPostAttachment,
         <IChatterPostAttachmentOption>{},
@@ -38,20 +38,19 @@ export function ChatterPostAttachmentTest() {
       ).toContain(ChatterUtils.buildURI(result.clickUri, result.raw.sffeeditemid, result.raw.sfcontentversionid));
     });
     it('should use sfcontentfilename if present', () => {
-      let result = generateResult('foo', 'bar', 'baz');
+      generateResult('foo', 'bar', 'baz');
       expect($$($$(test.cmp.element).find('a')).text()).toContain(result.raw.sfcontentfilename);
     });
     it('should use sftitle if sfcontentfilename is not present', () => {
-      let result = generateResult(undefined, 'bar', 'baz');
+      generateResult(undefined, 'bar', 'baz');
       expect($$($$(test.cmp.element).find('a')).text()).toContain(result.raw.sftitle);
     });
     it('should use sf_title if sftitle and sfcontentfilename are not present', () => {
-      let result;
       generateResult(undefined, undefined, 'baz');
       expect($$($$(test.cmp.element).find('a')).text()).toContain(result.raw.sf_title);
     });
     it('should behave correctly with no filename but with a contentversionid', () => {
-      let result = generateResult(undefined, undefined, undefined);
+      generateResult(undefined, undefined, undefined);
       expect($$($$(test.cmp.element).find('a')).text()).toContain(l('ShowAttachment'));
     });
   });

--- a/test/ui/ChatterPostAttachmentTest.ts
+++ b/test/ui/ChatterPostAttachmentTest.ts
@@ -38,7 +38,7 @@ export function ChatterPostAttachmentTest() {
     });
     it('should use sftitle if sfcontentfilename is not present', () => {
       let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
-      result.raw.sfcontentfilename = 'foo';
+      result.raw.sfcontentfilename = undefined;
       result.raw.sftitle = 'bar';
       result.raw.sf_title = 'baz';
       test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
@@ -50,8 +50,8 @@ export function ChatterPostAttachmentTest() {
     });
     it('should use sf_title if sftitle and sfcontentfilename are not present', () => {
       let result = FakeResults.createFakeFeedItemResult('token', 0, 0, true);
-      result.raw.sfcontentfilename = 'foo';
-      result.raw.sftitle = 'bar';
+      result.raw.sfcontentfilename = undefined;
+      result.raw.sftitle = undefined;
       result.raw.sf_title = 'baz';
       test = Mock.optionsResultComponentSetup<ChatterPostAttachment, IChatterPostAttachmentOption>(
         ChatterPostAttachment,


### PR DESCRIPTION
In the new version of the schema service, the field `sfcontentfilename` does not exist anymore and it's replaced by `sftitle` or `sf_title`. I added them as `alternative` to `sfcontentfilename`


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)