### PR TITLE
Use popper.js for quickview tooltip

### DIFF
--- a/sass/_Quickview.scss
+++ b/sass/_Quickview.scss
@@ -7,9 +7,6 @@
   }
   .coveo-list-layout &:hover .coveo-caption-for-icon {
     display: inline;
-    top: 26px;
-    transform: translateX(-50%);
-    left: 50%;
   }
   .coveo-caption-for-icon {
     font-size: $font-size-smallest;
@@ -21,7 +18,7 @@
     position: absolute;
     white-space: nowrap;
     z-index: 1;
-    &:before {
+    > div {
       border: solid;
       border-color: $color-greyish-dark-blue transparent;
       border-width: 0 6px 7px;

--- a/sass/_Quickview.scss
+++ b/sass/_Quickview.scss
@@ -21,12 +21,22 @@
     > div {
       border: solid;
       border-color: $color-greyish-dark-blue transparent;
-      border-width: 0 6px 7px;
       content: '';
       position: absolute;
       z-index: 99;
-      top: -6px;
       left: calc(50% - 6px);
+    }
+
+    // Tooltip under element, arrow on top
+    &[x-placement^='bottom'] > div {
+      top: -6px;
+      border-width: 0 6px 7px;
+    }
+
+    // Tooltip over element, arrow on bottom
+    &[x-placement^='top'] > div {
+      bottom: -6px;
+      border-width: 7px 6px 0;
     }
   }
 }

--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -1,4 +1,3 @@
-import 'styling/_Quickview';
 import PopperJs from 'popper.js';
 import { QuickviewEvents } from '../../events/QuickviewEvents';
 import { ResultListEvents } from '../../events/ResultListEvents';
@@ -256,17 +255,13 @@ export class Quickview extends Component {
 
   private buildContent() {
     const icon = this.buildIcon();
-    const { caption, arrow } = this.buildCaption();
+    const tooltip = this.buildTootip(icon);
+
     const content = $$('div');
-
     content.append(icon);
-    content.append(caption);
-    $$(this.element).append(content.el);
+    content.append(tooltip);
 
-    const popperReference = this.buildPopper(icon, caption, arrow);
-    $$(this.element).on('mouseover', () => {
-      popperReference.update();
-    });
+    $$(this.element).append(content.el);
   }
 
   private buildIcon() {
@@ -275,15 +270,17 @@ export class Quickview extends Component {
     return icon;
   }
 
-  private buildCaption() {
-    const caption = $$('div', { className: 'coveo-caption-for-icon', tabindex: 0 }, 'Quickview'.toLocaleString()).el;
+  private buildTootip(icon: HTMLElement) {
+    const tooltip = $$('div', { className: 'coveo-caption-for-icon', tabindex: 0 }, 'Quickview'.toLocaleString()).el;
     const arrow = $$('div').el;
-    caption.appendChild(arrow);
-    return { caption, arrow };
+    tooltip.appendChild(arrow);
+
+    this.buildPopper(icon, tooltip, arrow);
+    return tooltip;
   }
 
-  private buildPopper(icon, caption, arrow) {
-    return new PopperJs(icon, caption, {
+  private buildPopper(icon: HTMLElement, tooltip: HTMLElement, arrow: HTMLElement) {
+    const popperReference = new PopperJs(icon, tooltip, {
       placement: 'bottom',
       modifiers: {
         preventOverflow: {
@@ -298,6 +295,10 @@ export class Quickview extends Component {
           offset: '0,8'
         }
       }
+    });
+
+    $$(this.element).on('mouseover', () => {
+      popperReference.update();
     });
   }
 

--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -1,4 +1,5 @@
 import 'styling/_Quickview';
+import PopperJs from 'popper.js';
 import { QuickviewEvents } from '../../events/QuickviewEvents';
 import { ResultListEvents } from '../../events/ResultListEvents';
 import { ModalBox as ModalBoxModule } from '../../ExternalModulesShim';
@@ -244,13 +245,36 @@ export class Quickview extends Component {
     // If there is no content inside the Quickview div,
     // we need to add something that will show up in the result template itself
     if (/^\s*$/.test(this.element.innerHTML)) {
+      const resultsSection = $$(this.root).find('.coveo-results-column');
       const iconForQuickview = $$('div', { className: 'coveo-icon-for-quickview' }, SVGIcons.icons.quickview);
       SVGDom.addClassToSVGInContainer(iconForQuickview.el, 'coveo-icon-for-quickview-svg');
       const captionForQuickview = $$('div', { className: 'coveo-caption-for-icon', tabindex: 0 }, 'Quickview'.toLocaleString()).el;
+      const captionForQuickviewArrow = $$('div').el;
+      captionForQuickview.appendChild(captionForQuickviewArrow);
       const div = $$('div');
       div.append(iconForQuickview.el);
       div.append(captionForQuickview);
       $$(this.element).append(div.el);
+
+      const captionForQuickviewPopper = new PopperJs(iconForQuickview.el, captionForQuickview, {
+        placement: 'bottom',
+        modifiers: {
+          preventOverflow: {
+            boundariesElement: resultsSection,
+            padding: 0
+          },
+          arrow: {
+            element: captionForQuickviewArrow
+          },
+          offset: {
+            offset: '0,8'
+          }
+        }
+      });
+
+      $$(this.element).on('mouseover', () => {
+        captionForQuickviewPopper.update();
+      });
     }
 
     this.bindClick(result);

--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -245,41 +245,60 @@ export class Quickview extends Component {
     // If there is no content inside the Quickview div,
     // we need to add something that will show up in the result template itself
     if (/^\s*$/.test(this.element.innerHTML)) {
-      const iconForQuickview = $$('div', { className: 'coveo-icon-for-quickview' }, SVGIcons.icons.quickview);
-      SVGDom.addClassToSVGInContainer(iconForQuickview.el, 'coveo-icon-for-quickview-svg');
-      const captionForQuickview = $$('div', { className: 'coveo-caption-for-icon', tabindex: 0 }, 'Quickview'.toLocaleString()).el;
-      const captionForQuickviewArrow = $$('div').el;
-      captionForQuickview.appendChild(captionForQuickviewArrow);
-      const div = $$('div');
-      div.append(iconForQuickview.el);
-      div.append(captionForQuickview);
-      $$(this.element).append(div.el);
-
-      const captionForQuickviewPopper = new PopperJs(iconForQuickview.el, captionForQuickview, {
-        placement: 'bottom',
-        modifiers: {
-          preventOverflow: {
-            boundariesElement: $$(this.root).el,
-            padding: 0
-          },
-          arrow: {
-            element: captionForQuickviewArrow
-          },
-          offset: {
-            offset: '0,8'
-          }
-        }
-      });
-
-      $$(this.element).on('mouseover', () => {
-        captionForQuickviewPopper.update();
-      });
+      this.buildContent();
     }
 
     this.bindClick(result);
     if (this.bindings.resultElement) {
       this.bind.on(this.bindings.resultElement, ResultListEvents.openQuickview, () => this.open());
     }
+  }
+
+  private buildContent() {
+    const icon = this.buildIcon();
+    const { caption, arrow } = this.buildCaption();
+    const content = $$('div');
+
+    content.append(icon);
+    content.append(caption);
+    $$(this.element).append(content.el);
+
+    const popperReference = this.buildPopper(icon, caption, arrow);
+    $$(this.element).on('mouseover', () => {
+      popperReference.update();
+    });
+  }
+
+  private buildIcon() {
+    const icon = $$('div', { className: 'coveo-icon-for-quickview' }, SVGIcons.icons.quickview).el;
+    SVGDom.addClassToSVGInContainer(icon, 'coveo-icon-for-quickview-svg');
+    return icon;
+  }
+
+  private buildCaption() {
+    const caption = $$('div', { className: 'coveo-caption-for-icon', tabindex: 0 }, 'Quickview'.toLocaleString()).el;
+    const arrow = $$('div').el;
+    caption.appendChild(arrow);
+    return { caption, arrow };
+  }
+
+  private buildPopper(icon, caption, arrow) {
+    return new PopperJs(icon, caption, {
+      placement: 'bottom',
+      modifiers: {
+        preventOverflow: {
+          boundariesElement: $$(this.root).el,
+          padding: 0
+        },
+        arrow: {
+          element: arrow
+        },
+        // X,Y offset of the tooltip relative to the icon
+        offset: {
+          offset: '0,8'
+        }
+      }
+    });
   }
 
   /**

--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -245,7 +245,6 @@ export class Quickview extends Component {
     // If there is no content inside the Quickview div,
     // we need to add something that will show up in the result template itself
     if (/^\s*$/.test(this.element.innerHTML)) {
-      const resultsSection = $$(this.root).find('.coveo-results-column');
       const iconForQuickview = $$('div', { className: 'coveo-icon-for-quickview' }, SVGIcons.icons.quickview);
       SVGDom.addClassToSVGInContainer(iconForQuickview.el, 'coveo-icon-for-quickview-svg');
       const captionForQuickview = $$('div', { className: 'coveo-caption-for-icon', tabindex: 0 }, 'Quickview'.toLocaleString()).el;
@@ -260,7 +259,7 @@ export class Quickview extends Component {
         placement: 'bottom',
         modifiers: {
           preventOverflow: {
-            boundariesElement: resultsSection,
+            boundariesElement: $$(this.root).el,
             padding: 0
           },
           arrow: {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2207

Caption now moves according to the border of the results column
![screen shot 2018-09-07 at 12 02 26](https://user-images.githubusercontent.com/4923043/45230810-190f3400-b298-11e8-9830-e2f48501e413.png)
![screen shot 2018-09-07 at 12 01 15](https://user-images.githubusercontent.com/4923043/45230811-190f3400-b298-11e8-9e8c-c92e8f93a4ce.png)


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)