### PR TITLE
Change to use ?visitor= when calling UA

### DIFF
--- a/src/rest/AnalyticsEndpoint.ts
+++ b/src/rest/AnalyticsEndpoint.ts
@@ -1,21 +1,19 @@
-import { Logger } from '../misc/Logger';
-import { EndpointCaller, IEndpointCallerOptions } from '../rest/EndpointCaller';
-import { IAPIAnalyticsVisitResponseRest } from './APIAnalyticsVisitResponse';
-import { IErrorResponse } from '../rest/EndpointCaller';
-import { IAPIAnalyticsSearchEventsResponse } from '../rest/APIAnalyticsSearchEventsResponse';
-import { ISearchEvent } from '../rest/SearchEvent';
-import { IClickEvent } from '../rest/ClickEvent';
-import { IAPIAnalyticsEventResponse } from './APIAnalyticsEventResponse';
+import { first } from 'underscore';
 import { Assert } from '../misc/Assert';
+import { Logger } from '../misc/Logger';
+import { IAPIAnalyticsSearchEventsResponse } from '../rest/APIAnalyticsSearchEventsResponse';
+import { IClickEvent } from '../rest/ClickEvent';
+import { EndpointCaller, IEndpointCallerOptions, IErrorResponse, ISuccessResponse } from '../rest/EndpointCaller';
+import { IStringMap } from '../rest/GenericParam';
+import { ISearchEvent } from '../rest/SearchEvent';
+import { Cookie } from '../utils/CookieUtils';
+import { UrlUtils } from '../utils/UrlUtils';
+import { Utils } from '../utils/Utils';
+import { AccessToken } from './AccessToken';
+import { IAPIAnalyticsEventResponse } from './APIAnalyticsEventResponse';
+import { IAPIAnalyticsVisitResponseRest } from './APIAnalyticsVisitResponse';
 import { ICustomEvent } from './CustomEvent';
 import { ITopQueries } from './TopQueries';
-import { Cookie } from '../utils/CookieUtils';
-import { ISuccessResponse } from '../rest/EndpointCaller';
-import { IStringMap } from '../rest/GenericParam';
-import * as _ from 'underscore';
-import { Utils } from '../utils/Utils';
-import { UrlUtils } from '../utils/UrlUtils';
-import { AccessToken } from './AccessToken';
 
 export interface IAnalyticsEndpointOptions {
   accessToken: AccessToken;
@@ -100,7 +98,7 @@ export class AnalyticsEndpoint {
       paths: [this.options.serviceUrl, '/rest/', versionToCall, '/analytics/', path],
       query: {
         org: this.organization,
-        visitorId: Cookie.get('visitorId')
+        visitor: Cookie.get('visitorId')
       }
     });
     // We use pendingRequest because we don't want to have 2 request to analytics at the same time.
