### PR TITLE
Jsui 2158 Add the facet field in facetSelect search event

### DIFF
--- a/src/controllers/HistoryController.ts
+++ b/src/controllers/HistoryController.ts
@@ -223,6 +223,7 @@ export class HistoryController extends RootComponent implements IHistoryManager 
         if (facetInfo) {
           this.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(facetInfo.actionCause, {
             facetId: facetInfo.fieldName,
+            facetField: facetInfo.fieldName,
             facetTitle: facetInfo.fieldName,
             facetValue: facetInfo.valueModified
           });

--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -21,7 +21,6 @@ export interface IAnalyticsActionCause {
    * Example: All search box related events could have `searchbox` as their `type` value.
    */
   type: string;
-  metaMap?: { [name: string]: number };
 }
 
 export interface IAnalyticsNoMeta {}
@@ -240,8 +239,7 @@ export var analyticsActionCauseList = {
    */
   interfaceChange: <IAnalyticsActionCause>{
     name: 'interfaceChange',
-    type: 'interface',
-    metaMap: { interfaceChangeTo: 1 }
+    type: 'interface'
   },
   /**
    * Identifies the search event that gets logged when any `hd` or `hq` gets cleared from {@link QueryStateModel}, and then triggers a new query.
@@ -254,8 +252,7 @@ export var analyticsActionCauseList = {
    */
   contextRemove: <IAnalyticsActionCause>{
     name: 'contextRemove',
-    type: 'misc',
-    metaMap: { contextName: 1 }
+    type: 'misc'
   },
   /**
    * Identifies the search event that gets logged when `enableAutoCorrection: true` and the query is automatically corrected.
@@ -288,8 +285,7 @@ export var analyticsActionCauseList = {
    */
   resultsSort: <IAnalyticsActionCause>{
     name: 'resultsSort',
-    type: 'misc',
-    metaMap: { resultsSortBy: 1 }
+    type: 'misc'
   },
   /**
    * Identifies the search event that gets logged when a submit button is selected on a search box.
@@ -332,8 +328,7 @@ export var analyticsActionCauseList = {
    */
   breadcrumbFacet: <IAnalyticsActionCause>{
     name: 'breadcrumbFacet',
-    type: 'breadcrumb',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    type: 'breadcrumb'
   },
   /**
    * Identifies the search event that gets logged when a user clears all values from the advanced search filter summary.
@@ -368,8 +363,7 @@ export var analyticsActionCauseList = {
    */
   documentTag: <IAnalyticsActionCause>{
     name: 'documentTag',
-    type: 'document',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    type: 'document'
   },
   /**
    * Identifies the search event that gets logged when a user clicks a field value from an item field to add a filter.
@@ -385,8 +379,7 @@ export var analyticsActionCauseList = {
    */
   documentField: <IAnalyticsActionCause>{
     name: 'documentField',
-    type: 'document',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
+    type: 'document'
   },
   /**
    * Identifies the click event that gets logged when the Quick View element is selected and a Quick View modal of the document is displayed.
@@ -400,8 +393,7 @@ export var analyticsActionCauseList = {
    */
   documentQuickview: <IAnalyticsActionCause>{
     name: 'documentQuickview',
-    type: 'document',
-    metaMap: { documentTitle: 1, documentURL: 2 }
+    type: 'document'
   },
   /**
    * Identifies the click event that gets logged when a user clicks on a search result to open an item.
@@ -415,8 +407,7 @@ export var analyticsActionCauseList = {
    */
   documentOpen: <IAnalyticsActionCause>{
     name: 'documentOpen',
-    type: 'document',
-    metaMap: { documentTitle: 1, documentURL: 2 }
+    type: 'document'
   },
   /**
    * Identifies the search event that gets logged when a user selects or deselects a facet filter from the Omnibox.
@@ -432,8 +423,7 @@ export var analyticsActionCauseList = {
    */
   omniboxFacetSelect: <IAnalyticsActionCause>{
     name: 'omniboxFacetSelect',
-    type: 'omnibox',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
+    type: 'omnibox'
   },
   /**
    * Identifies the search event that gets logged when a user clicks a facet value to filter out results containing this value from the Omnibox.
@@ -449,8 +439,7 @@ export var analyticsActionCauseList = {
    */
   omniboxFacetExclude: <IAnalyticsActionCause>{
     name: 'omniboxFacetExclude',
-    type: 'omnibox',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
+    type: 'omnibox'
   },
   /**
    * Identifies the search event that gets logged when a user selects or deselects a facet filter from the Omnibox.
@@ -466,8 +455,7 @@ export var analyticsActionCauseList = {
    */
   omniboxFacetDeselect: <IAnalyticsActionCause>{
     name: 'omniboxFacetDeselect',
-    type: 'omnibox',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
+    type: 'omnibox'
   },
   /**
    * Identifies the search event that gets logged when a user clicks a facet value to not filter out results containing this value from the Omnibox.
@@ -483,8 +471,7 @@ export var analyticsActionCauseList = {
    */
   omniboxFacetUnexclude: <IAnalyticsActionCause>{
     name: 'omniboxFacetUnexclude',
-    type: 'omnibox',
-    metaMap: { faceId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
+    type: 'omnibox'
   },
   /**
    * Identifies the search event that gets logged when a user clicks a query suggestion based on the usage analytics recorded queries.
@@ -500,13 +487,7 @@ export var analyticsActionCauseList = {
    */
   omniboxAnalytics: <IAnalyticsActionCause>{
     name: 'omniboxAnalytics',
-    type: 'omnibox',
-    metaMap: {
-      partialQuery: 1,
-      suggestionRanking: 2,
-      partialQueries: 3,
-      suggestions: 4
-    }
+    type: 'omnibox'
   },
   /**
    * Identifies the search event that gets logged when a suggested search query is selected from a standalone searchbox.
@@ -522,13 +503,7 @@ export var analyticsActionCauseList = {
    */
   omniboxFromLink: <IAnalyticsActionCause>{
     name: 'omniboxFromLink',
-    type: 'omnibox',
-    metaMap: {
-      partialQuery: 1,
-      suggestionRanking: 2,
-      partialQueries: 3,
-      suggestions: 4
-    }
+    type: 'omnibox'
   },
   /**
    * Identifies the search event that gets logged when a user selects a query suggestion from a list built from values of a field.
@@ -552,8 +527,7 @@ export var analyticsActionCauseList = {
    */
   facetClearAll: <IAnalyticsActionCause>{
     name: 'facetClearAll',
-    type: 'facet',
-    metaMap: { facetId: 1, facetField: 2 }
+    type: 'facet'
   },
   /**
    * Identifies the custom event that gets logged when a query is being typed into the facet search box.
@@ -567,8 +541,7 @@ export var analyticsActionCauseList = {
    */
   facetSearch: <IAnalyticsActionCause>{
     name: 'facetSearch',
-    type: 'facet',
-    metaMap: { facetId: 1, facetField: 2 }
+    type: 'facet'
   },
   /**
    * Identifies the search event that gets logged when the user toggles the facet operator.
@@ -584,8 +557,7 @@ export var analyticsActionCauseList = {
    */
   facetToggle: <IAnalyticsActionCause>{
     name: 'facetToggle',
-    type: 'facet',
-    metaMap: { facetId: 1, facetOperatorBefore: 2, facetOperatorAfter: 3, facetField: 4 }
+    type: 'facet'
   },
   /**
    * Identifies the search event that gets logged when a facet slider changes range values.
@@ -601,8 +573,7 @@ export var analyticsActionCauseList = {
    */
   facetRangeSlider: <IAnalyticsActionCause>{
     name: 'facetRangeSlider',
-    type: 'facet',
-    metaMap: { facetId: 1, facetRangeStart: 2, facetRangeEnd: 3, facetField: 4 }
+    type: 'facet'
   },
   /**
    * Identifies the search event that gets logged when a facet graph changes range values.
@@ -618,8 +589,7 @@ export var analyticsActionCauseList = {
    */
   facetRangeGraph: <IAnalyticsActionCause>{
     name: 'facetRangeGraph',
-    type: 'facet',
-    metaMap: { facetId: 1, facetRangeStart: 2, facetRangeEnd: 3, facetField: 4 }
+    type: 'facet'
   },
   /**
    * Identifies the search event that gets logged when a facet check box is selected and the query is updated.
@@ -635,8 +605,7 @@ export var analyticsActionCauseList = {
    */
   facetSelect: <IAnalyticsActionCause>{
     name: 'facetSelect',
-    type: 'facet',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
+    type: 'facet'
   },
   /**
    * Identifies the search event that gets logged when all filters on a facet are selected.
@@ -652,8 +621,7 @@ export var analyticsActionCauseList = {
    */
   facetSelectAll: <IAnalyticsActionCause>{
     name: 'facetSelectAll',
-    type: 'facet',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
+    type: 'facet'
   },
   /**
    * Identifies the search event that gets logged when a facet check box is deselected and the query is updated.
@@ -669,8 +637,7 @@ export var analyticsActionCauseList = {
    */
   facetDeselect: <IAnalyticsActionCause>{
     name: 'facetDeselect',
-    type: 'facet',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
+    type: 'facet'
   },
   /**
    * Identifies the search event that gets logged when a user clicks a facet value to filter out results containing the facet value.
@@ -686,8 +653,7 @@ export var analyticsActionCauseList = {
    */
   facetExclude: <IAnalyticsActionCause>{
     name: 'facetExclude',
-    type: 'facet',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
+    type: 'facet'
   },
   /**
    * Identifies the search event that gets logged when a user clicks a facet value to not filter out results containing the facet value.
@@ -703,8 +669,7 @@ export var analyticsActionCauseList = {
    */
   facetUnexclude: <IAnalyticsActionCause>{
     name: 'facetUnexclude',
-    type: 'facet',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
+    type: 'facet'
   },
   facetUpdateSort: <IAnalyticsActionCause>{
     name: 'facetUpdateSort',
@@ -712,23 +677,19 @@ export var analyticsActionCauseList = {
   },
   categoryFacetSelect: <IAnalyticsActionCause>{
     name: 'categoryFacetSelect',
-    type: 'categoryFacet',
-    metaMap: { categoryFacetId: 1, categoryFacetValue: 2, categoryFacetTitle: 3 }
+    type: 'categoryFacet'
   },
   categoryFacetClear: <IAnalyticsActionCause>{
     name: 'categoryFacetClear',
-    type: 'categoryFacet',
-    metaMap: { categoryFacetId: 1, categoryFacetValue: 2, categoryFacetTitle: 3 }
+    type: 'categoryFacet'
   },
   categoryFacetBreadcrumb: <IAnalyticsActionCause>{
     name: 'categoryFacetBreadcrumb',
-    type: 'categoryFacet',
-    metaMap: { categoryFacetId: 1, categoryFacetValue: 2, categoryFacetTitle: 3 }
+    type: 'categoryFacet'
   },
   categoryFacetSearch: <IAnalyticsActionCause>{
     name: 'categoryFacetSearch',
-    type: 'categoryFacet',
-    metaMap: { categoryFacetId: 1, categoryFacetValue: 2, categoryFacetTitle: 3 }
+    type: 'categoryFacet'
   },
   /**
    * Identifies the search and custom event that gets logged when a user clicks the Go Back link after an error page.
@@ -831,8 +792,7 @@ export var analyticsActionCauseList = {
    */
   casecontextAdd: <IAnalyticsActionCause>{
     name: 'casecontextAdd',
-    type: 'casecontext',
-    metaMap: { caseID: 5 }
+    type: 'casecontext'
   },
   /**
    * In the context of Coveo for Salesforce, this search event is logged when a user clears the Show only contextual result checkbox from the Insight Panel.
@@ -845,8 +805,7 @@ export var analyticsActionCauseList = {
    */
   casecontextRemove: <IAnalyticsActionCause>{
     name: 'casecontextRemove',
-    type: 'casecontext',
-    metaMap: { caseID: 5 }
+    type: 'casecontext'
   },
   /**
    * Identifies the search and custom event that gets logged when a checkbox in the search preferences is toggled.
@@ -860,8 +819,7 @@ export var analyticsActionCauseList = {
    */
   preferencesChange: <IAnalyticsActionCause>{
     name: 'preferencesChange',
-    type: 'preferences',
-    metaMap: { preferenceName: 1, preferenceType: 2 }
+    type: 'preferences'
   },
   /**
    * In the context of Coveo for Salesforce, this is custom event logged when an agent opens the User Actions panel.
@@ -897,8 +855,7 @@ export var analyticsActionCauseList = {
    */
   caseAttach: <IAnalyticsActionCause>{
     name: 'caseAttach',
-    type: 'case',
-    metaMap: { documentTitle: 1, resultUriHash: 3, articleID: 4, caseID: 5 }
+    type: 'case'
   },
   /**
    * In the context of Coveo for Salesforce, this custom event is logged when a user detaches a knowledge base article to a case.
@@ -914,8 +871,7 @@ export var analyticsActionCauseList = {
    */
   caseDetach: <IAnalyticsActionCause>{
     name: 'caseDetach',
-    type: 'case',
-    metaMap: { documentTitle: 1, resultUriHash: 3, articleID: 4, caseID: 5 }
+    type: 'case'
   },
   /**
    * Identifies the search event that gets logged when a user modifies a custom search filter or removes one from the breadcrumbs.
@@ -930,8 +886,7 @@ export var analyticsActionCauseList = {
    */
   customfiltersChange: <IAnalyticsActionCause>{
     name: 'customfiltersChange',
-    type: 'customfilters',
-    metaMap: { customFilterName: 1, customFilterType: 2, customFilterExpression: 3 }
+    type: 'customfilters'
   },
   /**
    * Identifies the custom event that gets logged when a page number is selected and more items are loaded.
@@ -944,8 +899,7 @@ export var analyticsActionCauseList = {
    */
   pagerNumber: <IAnalyticsActionCause>{
     name: 'pagerNumber',
-    type: 'getMoreResults',
-    metaMap: { pagerNumber: 1 }
+    type: 'getMoreResults'
   },
   /**
    * Identifies the custom event that gets logged when the Next Page link is selected and more items are loaded.
@@ -958,8 +912,7 @@ export var analyticsActionCauseList = {
    */
   pagerNext: <IAnalyticsActionCause>{
     name: 'pagerNext',
-    type: 'getMoreResults',
-    metaMap: { pagerNumber: 1 }
+    type: 'getMoreResults'
   },
   /**
    * Identifies the custom event that gets logged when the Previous Page link is selected and more items are loaded.
@@ -972,8 +925,7 @@ export var analyticsActionCauseList = {
    */
   pagerPrevious: <IAnalyticsActionCause>{
     name: 'pagerPrevious',
-    type: 'getMoreResults',
-    metaMap: { pagerNumber: 1 }
+    type: 'getMoreResults'
   },
   /**
    * Identifies the custom event that gets logged when the user scrolls to the bottom of the item page and more results are loaded.
@@ -1071,8 +1023,7 @@ export var analyticsActionCauseList = {
    */
   queryError: <IAnalyticsActionCause>{
     name: 'query',
-    type: 'errors',
-    metaMap: { query: 1, aq: 2, cq: 3, dq: 4, errorType: 5, errorMessage: 6 }
+    type: 'errors'
   },
   /**
    * Identifies the custom event that gets logged when a user exports search results in an XLS file by clicking the Export to Excel option.
@@ -1197,8 +1148,7 @@ export var analyticsActionCauseList = {
    */
   simpleFilterSelectValue: <IAnalyticsActionCause>{
     name: 'selectValue',
-    type: 'simpleFilter',
-    metaMap: { simpleFilterTitle: 1, simpleFilterValue: 2, simpleFilterField: 3 }
+    type: 'simpleFilter'
   },
   /**
    * Identifies the search event that gets logged when a user deselects a simple filter value under the search box.
@@ -1213,8 +1163,7 @@ export var analyticsActionCauseList = {
    */
   simpleFilterDeselectValue: <IAnalyticsActionCause>{
     name: 'selectValue',
-    type: 'simpleFilter',
-    metaMap: { simpleFilterTitle: 1, simpleFilterValues: 2, simpleFilterField: 3 }
+    type: 'simpleFilter'
   },
   /**
    * Identifies the search event that gets logged when a user clicks the Clear all button to remove all simple filters under the search box.
@@ -1229,8 +1178,7 @@ export var analyticsActionCauseList = {
    */
   simpleFilterClearAll: <IAnalyticsActionCause>{
     name: 'selectValue',
-    type: 'simpleFilter',
-    metaMap: { simpleFilterTitle: 1, simpleFilterField: 3 }
+    type: 'simpleFilter'
   },
   /**
    * Identifies the search event that gets logged when a user changes the search results layout (list, card, or table).

--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -360,6 +360,7 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   documentTag: <IAnalyticsActionCause>{
     name: 'documentTag',

--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -67,6 +67,7 @@ export interface IAnalyticsDocumentViewMeta {
 
 export interface IAnalyticsOmniboxFacetMeta {
   facetId: string;
+  facetField: string;
   facetTitle: string;
   facetValue?: string;
   suggestions: string;
@@ -82,6 +83,7 @@ export interface IAnalyticsSimpleFilterMeta {
 
 export interface IAnalyticsFacetMeta {
   facetId: string;
+  facetField: string;
   facetValue?: string;
   facetTitle: string;
 }
@@ -92,6 +94,7 @@ export interface IAnalyticsFacetSortMeta extends IAnalyticsFacetMeta {
 
 export interface IAnalyticsCategoryFacetMeta {
   categoryFacetId: string;
+  categoryFacetField: string;
   categoryFacetPath?: string[];
   categoryFacetTitle: string;
 }
@@ -121,6 +124,7 @@ export interface IAnalyticsOmniboxSuggestionMeta {
 
 export interface IAnalyticsFacetSliderChangeMeta {
   facetId: string;
+  facetField: string;
   facetRangeStart: any;
   facetRangeEnd: any;
 }
@@ -377,11 +381,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   documentField: <IAnalyticsActionCause>{
     name: 'documentField',
     type: 'document',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
   },
   /**
    * Identifies the click event that gets logged when the Quick View element is selected and a Quick View modal of the document is displayed.
@@ -423,11 +428,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   omniboxFacetSelect: <IAnalyticsActionCause>{
     name: 'omniboxFacetSelect',
     type: 'omnibox',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when a user clicks a facet value to filter out results containing this value from the Omnibox.
@@ -439,11 +445,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   omniboxFacetExclude: <IAnalyticsActionCause>{
     name: 'omniboxFacetExclude',
     type: 'omnibox',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when a user selects or deselects a facet filter from the Omnibox.
@@ -455,11 +462,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   omniboxFacetDeselect: <IAnalyticsActionCause>{
     name: 'omniboxFacetDeselect',
     type: 'omnibox',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when a user clicks a facet value to not filter out results containing this value from the Omnibox.
@@ -471,11 +479,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   omniboxFacetUnexclude: <IAnalyticsActionCause>{
     name: 'omniboxFacetUnexclude',
     type: 'omnibox',
-    metaMap: { faceId: 1, facetValue: 2, facetTitle: 3 }
+    metaMap: { faceId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when a user clicks a query suggestion based on the usage analytics recorded queries.
@@ -539,11 +548,12 @@ export var analyticsActionCauseList = {
    *
    * Logging an event with this actionType also adds the following key-value pair in the custom data property of the Usage Analytics HTTP service request.
    * `"facetId":`: <correspondingFacetId>
+   * `"facetField":`: <correspondingFacetField>
    */
   facetClearAll: <IAnalyticsActionCause>{
     name: 'facetClearAll',
     type: 'facet',
-    metaMap: { facetId: 1 }
+    metaMap: { facetId: 1, facetField: 2 }
   },
   /**
    * Identifies the custom event that gets logged when a query is being typed into the facet search box.
@@ -553,11 +563,12 @@ export var analyticsActionCauseList = {
    *
    * Logging an event with this actionType also adds the following key-value pair in the custom data property of the Usage Analytics HTTP service request.
    * `"facetId":`: <correspondingFacetId>
+   * `"facetField":`: <correspondingFacetField>
    */
   facetSearch: <IAnalyticsActionCause>{
     name: 'facetSearch',
     type: 'facet',
-    metaMap: { facetId: 1 }
+    metaMap: { facetId: 1, facetField: 2 }
   },
   /**
    * Identifies the search event that gets logged when the user toggles the facet operator.
@@ -569,11 +580,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetOperatorBefore":`: <facetOperatorBeforeToggle>
    * `"facetOperatorAfter":`: <facetOperatorAfterToggle>
+   * `"facetField":`: <correspondingFacetField>
    */
   facetToggle: <IAnalyticsActionCause>{
     name: 'facetToggle',
     type: 'facet',
-    metaMap: { facetId: 1, facetOperatorBefore: 2, facetOperatorAfter: 3 }
+    metaMap: { facetId: 1, facetOperatorBefore: 2, facetOperatorAfter: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when a facet slider changes range values.
@@ -585,11 +597,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetRangeStart":`: <correspondingRangeStart>
    * `"facetRangeEnd":`: <correspondingRangeEnd>
+   * `"facetField":`: <correspondingFacetField>
    */
   facetRangeSlider: <IAnalyticsActionCause>{
     name: 'facetRangeSlider',
     type: 'facet',
-    metaMap: { facetId: 1, facetRangeStart: 2, facetRangeEnd: 3 }
+    metaMap: { facetId: 1, facetRangeStart: 2, facetRangeEnd: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when a facet graph changes range values.
@@ -601,11 +614,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetRangeStart":`: <correspondingRangeStart>
    * `"facetRangeEnd":`: <correspondingRangeEnd>
+   * `"facetField":`: <correspondingFacetField>
    */
   facetRangeGraph: <IAnalyticsActionCause>{
     name: 'facetRangeGraph',
     type: 'facet',
-    metaMap: { facetId: 1, facetRangeStart: 2, facetRangeEnd: 3 }
+    metaMap: { facetId: 1, facetRangeStart: 2, facetRangeEnd: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when a facet check box is selected and the query is updated.
@@ -617,11 +631,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   facetSelect: <IAnalyticsActionCause>{
     name: 'facetSelect',
     type: 'facet',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when all filters on a facet are selected.
@@ -633,11 +648,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   facetSelectAll: <IAnalyticsActionCause>{
     name: 'facetSelectAll',
     type: 'facet',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when a facet check box is deselected and the query is updated.
@@ -649,11 +665,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   facetDeselect: <IAnalyticsActionCause>{
     name: 'facetDeselect',
     type: 'facet',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when a user clicks a facet value to filter out results containing the facet value.
@@ -665,11 +682,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   facetExclude: <IAnalyticsActionCause>{
     name: 'facetExclude',
     type: 'facet',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
   },
   /**
    * Identifies the search event that gets logged when a user clicks a facet value to not filter out results containing the facet value.
@@ -681,11 +699,12 @@ export var analyticsActionCauseList = {
    * `"facetId":`: <correspondingFacetId>
    * `"facetValue":`: <correspondingFacetValue>
    * `"facetTitle":`: <correspondingFacetTitle>
+   * `"facetField":`: <correspondingFacetField>
    */
   facetUnexclude: <IAnalyticsActionCause>{
     name: 'facetUnexclude',
     type: 'facet',
-    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3 }
+    metaMap: { facetId: 1, facetValue: 2, facetTitle: 3, facetField: 4 }
   },
   facetUpdateSort: <IAnalyticsActionCause>{
     name: 'facetUpdateSort',

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -488,6 +488,7 @@ export class CategoryFacet extends Component {
   public logAnalyticsEvent(eventName: IAnalyticsActionCause) {
     this.usageAnalytics.logSearchEvent<IAnalyticsCategoryFacetMeta>(eventName, {
       categoryFacetId: this.options.id,
+      categoryFacetField: this.options.field.toString(),
       categoryFacetPath: this.activePath,
       categoryFacetTitle: this.options.title
     });

--- a/src/ui/CategoryFacet/CategoryFacetSearch.ts
+++ b/src/ui/CategoryFacet/CategoryFacetSearch.ts
@@ -195,6 +195,7 @@ export class CategoryFacetSearch implements IFacetSearch {
       analyticsActionCauseList.categoryFacetSearch,
       {
         categoryFacetId: this.categoryFacet.options.id,
+        categoryFacetField: this.categoryFacet.options.field.toString(),
         categoryFacetTitle: this.categoryFacet.options.title
       },
       this.categoryFacet.root

--- a/src/ui/Facet/BreadcrumbValueElement.ts
+++ b/src/ui/Facet/BreadcrumbValueElement.ts
@@ -93,6 +93,7 @@ export class BreadcrumbValueElement {
     this.facet.triggerNewQuery(() =>
       this.facet.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(analyticsActionCauseList.breadcrumbFacet, {
         facetId: this.facet.options.id,
+        facetField: this.facet.options.field.toString(),
         facetValue: this.facetValue.value,
         facetTitle: this.facet.options.title
       })

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1072,6 +1072,7 @@ export class Facet extends Component {
         {
           criteria,
           facetId: this.options.id,
+          facetField: this.options.field.toString(),
           facetTitle: this.options.title
         },
         this.element
@@ -1131,6 +1132,7 @@ export class Facet extends Component {
     this.triggerNewQuery(() =>
       this.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(analyticsActionCauseList.facetSelectAll, {
         facetId: this.options.id,
+        facetField: this.options.field.toString(),
         facetTitle: this.options.title
       })
     );

--- a/src/ui/Facet/FacetHeader.ts
+++ b/src/ui/Facet/FacetHeader.ts
@@ -170,6 +170,7 @@ export class FacetHeader {
       this.options.facet.triggerNewQuery(() =>
         this.options.facet.usageAnalytics.logSearchEvent<IAnalyticsFacetOperatorMeta>(analyticsActionCauseList.facetToggle, {
           facetId: this.options.facet.options.id,
+          facetField: this.options.field.toString(),
           facetOperatorBefore: operatorBefore,
           facetOperatorAfter: operatorNow,
           facetTitle: this.options.title
@@ -196,6 +197,7 @@ export class FacetHeader {
       cmp.reset();
       cmp.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(analyticsActionCauseList.facetClearAll, {
         facetId: cmp.options.id,
+        facetField: cmp.options.field.toString(),
         facetTitle: cmp.options.title
       });
       cmp.queryController.executeQuery();

--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -108,7 +108,11 @@ export class FacetSearch implements IFacetSearch {
         .then((fieldValues: IIndexFieldValue[]) => {
           this.facet.usageAnalytics.logCustomEvent<IAnalyticsFacetMeta>(
             analyticsActionCauseList.facetSearch,
-            { facetId: this.facet.options.id, facetTitle: this.facet.options.title },
+            {
+              facetId: this.facet.options.id,
+              facetField: this.facet.options.field.toString(),
+              facetTitle: this.facet.options.title
+            },
             this.facet.root
           );
           this.facet.logger.debug('Received field values', fieldValues);

--- a/src/ui/Facet/FacetSettings.ts
+++ b/src/ui/Facet/FacetSettings.ts
@@ -438,6 +438,7 @@ export class FacetSettings extends FacetSort {
     this.facet.triggerNewQuery(() =>
       this.facet.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(analyticsActionCauseList.facetClearAll, {
         facetId: this.facet.options.id,
+        facetField: this.facet.options.field.toString(),
         facetTitle: this.facet.options.title
       })
     );

--- a/src/ui/Facet/OmniboxValuesList.ts
+++ b/src/ui/Facet/OmniboxValuesList.ts
@@ -92,6 +92,7 @@ export class OmniboxValuesList {
     elem.facet.usageAnalytics.logSearchEvent<IAnalyticsOmniboxFacetMeta>(cause, {
       query: this.omniboxObject.completeQueryExpression.word,
       facetId: elem.facet.options.id,
+      facetField: elem.facet.options.field.toString(),
       facetTitle: elem.facet.options.title,
       facetValue: elem.facetValue.value,
       suggestions: strippedFacetValues.join(';'),

--- a/src/ui/Facet/ValueElement.ts
+++ b/src/ui/Facet/ValueElement.ts
@@ -189,6 +189,7 @@ export class ValueElement {
   private getAnalyticsFacetMeta(): IAnalyticsFacetMeta {
     return {
       facetId: this.facet.options.id,
+      facetField: this.facet.options.field.toString(),
       facetValue: this.facetValue.value,
       facetTitle: this.facet.options.title
     };

--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -651,6 +651,7 @@ export class FacetSlider extends Component {
       this.reset();
       this.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(analyticsActionCauseList.facetClearAll, {
         facetId: this.options.id,
+        facetField: this.options.field.toString(),
         facetTitle: this.options.title
       });
       this.queryController.executeQuery();
@@ -744,6 +745,7 @@ export class FacetSlider extends Component {
       this.updateAppearanceDependingOnState();
       this.usageAnalytics.logSearchEvent<IAnalyticsFacetSliderChangeMeta>(analyticsActionCauseList.facetRangeSlider, {
         facetId: this.options.id,
+        facetField: this.options.field.toString(),
         facetRangeStart: this.startOfSlider.toString(),
         facetRangeEnd: this.endOfSlider.toString()
       });
@@ -769,6 +771,7 @@ export class FacetSlider extends Component {
       this.updateQueryState();
       this.usageAnalytics.logSearchEvent<IAnalyticsFacetGraphSelectedMeta>(analyticsActionCauseList.facetRangeGraph, {
         facetId: this.options.id,
+        facetField: this.options.field.toString(),
         facetRangeStart: this.startOfSlider.toString(),
         facetRangeEnd: this.endOfSlider.toString()
       });

--- a/src/ui/FieldValue/FieldValue.ts
+++ b/src/ui/FieldValue/FieldValue.ts
@@ -32,6 +32,7 @@ export interface IFieldValueOptions {
 
 export interface IAnalyticsFieldValueMeta {
   facetId: string;
+  facetField: string;
   facetValue?: string;
   facetTitle?: string;
 }
@@ -429,6 +430,7 @@ export class FieldValue extends Component {
       beforeExecuteQuery: () =>
         this.usageAnalytics.logSearchEvent<IAnalyticsFieldValueMeta>(analyticsActionCauseList.documentField, {
           facetId: this.options.facet,
+          facetField: this.options.field.toString(),
           facetValue: value.toLowerCase()
         })
     });

--- a/src/ui/ResultTagging/ResultTagging.ts
+++ b/src/ui/ResultTagging/ResultTagging.ts
@@ -28,6 +28,7 @@ export interface IResultTaggingOptions {
 
 export interface IAnalyticsResultTaggingMeta {
   facetId: string;
+  facetField: string;
   facetValue?: string;
   facetTitle?: string;
 }
@@ -286,6 +287,7 @@ export class ResultTagging extends Component {
           beforeExecuteQuery: () =>
             this.usageAnalytics.logSearchEvent<IAnalyticsResultTaggingMeta>(analyticsActionCauseList.documentTag, {
               facetId: <string>this.options.field,
+              facetField: <string>this.options.field,
               facetValue: value
             })
         });

--- a/unitTests/controllers/HistoryControllerTest.ts
+++ b/unitTests/controllers/HistoryControllerTest.ts
@@ -123,6 +123,7 @@ export function HistoryControllerTest() {
         const assertFacetAnalyticsCall = (cause: IAnalyticsActionCause) => {
           expect(historyController.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(cause, {
             facetId: '@foo',
+            facetField: '@foo',
             facetTitle: '@foo',
             facetValue: 'bar'
           } as IAnalyticsFacetMeta);

--- a/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
@@ -62,7 +62,9 @@ export function CategoryFacetSearchTest() {
           func.apply(this, arguments);
         };
       });
-      categoryFacetMock = basicComponentSetup<CategoryFacet>(CategoryFacet).cmp;
+      categoryFacetMock = basicComponentSetup<CategoryFacet>(CategoryFacet, {
+        field: '@field'
+      }).cmp;
       fakeGroupByValues = FakeResults.createFakeGroupByResult('@field', 'value', 10).values;
       categoryFacetMock.categoryFacetQueryController = mock(CategoryFacetQueryController);
       categoryFacetMock.categoryFacetQueryController.searchFacetValues = () => new Promise(resolve => resolve(fakeGroupByValues));

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -172,6 +172,7 @@ export function FacetTest() {
       const expectedMetadata = jasmine.objectContaining({
         criteria: 'score',
         facetId: test.cmp.options.id,
+        facetField: test.cmp.options.field.toString(),
         facetTitle: test.cmp.options.title
       });
       expect(test.env.usageAnalytics.logCustomEvent).toHaveBeenCalledWith(


### PR DESCRIPTION
It was simple to add the facetField for all facet events sent to UA where the facetId was already sent. This way it will already be present if needed in the future.
https://coveord.atlassian.net/browse/JSUI-2158


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)