### PR TITLE
Add debounce on every resize listener

### DIFF
--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -2,7 +2,7 @@
 /// <reference path="../../controllers/FacetSliderQueryController.ts" />
 
 import 'styling/_FacetSlider';
-import { map } from 'underscore';
+import { map, debounce } from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 import { Defer } from '../../MiscModules';
 import { FacetSliderQueryController } from '../../controllers/FacetSliderQueryController';
@@ -542,7 +542,7 @@ export class FacetSlider extends Component {
   }
 
   private bindResizeEvents() {
-    this.onResize = () => {
+    this.onResize = debounce(() => {
       if (ResponsiveComponentsUtils.shouldDrawFacetSlider($$(this.root), $$(this.element)) && this.slider && !this.isEmpty) {
         if (this.delayedGraphData) {
           this.drawDelayedGraphData();
@@ -553,7 +553,7 @@ export class FacetSlider extends Component {
       if (this.slider) {
         this.slider.onMoving();
       }
-    };
+    }, 250);
     window.addEventListener('resize', this.onResize);
     this.bind.onRootElement(ResponsiveDropdownEvent.OPEN, this.onResize);
 

--- a/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
@@ -7,6 +7,7 @@ import * as _ from 'underscore';
 import { QueryEvents } from '../../events/QueryEvents';
 import { Logger } from '../../misc/Logger';
 import { DeviceUtils } from '../../utils/DeviceUtils';
+import { debounce } from 'underscore';
 
 export interface IResponsiveComponentOptions {
   enableResponsiveMode?: boolean;
@@ -122,7 +123,7 @@ export class ResponsiveComponentsManager {
     });
     this.searchBoxElement = this.getSearchBoxElement();
     this.logger = new Logger(this);
-    this.resizeListener = () => {
+    this.resizeListener = debounce(() => {
       if (this.coveoRoot.width() != 0) {
         this.addDropdownHeaderWrapperIfNeeded();
         if (this.shouldSwitchToSmallMode()) {
@@ -140,7 +141,7 @@ export class ResponsiveComponentsManager {
         interface display property be none? Could its visibility property be set to hidden? Also, if either of these scenarios happen during
         loading, it could be the cause of this issue.`);
       }
-    };
+    }, 250);
     // On many android devices, focusing on an input (eg: facet search input) causes the device to "zoom in"
     // and this triggers the window resize event. Since this class modify HTML nodes, Android has the quirks of removing the focus on the input.
     // As a net result, users focus on the text input, the keyboard appears for a few milliseconds, then dissapears instantly when the DOM is modified.

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -13,6 +13,7 @@ export function ResponsiveComponentsManagerTest() {
 
   describe('ResponsiveComponentsManager', () => {
     beforeEach(() => {
+      jasmine.clock().install();
       let searchInterfaceMock = Mock.optionsSearchInterfaceSetup<SearchInterface, ISearchInterfaceOptions>(SearchInterface, {
         enableAutomaticResponsiveMode: true
       });
@@ -29,28 +30,26 @@ export function ResponsiveComponentsManagerTest() {
       responsiveComponentsManager = new ResponsiveComponentsManager(root);
     });
 
-    it('calls handle resize event when resize listener is called', done => {
-      root.width = () => 400;
-      responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
-
-      responsiveComponentsManager.resizeListener();
-
-      setTimeout(() => {
-        expect(handleResizeEvent).toHaveBeenCalled();
-        done();
-      }, 250);
+    afterEach(() => {
+      jasmine.clock().uninstall();
     });
 
-    it('does not calls handle resize event when resize listener is called and width is zero', done => {
+    it('calls handle resize event when resize listener is called', () => {
+      root.width = () => 400;
+      responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+      responsiveComponentsManager.resizeListener();
+      jasmine.clock().tick(250);
+      expect(handleResizeEvent).toHaveBeenCalled();
+    });
+
+    it('does not calls handle resize event when resize listener is called and width is zero', () => {
       root.width = () => 0;
       responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+      jasmine.clock().tick(250);
 
       responsiveComponentsManager.resizeListener();
 
-      setTimeout(() => {
-        expect(handleResizeEvent).not.toHaveBeenCalled();
-        done();
-      });
+      expect(handleResizeEvent).not.toHaveBeenCalled();
     });
 
     it('registers component even when the corresponding responsive class has already been instanciated', () => {

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -38,7 +38,7 @@ export function ResponsiveComponentsManagerTest() {
       setTimeout(() => {
         expect(handleResizeEvent).toHaveBeenCalled();
         done();
-      });
+      }, 250);
     });
 
     it('does not calls handle resize event when resize listener is called and width is zero', done => {


### PR DESCRIPTION
Resize events are sometimes not triggered in SFINT, because the reflow of the document can take too long, making the outer window well resized but not the inner, nor the div in the document.
That can cause the responsive components breakpoints to not be triggered.

To fix this issue, I propose the following PR, based on the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/Events/resize).

In a nutshell, I'm waiting for the resize event to stop being triggered for at least 250ms before actually calling the listener.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)