### PR TITLE
Result actions menu stay open on click

### DIFF
--- a/src/ui/ResultActions/ResultActionsMenu.ts
+++ b/src/ui/ResultActions/ResultActionsMenu.ts
@@ -113,7 +113,7 @@ export class ResultActionsMenu extends Component {
   }
 
   private bindEvents() {
-    $$(this.parentResult).on('click', () => (this.isOpened ? this.hide() : this.show()));
+    $$(this.parentResult).on('click', () => this.show());
 
     $$(this.parentResult).on('mouseleave', () => this.hide());
     if (this.options.openOnMouseOver) {

--- a/src/ui/ResultActions/ResultActionsMenu.ts
+++ b/src/ui/ResultActions/ResultActionsMenu.ts
@@ -53,8 +53,6 @@ export class ResultActionsMenu extends Component {
     openOnMouseOver: ComponentOptions.buildBooleanOption({ defaultValue: true })
   };
 
-  private isOpened: boolean;
-
   /**
    * The rendered result that contains this menu.
    */
@@ -92,7 +90,6 @@ export class ResultActionsMenu extends Component {
    * Shows the floating menu.
    */
   public show() {
-    this.isOpened = true;
     $$(this.element).addClass(ResultActionsMenu.SHOW_CLASS);
   }
 
@@ -100,7 +97,6 @@ export class ResultActionsMenu extends Component {
    * Hides the floating menu.
    */
   public hide() {
-    this.isOpened = false;
     $$(this.element).removeClass(ResultActionsMenu.SHOW_CLASS);
   }
 

--- a/unitTests/ui/ResultActionsMenuTest.ts
+++ b/unitTests/ui/ResultActionsMenuTest.ts
@@ -19,7 +19,7 @@ export function ResultActionsMenuTest() {
       return component.hasClass(ResultActionsMenu.SHOW_CLASS);
     }
 
-    it('should add and remove show class on concecutive clicks', () => {
+    it('should not remove show class on concecutive clicks', () => {
       const component = $$(test.cmp.element);
 
       component.trigger('click');
@@ -27,7 +27,7 @@ export function ResultActionsMenuTest() {
 
       component.trigger('click');
 
-      expect(componentHasShowClass()).toBe(false);
+      expect(componentHasShowClass()).toBe(true);
     });
 
     it('should add show class on mouseenter when openOnMouseOver option is true', () => {


### PR DESCRIPTION
The menu should stay open when you click on a button, that way you can see the status of buttons like Attach To Case.

I also tested on mobile. I think it makes sense to always show the menu when you click on a result. Making it disappear when you click is confusing because again, the status of the button disappeared, so you have to click again to see if you item was attached to the case.

@sbelzile-Coveo @olamothe @tedre191 

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)