@@ -165,8 +163,8 @@ export class AnalyticsEndpoint {
       visitId = response['visitId'];
       visitorId = response['visitorId'];
     } else if (response['searchEventResponses']) {
-      visitId = (<IAPIAnalyticsEventResponse>_.first(response['searchEventResponses'])).visitId;
-      visitorId = (<IAPIAnalyticsEventResponse>_.first(response['searchEventResponses'])).visitorId;
+      visitId = (<IAPIAnalyticsEventResponse>first(response['searchEventResponses'])).visitId;
+      visitorId = (<IAPIAnalyticsEventResponse>first(response['searchEventResponses'])).visitorId;
     }
 
     if (visitId) {

--- a/src/utils/UrlUtils.ts
+++ b/src/utils/UrlUtils.ts
@@ -1,4 +1,4 @@
-import { isArray, pairs, compact, uniq, rest, first } from 'underscore';
+import { isArray, pairs, compact, uniq, rest, first, isString } from 'underscore';
 import { Utils } from './Utils';
 import { IEndpointCallParameters } from '../rest/EndpointCaller';
 
@@ -102,6 +102,9 @@ export class UrlUtils {
         const [key, value] = pair;
 
         if (Utils.isNullOrUndefined(value) || Utils.isNullOrUndefined(key)) {
+          return '';
+        }
+        if (isString(value) && Utils.isEmptyString(value)) {
           return '';
         }
 

--- a/unitTests/ui/AnalyticsEndpointTest.ts
+++ b/unitTests/ui/AnalyticsEndpointTest.ts
@@ -1,9 +1,11 @@
-import { AnalyticsEndpoint } from '../../src/rest/AnalyticsEndpoint';
-import { IErrorResponse } from '../../src/rest/EndpointCaller';
-import { FakeResults } from '../Fake';
-import { IAPIAnalyticsSearchEventsResponse } from '../../src/rest/APIAnalyticsSearchEventsResponse';
-import { IAPIAnalyticsEventResponse } from '../../src/rest/APIAnalyticsEventResponse';
 import { AccessToken } from '../../src/rest/AccessToken';
+import { AnalyticsEndpoint } from '../../src/rest/AnalyticsEndpoint';
+import { IAPIAnalyticsEventResponse } from '../../src/rest/APIAnalyticsEventResponse';
+import { IAPIAnalyticsSearchEventsResponse } from '../../src/rest/APIAnalyticsSearchEventsResponse';
+import { IErrorResponse } from '../../src/rest/EndpointCaller';
+import { Cookie } from '../../src/utils/CookieUtils';
+import { FakeResults } from '../Fake';
+
 export function AnalyticsEndpointTest() {
   function buildUrl(endpoint: AnalyticsEndpoint, path: string) {
     return endpoint.options.serviceUrl + '/rest/' + AnalyticsEndpoint.DEFAULT_ANALYTICS_VERSION + path;
@@ -118,6 +120,22 @@ export function AnalyticsEndpointTest() {
       endpoint.sendSearchEvents([fakeSearchEvent]);
 
       expect(jasmine.Ajax.requests.mostRecent().url.indexOf('org=organization') != -1).toBe(true);
+    });
+
+    it('send visitor as parameter when sending a search event and there is a cookie value', () => {
+      let fakeSearchEvent = FakeResults.createFakeSearchEvent();
+      Cookie.set('visitorId', 'omNomNomNom');
+      endpoint.sendSearchEvents([fakeSearchEvent]);
+
+      expect(jasmine.Ajax.requests.mostRecent().url.indexOf('visitor=omNomNomNom') != -1).toBe(true);
+    });
+
+    it('does not send visitor as parameter when sending a search event and there is no cookie value', () => {
+      let fakeSearchEvent = FakeResults.createFakeSearchEvent();
+      Cookie.erase('visitorId');
+      endpoint.sendSearchEvents([fakeSearchEvent]);
+
+      expect(jasmine.Ajax.requests.mostRecent().url.indexOf('visitor=') == -1).toBe(true);
     });
 
     it('allow to getTopQueries', done => {

--- a/unitTests/utils/UrlUtilsTest.ts
+++ b/unitTests/utils/UrlUtilsTest.ts
@@ -111,6 +111,39 @@ export function UrlUtilsTest() {
       expect(url).toBe(`https://a.com?123=4${Utils.safeEncodeURIComponent(' ')}56&abc=${Utils.safeEncodeURIComponent('&')}def`);
     });
 
+    it('should remove query string parameter that are an empty string', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        queryAsString: [`123=456`],
+        query: {
+          abc: ''
+        }
+      });
+      expect(url).toBe(`https://a.com?123=456`);
+    });
+
+    it('should remove query string parameter that are null', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        queryAsString: [`123=456`],
+        query: {
+          abc: null
+        }
+      });
+      expect(url).toBe(`https://a.com?123=456`);
+    });
+
+    it('should remove query string parameter that are undefined', () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        queryAsString: [`123=456`],
+        query: {
+          abc: undefined
+        }
+      });
+      expect(url).toBe(`https://a.com?123=456`);
+    });
+
     it('should remove incoherent "?" character', () => {
       const url = UrlUtils.normalizeAsString({
         paths: ['https://a.com/?'],


### PR DESCRIPTION
The official and documented parameter in UA is `visitor` and the AnalyticsEndpoint class was instead using `visitorId` instead.

Also did some cleaning in `UrlUtils` as it was needlessly sending query string parameters with no value.

https://coveord.atlassian.net/browse/JSUI-2225





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)