### PR TITLE
Doc 3103 fix default value for allow queries without keywords

### DIFF
--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -310,7 +310,7 @@ export class SearchInterface extends RootComponent implements IComponentBindings
      *
      * It also modifies the {@link IQuery.allowQueriesWithoutKeywords} query parameter.
      *
-     * Default value is `true`, except in Coveo for Salesforce Free edition in which it is `false`.
+     * Default value is `true`
      */
     allowQueriesWithoutKeywords: ComponentOptions.buildBooleanOption({ defaultValue: true }),
     endpoint: ComponentOptions.buildCustomOption(

--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -310,7 +310,7 @@ export class SearchInterface extends RootComponent implements IComponentBindings
      *
      * It also modifies the {@link IQuery.allowQueriesWithoutKeywords} query parameter.
      *
-     * Default value is `true`
+     * Default value is `true`, except in Coveo for Salesforce Free edition in which it is `false`.
      */
     allowQueriesWithoutKeywords: ComponentOptions.buildBooleanOption({ defaultValue: true }),
     endpoint: ComponentOptions.buildCustomOption(


### PR DESCRIPTION



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)