### PR TITLE
Add scroll "auto" to detection of scrolling parent

### DIFF
--- a/src/ui/Base/ComponentOptions.ts
+++ b/src/ui/Base/ComponentOptions.ts
@@ -1,14 +1,14 @@
-import { IFieldDescription } from '../../rest/FieldDescription';
+import { contains, each, extend, isArray, keys, map } from 'underscore';
 import { Assert } from '../../misc/Assert';
 import { Logger } from '../../misc/Logger';
-import { $$ } from '../../utils/Dom';
-import { Utils } from '../../utils/Utils';
-import { l } from '../../strings/Strings';
-import * as _ from 'underscore';
-import { SVGIcons } from '../../utils/SVGIcons';
+import { IFieldDescription } from '../../rest/FieldDescription';
 import { IStringMap } from '../../rest/GenericParam';
-import { IComponentOptionsTemplateOptionArgs, TemplateComponentOptions } from './TemplateComponentOptions';
+import { l } from '../../strings/Strings';
+import { $$ } from '../../utils/Dom';
+import { SVGIcons } from '../../utils/SVGIcons';
+import { Utils } from '../../utils/Utils';
 import { Template } from '../Templates/Template';
+import { IComponentOptionsTemplateOptionArgs, TemplateComponentOptions } from './TemplateComponentOptions';
 
 /**
  * The `IFieldOption` interface declares a type for options that should contain a field to be used in a query.
@@ -584,15 +584,15 @@ export class ComponentOptions {
     const loadOption: IComponentOptionsLoadOption<{
       [key: string]: any;
     }> = (element: HTMLElement, name: string, option: IComponentOptionsOption<any>) => {
-      const keys = _.keys(optionArgs.subOptions);
+      const extractedKeys = keys(optionArgs.subOptions);
       const scopedOptions: {
         [name: string]: IComponentOptionsOption<any>;
       } = {};
       const scopedValues: {
         [name: string]: any;
       } = {};
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
+      for (let i = 0; i < extractedKeys.length; i++) {
+        const key = extractedKeys[i];
         const scopedkey = ComponentOptions.mergeCamelCase(name, key);
         scopedOptions[scopedkey] = optionArgs.subOptions[key];
       }
@@ -601,8 +601,8 @@ export class ComponentOptions {
         [name: string]: any;
       } = {};
       let resultFound = false;
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i];
+      for (let i = 0; i < extractedKeys.length; i++) {
+        const key = extractedKeys[i];
         const scopedkey = ComponentOptions.mergeCamelCase(name, key);
         if (scopedValues[scopedkey] != null) {
           resultValues[key] = scopedValues[scopedkey];
@@ -667,7 +667,7 @@ export class ComponentOptions {
     if (values == null) {
       values = {};
     }
-    const names: string[] = _.keys(options);
+    const names: string[] = keys(options);
     for (let i = 0; i < names.length; i++) {
       const name = names[i];
       const optionDefinition = options[name];
@@ -688,9 +688,9 @@ export class ComponentOptions {
       if (value == null && values[name] == undefined) {
         if (optionDefinition.defaultValue != null) {
           if (optionDefinition.type == ComponentOptionsType.LIST) {
-            value = _.extend([], optionDefinition.defaultValue);
+            value = extend([], optionDefinition.defaultValue);
           } else if (optionDefinition.type == ComponentOptionsType.OBJECT) {
-            value = _.extend({}, optionDefinition.defaultValue);
+            value = extend({}, optionDefinition.defaultValue);
           } else {
             value = optionDefinition.defaultValue;
           }
@@ -711,7 +711,7 @@ export class ComponentOptions {
           }
         }
         if (optionDefinition.type == ComponentOptionsType.OBJECT && values[name] != null) {
-          values[name] = _.extend(values[name], value);
+          values[name] = extend(values[name], value);
         } else if (optionDefinition.type == ComponentOptionsType.LOCALIZED_STRING) {
           values[name] = l(value);
         } else {
@@ -772,7 +772,7 @@ export class ComponentOptions {
       return null;
     }
     const fields = fieldsAttr.split(fieldsSeperator);
-    _.each(fields, (field: string) => {
+    each(fields, (field: string) => {
       Assert.check(Utils.isCoveoField(field), field + ' is not a valid field');
     });
     return fields;
@@ -783,14 +783,14 @@ export class ComponentOptions {
     const locale: string = String['locale'] || String['defaultLocale'];
     if (locale != null && attributeValue != null) {
       const localeParts = locale.toLowerCase().split('-');
-      const locales = _.map(localeParts, (part, i) => localeParts.slice(0, i + 1).join('-'));
+      const locales = map(localeParts, (part, i) => localeParts.slice(0, i + 1).join('-'));
       const localizers = attributeValue.match(localizer);
       if (localizers != null) {
         for (let i = 0; i < localizers.length; i++) {
           const groups = localizer.exec(localizers[i]);
           if (groups != null) {
             const lang = groups[1].toLowerCase();
-            if (_.contains(locales, lang)) {
+            if (contains(locales, lang)) {
               return groups[2].replace(/^\s+|\s+$/g, '');
             }
           }
@@ -920,13 +920,14 @@ export class ComponentOptions {
   }
 
   static isElementScrollable(element: HTMLElement) {
-    return $$(element).css('overflow-y') == 'scroll' || element.style.overflowY == 'scroll';
+    const overflowProperty = $$(element).css('overflow-y') || element.style.overflowY;
+    return overflowProperty == 'scroll' || overflowProperty == 'auto';
   }
 
   static getAttributeFromAlias(element: HTMLElement, option: IComponentOptions<any>) {
-    if (_.isArray(option.alias)) {
+    if (isArray(option.alias)) {
       let attributeFound;
-      _.each(option.alias, alias => {
+      each(option.alias, alias => {
         const attributeFoundWithThisAlias = element.getAttribute(ComponentOptions.attrNameFromName(alias));
         if (attributeFoundWithThisAlias) {
           attributeFound = attributeFoundWithThisAlias;

--- a/unitTests/ui/ComponentOptionsTest.ts
+++ b/unitTests/ui/ComponentOptionsTest.ts
@@ -1,8 +1,7 @@
-import { ComponentOptions } from '../../src/ui/Base/ComponentOptions';
-import { ComponentOptionsType, IComponentOptions } from '../../src/ui/Base/ComponentOptions';
-import { Dom } from '../../src/utils/Dom';
-import { TemplateCache } from '../../src/ui/Templates/TemplateCache';
+import { ComponentOptions, ComponentOptionsType, IComponentOptions } from '../../src/ui/Base/ComponentOptions';
 import { TemplateComponentOptions } from '../../src/ui/Base/TemplateComponentOptions';
+import { TemplateCache } from '../../src/ui/Templates/TemplateCache';
+import { Dom } from '../../src/utils/Dom';
 
 export function ComponentOptionsTest() {
   describe('ComponentOptions', () => {
@@ -575,9 +574,28 @@ export function ComponentOptionsTest() {
       });
 
       describe('findParentScrolling', () => {
-        it('which finds a scrollable parent', () => {
+        it('which finds a scrollable parent with overflow scroll', () => {
+          scrollElem.style.overflowY = 'scroll';
           const option = ComponentOptions.findParentScrolling(elem, doc);
           expect(option).toBe(scrollElem);
+        });
+
+        it('which finds a scrollable parent with overflow auto', () => {
+          scrollElem.style.overflowY = 'auto';
+          const option = ComponentOptions.findParentScrolling(elem, doc);
+          expect(option).toBe(scrollElem);
+        });
+
+        it("which won't detect overflow visible as scrollable", () => {
+          scrollElem.style.overflowY = 'visible';
+          const option = ComponentOptions.findParentScrolling(elem, doc);
+          expect(option).not.toBe(scrollElem);
+        });
+
+        it("which won't detect overflow inherit as scrollable", () => {
+          scrollElem.style.overflowY = 'inherit';
+          const option = ComponentOptions.findParentScrolling(elem, doc);
+          expect(option).not.toBe(scrollElem);
         });
       });
 


### PR DESCRIPTION
Added overflowY : auto to "auto detection of scrolling container" in the result list.

Interesting to note that even though the UI could not properly detect automatically the correct container with the test page configuration, it at least had multiple warning message and protection mechanism that did their job properly (eg: querying non stop to try and fill an impossible to fill scrolling container).

I simply added auto since it makes sense and makes things a bit easier to configure.

https://coveord.atlassian.net/browse/JSUI-2071





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)