### PR TITLE
Allow to defer initialization through event args

### DIFF
--- a/src/events/InitializationEvents.ts
+++ b/src/events/InitializationEvents.ts
@@ -1,4 +1,11 @@
 /**
+ * Argument sent to all handlers bound on {@link InitializationEvents.beforeInitialization}, {@link InitializationEvents.afterComponentsInitialization}, and {@link InitializationEvents.afterInitialization}.
+ */
+export interface IInitializationEventArgs {
+  defer: Promise<any>[];
+}
+
+/**
  * This static class is there to contain the different string definitions for all the events related to initialization.
  *
  * Note that these events will only be triggered when the {@link init} function is called.

--- a/src/events/InitializationEvents.ts
+++ b/src/events/InitializationEvents.ts
@@ -1,5 +1,5 @@
 /**
- * Argument sent to all handlers bound on {@link InitializationEvents.beforeInitialization}, {@link InitializationEvents.afterComponentsInitialization}, and {@link InitializationEvents.afterInitialization}.
+ * Argument sent to all handlers bound on {@link InitializationEvents.afterComponentsInitialization}, and {@link InitializationEvents.afterInitialization}.
  */
 export interface IInitializationEventArgs {
   defer: Promise<any>[];

--- a/src/ui/Distance/DistanceResources.ts
+++ b/src/ui/Distance/DistanceResources.ts
@@ -53,7 +53,7 @@ export class DistanceResources extends Component {
   };
   private latitude: number;
   private longitude: number;
-  private lastPositionRequest: Promise<IGeolocationPosition | void>;
+  private lastPositionRequest: Promise<void>;
   private isFirstPositionResolved = false;
 
   /**
@@ -242,8 +242,16 @@ export class DistanceResources extends Component {
    *
    * @returns {Promise<IGeolocationPosition>} A promise of the last resolved position value.
    */
-  public getLastPositionRequest(): Promise<IGeolocationPosition> {
-    return this.lastPositionRequest || Promise.reject('No position request was executed yet.');
+  public async getLastPositionRequest(): Promise<IGeolocationPosition> {
+    if (!!this.lastPositionRequest) {
+      await this.lastPositionRequest;
+      return {
+        latitude: this.latitude,
+        longitude: this.longitude
+      };
+    } else {
+      Promise.reject('No position request was executed yet.');
+    }
   }
 
   private sendAnalytics() {
@@ -269,7 +277,7 @@ export class DistanceResources extends Component {
     }
   }
 
-  private async tryToSetPositionFromProviders(providers: IGeolocationPositionProvider[]): Promise<IGeolocationPosition> {
+  private async tryToSetPositionFromProviders(providers: IGeolocationPositionProvider[]): Promise<void> {
     try {
       const position = await this.tryGetPositionFromProviders(providers);
       if (position) {
@@ -277,7 +285,6 @@ export class DistanceResources extends Component {
       } else {
         this.triggerDistanceNotSet();
       }
-      return position;
     } catch (error) {
       this.logger.error('An error occurred while trying to resolve the current position.', error);
       this.triggerDistanceNotSet();

--- a/src/ui/Distance/DistanceResources.ts
+++ b/src/ui/Distance/DistanceResources.ts
@@ -7,7 +7,7 @@ import {
   IPositionResolvedEventArgs
 } from '../../events/DistanceEvents';
 
-import { analyticsActionCauseList, IAnalyticsActionCause } from '../Analytics/AnalyticsActionListMeta';
+import { analyticsActionCauseList } from '../Analytics/AnalyticsActionListMeta';
 import { Component } from '../Base/Component';
 import { IFieldOption, ComponentOptions } from '../Base/ComponentOptions';
 import { IComponentBindings } from '../Base/ComponentBindings';
@@ -20,7 +20,7 @@ import { exportGlobally } from '../../GlobalExports';
 import { NavigatorPositionProvider } from './NavigatorPositionProvider';
 import { GoogleApiPositionProvider } from './GoogleApiPositionProvider';
 import { StaticPositionProvider } from './StaticPositionProvider';
-import { PendingSearchEvent } from '../Analytics/PendingSearchEvent';
+import { IInitializationEventArgs } from '../../events/InitializationEvents';
 
 export interface IDistanceOptions {
   distanceField: IFieldOption;
@@ -55,7 +55,6 @@ export class DistanceResources extends Component {
   private longitude: number;
   private lastPositionRequest: Promise<IGeolocationPosition | void>;
   private isFirstPositionResolved = false;
-  private pendingSearchEventOnCancellation: PendingSearchEvent;
 
   /**
    * The possible options for a DistanceResources.
@@ -202,7 +201,9 @@ export class DistanceResources extends Component {
 
     this.options = ComponentOptions.initComponentOptions(element, DistanceResources, options);
     this.registerDistanceQuery();
-    this.bind.onRootElement(InitializationEvents.afterComponentsInitialization, () => this.onAfterComponentsInitialization());
+    this.bind.onRootElement(InitializationEvents.afterComponentsInitialization, (args: IInitializationEventArgs) =>
+      this.onAfterComponentsInitialization(args)
+    );
   }
 
   /**
@@ -231,7 +232,8 @@ export class DistanceResources extends Component {
     const shouldTriggerQuery = this.shouldTriggerQueryWhenPositionSet();
     this.isFirstPositionResolved = true;
     if (shouldTriggerQuery) {
-      this.executeQuery();
+      this.sendAnalytics();
+      this.queryController.executeQuery();
     }
   }
 
@@ -244,47 +246,42 @@ export class DistanceResources extends Component {
     return this.lastPositionRequest || Promise.reject('No position request was executed yet.');
   }
 
-  private executeQuery() {
-    // Since this DistanceResource component often blocks initial queries,
-    // and relaunch the query automatically when it is able to do so (when a position provider resolves)
-    // we need to have a mechanism to still log something useful for usage analytics, instead of always a "position set".
-    // We want it to be "interface load" on a direct page access, or a "search from link" if coming from an external standalone search box
-    // Everytime this component blocks a query, we keep a copy of the pending search event, and resend this instead of a generic "position set" event.
-    if (this.pendingSearchEventOnCancellation) {
-      this.usageAnalytics.logSearchEvent(this.getPendingEventOnCancellation(), this.pendingSearchEventOnCancellation.getEventMeta());
-      delete this.pendingSearchEventOnCancellation;
-    } else {
-      this.usageAnalytics.logSearchEvent(analyticsActionCauseList.positionSet, {});
-    }
-    this.queryController.executeQuery();
+  private sendAnalytics() {
+    this.usageAnalytics.logSearchEvent(analyticsActionCauseList.positionSet, {});
   }
 
   private shouldTriggerQueryWhenPositionSet() {
-    // If query has been cancelled, we need to trigger the first one.
-    const triggerFirstQueryWithPosition = this.options.cancelQueryUntilPositionResolved && !this.isFirstPositionResolved;
-    return this.options.triggerNewQueryOnNewPosition || triggerFirstQueryWithPosition;
+    // Don't trigger the query if the first one is not yet executed.
+    return !this.queryController.firstQuery && this.options.triggerNewQueryOnNewPosition;
   }
 
-  private onAfterComponentsInitialization(): void {
+  private onAfterComponentsInitialization(afterComponentsInitializationArgs: IInitializationEventArgs): void {
     const args: IResolvingPositionEventArgs = {
       providers: this.getProvidersFromOptions()
     };
 
     this.bind.trigger(this.element, DistanceEvents.onResolvingPosition, args);
 
-    this.lastPositionRequest = this.tryGetPositionFromProviders(args.providers)
-      .then(position => {
-        if (position) {
-          this.setPosition(position.latitude, position.longitude);
-        } else {
-          this.triggerDistanceNotSet();
-        }
-        return position;
-      })
-      .catch(error => {
-        this.logger.error('An error occurred while trying to resolve the current position.', error);
+    this.lastPositionRequest = this.tryToSetPositionFromProviders(args.providers);
+
+    if (this.options.cancelQueryUntilPositionResolved) {
+      afterComponentsInitializationArgs.defer.push(this.lastPositionRequest);
+    }
+  }
+
+  private async tryToSetPositionFromProviders(providers: IGeolocationPositionProvider[]): Promise<IGeolocationPosition> {
+    try {
+      const position = await this.tryGetPositionFromProviders(providers);
+      if (position) {
+        this.setPosition(position.latitude, position.longitude);
+      } else {
         this.triggerDistanceNotSet();
-      });
+      }
+      return position;
+    } catch (error) {
+      this.logger.error('An error occurred while trying to resolve the current position.', error);
+      this.triggerDistanceNotSet();
+    }
   }
 
   private getProvidersFromOptions(): IGeolocationPositionProvider[] {
@@ -305,30 +302,19 @@ export class DistanceResources extends Component {
     return providers;
   }
 
-  private tryGetPositionFromProviders(providers: IGeolocationPositionProvider[]): Promise<IGeolocationPosition> {
-    return new Promise<IGeolocationPosition>((resolve, reject) => {
-      const tryNextProvider = () => {
-        if (providers.length > 0) {
-          const provider = providers.shift();
-          provider
-            .getPosition()
-            .then(position => {
-              if (!!position.latitude && !!position.longitude) {
-                resolve(position);
-              } else {
-                tryNextProvider();
-              }
-            })
-            .catch(error => {
-              this.logger.warn('An error occurred while trying to resolve the position within a position provider.', error);
-              tryNextProvider();
-            });
-        } else {
-          resolve();
+  private async tryGetPositionFromProviders(providers: IGeolocationPositionProvider[]): Promise<IGeolocationPosition> {
+    while (providers.length > 0) {
+      const provider = providers.shift();
+      try {
+        const position = await provider.getPosition();
+        if (!!position.latitude && !!position.longitude) {
+          return position;
         }
-      };
-      tryNextProvider();
-    });
+      } catch (error) {
+        this.logger.warn('An error occurred while trying to resolve the position within a position provider.', error);
+      }
+    }
+    return;
   }
 
   private triggerDistanceNotSet(): void {
@@ -338,7 +324,6 @@ export class DistanceResources extends Component {
     );
     this.bind.trigger(this.element, DistanceEvents.onPositionNotResolved, {});
     this.disable();
-    this.executeQuery();
   }
 
   private registerDistanceQuery(): void {
@@ -354,10 +339,6 @@ export class DistanceResources extends Component {
           args.queryBuilder.queryFunctions.push(geoQueryFunction);
           this.enableDistanceComponents();
         }
-      } else if (this.options.cancelQueryUntilPositionResolved) {
-        this.pendingSearchEventOnCancellation = this.usageAnalytics.getPendingSearchEvent();
-        this.logger.info('Query cancelled, waiting for position.');
-        args.cancel = true;
       }
     });
   }
@@ -380,13 +361,6 @@ export class DistanceResources extends Component {
 
   private getConvertedUnitsFunction(queryFunction: string): string {
     return `${queryFunction}/${this.options.unitConversionFactor}`;
-  }
-
-  private getPendingEventOnCancellation(): IAnalyticsActionCause {
-    return <IAnalyticsActionCause>{
-      name: this.pendingSearchEventOnCancellation.templateSearchEvent.actionCause,
-      type: this.pendingSearchEventOnCancellation.templateSearchEvent.actionType
-    };
   }
 }
 

--- a/src/ui/Distance/GoogleApiPositionProvider.ts
+++ b/src/ui/Distance/GoogleApiPositionProvider.ts
@@ -22,22 +22,19 @@ interface IGeolocationResponseLocation {
 export class GoogleApiPositionProvider implements IGeolocationPositionProvider {
   constructor(private googleApiKey: string) {}
 
-  public getPosition(): Promise<IGeolocationPosition> {
-    return new EndpointCaller()
-      .call<IGeolocationResponse>({
-        errorsAsSuccess: false,
-        method: 'POST',
-        queryString: [`key=${this.googleApiKey}`],
-        requestData: {},
-        responseType: 'json',
-        url: GOOGLE_MAP_BASE_URL
-      })
-      .then(responseData => {
-        const location = responseData.data.location;
-        return {
-          longitude: location.lng,
-          latitude: location.lat
-        };
-      });
+  public async getPosition(): Promise<IGeolocationPosition> {
+    const responseData = await new EndpointCaller().call<IGeolocationResponse>({
+      errorsAsSuccess: false,
+      method: 'POST',
+      queryString: [`key=${this.googleApiKey}`],
+      requestData: {},
+      responseType: 'json',
+      url: GOOGLE_MAP_BASE_URL
+    });
+    const location = responseData.data.location;
+    return {
+      longitude: location.lng,
+      latitude: location.lat
+    };
   }
 }

--- a/unitTests/ui/DistanceResourcesTest.ts
+++ b/unitTests/ui/DistanceResourcesTest.ts
@@ -87,7 +87,7 @@ export function DistanceResourcesTest() {
         test = Mock.optionsComponentSetup<DistanceResources, IDistanceOptions>(DistanceResources, defaultMockOptions);
       });
 
-      it('should should register an afterComponentsInitialization defer', () => {
+      it('should register an afterComponentsInitialization defer', () => {
         triggerAfterComponentsInitialization();
 
         expect(afterComponentsInitialization.defer.length).toBe(1);
@@ -118,7 +118,7 @@ export function DistanceResourcesTest() {
         expect(test.env.queryController.executeQuery).toHaveBeenCalledTimes(2);
       });
 
-      it('should send a search event triggered caused by the positionSet', () => {
+      it('should send an analytics search event with "positionSet" as the cause', () => {
         test.cmp.setPosition(latitudeForANicePlace, longitudeForANicePlace);
 
         triggerOnBuildingQuery();

--- a/unitTests/ui/DistanceResourcesTest.ts
+++ b/unitTests/ui/DistanceResourcesTest.ts
@@ -14,6 +14,7 @@ import { InitializationEvents } from '../../src/EventsModules';
 import { QueryEvents, IBuildingQueryEventArgs } from '../../src/events/QueryEvents';
 import { IQueryFunction } from '../../src/rest/QueryFunction';
 import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
+import { IInitializationEventArgs } from '../../src/events/InitializationEvents';
 
 export function DistanceResourcesTest() {
   describe('DistanceResources', () => {
@@ -39,9 +40,15 @@ export function DistanceResourcesTest() {
 
     function triggerOnBuildingQuery() {
       $$(test.env.root).trigger(QueryEvents.buildingQuery, buildingQueryArgs);
+      test.env.queryController.firstQuery = false;
+    }
+
+    function triggerAfterComponentsInitialization() {
+      $$(test.env.root).trigger(InitializationEvents.afterComponentsInitialization, afterComponentsInitialization);
     }
 
     let buildingQueryArgs: IBuildingQueryEventArgs;
+    let afterComponentsInitialization: IInitializationEventArgs;
     let defaultMockOptions: IDistanceOptions;
     let test: Mock.IBasicComponentSetup<DistanceResources>;
 
@@ -50,6 +57,9 @@ export function DistanceResourcesTest() {
         cancel: false,
         queryBuilder: new QueryBuilder(),
         searchAsYouType: false
+      };
+      afterComponentsInitialization = <IInitializationEventArgs>{
+        defer: []
       };
       defaultMockOptions = <IDistanceOptions>{
         distanceField: distanceField,
@@ -77,17 +87,10 @@ export function DistanceResourcesTest() {
         test = Mock.optionsComponentSetup<DistanceResources, IDistanceOptions>(DistanceResources, defaultMockOptions);
       });
 
-      it('should cancel the query when the position is not set', () => {
-        triggerOnBuildingQuery();
+      it('should should register an afterComponentsInitialization defer', () => {
+        triggerAfterComponentsInitialization();
 
-        expect(buildingQueryArgs.cancel).toBe(true);
-      });
-
-      it('should trigger a query the first time the position is resolved', () => {
-        test.cmp.setPosition(latitudeForANicePlace, longitudeForANicePlace);
-        test.cmp.setPosition(1.1, 2.3);
-
-        expect(test.env.queryController.executeQuery).toHaveBeenCalledTimes(1);
+        expect(afterComponentsInitialization.defer.length).toBe(1);
       });
 
       it('should add a new query function with the given position after the position is set', () => {
@@ -96,47 +99,6 @@ export function DistanceResourcesTest() {
         triggerOnBuildingQuery();
 
         expect(buildingQueryArgs.queryBuilder.queryFunctions).toContain(expectedQueryFunctionForANicePlace);
-      });
-
-      describe('with usage analytics', () => {
-        let fakePendingSearchEvent;
-
-        beforeEach(() => {
-          fakePendingSearchEvent = {};
-          fakePendingSearchEvent.templateSearchEvent = {
-            actionCause: 'foo',
-            actionType: 'bar'
-          };
-          fakePendingSearchEvent.getEventMeta = () => ({ baz: 'buzz' });
-        });
-
-        afterEach(() => {
-          fakePendingSearchEvent = null;
-        });
-
-        it('should send the event associated with the blocked query', () => {
-          const spy = jasmine.createSpy('getPendingSearchEvent').and.returnValue(fakePendingSearchEvent);
-          test.env.usageAnalytics.getPendingSearchEvent = <any>spy;
-          triggerOnBuildingQuery();
-          test.cmp.setPosition(latitudeForANicePlace, longitudeForANicePlace);
-
-          expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(
-            jasmine.objectContaining({
-              type: fakePendingSearchEvent.templateSearchEvent.actionType,
-              name: fakePendingSearchEvent.templateSearchEvent.actionCause
-            }),
-            jasmine.objectContaining({
-              baz: 'buzz'
-            })
-          );
-        });
-
-        it('should send basic event if there are none sent before the blocked query', () => {
-          triggerOnBuildingQuery();
-          test.cmp.setPosition(latitudeForANicePlace, longitudeForANicePlace);
-
-          expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.positionSet, jasmine.any(Object));
-        });
       });
     });
 
@@ -154,6 +116,14 @@ export function DistanceResourcesTest() {
         test.cmp.setPosition(latitudeForANicePlace, longitudeForANicePlace);
 
         expect(test.env.queryController.executeQuery).toHaveBeenCalledTimes(2);
+      });
+
+      it('should send a search event triggered caused by the positionSet', () => {
+        test.cmp.setPosition(latitudeForANicePlace, longitudeForANicePlace);
+
+        triggerOnBuildingQuery();
+
+        expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.positionSet, jasmine.any(Object));
       });
     });
 
@@ -214,7 +184,7 @@ export function DistanceResourcesTest() {
         let spy = jasmine.createSpy('onPositionResolved');
         $$(test.env.element).on(DistanceEvents.onPositionResolved, spy);
 
-        $$(test.env.root).trigger(InitializationEvents.afterComponentsInitialization);
+        triggerAfterComponentsInitialization();
 
         test.cmp.getLastPositionRequest().then(() => {
           expect(spy).toHaveBeenCalledWith(jasmine.any(Object), <IPositionResolvedEventArgs>{
@@ -241,7 +211,7 @@ export function DistanceResourcesTest() {
         let spy = jasmine.createSpy('onPositionResolved');
         $$(test.env.element).on(DistanceEvents.onPositionResolved, spy);
 
-        $$(test.env.root).trigger(InitializationEvents.afterComponentsInitialization);
+        triggerAfterComponentsInitialization();
 
         test.cmp.getLastPositionRequest().then(() => {
           expect(spy).toHaveBeenCalledWith(jasmine.any(Object), <IPositionResolvedEventArgs>{
@@ -263,7 +233,7 @@ export function DistanceResourcesTest() {
         let spy = jasmine.createSpy('onPositionNotResolved');
         $$(test.env.element).on(DistanceEvents.onPositionNotResolved, spy);
 
-        $$(test.env.root).trigger(InitializationEvents.afterComponentsInitialization);
+        triggerAfterComponentsInitialization();
 
         test.cmp.getLastPositionRequest().then(() => {
           expect(spy).toHaveBeenCalled();
@@ -271,19 +241,9 @@ export function DistanceResourcesTest() {
         });
       });
 
-      it('should re-trigger a query when no position resolves and the cancelQueryUntilPositionResolved option is set', done => {
-        test.cmp.options.cancelQueryUntilPositionResolved = true;
-        $$(test.env.root).trigger(InitializationEvents.afterComponentsInitialization);
-        triggerOnBuildingQuery();
-        test.cmp.getLastPositionRequest().then(() => {
-          expect(test.cmp.queryController.executeQuery).toHaveBeenCalledTimes(1);
-          done();
-        });
-      });
-
       it('should disable the component when no position resolves', done => {
         test.cmp.options.cancelQueryUntilPositionResolved = true;
-        $$(test.env.root).trigger(InitializationEvents.afterComponentsInitialization);
+        triggerAfterComponentsInitialization();
         triggerOnBuildingQuery();
         test.cmp.getLastPositionRequest().then(() => {
           expect(test.cmp.disabled).toBe(true);
@@ -296,7 +256,7 @@ export function DistanceResourcesTest() {
       let spy = jasmine.createSpy('onPositionNotResolved');
       $$(test.env.element).on(DistanceEvents.onPositionNotResolved, spy);
 
-      $$(test.env.root).trigger(InitializationEvents.afterComponentsInitialization);
+      triggerAfterComponentsInitialization();
 
       test.cmp.getLastPositionRequest().then(() => {
         expect(spy).toHaveBeenCalled();

--- a/unitTests/ui/InitializationTest.ts
+++ b/unitTests/ui/InitializationTest.ts
@@ -137,7 +137,7 @@ export function InitializationTest() {
       });
     });
 
-    it('allows to register default options ahead of init call, and merge them', done => {
+    it('allows to register default options ahead of init call, and merge them', async done => {
       Initialization.registerDefaultOptions(root, {
         Querybox: {
           enableSearchAsYouType: true
@@ -150,18 +150,17 @@ export function InitializationTest() {
       });
 
       expect(Component.get(queryBox) instanceof Querybox).toBe(false);
-      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
-      }).then(() => {
-        expect(Component.get(queryBox) instanceof Querybox).toBe(true);
-        const sBox = <Querybox>Component.get(queryBox);
-        expect(sBox.options.enableSearchAsYouType).toBe(true);
-        expect(sBox.options.enablePartialMatch).toBe(true);
-        done();
       });
+      expect(Component.get(queryBox) instanceof Querybox).toBe(true);
+      const sBox = <Querybox>Component.get(queryBox);
+      expect(sBox.options.enableSearchAsYouType).toBe(true);
+      expect(sBox.options.enablePartialMatch).toBe(true);
+      done();
     });
 
-    it('allows to registerAutoCreateComponent', done => {
+    it('allows to registerAutoCreateComponent', async done => {
       const dummyCmp: any = jasmine.createSpy('foobar');
       dummyCmp.ID = 'FooBar';
       const dummyElem = document.createElement('div');
@@ -169,15 +168,15 @@ export function InitializationTest() {
       root.appendChild(dummyElem);
 
       Initialization.registerAutoCreateComponent(dummyCmp);
-      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
-      }).then(() => {
-        expect(dummyCmp).toHaveBeenCalled();
-        done();
       });
+
+      expect(dummyCmp).toHaveBeenCalled();
+      done();
     });
 
-    it('allows to registerAutoCreateComponent with aliases', done => {
+    it('allows to registerAutoCreateComponent with aliases', async done => {
       const aliasedComponent: any = jasmine.createSpy('aliasedComponent');
       aliasedComponent.ID = 'OriginalId';
       aliasedComponent.aliases = ['AliasedId'];
@@ -186,12 +185,12 @@ export function InitializationTest() {
       $$(root).append(dummyElem.el);
 
       Initialization.registerAutoCreateComponent(aliasedComponent);
-      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
-      }).then(() => {
-        expect(aliasedComponent).toHaveBeenCalled();
-        done();
       });
+
+      expect(aliasedComponent).toHaveBeenCalled();
+      done();
     });
 
     it('allows to check if isComponentClassIdRegistered', () => {
@@ -380,9 +379,10 @@ export function InitializationTest() {
       done();
     });
 
-    it('should throw when dispatchNamedMethodCallOrComponentCreation is called with something that does not exist', () => {
-      init(root, searchInterfaceOptions);
+    it('should throw when dispatchNamedMethodCallOrComponentCreation is called with something that does not exist', async done => {
+      await init(root, searchInterfaceOptions);
       expect(() => Initialization.dispatchNamedMethodCallOrComponentCreation('nope', root, [])).toThrow();
+      done();
     });
 
     it('can initialize external components', async done => {

--- a/unitTests/ui/InitializationTest.ts
+++ b/unitTests/ui/InitializationTest.ts
@@ -412,10 +412,6 @@ export function InitializationTest() {
         $$(root).on(InitializationEvents.afterComponentsInitialization, spyAfterComponentsInitialized);
       });
 
-      afterEach(() => {
-        spyAfterComponentsInitialized = null;
-      });
-
       it('will trigger the afterComponentsInitialized event handler', async done => {
         await doInit();
         expect(spyAfterComponentsInitialized).toHaveBeenCalled();
@@ -438,10 +434,6 @@ export function InitializationTest() {
           });
           afterDeferInitializationSpy = jasmine.createSpy('afterInitializationSpy');
           $$(root).on(InitializationEvents.afterInitialization, afterDeferInitializationSpy);
-        });
-
-        afterEach(() => {
-          deferSpy = null;
         });
 
         it('will trigger the deferred promise', async done => {
@@ -476,10 +468,6 @@ export function InitializationTest() {
           $$(root).on(InitializationEvents.afterInitialization, afterDeferInitializationSpy);
         });
 
-        afterEach(() => {
-          afterDeferInitializationSpy = null;
-        });
-
         it('will wait for all the promises before executing the rest of the pipeline after the promises', async done => {
           await doInit();
           (<any>expect(deferSpy)).toHaveBeenCalledBefore(afterDeferInitializationSpy);
@@ -506,11 +494,6 @@ export function InitializationTest() {
           $$(root).on(InitializationEvents.afterInitialization, afterDeferInitializationSpy);
         });
 
-        afterEach(() => {
-          deferSpy = null;
-          afterDeferInitializationSpy = null;
-        });
-
         it('will skip the rejected promise and wait for the working one', async done => {
           await doInit();
           expect(deferSpy).toHaveBeenCalled();
@@ -535,10 +518,6 @@ export function InitializationTest() {
           $$(root).on(InitializationEvents.afterComponentsInitialization, afterComponentsInitializationSpy);
         });
 
-        afterEach(() => {
-          afterComponentsInitializationSpy = null;
-        });
-
         it('will continue the execution of the pipeline without crashing', async done => {
           await doInit();
           expect(afterComponentsInitializationSpy).toHaveBeenCalled();
@@ -560,10 +539,6 @@ export function InitializationTest() {
 
       beforeEach(() => {
         searchInterfaceOptions['SearchInterface'].autoTriggerQuery = true;
-      });
-
-      afterEach(() => {
-        spyOnQuery = null;
       });
 
       it('will trigger a query automatically by default', done => {

--- a/unitTests/ui/InitializationTest.ts
+++ b/unitTests/ui/InitializationTest.ts
@@ -137,7 +137,7 @@ export function InitializationTest() {
       });
     });
 
-    it('allows to register default options ahead of init call, and merge them', async done => {
+    it('allows to register default options ahead of init call, and merge them', () => {
       Initialization.registerDefaultOptions(root, {
         Querybox: {
           enableSearchAsYouType: true
@@ -150,17 +150,16 @@ export function InitializationTest() {
       });
 
       expect(Component.get(queryBox) instanceof Querybox).toBe(false);
-      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       });
       expect(Component.get(queryBox) instanceof Querybox).toBe(true);
       const sBox = <Querybox>Component.get(queryBox);
       expect(sBox.options.enableSearchAsYouType).toBe(true);
       expect(sBox.options.enablePartialMatch).toBe(true);
-      done();
     });
 
-    it('allows to registerAutoCreateComponent', async done => {
+    it('allows to registerAutoCreateComponent', () => {
       const dummyCmp: any = jasmine.createSpy('foobar');
       dummyCmp.ID = 'FooBar';
       const dummyElem = document.createElement('div');
@@ -168,15 +167,13 @@ export function InitializationTest() {
       root.appendChild(dummyElem);
 
       Initialization.registerAutoCreateComponent(dummyCmp);
-      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       });
-
       expect(dummyCmp).toHaveBeenCalled();
-      done();
     });
 
-    it('allows to registerAutoCreateComponent with aliases', async done => {
+    it('allows to registerAutoCreateComponent with aliases', () => {
       const aliasedComponent: any = jasmine.createSpy('aliasedComponent');
       aliasedComponent.ID = 'OriginalId';
       aliasedComponent.aliases = ['AliasedId'];
@@ -185,12 +182,10 @@ export function InitializationTest() {
       $$(root).append(dummyElem.el);
 
       Initialization.registerAutoCreateComponent(aliasedComponent);
-      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       });
-
       expect(aliasedComponent).toHaveBeenCalled();
-      done();
     });
 
     it('allows to check if isComponentClassIdRegistered', () => {
@@ -320,26 +315,24 @@ export function InitializationTest() {
       });
     });
 
-    it('allow to monkeyPatchComponentMethod', async done => {
-      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+    it('allow to monkeyPatchComponentMethod', () => {
+      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       });
       const patch = jasmine.createSpy('patch');
       Initialization.monkeyPatchComponentMethod('submit', queryBox, patch);
       (<Querybox>Component.get(queryBox)).submit();
       expect(patch).toHaveBeenCalled();
-      done();
     });
 
-    it('allow to monkeyPatchComponentMethod with the component name', async done => {
-      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+    it('allow to monkeyPatchComponentMethod with the component name', () => {
+      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       });
       const patch = jasmine.createSpy('patch');
       Initialization.monkeyPatchComponentMethod('Querybox.submit', queryBox, patch);
       (<Querybox>Component.get(queryBox)).submit();
       expect(patch).toHaveBeenCalled();
-      done();
     });
 
     it('allows to determine if a top level method is already registed', () => {
@@ -357,90 +350,77 @@ export function InitializationTest() {
       });
     });
 
-    it('should allow to dispatch a named method call', async done => {
-      await init(root, searchInterfaceOptions);
+    it('should allow to dispatch a named method call', () => {
+      init(root, searchInterfaceOptions);
       Initialization.dispatchNamedMethodCall('executeQuery', root, []);
       expect(endpoint.search).toHaveBeenCalled();
-      done();
     });
 
-    it('should throw when calling a named method that does not exist', async done => {
-      await init(root, searchInterfaceOptions);
+    it('should throw when calling a named method that does not exist', () => {
+      init(root, searchInterfaceOptions);
       expect(() => Initialization.dispatchNamedMethodCall('nope', root, [])).toThrow();
-      done();
     });
 
-    it('should allow to dispatchNamedMethodCallOrComponentCreation', async done => {
-      await init(root, searchInterfaceOptions);
+    it('should allow to dispatchNamedMethodCallOrComponentCreation', () => {
+      init(root, searchInterfaceOptions);
       Initialization.dispatchNamedMethodCallOrComponentCreation('executeQuery', root, []);
       expect(endpoint.search).toHaveBeenCalled();
       Initialization.dispatchNamedMethodCallOrComponentCreation('submit', queryBox, []);
       expect(endpoint.search).toHaveBeenCalled();
-      done();
     });
 
-    it('should throw when dispatchNamedMethodCallOrComponentCreation is called with something that does not exist', async done => {
-      await init(root, searchInterfaceOptions);
+    it('should throw when dispatchNamedMethodCallOrComponentCreation is called with something that does not exist', () => {
+      init(root, searchInterfaceOptions);
       expect(() => Initialization.dispatchNamedMethodCallOrComponentCreation('nope', root, [])).toThrow();
-      done();
     });
 
-    it('can initialize external components', async done => {
+    it('can initialize external components', () => {
       const external = $$('div', {
         className: 'CoveoPager'
       }).el;
 
       searchInterfaceOptions['externalComponents'] = [external];
       searchInterfaceOptions['SearchInterface'].autoTriggerQuery = false;
-      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       });
-
       expect(Component.get(external) instanceof Pager).toBe(true);
-      done();
     });
 
-    it('can initialize external components passed in as a jquery instance', async done => {
+    it('can initialize external components passed in as a jquery instance', () => {
       Simulate.addJQuery();
       const external = $('<div class="CoveoPager"></div>');
       searchInterfaceOptions['externalComponents'] = [external];
       searchInterfaceOptions['SearchInterface'].autoTriggerQuery = false;
-      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       });
       expect(Component.get(external.get(0)) instanceof Pager).toBe(true);
       Simulate.removeJQuery();
-      done();
     });
 
     describe('when initializing a Search Interface', () => {
       let spyAfterComponentsInitialized;
-
       const doInit = () => {
         return Initialization.initializeFramework(root, searchInterfaceOptions, () => {
           const initResult = Initialization.initSearchInterface(root, searchInterfaceOptions);
           return initResult;
         });
       };
-
       beforeEach(() => {
         spyAfterComponentsInitialized = jasmine.createSpy('afterComponentsInitialized');
         $$(root).on(InitializationEvents.afterComponentsInitialization, spyAfterComponentsInitialized);
       });
-
       afterEach(() => {
         spyAfterComponentsInitialized = null;
       });
-
       it('will trigger the afterComponentsInitialized event handler', async done => {
         await doInit();
         expect(spyAfterComponentsInitialized).toHaveBeenCalled();
         done();
       });
-
       describe('when afterComponentsInitialized is deferred by a component', () => {
         let deferSpy;
-
         beforeEach(() => {
           deferSpy = jasmine.createSpy('initializationSpy');
           $$(root).on(InitializationEvents.afterComponentsInitialization, (event, data: IInitializationEventArgs) => {
@@ -452,21 +432,17 @@ export function InitializationTest() {
             );
           });
         });
-
         afterEach(() => {
           deferSpy = null;
         });
-
         it('will trigger the deferred promise', async done => {
           await doInit();
           expect(deferSpy).toHaveBeenCalled();
           done();
         });
       });
-
       describe('when afterComponentsInitialized is deferred by a failing promise', () => {
         let deferSpy;
-
         beforeEach(() => {
           deferSpy = jasmine.createSpy('initializationSpy');
           $$(root).on(InitializationEvents.afterComponentsInitialization, (event, data: IInitializationEventArgs) => {
@@ -479,11 +455,9 @@ export function InitializationTest() {
             );
           });
         });
-
         afterEach(() => {
           deferSpy = null;
         });
-
         it('will skip the rejected promise and wait for the working one', async done => {
           await doInit();
           expect(deferSpy).toHaveBeenCalled();
@@ -511,19 +485,19 @@ export function InitializationTest() {
         spyOnQuery = null;
       });
 
-      it('will trigger a query automatically by default', async done => {
-        await doInit();
-
-        expect(spyOnQuery).toHaveBeenCalled();
-        done();
+      it('will trigger a query automatically by default', done => {
+        doInit().then(() => {
+          expect(spyOnQuery).toHaveBeenCalled();
+          done();
+        });
       });
 
-      it('will not trigger a query automatically if specified', async done => {
+      it('will not trigger a query automatically if specified', done => {
         searchInterfaceOptions['SearchInterface'].autoTriggerQuery = false;
-        await doInit();
-
-        expect(spyOnQuery).not.toHaveBeenCalled();
-        done();
+        doInit().then(() => {
+          expect(spyOnQuery).not.toHaveBeenCalled();
+          done();
+        });
       });
 
       describe('when query with no keywords are not allowed', () => {
@@ -531,38 +505,41 @@ export function InitializationTest() {
           searchInterfaceOptions['SearchInterface'].allowQueriesWithoutKeywords = false;
         });
 
-        it('will trigger a query automatically if the interface contains keywords', async done => {
+        it('will trigger a query automatically if the interface contains keywords', done => {
           $$(root).on(InitializationEvents.afterInitialization, () => {
             state(root, 'q', 'foo');
           });
 
-          await doInit();
-          expect(spyOnQuery).toHaveBeenCalled();
-          done();
+          doInit().then(() => {
+            expect(spyOnQuery).toHaveBeenCalled();
+            done();
+          });
         });
 
-        it('will not trigger a query automatically if the interface contains no keywords', async done => {
+        it('will not trigger a query automatically if the interface contains no keywords', done => {
           $$(root).on(InitializationEvents.afterInitialization, () => {
             state(root, 'q', '');
           });
 
-          await doInit();
-          expect(spyOnQuery).not.toHaveBeenCalled();
-          done();
+          doInit().then(() => {
+            expect(spyOnQuery).not.toHaveBeenCalled();
+            done();
+          });
         });
       });
     });
 
-    it('will send action history on automatic query', async done => {
+    it('will send action history on automatic query', done => {
       localStorage.removeItem('__coveo.analytics.history');
       expect(localStorage.getItem('__coveo.analytics.history')).toBeNull();
-      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
+      }).then(() => {
+        const actionHistory = localStorage.getItem('__coveo.analytics.history');
+        expect(actionHistory).not.toBeNull();
+        expect(JSON.parse(actionHistory)[0].name).toEqual('Query');
+        done();
       });
-      const actionHistory = localStorage.getItem('__coveo.analytics.history');
-      expect(actionHistory).not.toBeNull();
-      expect(JSON.parse(actionHistory)[0].name).toEqual('Query');
-      done();
     });
 
     describe('when initializing recommendation interface', () => {

--- a/unitTests/ui/RegisteredNamedMethodsTest.ts
+++ b/unitTests/ui/RegisteredNamedMethodsTest.ts
@@ -68,43 +68,46 @@ export function RegisteredNamedMethodsTest() {
       expect(env.queryStateModel.get).toHaveBeenCalledWith('q');
     });
 
-    it('should allow to call init correctly', async done => {
-      await RegisteredNamedMethod.init(root, {
-        Searchbox: { addSearchButton: false },
-        SearchInterface: { autoTriggerQuery: false }
-      });
+    it('should allow to call init correctly', () => {
+      expect(() =>
+        RegisteredNamedMethod.init(root, {
+          Searchbox: { addSearchButton: false },
+          SearchInterface: { autoTriggerQuery: false }
+        })
+      ).not.toThrow();
       expect((<Component>Component.get(searchbox)).options.addSearchButton).toBe(false);
-      done();
     });
 
-    it('should allow to call initSearchbox correctly', async done => {
-      await RegisteredNamedMethod.initSearchbox(root, '/search', {
-        Searchbox: { addSearchButton: false },
-        SearchInterface: { autoTriggerQuery: false }
-      });
+    it('should allow to call initSearchbox correctly', () => {
+      expect(() =>
+        RegisteredNamedMethod.initSearchbox(root, '/search', {
+          Searchbox: { addSearchButton: false },
+          SearchInterface: { autoTriggerQuery: false }
+        })
+      ).not.toThrow();
+
       expect((<Component>Component.get(searchbox)).options.addSearchButton).toBe(false);
       expect((<Component>Component.get(searchbox)).options.triggerQueryOnClear).toBe(false);
-      done();
     });
 
-    it('should allow to call initSearchbox if the searchbox is on the root of the element', async done => {
-      await RegisteredNamedMethod.initSearchbox(searchbox, '/search', {
-        Searchbox: { addSearchButton: false },
-        SearchInterface: { autoTriggerQuery: false }
-      });
+    it('should allow to call initSearchbox if the searchbox is on the root of the element', () => {
+      expect(() =>
+        RegisteredNamedMethod.initSearchbox(searchbox, '/search', {
+          Searchbox: { addSearchButton: false },
+          SearchInterface: { autoTriggerQuery: false }
+        })
+      ).not.toThrow();
 
       expect(<Component>Component.get(searchbox, Searchbox) instanceof Searchbox).toBe(true);
       expect(<Component>Component.get(searchbox, SearchInterface) instanceof SearchInterface).toBe(true);
-      done();
     });
 
     it('should allow to call init recommendation correctly', done => {
-      expect(
-        async () =>
-          await RegisteredNamedMethod.initRecommendation(root, undefined, undefined, {
-            Searchbox: { addSearchButton: false },
-            SearchInterface: { autoTriggerQuery: false }
-          })
+      expect(() =>
+        RegisteredNamedMethod.initRecommendation(root, undefined, undefined, {
+          Searchbox: { addSearchButton: false },
+          SearchInterface: { autoTriggerQuery: false }
+        })
       ).not.toThrow();
 
       Defer.defer(() => {
@@ -118,14 +121,13 @@ export function RegisteredNamedMethodsTest() {
       expect(env.queryController.executeQuery).toHaveBeenCalled();
     });
 
-    it('should allow to call get', async done => {
-      await RegisteredNamedMethod.init(root, {
+    it('should allow to call get', () => {
+      RegisteredNamedMethod.init(root, {
         Searchbox: { addSearchButton: false },
         SearchInterface: { autoTriggerQuery: false }
       });
 
       expect(RegisteredNamedMethod.get(searchbox) instanceof Searchbox).toBe(true);
-      done();
     });
 
     it('should allow to call result', () => {
@@ -143,18 +145,17 @@ export function RegisteredNamedMethodsTest() {
       expect(RegisteredNamedMethod.result(searchbox)).toBe(fakeResult);
     });
 
-    it('should allow to pass options ahead of init', async done => {
+    it('should allow to pass options ahead of init', () => {
       RegisteredNamedMethod.options(root, { Searchbox: { enableOmnibox: true } });
-      await RegisteredNamedMethod.init(root, {
+      RegisteredNamedMethod.init(root, {
         Searchbox: { addSearchButton: false },
         SearchInterface: { autoTriggerQuery: false }
       });
       expect((<Component>Component.get(searchbox)).options.enableOmnibox).toBe(true);
-      done();
     });
 
-    it('should allow to patch', async done => {
-      await RegisteredNamedMethod.init(root, {
+    it('should allow to patch', () => {
+      RegisteredNamedMethod.init(root, {
         Searchbox: { addSearchButton: false },
         SearchInterface: { autoTriggerQuery: false }
       });
@@ -162,7 +163,6 @@ export function RegisteredNamedMethodsTest() {
       RegisteredNamedMethod.patch(searchbox, 'disable', spy);
       (<Searchbox>Component.get(searchbox)).disable();
       expect(spy).toHaveBeenCalled();
-      done();
     });
 
     describe('with analytics', () => {

--- a/unitTests/ui/RegisteredNamedMethodsTest.ts
+++ b/unitTests/ui/RegisteredNamedMethodsTest.ts
@@ -68,46 +68,43 @@ export function RegisteredNamedMethodsTest() {
       expect(env.queryStateModel.get).toHaveBeenCalledWith('q');
     });
 
-    it('should allow to call init correctly', () => {
-      expect(() =>
-        RegisteredNamedMethod.init(root, {
-          Searchbox: { addSearchButton: false },
-          SearchInterface: { autoTriggerQuery: false }
-        })
-      ).not.toThrow();
+    it('should allow to call init correctly', async done => {
+      await RegisteredNamedMethod.init(root, {
+        Searchbox: { addSearchButton: false },
+        SearchInterface: { autoTriggerQuery: false }
+      });
       expect((<Component>Component.get(searchbox)).options.addSearchButton).toBe(false);
+      done();
     });
 
-    it('should allow to call initSearchbox correctly', () => {
-      expect(() =>
-        RegisteredNamedMethod.initSearchbox(root, '/search', {
-          Searchbox: { addSearchButton: false },
-          SearchInterface: { autoTriggerQuery: false }
-        })
-      ).not.toThrow();
-
+    it('should allow to call initSearchbox correctly', async done => {
+      await RegisteredNamedMethod.initSearchbox(root, '/search', {
+        Searchbox: { addSearchButton: false },
+        SearchInterface: { autoTriggerQuery: false }
+      });
       expect((<Component>Component.get(searchbox)).options.addSearchButton).toBe(false);
       expect((<Component>Component.get(searchbox)).options.triggerQueryOnClear).toBe(false);
+      done();
     });
 
-    it('should allow to call initSearchbox if the searchbox is on the root of the element', () => {
-      expect(() =>
-        RegisteredNamedMethod.initSearchbox(searchbox, '/search', {
-          Searchbox: { addSearchButton: false },
-          SearchInterface: { autoTriggerQuery: false }
-        })
-      ).not.toThrow();
+    it('should allow to call initSearchbox if the searchbox is on the root of the element', async done => {
+      await RegisteredNamedMethod.initSearchbox(searchbox, '/search', {
+        Searchbox: { addSearchButton: false },
+        SearchInterface: { autoTriggerQuery: false }
+      });
 
       expect(<Component>Component.get(searchbox, Searchbox) instanceof Searchbox).toBe(true);
       expect(<Component>Component.get(searchbox, SearchInterface) instanceof SearchInterface).toBe(true);
+      done();
     });
 
     it('should allow to call init recommendation correctly', done => {
-      expect(() =>
-        RegisteredNamedMethod.initRecommendation(root, undefined, undefined, {
-          Searchbox: { addSearchButton: false },
-          SearchInterface: { autoTriggerQuery: false }
-        })
+      expect(
+        async () =>
+          await RegisteredNamedMethod.initRecommendation(root, undefined, undefined, {
+            Searchbox: { addSearchButton: false },
+            SearchInterface: { autoTriggerQuery: false }
+          })
       ).not.toThrow();
 
       Defer.defer(() => {
@@ -121,13 +118,14 @@ export function RegisteredNamedMethodsTest() {
       expect(env.queryController.executeQuery).toHaveBeenCalled();
     });
 
-    it('should allow to call get', () => {
-      RegisteredNamedMethod.init(root, {
+    it('should allow to call get', async done => {
+      await RegisteredNamedMethod.init(root, {
         Searchbox: { addSearchButton: false },
         SearchInterface: { autoTriggerQuery: false }
       });
 
       expect(RegisteredNamedMethod.get(searchbox) instanceof Searchbox).toBe(true);
+      done();
     });
 
     it('should allow to call result', () => {
@@ -145,17 +143,18 @@ export function RegisteredNamedMethodsTest() {
       expect(RegisteredNamedMethod.result(searchbox)).toBe(fakeResult);
     });
 
-    it('should allow to pass options ahead of init', () => {
+    it('should allow to pass options ahead of init', async done => {
       RegisteredNamedMethod.options(root, { Searchbox: { enableOmnibox: true } });
-      RegisteredNamedMethod.init(root, {
+      await RegisteredNamedMethod.init(root, {
         Searchbox: { addSearchButton: false },
         SearchInterface: { autoTriggerQuery: false }
       });
       expect((<Component>Component.get(searchbox)).options.enableOmnibox).toBe(true);
+      done();
     });
 
-    it('should allow to patch', () => {
-      RegisteredNamedMethod.init(root, {
+    it('should allow to patch', async done => {
+      await RegisteredNamedMethod.init(root, {
         Searchbox: { addSearchButton: false },
         SearchInterface: { autoTriggerQuery: false }
       });
@@ -163,6 +162,7 @@ export function RegisteredNamedMethodsTest() {
       RegisteredNamedMethod.patch(searchbox, 'disable', spy);
       (<Searchbox>Component.get(searchbox)).disable();
       expect(spy).toHaveBeenCalled();
+      done();
     });
 
     describe('with analytics', () => {


### PR DESCRIPTION
So the idea here is to support a parameter that blocks the Initialization pipeline until an operation is finished.

This allows other components to add an event handler on `beforeInitialization`, `afterComponentsInitialization` or `afterInitialization` to defer the step until some async stuff is done.

For instance, the Distance Resources component could defer the initialization when "cancelQueryUntilPositionResolved" is true instead of canceling all queries. It would end up in a much more natural flow, leaving the placeholders on until the position is resolved.

Another use case is to dynamically fetch values asynchronously to create HTML that contains Components. This way, the components will be properly initialized before the whole Search Interface initialization process finishes.

It unearthed something weird in the tests where the tests were not properly waiting for the initialization to finish, which is why there are a couple of `await` that appeared in front of `Initialization.initializeFramework` in the unit tests.

I also changed some stuff that were not "async/await" yet, and it makes some parts of the code more readable (`tryGetPositionFromProviders` looks amazing now)

Comments are more than welcome! 😄 

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)