### PR TITLE
Fix issue to respect the "keepLastSearchUid" parameter.

### DIFF
--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -1,35 +1,35 @@
-import { RootComponent } from '../ui/Base/RootComponent';
-import { IQueryResults } from '../rest/QueryResults';
-import { QueryBuilder } from '../ui/Base/QueryBuilder';
-import { IQuery } from '../rest/Query';
-import { ISearchEndpoint, IEndpointCallOptions } from '../rest/SearchEndpointInterface';
-import { SearchEndpoint } from '../rest/SearchEndpoint';
-import { LocalStorageUtils } from '../utils/LocalStorageUtils';
-import { ISearchInterfaceOptions } from '../ui/SearchInterface/SearchInterface';
-import { Assert } from '../misc/Assert';
-import { SearchEndpointWithDefaultCallOptions } from '../rest/SearchEndpointWithDefaultCallOptions';
-import {
-  INewQueryEventArgs,
-  IPreprocessResultsEventArgs,
-  INoResultsEventArgs,
-  IQuerySuccessEventArgs,
-  IQueryErrorEventArgs,
-  IDuringQueryEventArgs,
-  QueryEvents,
-  IFetchMoreSuccessEventArgs,
-  IDoneBuildingQueryEventArgs,
-  IBuildingQueryEventArgs,
-  IBuildingCallOptionsEventArgs
-} from '../events/QueryEvents';
-import { QueryUtils } from '../utils/QueryUtils';
-import { Defer } from '../misc/Defer';
-import { $$, Dom } from '../utils/Dom';
-import { Utils } from '../utils/Utils';
-import { BaseComponent } from '../ui/Base/BaseComponent';
-import { ModalBox } from '../ExternalModulesShim';
 import { history } from 'coveo.analytics';
 import * as _ from 'underscore';
+import {
+  IBuildingCallOptionsEventArgs,
+  IBuildingQueryEventArgs,
+  IDoneBuildingQueryEventArgs,
+  IDuringQueryEventArgs,
+  IFetchMoreSuccessEventArgs,
+  INewQueryEventArgs,
+  INoResultsEventArgs,
+  IPreprocessResultsEventArgs,
+  IQueryErrorEventArgs,
+  IQuerySuccessEventArgs,
+  QueryEvents
+} from '../events/QueryEvents';
+import { ModalBox } from '../ExternalModulesShim';
+import { Assert } from '../misc/Assert';
+import { Defer } from '../misc/Defer';
+import { IQuery } from '../rest/Query';
+import { IQueryResults } from '../rest/QueryResults';
+import { SearchEndpoint } from '../rest/SearchEndpoint';
+import { IEndpointCallOptions, ISearchEndpoint } from '../rest/SearchEndpointInterface';
+import { SearchEndpointWithDefaultCallOptions } from '../rest/SearchEndpointWithDefaultCallOptions';
+import { BaseComponent } from '../ui/Base/BaseComponent';
+import { QueryBuilder } from '../ui/Base/QueryBuilder';
+import { RootComponent } from '../ui/Base/RootComponent';
+import { ISearchInterfaceOptions } from '../ui/SearchInterface/SearchInterface';
+import { $$, Dom } from '../utils/Dom';
+import { LocalStorageUtils } from '../utils/LocalStorageUtils';
+import { QueryUtils } from '../utils/QueryUtils';
 import { UrlUtils } from '../utils/UrlUtils';
