### PR TITLE
Leave the menu open when someone clicks on it.

### DIFF
--- a/src/ui/ResultActions/ResultActionsMenu.ts
+++ b/src/ui/ResultActions/ResultActionsMenu.ts
@@ -113,7 +113,7 @@ export class ResultActionsMenu extends Component {
   }
 
   private bindEvents() {
-    $$(this.parentResult).on('click', () => (this.isOpened ? this.hide() : this.show()));
+    $$(this.parentResult).on('click', () => this.show());
 
     $$(this.parentResult).on('mouseleave', () => this.hide());
     if (this.options.openOnMouseOver) {


### PR DESCRIPTION
I think it's better if the menu stays there when you click on an option, that way we can show a status.


@olamothe @sbelzile-Coveo 

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)