### PR TITLE
JSUI-2120 Converting display:box to display:flex

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ script:
 - yarn run test
 - yarn run uploadCoverage
 - yarn run testChunks
+- yarn run validateTypeDefinitions
 after_success:
-- yarn run doc
 - if [ "x$TRAVIS_TAG" != "x" ]; then bash ./deploy.doc.sh ; fi
 - yarn run docsitemap
 - yarn run zipForGitReleases

--- a/gulpTasks/definition.js
+++ b/gulpTasks/definition.js
@@ -8,7 +8,7 @@ const shell = require('gulp-shell');
 const tvm = require('tvm');
 
 gulp.task('definitions', function(done) {
-  runsequence('externalDefs', 'internalDefs', 'cleanDefs', 'validateDefs', done);
+  runsequence('externalDefs', 'internalDefs', 'cleanDefs', done);
 });
 
 gulp.task('cleanDefs', function() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,7 +4,7 @@ const runsequence = require('run-sequence');
 
 requireDir('./gulpTasks');
 
-gulp.task('default', ['buildLegacy', 'build']);
+gulp.task('default', ['buildLegacy', 'build', 'doc']);
 
 gulp.task('build', ['linkGitHooks', 'setNodeProdEnv'], done => {
   runsequence(['fileTypes', 'iconList', 'strings', 'setup', 'templates'], 'src', done);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "heroku-postbuild": "npm run build",
     "start": "node index.js",
     "zipForGitReleases": "gulp zip",
-    "uploadCoverage": "gulp uploadCoverage"
+    "uploadCoverage": "gulp uploadCoverage",
+    "validateTypeDefinitions": "gulp validateDefs"
   },
   "lint-staged": {
     "*.{js,ts,json,scss}": ["prettier --write", "git add"]

--- a/sass/bourbon/css3/_flex-box.scss
+++ b/sass/bourbon/css3/_flex-box.scss
@@ -12,7 +12,7 @@
   display: -webkit-box;
   display: -moz-box;
   display: -ms-flexbox; // IE 10
-  display: box;
+  display: flex;
 }
 
 @mixin box-orient($orient: inline-axis) {
@@ -65,18 +65,17 @@
 // 2012 - display (flex | inline-flex)
 @mixin display($value) {
   // flex | inline-flex
-  @if $value == "flex" {
+  @if $value == 'flex' {
     // 2009
     display: -webkit-box;
     display: -moz-box;
-    display: box;
 
     // 2012
     display: -webkit-flex;
     display: -moz-flex;
     display: -ms-flexbox; // 2011 (IE 10)
     display: flex;
-  } @else if $value == "inline-flex" {
+  } @else if $value == 'inline-flex' {
     display: -webkit-inline-box;
     display: -moz-inline-box;
     display: inline-box;
@@ -94,7 +93,6 @@
 // 2011 - flex (decimal | width decimal)
 // 2012 - flex (integer integer width)
 @mixin flex($value) {
-
   // Grab flex-grow for older browsers.
   $flex-grow: nth($value, 1);
 
@@ -110,7 +108,6 @@
 // 2011 - flex-direction (row | row-reverse | column | column-reverse)
 // 2012 - flex-direction (row | row-reverse | column | column-reverse)
 @mixin flex-direction($value: row) {
-
   // Alt values.
   $value-2009: $value;
   $value-2011: $value;
@@ -118,12 +115,12 @@
 
   @if $value == row {
     $value-2009: horizontal;
-  } @else if $value == "row-reverse" {
+  } @else if $value == 'row-reverse' {
     $value-2009: horizontal;
     $direction: reverse;
   } @else if $value == column {
     $value-2009: vertical;
-  } @else if $value == "column-reverse" {
+  } @else if $value == 'column-reverse' {
     $value-2009: vertical;
     $direction: reverse;
   }
@@ -149,7 +146,7 @@
     $alt-value: single;
   } @else if $value == wrap {
     $alt-value: multiple;
-  } @else if $value == "wrap-reverse" {
+  } @else if $value == 'wrap-reverse' {
     $alt-value: multiple;
   }
 
@@ -200,16 +197,15 @@
 // 2011 - flex-pack (start | end | center | justify)
 // 2012 - justify-content (flex-start | flex-end | center | space-between | space-around)
 @mixin justify-content($value: flex-start) {
-
   // Alt values.
   $alt-value: $value;
-  @if $value == "flex-start" {
+  @if $value == 'flex-start' {
     $alt-value: start;
-  } @else if $value == "flex-end" {
+  } @else if $value == 'flex-end' {
     $alt-value: end;
-  } @else if $value == "space-between" {
+  } @else if $value == 'space-between' {
     $alt-value: justify;
-  } @else if $value == "space-around" {
+  } @else if $value == 'space-around' {
     $alt-value: distribute;
   }
 
@@ -227,12 +223,11 @@
 // 2011 - flex-align (start | end | center | baseline | stretch)
 // 2012 - align-items (flex-start | flex-end | center | baseline | stretch)
 @mixin align-items($value: stretch) {
-
   $alt-value: $value;
 
-  @if $value == "flex-start" {
+  @if $value == 'flex-start' {
     $alt-value: start;
-  } @else if $value == "flex-end" {
+  } @else if $value == 'flex-end' {
     $alt-value: end;
   }
 
@@ -249,11 +244,10 @@
 // 2011 - flex-item-align (auto | start | end | center | baseline | stretch)
 // 2012 - align-self (auto | flex-start | flex-end | center | baseline | stretch)
 @mixin align-self($value: auto) {
-
   $value-2011: $value;
-  @if $value == "flex-start" {
+  @if $value == 'flex-start' {
     $value-2011: start;
-  } @else if $value == "flex-end" {
+  } @else if $value == 'flex-end' {
     $value-2011: end;
   }
 
@@ -267,15 +261,14 @@
 // 2011 - flex-line-pack (start | end | center | justify | distribute | stretch)
 // 2012 - align-content (flex-start | flex-end | center | space-between | space-around | stretch)
 @mixin align-content($value: stretch) {
-
   $value-2011: $value;
-  @if $value == "flex-start" {
+  @if $value == 'flex-start' {
     $value-2011: start;
-  } @else if $value == "flex-end" {
+  } @else if $value == 'flex-end' {
     $value-2011: end;
-  } @else if $value == "space-between" {
+  } @else if $value == 'space-between' {
     $value-2011: justify;
-  } @else if $value == "space-around" {
+  } @else if $value == 'space-around' {
     $value-2011: distribute;
   }
 

--- a/sass/bourbon/css3/_flex-box.scss
+++ b/sass/bourbon/css3/_flex-box.scss
@@ -1,20 +1,5 @@
 // CSS3 Flexible Box Model and property defaults
 
-// Custom shorthand notation for flexbox
-@mixin box($orient: inline-axis, $pack: start, $align: stretch) {
-  @include display-box;
-  @include box-orient($orient);
-  @include box-pack($pack);
-  @include box-align($align);
-}
-
-@mixin display-box {
-  display: -webkit-box;
-  display: -moz-box;
-  display: -ms-flexbox; // IE 10
-  display: flex;
-}
-
 @mixin box-orient($orient: inline-axis) {
   // horizontal|vertical|inline-axis|block-axis|inherit
   @include prefixer(box-orient, $orient, webkit moz spec);


### PR DESCRIPTION
In addition to coverting box -> flex, I:

- Moved the `gulp doc` task to be part of the default gulp task.
- Moved the typedefintion validation gulp task to Travis.

I tested that the conversion from box to flex resolves the warnings when compiling the interface editor. To do this however, I needed to delete all search-ui CSS lines that contained:
`background-image: url(<svg>)`

For some reason, building the search-ui on my machine was adding an svg tag inline in the CSS file instead of placing a url to the svg image.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)