### PR TITLE
Replace history state when doing auto query correction

### DIFF
--- a/src/controllers/HistoryController.ts
+++ b/src/controllers/HistoryController.ts
@@ -14,6 +14,7 @@ import { IAnalyticsClient } from '../ui/Analytics/AnalyticsClient';
 import { analyticsActionCauseList, IAnalyticsFacetMeta, IAnalyticsActionCause } from '../ui/Analytics/AnalyticsActionListMeta';
 import { logSearchBoxSubmitEvent, logSortEvent } from '../ui/Analytics/SharedAnalyticsCalls';
 import { Model } from '../models/Model';
+import { IHistoryManager } from './HistoryManager';
 
 /**
  * This component is instantiated automatically by the framework on the root if the {@link SearchInterface}.<br/>
@@ -21,7 +22,7 @@ import { Model } from '../models/Model';
  * It's only job is to apply changes in the {@link QueryStateModel} to the hash in the URL, and vice versa.<br/>
  * This component does *not* hold the state of the interface, it only represent it in the URL.
  */
-export class HistoryController extends RootComponent {
+export class HistoryController extends RootComponent implements IHistoryManager {
   static ID = 'HistoryController';
 
   static attributesThatDoNotTriggerQuery = ['quickview'];
@@ -81,6 +82,15 @@ export class HistoryController extends RootComponent {
     return this.hashUtilsModule ? this.hashUtilsModule : HashUtils;
   }
 
+  public setState(state: Record<string, any>) {
+    return this.setHashValues(state);
+  }
+
+  public replaceState(state: Record<string, any>) {
+    const hash = '#' + this.hashUtils.encodeValues(state);
+    this.window.location.replace(hash);
+  }
+
   /**
    * Set the given map of key value in the hash of the URL
    * @param values
@@ -101,7 +111,7 @@ export class HistoryController extends RootComponent {
       if (hashHasChanged) {
         // Using replace avoids adding an entry in the History of the browser.
         // This means that this new URL will become the new initial URL.
-        this.window.location.replace(hash);
+        this.replaceState(values);
         this.logger.trace('History hash modified', hash);
       }
     } else if (hashHasChanged) {

--- a/src/controllers/HistoryController.ts
+++ b/src/controllers/HistoryController.ts
@@ -83,7 +83,7 @@ export class HistoryController extends RootComponent implements IHistoryManager 
   }
 
   public setState(state: Record<string, any>) {
-    return this.setHashValues(state);
+    this.setHashValues(state);
   }
 
   public replaceState(state: Record<string, any>) {

--- a/src/controllers/HistoryManager.ts
+++ b/src/controllers/HistoryManager.ts
@@ -1,0 +1,4 @@
+export interface IHistoryManager {
+  setState(state: Record<string, any>): void;
+  replaceState(state: Record<string, any>): void;
+}

--- a/src/controllers/LocalStorageHistoryController.ts
+++ b/src/controllers/LocalStorageHistoryController.ts
@@ -7,13 +7,14 @@ import { InitializationEvents } from '../events/InitializationEvents';
 import { RootComponent } from '../ui/Base/RootComponent';
 import { $$ } from '../utils/Dom';
 import * as _ from 'underscore';
+import { IHistoryManager } from './HistoryManager';
 
 /**
  * This component acts like the {@link HistoryController} excepts that is saves the {@link QueryStateModel} in the local storage.<br/>
  * This will not allow 'back' and 'forward' navigation in the history, like the standard {@link HistoryController} allows. Instead, it load the query state only on page load.<br/>
  * To enable this component, you should set the {@link SearchInterface.options.useLocalStorageForHistory} as well as the {@link SearchInterface.options.enableHistory} options to true.
  */
-export class LocalStorageHistoryController extends RootComponent {
+export class LocalStorageHistoryController extends RootComponent implements IHistoryManager {
   static ID = 'LocalStorageHistoryController';
 
   public storage: LocalStorageUtils<{ [key: string]: any }>;
@@ -42,6 +43,10 @@ export class LocalStorageHistoryController extends RootComponent {
     }
   }
 
+  public replaceState(state: Record<string, any>) {
+    return this.storage.save(state);
+  }
+
   /**
    * Specifies an array of attributes from the query state model that should not be persisted in the local storage
    * @param attributes
@@ -52,7 +57,7 @@ export class LocalStorageHistoryController extends RootComponent {
 
   private updateLocalStorageFromModel() {
     const attributes = _.omit(this.model.getAttributes(), this.omit);
-    this.setStorageValues(attributes);
+    this.setState(attributes);
     this.logger.debug('Saving state to localstorage', attributes);
   }
 
@@ -69,7 +74,7 @@ export class LocalStorageHistoryController extends RootComponent {
     this.model.setMultiple(toSet);
   }
 
-  public setStorageValues(values: { [key: string]: any }) {
+  public setState(values: Record<string, any>) {
     this.storage.save(values);
   }
 }

--- a/src/controllers/LocalStorageHistoryController.ts
+++ b/src/controllers/LocalStorageHistoryController.ts
@@ -44,7 +44,7 @@ export class LocalStorageHistoryController extends RootComponent implements IHis
   }
 
   public replaceState(state: Record<string, any>) {
-    return this.storage.save(state);
+    this.storage.save(state);
   }
 
   /**

--- a/src/controllers/NoopHistoryController.ts
+++ b/src/controllers/NoopHistoryController.ts
@@ -1,0 +1,6 @@
+import { IHistoryManager } from './HistoryManager';
+
+export class NoopHistoryController implements IHistoryManager {
+  public setState(state: Record<string, any>) {}
+  public replaceState(state: Record<string, any>) {}
+}

--- a/src/ui/DidYouMean/DidYouMean.ts
+++ b/src/ui/DidYouMean/DidYouMean.ts
@@ -111,6 +111,7 @@ export class DidYouMean extends Component {
       this.correctedTerm = data.results.queryCorrections[0].correctedQuery;
       let correctedSentence = this.buildCorrectedSentence(data.results.queryCorrections[0]);
       this.queryStateModel.set(QueryStateModel.attributesEnum.q, data.results.queryCorrections[0].correctedQuery);
+      this.searchInterface.historyManager.replaceState(this.queryStateModel.getAttributes());
       data.retryTheQuery = true;
       this.hideNext = false;
 

--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -6,7 +6,9 @@ import 'styling/_SearchInterface';
 import 'styling/_SearchModalBox';
 import { any, chain, each, find, first, indexOf, isEmpty, partition, tail } from 'underscore';
 import { HistoryController } from '../../controllers/HistoryController';
+import { IHistoryManager } from '../../controllers/HistoryManager';
 import { LocalStorageHistoryController } from '../../controllers/LocalStorageHistoryController';
+import { NoopHistoryController } from '../../controllers/NoopHistoryController';
 import { QueryController } from '../../controllers/QueryController';
 import { InitializationEvents } from '../../events/InitializationEvents';
 import {
@@ -42,18 +44,6 @@ import { MEDIUM_SCREEN_WIDTH, ResponsiveComponents, SMALL_SCREEN_WIDTH } from '.
 import { FacetColumnAutoLayoutAdjustment } from './FacetColumnAutoLayoutAdjustment';
 import { FacetValueStateHandler } from './FacetValueStateHandler';
 import RelevanceInspectorModule = require('../RelevanceInspector/RelevanceInspector');
-
-import * as fastclick from 'fastclick';
-import * as jstz from 'jstimezonedetect';
-
-import 'styling/Globals';
-import 'styling/_SearchInterface';
-import 'styling/_SearchModalBox';
-import 'styling/_SearchButton';
-import { each, indexOf, isEmpty, chain, any, find, partition, first, tail } from 'underscore';
-import { FacetColumnAutoLayoutAdjustment } from './FacetColumnAutoLayoutAdjustment';
-import { IHistoryManager } from '../../controllers/HistoryManager';
-import { NoopHistoryController } from '../../controllers/NoopHistoryController';
 
 export interface ISearchInterfaceOptions {
   enableHistory?: boolean;
@@ -493,7 +483,7 @@ export class SearchInterface extends RootComponent implements IComponentBindings
     Assert.exists(this.options);
     this.root = element;
 
-    this.setupWithEmptyQueryMode();
+    this.setupQueryMode();
     this.setupMobileFastclick(element);
 
     this.queryStateModel = new QueryStateModel(element);
@@ -668,7 +658,7 @@ export class SearchInterface extends RootComponent implements IComponentBindings
     this.historyManager = new HistoryController(element, _window, this.queryStateModel, this.queryController, this.usageAnalytics);
   }
 
-  private setupWithEmptyQueryMode() {
+  private setupQueryMode() {
     if (this.options.allowQueriesWithoutKeywords) {
       this.initializeEmptyQueryAllowed();
     } else {
@@ -680,9 +670,7 @@ export class SearchInterface extends RootComponent implements IComponentBindings
     // The definition file for fastclick does not match the way that fast click gets loaded (AMD)
     // So we have to do some typecasting gymnastics
     const attachFastclick = (fastclick as any).attach;
-    if (attachFastclick) {
-      attachFastclick(element);
-    }
+    attachFastclick(element);
   }
 
   private setupEventsHandlers() {
@@ -713,7 +701,7 @@ export class SearchInterface extends RootComponent implements IComponentBindings
     this.responsiveComponents.setSmallScreenWidth(this.options.responsiveSmallBreakpoint);
   }
 
-  private async handleDebugModeChange(args: IAttributeChangedEventArg) {
+  private handleDebugModeChange(args: IAttributeChangedEventArg) {
     if (args.value && !this.relevanceInspector && this.options.enableDebugInfo) {
       require.ensure(
         ['../RelevanceInspector/RelevanceInspector'],

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -1,21 +1,22 @@
-import { IComponentBindings } from '../src/ui/Base/ComponentBindings';
-import { IQueryResult } from '../src/rest/QueryResult';
-import { SearchInterface } from '../src/ui/SearchInterface/SearchInterface';
-import { QueryStateModel } from '../src/models/QueryStateModel';
-import { IAnalyticsClient } from '../src/ui/Analytics/AnalyticsClient';
-import { $$ } from '../src/utils/Dom';
-import { ComponentStateModel } from '../src/models/ComponentStateModel';
+import { NoopHistoryController } from '../src/controllers/NoopHistoryController';
+import { QueryController } from '../src/controllers/QueryController';
 import { ComponentOptionsModel } from '../src/models/ComponentOptionsModel';
+import { ComponentStateModel } from '../src/models/ComponentStateModel';
+import { QueryStateModel } from '../src/models/QueryStateModel';
+import { AnalyticsEndpoint } from '../src/rest/AnalyticsEndpoint';
+import { IQueryResult } from '../src/rest/QueryResult';
+import { SearchEndpoint } from '../src/rest/SearchEndpoint';
+import { IAnalyticsClient } from '../src/ui/Analytics/AnalyticsClient';
+import { NoopAnalyticsClient } from '../src/ui/Analytics/NoopAnalyticsClient';
+import { BaseComponent } from '../src/ui/Base/BaseComponent';
+import { Component } from '../src/ui/Base/Component';
+import { IComponentBindings } from '../src/ui/Base/ComponentBindings';
+import { QueryBuilder } from '../src/ui/Base/QueryBuilder';
+import { ResponsiveComponents } from '../src/ui/ResponsiveComponents/ResponsiveComponents';
+import { SearchInterface } from '../src/ui/SearchInterface/SearchInterface';
+import { $$ } from '../src/utils/Dom';
 import { OS_NAME } from '../src/utils/OSUtils';
 import { FakeResults } from './Fake';
-import { Component } from '../src/ui/Base/Component';
-import { BaseComponent } from '../src/ui/Base/BaseComponent';
-import { NoopAnalyticsClient } from '../src/ui/Analytics/NoopAnalyticsClient';
-import { AnalyticsEndpoint } from '../src/rest/AnalyticsEndpoint';
-import { SearchEndpoint } from '../src/rest/SearchEndpoint';
-import { QueryController } from '../src/controllers/QueryController';
-import { ResponsiveComponents } from '../src/ui/ResponsiveComponents/ResponsiveComponents';
-import { QueryBuilder } from '../src/ui/Base/QueryBuilder';
 import { Simulate } from './Simulate';
 import ModalBox = Coveo.ModalBox.ModalBox;
 
@@ -45,6 +46,7 @@ export class MockEnvironmentBuilder {
   public componentStateModel = mockComponent<ComponentStateModel>(ComponentStateModel, ComponentStateModel.ID);
   public usageAnalytics = mockUsageAnalytics();
   public componentOptionsModel = mockComponent<ComponentOptionsModel>(ComponentOptionsModel, ComponentOptionsModel.ID);
+  public historyManager = new NoopHistoryController();
   public os: OS_NAME;
   private built = false;
 
@@ -108,6 +110,7 @@ export class MockEnvironmentBuilder {
     this.searchInterface.componentOptionsModel = this.componentOptionsModel;
     this.searchInterface.element = this.root;
     this.searchInterface.getBindings = () => this.getBindings() as any;
+    this.searchInterface.historyManager = this.historyManager;
 
     if (!this.searchEndpoint) {
       this.searchEndpoint = mockSearchEndpoint();

--- a/unitTests/ui/DidYouMeanTest.ts
+++ b/unitTests/ui/DidYouMeanTest.ts
@@ -11,10 +11,10 @@ import { QueryStateModel } from '../../src/models/QueryStateModel';
 import { $$ } from '../../src/utils/Dom';
 
 export function DidYouMeanTest() {
-  describe('DidYouMean', function() {
-    var test: Mock.IBasicComponentSetup<DidYouMean>;
-    var fakeQueryCorrection: IQueryCorrection;
-    beforeEach(function() {
+  describe('DidYouMean', () => {
+    let test: Mock.IBasicComponentSetup<DidYouMean>;
+    let fakeQueryCorrection: IQueryCorrection;
+    beforeEach(() => {
       test = Mock.basicComponentSetup<DidYouMean>(DidYouMean);
       fakeQueryCorrection = {
         correctedQuery: 'this is the corrected query',
@@ -30,11 +30,11 @@ export function DidYouMeanTest() {
       test.env.queryStateModel.get = () => 'originalquery';
     });
 
-    it('should be hidden before making a query', function() {
+    it('should be hidden before making a query', () => {
       expect(test.cmp.element.style.display).toBe('none');
     });
 
-    it('should be shown when there are both query corrections and results', function() {
+    it('should be shown when there are both query corrections and results', () => {
       Simulate.query(test.env, {
         results: FakeResults.createFakeResults(2),
         queryCorrections: [fakeQueryCorrection]
@@ -43,7 +43,7 @@ export function DidYouMeanTest() {
       expect(test.cmp.element.style.display).not.toBe('none');
     });
 
-    it('should be hidden when there are no query corrections', function() {
+    it('should be hidden when there are no query corrections', () => {
       Simulate.query(test.env, {
         results: FakeResults.createFakeResults(0),
         queryCorrections: []
@@ -52,8 +52,8 @@ export function DidYouMeanTest() {
       expect(test.cmp.element.style.display).toBe('none');
     });
 
-    it('should send an analytics event when doQueryWithCorrectedTerm is called', function() {
-      var analyticsSpy = jasmine.createSpy('analyticsSpy');
+    it('should send an analytics event when doQueryWithCorrectedTerm is called', () => {
+      const analyticsSpy = jasmine.createSpy('analyticsSpy');
       test.env.usageAnalytics.logSearchEvent = analyticsSpy;
       Simulate.query(test.env, <ISimulateQueryData>{
         queryCorrections: [fakeQueryCorrection]
@@ -65,61 +65,89 @@ export function DidYouMeanTest() {
       expect(analyticsSpy).toHaveBeenCalledWith(analyticsActionCauseList.didyoumeanClick, {});
     });
 
-    describe('exposes options', function() {
-      describe('enableAutoCorrection', function() {
-        it('set to true should autocorrect the query when no results are found', function() {
-          test = Mock.optionsComponentSetup<DidYouMean, IDidYouMeanOptions>(DidYouMean, <IDidYouMeanOptions>{
-            enableAutoCorrection: true
-          });
-          test.env.queryStateModel.get = () => 'foobar';
-          var qsmSpy = jasmine.createSpy('queryStateModelSpy');
-          test.env.queryStateModel.set = qsmSpy;
-
-          Simulate.query(test.env, {
-            results: FakeResults.createFakeResults(0),
-            queryCorrections: [fakeQueryCorrection]
+    describe('exposes options', () => {
+      describe('enableAutoCorrection', () => {
+        describe('set to true', () => {
+          beforeEach(() => {
+            test = Mock.optionsComponentSetup<DidYouMean, IDidYouMeanOptions>(DidYouMean, <IDidYouMeanOptions>{
+              enableAutoCorrection: true
+            });
+            test.env.queryStateModel.get = () => 'foobar';
           });
 
-          expect(qsmSpy).toHaveBeenCalledWith(QueryStateModel.attributesEnum.q, 'this is the corrected query');
+          it('should autocorrect the query when no results are found', () => {
+            const qsmSpy = jasmine.createSpy('queryStateModelSpy');
+            test.env.queryStateModel.set = qsmSpy;
+
+            Simulate.query(test.env, {
+              results: FakeResults.createFakeResults(0),
+              queryCorrections: [fakeQueryCorrection]
+            });
+
+            expect(qsmSpy).toHaveBeenCalledWith(QueryStateModel.attributesEnum.q, 'this is the corrected query');
+          });
+
+          it('should send an analytics event when query is autocorrected', () => {
+            const analyticsSpy = jasmine.createSpy('analyticsSpy');
+            test.cmp.usageAnalytics.logSearchEvent = analyticsSpy;
+
+            Simulate.query(test.env, {
+              results: FakeResults.createFakeResults(0),
+              queryCorrections: [fakeQueryCorrection]
+            });
+
+            expect(analyticsSpy).toHaveBeenCalledWith(analyticsActionCauseList.didyoumeanAutomatic, {});
+            expect(analyticsSpy.calls.count()).toBe(1);
+          });
+
+          it('should replace the state in history manager when query is autocorrected', () => {
+            spyOn(test.env.searchInterface.historyManager, 'replaceState');
+
+            Simulate.query(test.env, {
+              results: FakeResults.createFakeResults(0),
+              queryCorrections: [fakeQueryCorrection]
+            });
+
+            expect(test.env.searchInterface.historyManager.replaceState).toHaveBeenCalled();
+          });
         });
 
-        it('set to true should send an analytics event when query is autocorrected', function() {
-          test = Mock.optionsComponentSetup<DidYouMean, IDidYouMeanOptions>(DidYouMean, <IDidYouMeanOptions>{
-            enableAutoCorrection: true
-          });
-          test.env.queryStateModel.get = () => 'foobar';
-          var analyticsSpy = jasmine.createSpy('analyticsSpy');
-          test.cmp.usageAnalytics.logSearchEvent = analyticsSpy;
-
-          Simulate.query(test.env, {
-            results: FakeResults.createFakeResults(0),
-            queryCorrections: [fakeQueryCorrection]
+        describe('set to false', () => {
+          beforeEach(() => {
+            test = Mock.optionsComponentSetup<DidYouMean, IDidYouMeanOptions>(DidYouMean, <IDidYouMeanOptions>{
+              enableAutoCorrection: false
+            });
           });
 
-          expect(analyticsSpy).toHaveBeenCalledWith(analyticsActionCauseList.didyoumeanAutomatic, {});
-          expect(analyticsSpy.calls.count()).toBe(1);
-        });
+          it('should not autocorrect the query when no results are found', () => {
+            test.env.queryStateModel.get = () => 'foobar';
+            const qsmSpy = jasmine.createSpy('queryStateModelSpy');
+            test.env.queryStateModel.set = qsmSpy;
 
-        it('set to false should not autocorrect the query when no results are found', function() {
-          test = Mock.optionsComponentSetup<DidYouMean, IDidYouMeanOptions>(DidYouMean, <IDidYouMeanOptions>{
-            enableAutoCorrection: false
-          });
-          test.env.queryStateModel.get = () => 'foobar';
-          var qsmSpy = jasmine.createSpy('queryStateModelSpy');
-          test.env.queryStateModel.set = qsmSpy;
+            Simulate.query(test.env, {
+              results: FakeResults.createFakeResults(0),
+              queryCorrections: [fakeQueryCorrection]
+            });
 
-          Simulate.query(test.env, {
-            results: FakeResults.createFakeResults(0),
-            queryCorrections: [fakeQueryCorrection]
+            expect(qsmSpy).not.toHaveBeenCalled();
           });
 
-          expect(qsmSpy).not.toHaveBeenCalled();
+          it('should not replace the state in history manager', () => {
+            spyOn(test.env.searchInterface.historyManager, 'replaceState');
+
+            Simulate.query(test.env, {
+              results: FakeResults.createFakeResults(0),
+              queryCorrections: [fakeQueryCorrection]
+            });
+
+            expect(test.env.searchInterface.historyManager.replaceState).not.toHaveBeenCalled();
+          });
         });
       });
     });
 
-    it('should not autocorrect search-as-you-type queries', function() {
-      var qsmSpy = jasmine.createSpy('queryStateModelSpy');
+    it('should not autocorrect search-as-you-type queries', () => {
+      const qsmSpy = jasmine.createSpy('queryStateModelSpy');
       test.env.queryStateModel.set = qsmSpy;
 
       Simulate.query(test.env, {
@@ -131,11 +159,11 @@ export function DidYouMeanTest() {
       expect(qsmSpy).not.toHaveBeenCalled();
     });
 
-    it('correctedTerm should be null before a query', function() {
+    it('correctedTerm should be null before a query', () => {
       expect(test.cmp.correctedTerm).toBeNull();
     });
 
-    it('correctedTerm should be initialized properly from the queryCorrections', function() {
+    it('correctedTerm should be initialized properly from the queryCorrections', () => {
       Simulate.query(test.env, {
         queryCorrections: [fakeQueryCorrection]
       });
@@ -143,12 +171,12 @@ export function DidYouMeanTest() {
       expect(test.cmp.correctedTerm).toBe(fakeQueryCorrection.correctedQuery);
     });
 
-    describe('doQueryWithCorrectedTerm', function() {
-      it('should throw an exception if no query was made', function() {
+    describe('doQueryWithCorrectedTerm', () => {
+      it('should throw an exception if no query was made', () => {
         expect(() => test.cmp.doQueryWithCorrectedTerm()).toThrow();
       });
 
-      it('should throw an exception if no corrections were available', function() {
+      it('should throw an exception if no corrections were available', () => {
         Simulate.query(test.env, {
           queryCorrections: []
         });
@@ -156,12 +184,12 @@ export function DidYouMeanTest() {
         expect(() => test.cmp.doQueryWithCorrectedTerm()).toThrow();
       });
 
-      it('should execute a query when corrections were available', function() {
+      it('should execute a query when corrections were available', () => {
         Simulate.query(test.env, {
           queryCorrections: [fakeQueryCorrection]
         });
 
-        var qsmSpy = jasmine.createSpy('queryStateModelSpy');
+        const qsmSpy = jasmine.createSpy('queryStateModelSpy');
         test.env.queryStateModel.set = qsmSpy;
         test.cmp.doQueryWithCorrectedTerm();
 
@@ -170,10 +198,10 @@ export function DidYouMeanTest() {
       });
     });
 
-    describe('escape the HTML against XSS', function() {
-      beforeEach(function() {});
+    describe('escape the HTML against XSS', () => {
+      beforeEach(() => {});
 
-      it('when there are results', function() {
+      it('when there are results', () => {
         Simulate.query(test.env, {
           queryCorrections: [
             <IQueryCorrection>{
@@ -186,7 +214,7 @@ export function DidYouMeanTest() {
         );
       });
 
-      it('when query is autocorrected', function() {
+      it('when query is autocorrected', () => {
         Simulate.query(test.env, {
           results: FakeResults.createFakeResults(10),
           queryCorrections: [

--- a/unitTests/ui/DidYouMeanTest.ts
+++ b/unitTests/ui/DidYouMeanTest.ts
@@ -76,15 +76,15 @@ export function DidYouMeanTest() {
           });
 
           it('should autocorrect the query when no results are found', () => {
-            const qsmSpy = jasmine.createSpy('queryStateModelSpy');
-            test.env.queryStateModel.set = qsmSpy;
+            const spy = jasmine.createSpy('queryStateModelSpy');
+            test.env.queryStateModel.set = spy;
 
             Simulate.query(test.env, {
               results: FakeResults.createFakeResults(0),
               queryCorrections: [fakeQueryCorrection]
             });
 
-            expect(qsmSpy).toHaveBeenCalledWith(QueryStateModel.attributesEnum.q, 'this is the corrected query');
+            expect(spy).toHaveBeenCalledWith(QueryStateModel.attributesEnum.q, 'this is the corrected query');
           });
 
           it('should send an analytics event when query is autocorrected', () => {
@@ -97,7 +97,7 @@ export function DidYouMeanTest() {
             });
 
             expect(analyticsSpy).toHaveBeenCalledWith(analyticsActionCauseList.didyoumeanAutomatic, {});
-            expect(analyticsSpy.calls.count()).toBe(1);
+            expect(analyticsSpy).toHaveBeenCalledTimes(1);
           });
 
           it('should replace the state in history manager when query is autocorrected', () => {
@@ -108,7 +108,7 @@ export function DidYouMeanTest() {
               queryCorrections: [fakeQueryCorrection]
             });
 
-            expect(test.env.searchInterface.historyManager.replaceState).toHaveBeenCalled();
+            expect(test.env.searchInterface.historyManager.replaceState).toHaveBeenCalledTimes(1);
           });
         });
 
@@ -121,15 +121,15 @@ export function DidYouMeanTest() {
 
           it('should not autocorrect the query when no results are found', () => {
             test.env.queryStateModel.get = () => 'foobar';
-            const qsmSpy = jasmine.createSpy('queryStateModelSpy');
-            test.env.queryStateModel.set = qsmSpy;
+            const spy = jasmine.createSpy('queryStateModelSpy');
+            test.env.queryStateModel.set = spy;
 
             Simulate.query(test.env, {
               results: FakeResults.createFakeResults(0),
               queryCorrections: [fakeQueryCorrection]
             });
 
-            expect(qsmSpy).not.toHaveBeenCalled();
+            expect(spy).not.toHaveBeenCalled();
           });
 
           it('should not replace the state in history manager', () => {
@@ -147,8 +147,8 @@ export function DidYouMeanTest() {
     });
 
     it('should not autocorrect search-as-you-type queries', () => {
-      const qsmSpy = jasmine.createSpy('queryStateModelSpy');
-      test.env.queryStateModel.set = qsmSpy;
+      const spy = jasmine.createSpy('queryStateModelSpy');
+      test.env.queryStateModel.set = spy;
 
       Simulate.query(test.env, {
         results: FakeResults.createFakeResults(0),
@@ -156,7 +156,7 @@ export function DidYouMeanTest() {
         queryCorrections: [fakeQueryCorrection]
       });
 
-      expect(qsmSpy).not.toHaveBeenCalled();
+      expect(spy).not.toHaveBeenCalled();
     });
 
     it('correctedTerm should be null before a query', () => {
@@ -189,12 +189,12 @@ export function DidYouMeanTest() {
           queryCorrections: [fakeQueryCorrection]
         });
 
-        const qsmSpy = jasmine.createSpy('queryStateModelSpy');
-        test.env.queryStateModel.set = qsmSpy;
+        const spy = jasmine.createSpy('queryStateModelSpy');
+        test.env.queryStateModel.set = spy;
         test.cmp.doQueryWithCorrectedTerm();
 
-        expect(qsmSpy).toHaveBeenCalledWith(QueryStateModel.attributesEnum.q, fakeQueryCorrection.correctedQuery);
-        expect(qsmSpy.calls.count()).toBe(1);
+        expect(spy).toHaveBeenCalledWith(QueryStateModel.attributesEnum.q, fakeQueryCorrection.correctedQuery);
+        expect(spy.calls.count()).toBe(1);
       });
     });
 

--- a/unitTests/ui/SearchInterfaceTest.ts
+++ b/unitTests/ui/SearchInterfaceTest.ts
@@ -19,6 +19,7 @@ import { PipelineContext } from '../../src/ui/PipelineContext/PipelineContext';
 import { SearchEndpoint } from '../Test';
 import { Quickview } from '../../src/ui/Quickview/Quickview';
 import { MEDIUM_SCREEN_WIDTH, SMALL_SCREEN_WIDTH } from '../../src/ui/ResponsiveComponents/ResponsiveComponents';
+import { NoopHistoryController } from '../../src/controllers/NoopHistoryController';
 
 export function SearchInterfaceTest() {
   describe('SearchInterface', () => {
@@ -370,11 +371,25 @@ export function SearchInterfaceTest() {
           expect(Component.resolveBinding(cmp.element, HistoryController)).toBeDefined();
         });
 
+        it("enableHistory uses a full fledge HistoryController by default as it's manager", () => {
+          const searchInterface = setupSearchInterface({
+            enableHistory: true
+          });
+          expect(searchInterface.historyManager instanceof HistoryController).toBe(true);
+        });
+
         it("enableHistory can be disabled and won't save history in the url", () => {
           setupSearchInterface({
             enableHistory: false
           });
           expect(Component.resolveBinding(cmp.element, HistoryController)).toBeUndefined();
+        });
+
+        it('enableHistory can be disabled and there will still be an history manager to access', () => {
+          const searchInterface = setupSearchInterface({
+            enableHistory: false
+          });
+          expect(searchInterface.historyManager instanceof NoopHistoryController).toBe(true);
         });
 
         it('useLocalStorageForHistory allow to use local storage for history', () => {
@@ -384,6 +399,14 @@ export function SearchInterfaceTest() {
           });
           expect(Component.resolveBinding(cmp.element, HistoryController)).toBeUndefined();
           expect(Component.resolveBinding(cmp.element, LocalStorageHistoryController)).toBeDefined();
+        });
+
+        it("useLocalStorageForHistory uses a LocalStorageHistoryController as it's manager", () => {
+          const searchInterface = setupSearchInterface({
+            enableHistory: true,
+            useLocalStorageForHistory: true
+          });
+          expect(searchInterface.historyManager instanceof LocalStorageHistoryController).toBe(true);
         });
 
         it('useLocalStorageForHistory allow to use local storage for history, but not if history is disabled', () => {


### PR DESCRIPTION
Replace history state will not create a new history entry, and so it will be possible to "pop" from the last browser state properly without getting stuck in a loop where you are going back to an invalid query that return corrections automatically.

https://coveord.atlassian.net/browse/JSUI-2058





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)