### PR TITLE
Change order to bind the `onload` function for Quickview

### DIFF
--- a/src/ui/Quickview/QuickviewDocumentIframe.ts
+++ b/src/ui/Quickview/QuickviewDocumentIframe.ts
@@ -38,13 +38,14 @@ export class QuickviewDocumentIframe {
     }
 
     return new Promise((resolve, reject) => {
-      this.addClientSideTweaksToIFrameStyling(htmlDocument);
-
-      this.writeToIFrame(htmlDocument);
-
+      // Take care to bind the onload function before actually writing to the iframe :
+      // Safari, IE, Edge need this, otherwise the onload function is never called
       this.iframeElement.onload = () => {
         resolve(this.iframeElement);
       };
+
+      this.addClientSideTweaksToIFrameStyling(htmlDocument);
+      this.writeToIFrame(htmlDocument);
     });
   }
 


### PR DESCRIPTION
 For cross browser compatibility : onload event was not being triggered properly in IE/Safari/Edge

https://coveord.atlassian.net/browse/JSUI-2145





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)