### PR TITLE
JSUI-2212 Removing blur event from filter button

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
@@ -82,8 +82,7 @@ export class ResponsiveDropdown {
           this.open();
         }
       })
-      .withBlurAction(() => this.close())
-      .withLabel('yo')
+      .withLabel('Filters')
       .build();
   }
 

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
@@ -75,13 +75,7 @@ export class ResponsiveDropdown {
   private bindOnClickDropdownHeaderEvent() {
     new AccessibleButton()
       .withElement(this.dropdownHeader.element)
-      .withSelectAction(() => {
-        if (this.isOpened) {
-          this.close();
-        } else {
-          this.open();
-        }
-      })
+      .withSelectAction(() => (this.isOpened ? this.close() : this.open()))
       .withLabel('Filters')
       .build();
   }


### PR DESCRIPTION
The simplest solution I could find was to remove the blur event. I think this is inline with accessibility practices. I looked at sites like github and stackoverflow and found that "dropdowns" are not closed when blurring/tabbing away from the parent element.

https://coveord.atlassian.net/browse/JSUI-2212





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)