+import { Utils } from '../utils/Utils';
 
 /**
  * Possible options when performing a query with the query controller

--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -220,7 +220,6 @@ export class QueryController extends RootComponent {
     promise
       .then(queryResults => {
         Assert.exists(queryResults);
-        let firstQuery = this.firstQuery;
         if (this.firstQuery) {
           this.firstQuery = false;
         }
@@ -231,9 +230,8 @@ export class QueryController extends RootComponent {
         }
 
         this.logger.debug('Query results received', query, queryResults);
-        let enableHistory = this.searchInterface && this.searchInterface.options && this.searchInterface.options.enableHistory;
 
-        if ((!firstQuery || enableHistory) && this.keepLastSearchUid(query, queryResults)) {
+        if (this.keepLastSearchUid(query, queryResults, options)) {
           queryResults.searchUid = this.getLastSearchUid();
           queryResults._reusedSearchUid = true;
           QueryUtils.setPropertyOnResults(queryResults, 'queryUid', this.getLastSearchUid());
@@ -522,8 +520,13 @@ export class QueryController extends RootComponent {
     }
   }
 
-  private keepLastSearchUid(query: IQuery, queryResults: IQueryResults) {
-    return this.getLastQueryHash() == this.queryHash(query, queryResults);
+  private keepLastSearchUid(query: IQuery, queryResults: IQueryResults, options: IQueryOptions) {
+    if (options.keepLastSearchUid === true) {
+      return true;
+    }
+
+    const enableHistory = this.searchInterface && this.searchInterface.options && this.searchInterface.options.enableHistory;
+    return enableHistory && this.getLastQueryHash() == this.queryHash(query, queryResults);
   }
 
   private queryHash(query: IQuery, queryResults?: IQueryResults): string {

--- a/unitTests/controllers/QueryControllerTest.ts
+++ b/unitTests/controllers/QueryControllerTest.ts
@@ -7,10 +7,10 @@ import { QueryEvents, IBuildingQueryEventArgs } from '../../src/events/QueryEven
 import { Simulate } from '../Simulate';
 
 export function QueryControllerTest() {
-  describe('QueryController', function() {
-    var test: Mock.IBasicComponentSetup<QueryController>;
+  describe('QueryController', () => {
+    let test: Mock.IBasicComponentSetup<QueryController>;
 
-    beforeEach(function() {
+    beforeEach(() => {
       test = <Mock.IBasicComponentSetup<QueryController>>{};
       test.env = new Mock.MockEnvironmentBuilder().build();
       test.cmp = new QueryController(test.env.root, {}, test.env.usageAnalytics, test.env.searchInterface);
@@ -18,13 +18,13 @@ export function QueryControllerTest() {
       test.cmp.element = test.env.root;
     });
 
-    afterEach(function() {
+    afterEach(() => {
       test = null;
     });
 
     it('should correctly raise errors from the endpoint', done => {
-      var spy = <jasmine.Spy>test.env.searchEndpoint.search;
-      var error = {
+      const spy = <jasmine.Spy>test.env.searchEndpoint.search;
+      const error = {
         statusCode: 401,
         data: {
           message: 'the message',
@@ -48,7 +48,7 @@ export function QueryControllerTest() {
       );
     });
 
-    it('should allow to fetchMore', function() {
+    it('should allow to fetchMore', () => {
       test.cmp.fetchMore(50);
       expect(test.env.searchEndpoint.search).toHaveBeenCalledWith(
         jasmine.objectContaining({
@@ -63,8 +63,8 @@ export function QueryControllerTest() {
       $$(test.cmp.element).on(QueryEvents.buildingQuery, (e, args: IBuildingQueryEventArgs) => {
         args.queryBuilder.expression.add('mamamia');
       });
-      var search = <jasmine.Spy>test.env.searchEndpoint.search;
-      var results = FakeResults.createFakeResults();
+      const search = <jasmine.Spy>test.env.searchEndpoint.search;
+      const results = FakeResults.createFakeResults();
       search.and.returnValue(
         new Promise((resolve, reject) => {
           resolve(results);
@@ -86,8 +86,8 @@ export function QueryControllerTest() {
     });
 
     it('should allow to get the last query results', done => {
-      var search = <jasmine.Spy>test.env.searchEndpoint.search;
-      var results = FakeResults.createFakeResults();
+      const search = <jasmine.Spy>test.env.searchEndpoint.search;
+      const results = FakeResults.createFakeResults();
       search.and.returnValue(
         new Promise((resolve, reject) => {
           resolve(results);
@@ -101,11 +101,11 @@ export function QueryControllerTest() {
       }, 10);
     });
 
-    describe('trigger query events', function() {
-      it('should trigger newQuery', function(done) {
-        var spy = jasmine.createSpy('spy');
+    describe('trigger query events', () => {
+      it('should trigger newQuery', done => {
+        const spy = jasmine.createSpy('spy');
         $$(test.env.root).on('newQuery', spy);
-        var search = <jasmine.Spy>test.env.searchEndpoint.search;
+        const search = <jasmine.Spy>test.env.searchEndpoint.search;
         search.and.returnValue(
           new Promise((resolve, reject) => {
             resolve(FakeResults.createFakeResults());
@@ -126,10 +126,10 @@ export function QueryControllerTest() {
         }, 10);
       });
 
-      it('should trigger buildingQuery', function(done) {
-        var spy = jasmine.createSpy('spy');
+      it('should trigger buildingQuery', done => {
+        const spy = jasmine.createSpy('spy');
         $$(test.env.root).on('buildingQuery', spy);
-        var search = <jasmine.Spy>test.env.searchEndpoint.search;
+        const search = <jasmine.Spy>test.env.searchEndpoint.search;
         search.and.returnValue(
           new Promise((resolve, reject) => {
             resolve(FakeResults.createFakeResults());
@@ -150,10 +150,10 @@ export function QueryControllerTest() {
         }, 10);
       });
 
-      it('should trigger doneBuildingQuery', function(done) {
-        var spy = jasmine.createSpy('spy');
+      it('should trigger doneBuildingQuery', done => {
+        const spy = jasmine.createSpy('spy');
         $$(test.env.root).on('doneBuildingQuery', spy);
-        var search = <jasmine.Spy>test.env.searchEndpoint.search;
+        const search = <jasmine.Spy>test.env.searchEndpoint.search;
         search.and.returnValue(
           new Promise((resolve, reject) => {
             resolve(FakeResults.createFakeResults());
@@ -173,10 +173,10 @@ export function QueryControllerTest() {
         }, 10);
       });
 
-      it('should trigger querySuccess', function(done) {
-        var spy = jasmine.createSpy('spy');
+      it('should trigger querySuccess', done => {
+        const spy = jasmine.createSpy('spy');
         $$(test.env.root).on('querySuccess', spy);
-        var search = <jasmine.Spy>test.env.searchEndpoint.search;
+        const search = <jasmine.Spy>test.env.searchEndpoint.search;
         search.and.returnValue(
           new Promise((resolve, reject) => {
             resolve(FakeResults.createFakeResults());
@@ -198,11 +198,29 @@ export function QueryControllerTest() {
         }, 10);
       });
 
-      it('should trigger preprocessResults', function(done) {
-        var spy = jasmine.createSpy('spy');
+      it('should respect the keepLastSearchUid option set to true', async done => {
+        test.cmp['lastSearchUid'] = 'foo';
+        (test.env.searchEndpoint.search as jasmine.Spy).and.returnValue(Promise.resolve(FakeResults.createFakeResults()));
+
+        const response = await test.cmp.executeQuery({ keepLastSearchUid: true });
+        response.results.forEach(res => expect(res.queryUid).toBe('foo'));
+        done();
+      });
+
+      it('should respect the keepLastSearchUid option set to false', async done => {
+        test.cmp['lastSearchUid'] = 'foo';
+        (test.env.searchEndpoint.search as jasmine.Spy).and.returnValue(Promise.resolve(FakeResults.createFakeResults()));
+
+        const response = await test.cmp.executeQuery({ keepLastSearchUid: false });
+        response.results.forEach(res => expect(res.queryUid).not.toBe('foo'));
+        done();
+      });
+
+      it('should trigger preprocessResults', done => {
+        const spy = jasmine.createSpy('spy');
         $$(test.env.root).on('preprocessResults', spy);
-        var search = <jasmine.Spy>test.env.searchEndpoint.search;
-        var results = FakeResults.createFakeResults();
+        const search = <jasmine.Spy>test.env.searchEndpoint.search;
+        const results = FakeResults.createFakeResults();
         search.and.returnValue(
           new Promise((resolve, reject) => {
             resolve(results);
@@ -224,11 +242,11 @@ export function QueryControllerTest() {
         }, 10);
       });
 
-      it('should trigger noResults', function(done) {
-        var spy = jasmine.createSpy('spy');
+      it('should trigger noResults', done => {
+        const spy = jasmine.createSpy('spy');
         $$(test.env.root).on('noResults', spy);
-        var search = <jasmine.Spy>test.env.searchEndpoint.search;
-        var results = FakeResults.createFakeResults(0);
+        const search = <jasmine.Spy>test.env.searchEndpoint.search;
+        const results = FakeResults.createFakeResults(0);
         search.and.returnValue(
           new Promise((resolve, reject) => {
             resolve(results);
@@ -251,7 +269,7 @@ export function QueryControllerTest() {
         }, 10);
       });
 
-      it('should cancel the query if set during an event', function() {
+      it('should cancel the query if set during an event', () => {
         $$(test.env.root).on('newQuery', (e, args) => {
           args.cancel = true;
         });
@@ -260,26 +278,26 @@ export function QueryControllerTest() {
       });
     });
 
-    describe('coveoanalytics', function() {
+    describe('coveoanalytics', () => {
       let store: CoveoAnalytics.HistoryStore;
 
-      beforeEach(function() {
+      beforeEach(() => {
         store = Simulate.analyticsStoreModule();
         test.cmp.historyStore = store;
         spyOn(store, 'addElement');
       });
 
-      afterEach(function() {
+      afterEach(() => {
         store = undefined;
         window['coveoanalytics'] = undefined;
       });
 
-      it('should not log the query in the user history if not specified', function() {
+      it('should not log the query in the user history if not specified', () => {
         test.cmp.executeQuery({ logInActionsHistory: false });
         expect(store.addElement).not.toHaveBeenCalled();
       });
 
-      it('should log the query in the user history if specified', function() {
+      it('should log the query in the user history if specified', () => {
         test.cmp.executeQuery({ logInActionsHistory: true });
         expect(store.addElement).toHaveBeenCalled();
       });

--- a/unitTests/controllers/QueryControllerTest.ts
+++ b/unitTests/controllers/QueryControllerTest.ts
@@ -1,9 +1,9 @@
-import * as Mock from '../MockEnvironment';
 import { QueryController } from '../../src/controllers/QueryController';
+import { IBuildingQueryEventArgs, QueryEvents } from '../../src/events/QueryEvents';
+import { QueryBuilder } from '../../src/ui/Base/QueryBuilder';
 import { $$ } from '../../src/utils/Dom';
 import { FakeResults } from '../Fake';
-import { QueryBuilder } from '../../src/ui/Base/QueryBuilder';
-import { QueryEvents, IBuildingQueryEventArgs } from '../../src/events/QueryEvents';
+import * as Mock from '../MockEnvironment';
 import { Simulate } from '../Simulate';
 
 export function QueryControllerTest() {


### PR DESCRIPTION
Whenever there's a new query, we receive a search UID from the API, that we need to set on each query results so that we can track it on click of each document. When fetching more results (eg: pager), we do not want to mark that as a "new" query, but instead a continuation of the last one.

The keepLastSearchUid parameter was not respected properly when passed in as an option to the query controller, making it so that the "Results per page component" would not correctly re-use the same ID, leading to incoherent event in UA.

Also did some janitor duty (reorganize imports/var -> const)

https://coveord.atlassian.net/browse/JSUI-2223

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)