### PR TITLE
Rework isSimpleSliderConfig to property set on init

### DIFF
--- a/src/controllers/FacetSliderQueryController.ts
+++ b/src/controllers/FacetSliderQueryController.ts
@@ -129,7 +129,7 @@ export class FacetSliderQueryController {
     this.graphGroupByQueriesIndex = queryBuilder.groupByRequests.length;
     const basicGroupByRequestForGraph = this.createBasicGroupByRequest();
 
-    if (this.facet.isSimpleSliderConfig()) {
+    if (this.facet.isSimpleSliderConfig) {
       basicGroupByRequestForGraph.rangeValues = this.createRangeValuesForGraphUsingStartAndEnd();
       basicGroupByRequestForGraph.generateAutomaticRanges = false;
     } else {
@@ -154,7 +154,7 @@ export class FacetSliderQueryController {
 
     let rangeValues = undefined;
     const { start, end } = this.formatStartAndEnd();
-    if (this.facet.isSimpleSliderConfig()) {
+    if (this.facet.isSimpleSliderConfig) {
       rangeValues = [
         {
           start: start,
@@ -170,7 +170,7 @@ export class FacetSliderQueryController {
     const basicGroupByRequestForSlider = this.createBasicGroupByRequest();
     basicGroupByRequestForSlider.maximumNumberOfValues = maximumNumberOfValues;
     basicGroupByRequestForSlider.sortCriteria = 'nosort';
-    basicGroupByRequestForSlider.generateAutomaticRanges = !this.facet.isSimpleSliderConfig();
+    basicGroupByRequestForSlider.generateAutomaticRanges = !this.facet.isSimpleSliderConfig;
     basicGroupByRequestForSlider.rangeValues = rangeValues;
     const filter = this.computeOurFilterExpression(this.facet.getSliderBoundaryForQuery());
     this.processQueryOverride(filter, basicGroupByRequestForSlider, queryBuilder);

--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -365,6 +365,7 @@ export class FacetSlider extends Component {
   public facetQueryController: FacetSliderQueryController;
   public facetHeader: FacetHeader;
   public onResize: EventListener;
+  public isSimpleSliderConfig = false;
 
   private rangeQueryStateAttribute: string;
   private isEmpty = false;
@@ -382,7 +383,7 @@ export class FacetSlider extends Component {
   constructor(public element: HTMLElement, public options: IFacetSliderOptions, bindings?: IComponentBindings, private slider?: Slider) {
     super(element, FacetSlider.ID, bindings);
     this.options = ComponentOptions.initComponentOptions(element, FacetSlider, options);
-
+    this.isSimpleSliderConfig = this.options.start != null && this.options.end != null;
     ResponsiveFacetSlider.init(this.root, this, this.options);
 
     if (this.options.excludeOuterBounds == null) {
@@ -508,10 +509,6 @@ export class FacetSlider extends Component {
       this.slider.drawGraph(this.delayedGraphData);
     }
     this.delayedGraphData = null;
-  }
-
-  public isSimpleSliderConfig() {
-    return this.options.start != null && this.options.end != null;
   }
 
   public hasAGraph() {
@@ -827,7 +824,7 @@ export class FacetSlider extends Component {
       // Special corner case for "simple slider facet" : Do not only handle the group by results,
       // but also look for the complete result set when determining if we should show the facet.
       // This allows simple slider facet to still show with query function fields
-      if (this.isSimpleSliderConfig()) {
+      if (this.isSimpleSliderConfig) {
         this.isEmpty = data.results.results.length == 0;
       } else {
         this.isEmpty = true;

--- a/unitTests/controllers/FacetSliderQueryControllerTest.ts
+++ b/unitTests/controllers/FacetSliderQueryControllerTest.ts
@@ -95,7 +95,7 @@ export function FacetSliderQueryControllerTest() {
     });
 
     it('should allow to put the group by into a query builder with simple slider config', () => {
-      facet.isSimpleSliderConfig = () => true;
+      facet.isSimpleSliderConfig = true;
       const builder = new QueryBuilder();
       controller.putGroupByIntoQueryBuilder(builder);
       expect(builder.groupByRequests).toEqual(
@@ -117,7 +117,7 @@ export function FacetSliderQueryControllerTest() {
     });
 
     it("should add a group by for graph if needed if it's not a simple slider config", () => {
-      facet.isSimpleSliderConfig = () => false;
+      facet.isSimpleSliderConfig = false;
       facet.options.graph = {};
       facet.options.graph.steps = 10;
       facet.getSliderBoundaryForQuery = () => [5, 99];
@@ -136,7 +136,7 @@ export function FacetSliderQueryControllerTest() {
     });
 
     it('should add a group by for graph using the query override if specified', () => {
-      facet.isSimpleSliderConfig = () => false;
+      facet.isSimpleSliderConfig = false;
       facet.options.graph = {};
       facet.options.graph.steps = 10;
       facet.options.queryOverride = 'my query override';
@@ -156,7 +156,7 @@ export function FacetSliderQueryControllerTest() {
     });
 
     it('should add a range request if needed for graph', () => {
-      facet.isSimpleSliderConfig = () => true;
+      facet.isSimpleSliderConfig = true;
       facet.options.graph = {};
       facet.options.graph.steps = 10;
       facet.options.start = 0;
@@ -184,7 +184,7 @@ export function FacetSliderQueryControllerTest() {
     });
 
     it("should add a group by for graph if it's a date", () => {
-      facet.isSimpleSliderConfig = () => true;
+      facet.isSimpleSliderConfig = true;
       facet.options.graph = {};
       facet.options.graph.steps = 10;
       facet.options.start = 1;

--- a/unitTests/ui/FacetSliderTest.ts
+++ b/unitTests/ui/FacetSliderTest.ts
@@ -310,6 +310,26 @@ export function FacetSliderTest() {
         test.cmp.ensureDom();
         expect($$($$(test.cmp.facetHeader.build()).find('.coveo-facet-header-title')).text()).toBe('nice title');
       });
+
+      it('should have a "simpleSliderConfig" attribute if the start and end attribute is specified', () => {
+        test = Mock.optionsComponentSetup<FacetSlider, IFacetSliderOptions>(FacetSlider, {
+          start: 0,
+          end: 100,
+          field: '@foo',
+          title: 'nice title'
+        });
+
+        expect(test.cmp.isSimpleSliderConfig).toBeTruthy();
+      });
+
+      it('should not have a "simpleSliderConfig" attribute if the start and end attribute is not specified', () => {
+        test = Mock.optionsComponentSetup<FacetSlider, IFacetSliderOptions>(FacetSlider, {
+          field: '@foo',
+          title: 'nice title'
+        });
+
+        expect(test.cmp.isSimpleSliderConfig).toBeFalsy();
+      });
     });
   });
 }


### PR DESCRIPTION
Versus a method, which would read the options after the fact. Since those options are not readonly, they can get modified after init, which would cause the component to be falsely identified as "simpleConfig" when it was in fact a "complex" config that needs the automatic range form the index.

https://coveord.atlassian.net/browse/JSUI-2128





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)