### PR TITLE
JSUI-2236 Improving Facet accessibility

### DIFF
--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -50,13 +50,6 @@ import { ValueElementRenderer } from './ValueElementRenderer';
 import { DependentFacetManager } from './DependentFacetManager';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 
-export interface IAccessibleButtonOptions {
-  element: HTMLElement;
-  label: string;
-  clickAction: () => void;
-  enterAction: () => void;
-}
-
 export interface IFacetOptions {
   title?: string;
   field?: IFieldOption;
@@ -1857,16 +1850,13 @@ export class Facet extends Component {
   private buildMore(): HTMLElement {
     const svgContainer = $$('span', { className: 'coveo-facet-more-icon' }, SVGIcons.icons.arrowDown).el;
     SVGDom.addClassToSVGInContainer(svgContainer, 'coveo-facet-more-icon-svg');
-    const more: HTMLElement = $$('div', { className: 'coveo-facet-more', tabindex: 0 }, svgContainer).el;
+    const more = $$('div', { className: 'coveo-facet-more', tabindex: 0 }, svgContainer).el;
 
-    const moreAction = () => this.handleClickMore();
-
-    this.makeButtonAccessible({
-      element: more,
-      label: l('ExpandFacetValues'),
-      clickAction: moreAction,
-      enterAction: moreAction
-    });
+    new AccessibleButton()
+      .withElement(more)
+      .withLabel(l('ExpandFacetValues'))
+      .withSelectAction(() => this.handleClickMore())
+      .build();
 
     return more;
   }
@@ -1874,27 +1864,15 @@ export class Facet extends Component {
   private buildLess(): HTMLElement {
     const svgContainer = $$('span', { className: 'coveo-facet-less-icon' }, SVGIcons.icons.arrowUp).el;
     SVGDom.addClassToSVGInContainer(svgContainer, 'coveo-facet-less-icon-svg');
-    const less: HTMLElement = $$('div', { className: 'coveo-facet-less', tabindex: 0 }, svgContainer).el;
+    const less = $$('div', { className: 'coveo-facet-less', tabindex: 0 }, svgContainer).el;
 
-    const lessAction = () => this.handleClickLess();
-
-    this.makeButtonAccessible({
-      element: less,
-      label: l('CollapseFacetValues'),
-      clickAction: lessAction,
-      enterAction: lessAction
-    });
+    new AccessibleButton()
+      .withElement(less)
+      .withLabel(l('CollapseFacetValues'))
+      .withSelectAction(() => this.handleClickLess())
+      .build();
 
     return less;
-  }
-
-  private makeButtonAccessible(options: IAccessibleButtonOptions) {
-    new AccessibleButton()
-      .withElement(options.element)
-      .withLabel(options.label)
-      .withClickAction(options.clickAction)
-      .withEnterKeyboardAction(options.enterAction)
-      .build();
   }
 
   private triggerMoreQuery() {

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1441,7 +1441,7 @@ export class Facet extends Component {
 
     new AccessibleButton()
       .withElement(this.searchContainer.accessibleElement)
-      .withLabel(l('FacetSearch'))
+      .withLabel(l('Search'))
       .withTitle(l('PressKeyToActivateFacetSearch', l('Enter')))
       .withEnterKeyboardAction(e => this.toggleSearchMenu(e))
       .build();
@@ -1854,7 +1854,7 @@ export class Facet extends Component {
 
     new AccessibleButton()
       .withElement(more)
-      .withLabel(l('ExpandFacetValues'))
+      .withLabel(l('Expand'))
       .withSelectAction(() => this.handleClickMore())
       .build();
 
@@ -1868,7 +1868,7 @@ export class Facet extends Component {
 
     new AccessibleButton()
       .withElement(less)
-      .withLabel(l('CollapseFacetValues'))
+      .withLabel(l('Collapse'))
       .withSelectAction(() => this.handleClickLess())
       .build();
 

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -49,6 +49,7 @@ import { OmniboxValuesList } from './OmniboxValuesList';
 import { ValueElement } from './ValueElement';
 import { ValueElementRenderer } from './ValueElementRenderer';
 import { DependentFacetManager } from './DependentFacetManager';
+import { AccessibleButton } from '../../utils/AccessibleButton';
 
 export interface IFacetOptions {
   title?: string;
@@ -1831,27 +1832,36 @@ export class Facet extends Component {
   }
 
   private buildMore(): HTMLElement {
-    let more: HTMLElement;
     const svgContainer = $$('span', { className: 'coveo-facet-more-icon' }, SVGIcons.icons.arrowDown).el;
     SVGDom.addClassToSVGInContainer(svgContainer, 'coveo-facet-more-icon-svg');
-    more = $$('div', { className: 'coveo-facet-more', tabindex: 0 }, svgContainer).el;
+    const more: HTMLElement = $$('div', { className: 'coveo-facet-more', tabindex: 0 }, svgContainer).el;
 
     const moreAction = () => this.handleClickMore();
     $$(more).on('click', moreAction);
     $$(more).on('keyup', KeyboardUtils.keypressAction(KEYBOARD.ENTER, moreAction));
+    this.makeButtonAccessible(more, l('ExpandFacetValues'));
+
     return more;
   }
 
   private buildLess(): HTMLElement {
-    let less: HTMLElement;
     const svgContainer = $$('span', { className: 'coveo-facet-less-icon' }, SVGIcons.icons.arrowUp).el;
     SVGDom.addClassToSVGInContainer(svgContainer, 'coveo-facet-less-icon-svg');
-    less = $$('div', { className: 'coveo-facet-less', tabIndex: 0 }, svgContainer).el;
+    const less: HTMLElement = $$('div', { className: 'coveo-facet-less', tabindex: 0 }, svgContainer).el;
 
     const lessAction = () => this.handleClickLess();
     $$(less).on('click', lessAction);
     $$(less).on('keyup', KeyboardUtils.keypressAction(KEYBOARD.ENTER, lessAction));
+    this.makeButtonAccessible(less, l('CollapseFacetValues'));
+
     return less;
+  }
+
+  private makeButtonAccessible(button: HTMLElement, label: string) {
+    new AccessibleButton()
+      .withElement(button)
+      .withLabel(label)
+      .build();
   }
 
   private triggerMoreQuery() {

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -20,7 +20,6 @@ import { ISearchEndpoint } from '../../rest/SearchEndpointInterface';
 import { l } from '../../strings/Strings';
 import { DeviceUtils } from '../../utils/DeviceUtils';
 import { $$, Win } from '../../utils/Dom';
-import { KEYBOARD, KeyboardUtils } from '../../utils/KeyboardUtils';
 import { SVGDom } from '../../utils/SVGDom';
 import { SVGIcons } from '../../utils/SVGIcons';
 import { Utils } from '../../utils/Utils';
@@ -50,6 +49,13 @@ import { ValueElement } from './ValueElement';
 import { ValueElementRenderer } from './ValueElementRenderer';
 import { DependentFacetManager } from './DependentFacetManager';
 import { AccessibleButton } from '../../utils/AccessibleButton';
+
+export interface IAccessibleButtonOptions {
+  element: HTMLElement;
+  label: string;
+  clickAction: () => void;
+  enterAction: () => void;
+}
 
 export interface IFacetOptions {
   title?: string;
@@ -1854,9 +1860,13 @@ export class Facet extends Component {
     const more: HTMLElement = $$('div', { className: 'coveo-facet-more', tabindex: 0 }, svgContainer).el;
 
     const moreAction = () => this.handleClickMore();
-    $$(more).on('click', moreAction);
-    $$(more).on('keyup', KeyboardUtils.keypressAction(KEYBOARD.ENTER, moreAction));
-    this.makeButtonAccessible(more, l('ExpandFacetValues'));
+
+    this.makeButtonAccessible({
+      element: more,
+      label: l('ExpandFacetValues'),
+      clickAction: moreAction,
+      enterAction: moreAction
+    });
 
     return more;
   }
@@ -1867,17 +1877,23 @@ export class Facet extends Component {
     const less: HTMLElement = $$('div', { className: 'coveo-facet-less', tabindex: 0 }, svgContainer).el;
 
     const lessAction = () => this.handleClickLess();
-    $$(less).on('click', lessAction);
-    $$(less).on('keyup', KeyboardUtils.keypressAction(KEYBOARD.ENTER, lessAction));
-    this.makeButtonAccessible(less, l('CollapseFacetValues'));
+
+    this.makeButtonAccessible({
+      element: less,
+      label: l('CollapseFacetValues'),
+      clickAction: lessAction,
+      enterAction: lessAction
+    });
 
     return less;
   }
 
-  private makeButtonAccessible(button: HTMLElement, label: string) {
+  private makeButtonAccessible(options: IAccessibleButtonOptions) {
     new AccessibleButton()
-      .withElement(button)
-      .withLabel(label)
+      .withElement(options.element)
+      .withLabel(options.label)
+      .withClickAction(options.clickAction)
+      .withEnterKeyboardAction(options.enterAction)
       .build();
   }
 

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1437,15 +1437,18 @@ export class Facet extends Component {
     const renderer = new ValueElementRenderer(this, FacetValue.create(l('Search')));
     this.searchContainer = renderer.build().withNo([renderer.excludeIcon, renderer.icon]);
     $$(this.searchContainer.listItem).addClass('coveo-facet-search-button');
-    renderer.accessibleElement.setAttribute('title', l('PressKeyToActivateFacetValueSearch', l('Enter')));
+
+    new AccessibleButton()
+      .withElement(this.searchContainer.accessibleElement)
+      .withLabel(l('FacetSearch'))
+      .withTitle(l('PressKeyToActivateFacetSearch', l('Enter')))
+      .withEnterKeyboardAction(e => this.toggleSearchMenu(e))
+      .build();
 
     // Mobile do not like label. Use click event
     if (DeviceUtils.isMobileDevice()) {
       $$(this.searchContainer.label).on('click', e => this.toggleSearchMenu(e));
     }
-
-    const handleKeyUp = KeyboardUtils.keypressAction(KEYBOARD.ENTER, e => this.toggleSearchMenu(e));
-    $$(this.searchContainer.listItem).on('keyup', handleKeyUp);
 
     $$(this.searchContainer.checkbox).on('change', () => {
       $$(this.element).addClass('coveo-facet-searching');

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1437,6 +1437,7 @@ export class Facet extends Component {
     const renderer = new ValueElementRenderer(this, FacetValue.create(l('Search')));
     this.searchContainer = renderer.build().withNo([renderer.excludeIcon, renderer.icon]);
     $$(this.searchContainer.listItem).addClass('coveo-facet-search-button');
+    renderer.accessibleElement.setAttribute('title', l('PressKeyToActivateFacetValueSearch', l('Enter')));
 
     // Mobile do not like label. Use click event
     if (DeviceUtils.isMobileDevice()) {

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1442,7 +1442,6 @@ export class Facet extends Component {
     new AccessibleButton()
       .withElement(this.searchContainer.accessibleElement)
       .withLabel(l('Search'))
-      .withTitle(l('PressKeyToActivateFacetSearch', l('Enter')))
       .withEnterKeyboardAction(e => this.toggleSearchMenu(e))
       .build();
 

--- a/src/ui/Facet/FacetHeader.ts
+++ b/src/ui/Facet/FacetHeader.ts
@@ -196,7 +196,7 @@ export class FacetHeader {
 
     new AccessibleButton()
       .withElement(eraser.el)
-      .withLabel(l('ResetFacet'))
+      .withLabel(l('Reset'))
       .withClickAction(() => this.onEraserClick())
       .withEnterKeyboardAction(() => this.onEraserClick())
       .build();

--- a/src/ui/Facet/FacetHeader.ts
+++ b/src/ui/Facet/FacetHeader.ts
@@ -8,6 +8,7 @@ import { IAnalyticsFacetOperatorMeta, IAnalyticsFacetMeta, analyticsActionCauseL
 import 'styling/_FacetHeader';
 import { SVGIcons } from '../../utils/SVGIcons';
 import { SVGDom } from '../../utils/SVGDom';
+import { AccessibleButton } from '../../utils/AccessibleButton';
 
 export interface IFacetHeaderOptions {
   facetElement: HTMLElement;
@@ -188,18 +189,27 @@ export class FacetHeader {
   }
 
   public buildEraser(): HTMLElement {
-    const eraser = $$('div', { title: l('Clear', this.options.title), className: 'coveo-facet-header-eraser' }, SVGIcons.icons.mainClear);
+    const eraser = $$('div', { className: 'coveo-facet-header-eraser' }, SVGIcons.icons.mainClear);
+
     SVGDom.addClassToSVGInContainer(eraser.el, 'coveo-facet-header-eraser-svg');
 
-    eraser.on('click', () => {
-      const cmp = this.options.facet || this.options.facetSlider;
-      cmp.reset();
-      cmp.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(analyticsActionCauseList.facetClearAll, {
-        facetId: cmp.options.id,
-        facetTitle: cmp.options.title
-      });
-      cmp.queryController.executeQuery();
-    });
+    new AccessibleButton()
+      .withElement(eraser.el)
+      .withLabel(l('ResetFacet'))
+      .withClickAction(() => this.onEraserClick())
+      .withEnterKeyboardAction(() => this.onEraserClick())
+      .build();
+
     return eraser.el;
+  }
+
+  private onEraserClick() {
+    const cmp = this.options.facet || this.options.facetSlider;
+    cmp.reset();
+    cmp.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(analyticsActionCauseList.facetClearAll, {
+      facetId: cmp.options.id,
+      facetTitle: cmp.options.title
+    });
+    cmp.queryController.executeQuery();
   }
 }

--- a/src/ui/Facet/FacetHeader.ts
+++ b/src/ui/Facet/FacetHeader.ts
@@ -181,11 +181,11 @@ export class FacetHeader {
   }
 
   private buildTitle(): HTMLElement {
-    const title = $$('div', {
-      title: this.options.title,
-      className: 'coveo-facet-header-title'
-    });
+    const title = $$('div', { className: 'coveo-facet-header-title' });
     title.text(this.options.title);
+    title.setAttribute('role', 'heading');
+    title.setAttribute('aria-level', '2');
+    title.setAttribute('aria-label', `${l('FacetTitle', this.options.title)}.`);
     return title.el;
   }
 

--- a/src/ui/Facet/FacetSettings.ts
+++ b/src/ui/Facet/FacetSettings.ts
@@ -196,7 +196,7 @@ export class FacetSettings extends FacetSort {
 
     new AccessibleButton()
       .withElement(this.settingsButton)
-      .withLabel(l('FacetSettings'))
+      .withLabel(l('Settings'))
       .withClickAction(e => this.handleSettingsButtonClick(e))
       .withEnterKeyboardAction(e => this.handleSettingsButtonClick(e))
       .build();

--- a/src/ui/Facet/FacetSettings.ts
+++ b/src/ui/Facet/FacetSettings.ts
@@ -30,13 +30,13 @@ export interface IFacetState {
  */
 export class FacetSettings extends FacetSort {
   public loadedFromSettings: { [attribute: string]: any };
+  public settingsButton: HTMLElement;
   public settingsPopup: HTMLElement;
 
   private facetStateLocalStorage: LocalStorageUtils<IFacetState>;
   private includedStateAttribute: string;
   private excludedStateAttribute: string;
   private operatorStateAttribute: string;
-  private settingsButton: HTMLElement;
   private directionSection: HTMLElement[];
   private saveStateSection: HTMLElement;
   private clearStateSection: HTMLElement;

--- a/src/ui/Facet/FacetSettings.ts
+++ b/src/ui/Facet/FacetSettings.ts
@@ -193,7 +193,13 @@ export class FacetSettings extends FacetSort {
     SVGDom.addClassToSVGInContainer(this.settingsButton, 'coveo-facet-settings-more-svg');
 
     this.hideElementOnMouseEnterLeave(this.settingsButton);
-    this.makeSettingsButtonAccessible();
+
+    new AccessibleButton()
+      .withElement(this.settingsButton)
+      .withLabel(l('FacetSettings'))
+      .withClickAction(e => this.handleSettingsButtonClick(e))
+      .withEnterKeyboardAction(e => this.handleSettingsButtonClick(e))
+      .build();
   }
 
   private hideElementOnMouseEnterLeave(el: HTMLElement) {
@@ -202,15 +208,6 @@ export class FacetSettings extends FacetSort {
 
     $$(el).on('mouseleave', mouseLeave);
     $$(el).on('mouseenter', mouseEnter);
-  }
-
-  private makeSettingsButtonAccessible() {
-    new AccessibleButton()
-      .withElement(this.settingsButton)
-      .withLabel(l('FacetSettings'))
-      .withClickAction(e => this.handleSettingsButtonClick(e))
-      .withEnterKeyboardAction(e => this.handleSettingsButtonClick(e))
-      .build();
   }
 
   private buildSettingsPopup() {

--- a/src/ui/Facet/FacetSettings.ts
+++ b/src/ui/Facet/FacetSettings.ts
@@ -83,7 +83,9 @@ export class FacetSettings extends FacetSort {
       this.appendIfNotUndefined(this.showSection);
     };
 
-    this.addMiscellaneousEventHandlers();
+    this.addOnDocumentClickHandler();
+    this.addOnNukeHandler();
+
     if (Utils.isNonEmptyArray(this.enabledSorts)) {
       this.settingsPopup.appendChild(this.sortSection.element);
       _.each(this.directionSection, d => {
@@ -468,9 +470,12 @@ export class FacetSettings extends FacetSort {
     );
   }
 
-  private addMiscellaneousEventHandlers() {
-    document.addEventListener('click', () => this.onDocumentClick());
+  private addOnNukeHandler() {
     $$(this.facet.root).on(InitializationEvents.nuke, () => this.handleNuke());
+  }
+
+  private addOnDocumentClickHandler() {
+    document.addEventListener('click', () => this.onDocumentClick());
   }
 
   public getCurrentDirectionItem(directionSection = this.directionSection) {

--- a/src/ui/Facet/ValueElementRenderer.ts
+++ b/src/ui/Facet/ValueElementRenderer.ts
@@ -260,7 +260,9 @@ export class ValueElementRenderer {
   }
 
   private get ariaLabel() {
-    const selectOrUnselect = !this.facetValue.selected ? 'Select' : 'Unselect';
-    return `${l(selectOrUnselect)} ${this.caption} ${l('With')} ${l('ResultCount', this.count)}`;
+    const selectOrUnselect = !this.facetValue.selected ? 'SelectValueWithResultCount' : 'UnselectValueWithResultCount';
+    const resultCount = l('ResultCount', this.count);
+
+    return `${l(selectOrUnselect, this.caption, resultCount)}`;
   }
 }

--- a/src/ui/Facet/ValueElementRenderer.ts
+++ b/src/ui/Facet/ValueElementRenderer.ts
@@ -44,12 +44,17 @@ export class ValueElementRenderer {
     this.initAndAppendLabel();
     this.initAndAppendExcludeIcon();
     this.setCssClassOnListValueElement();
+    this.addAccessibilityAttributesToTargetElement();
     return this;
   }
 
   public setCssClassOnListValueElement(): void {
     $$(this.listItem).toggleClass('coveo-selected', this.facetValue.selected);
     $$(this.listItem).toggleClass('coveo-excluded', this.facetValue.excluded);
+  }
+
+  public get accessibleElement() {
+    return this.stylishCheckbox;
   }
 
   protected buildExcludeIcon(): HTMLElement {
@@ -101,7 +106,6 @@ export class ValueElementRenderer {
       tabindex: 0
     }).el;
     checkbox.innerHTML = SVGIcons.icons.checkboxHookExclusionMore;
-    this.addAccessibilityAttributesTo(checkbox);
     SVGDom.addClassToSVGInContainer(checkbox, 'coveo-facet-value-checkbox-svg');
     this.addFocusAndBlurEventListeners(checkbox);
     return checkbox;
@@ -248,10 +252,11 @@ export class ValueElementRenderer {
     this.facetValueLabelWrapper.appendChild(this.valueCaption);
   }
 
-  private addAccessibilityAttributesTo(el: HTMLElement) {
+  private addAccessibilityAttributesToTargetElement() {
+    const el = this.accessibleElement;
     el.setAttribute('aria-label', this.ariaLabel);
-    // el.setAttribute('role', 'heading');
-    // el.setAttribute('aria-level', '3');
+    el.setAttribute('role', 'heading');
+    el.setAttribute('aria-level', '3');
   }
 
   private get ariaLabel() {

--- a/src/ui/Facet/ValueElementRenderer.ts
+++ b/src/ui/Facet/ValueElementRenderer.ts
@@ -256,6 +256,6 @@ export class ValueElementRenderer {
 
   private get ariaLabel() {
     const selectOrUnselect = !this.facetValue.selected ? 'Select' : 'Unselect';
-    return `${selectOrUnselect} ${this.caption} with ${this.count} results`;
+    return `${l(selectOrUnselect)} ${this.caption} ${l('With')} ${l('ResultCount', this.count)}`;
   }
 }

--- a/src/utils/AccessibleButton.ts
+++ b/src/utils/AccessibleButton.ts
@@ -7,6 +7,7 @@ import 'styling/_AccessibleButton';
 export class AccessibleButton {
   private element: Dom;
   private label: string;
+  private title: string;
 
   private clickAction: (e: Event) => void;
   private enterKeyboardAction: (e: Event) => void;
@@ -38,6 +39,11 @@ export class AccessibleButton {
 
   public withLabel(label: string) {
     this.label = label;
+    return this;
+  }
+
+  public withTitle(title: string) {
+    this.title = title;
     return this;
   }
 
@@ -96,6 +102,7 @@ export class AccessibleButton {
 
     this.ensureCorrectRole();
     this.ensureCorrectLabel();
+    this.ensureTitle();
     this.ensureSelectAction();
     this.ensureUnselectAction();
     this.ensureMouseenterAndFocusAction();
@@ -136,6 +143,10 @@ export class AccessibleButton {
     }
     this.element.setAttribute('aria-label', this.label);
     this.element.setAttribute('title', this.label);
+  }
+
+  private ensureTitle() {
+    this.title && this.element.setAttribute('title', this.title);
   }
 
   private ensureTabIndex() {

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7388,5 +7388,13 @@
   "CollapseFacetValues": {
     "en": "Collapse facet values",
     "fr": "Réduire les valeurs de facette"
+  },
+  "PressKeyToActivateFacetValueSearch": {
+    "en": "Press {0} to activate facet value search",
+    "fr": "Appuyez sur {0} pour activer la recherche de valeurs de facette"
+  },
+  "Enter": {
+    "en": "Enter",
+    "fr": "Entrée"
   }
 }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7389,9 +7389,13 @@
     "en": "Collapse facet values",
     "fr": "Réduire les valeurs de facette"
   },
-  "PressKeyToActivateFacetValueSearch": {
-    "en": "Press {0} to activate facet value search",
-    "fr": "Appuyez sur {0} pour activer la recherche de valeurs de facette"
+  "FacetSearch": {
+    "en": "Facet search",
+    "fr": "Recherche de facette"
+  },
+  "PressKeyToActivateFacetSearch": {
+    "en": "Press {0} to activate facet search",
+    "fr": "Appuyez sur {0} pour activer la recherche de facette"
   },
   "Enter": {
     "en": "Enter",

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -3250,48 +3250,27 @@
     "zh-tw": "在從您的設備讀取資訊時出錯"
   },
   "AppIntro": {
-    "en":
-      "Speak with a product specialist who can answer your questions about Coveo and help you decide which Coveo solution is right for you. Or, try a live demo !",
-    "fr":
-      "Contactez-nous pour parler avec un spécialiste de produit qui pourra répondre à vos questions a propos de Coveo. Ou bien, essayer une demonstration !",
-    "cs":
-      "Promluvte si s produktovým specialistou, který vám pomůže vybrat nejvhodnější řešení Coveo a zodpoví vaše dotazy týkající se této platformy. Vyzkoušet můžete rovněž živou ukázku!",
-    "da":
-      "Tal med en produktspecialist, der kan besvare dine spørgsmål om Coveo og hjælpe dig med at beslutte hvilken Coveo-løsning, der passer til dig. Eller prøv en live demo!",
-    "de":
-      "Sprechen Sie mit einem Produktspezialisten, der Ihre Fragen zu Coveo beantworten und Ihnen helfen kann, die für Sie am besten geeignete Coveo-Lösung zu finden. Oder probieren Sie eine Testversion aus!",
-    "el":
-      "Επικοινωνήστε με άτομο εξειδικευμένο στο προϊόν, το οποίο μπορεί να απαντήσει στις ερωτήσεις σας σχετικά με την πλατφόρμα Coveo, το οποίο θα σας βοηθήσει να αποφασίσετε ποια λύση Coveo είναι η κατάλληλη για εσάς. Ή δοκιμάστε μία ζωντανή επίδειξη!",
-    "es-es":
-      "Hable con un especialista en el producto que pueda responder a sus preguntas sobre Coveo y le ayude a decidir qué solución Coveo se adapta a sus necesidades. O pruebe una versión de prueba.",
-    "fi":
-      "Puhu tuoteasiantuntijan kanssa, joka pystyy vastaamaan kysymyksiisi   Coveosta ja auttamaan sinua päättämään, mikä Coveo-ratkaisu on oikea sinulle. Kokeile live-demoa!",
-    "hu":
-      "Beszéljen egy termékszakértővel, aki örömmel válaszol a Coveóval kapcsolatos kérdéseire, és segít Önnek megtalálni az ideális Coveo-megoldást. Vagy próbálja ki az élő demót!",
-    "id":
-      "Bicaralah dengan spesialis produk yang dapat menjawab pertanyaan Anda tentang Coveo dan membantu Anda menentukan solusi Coveo mana yang tepat untuk Anda. Atau, coba demo langsung!",
-    "it":
-      "Rivolgersi a uno specialista del prodotto in grado di rispondere a domande relative a Coveo e di assistere nella scelta della soluzione Coveo più adatta. In alternativa, provare una demo dal vivo,",
-    "ja":
-      "Coveoに関するご質問にお答えし、お客様に合ったCoveoソリューションの選択をお手伝いする製品スペシャリストと話す。または、実践デモをお試しください！",
-    "ko":
-      "Coveo에 관한 질문에 답하고 Coveo 솔루션이 사용자에게 적합한지 알아보는 데 도움을 줄 수 있는 제품 전문가와 상담하십시오. 또는 실제 시연을 이용하십시오!",
-    "nl":
-      "Een productspecialist spreken die uw vragen over Coveo kan beantwoorden en u helpen te beslissen welke Coveo-oplossing geschikt is voor u. Of probeer een live demo!",
-    "no":
-      "Snakk med en produktspesialist som kan besvare dine spørsmål om Coveo og hjelpe deg å avgjøre hvilken Coveo-løsning som er riktig for deg. Eller prøv en live demo!",
-    "pl":
-      "Skontaktuj się ze specjalistą ds. produktów, który odpowie na pytania dotyczące Coveo i pomoże Ci w wyborze odpowiedniego rozwiązania Coveo. Możesz też wypróbować interaktywne demo!",
-    "pt-br":
-      "Fale com um especialista de produto que possa responder suas dúvidas sobre a Coveo e ajudá-lo a decidir qual solução Coveo é adequada para você. Ou experimente uma demonstração ao vivo!",
-    "ru":
-      "Пообщайтесь со специалистом по продукции, который сможет ответить на ваши вопросы о Conveo и поможет решить, какое решение Coveo вам подойдет. Или попробуйте демоверсию с автоматическим обновлением!",
-    "sv":
-      "Tala med en produktspecialist som kan svara på dina frågor om Coveo och hjälpa dig välja vilken Coveolösning som passar dig. Eller, prova en live demo",
-    "th":
-      "พูดคุยกับผู้เชี่ยวชาญด้านผลิตภัณฑ์ซึ่งสามารถตอบคำถามของคุณเกี่ยวกับ Coveo และช่วยคุณตัดสินใจว่าโซลูชัน Coveo ใดที่เหมาะสมกับคุณ หรือทดลองใช้ผลิตภัณฑ์ตัวอย่าง!",
-    "tr":
-      "Coveo hakkındaki sorularınıza cevap verebilecek ve hangi Coveo çözümünün sizin için doğru olduğu konusunda size yardımcı olabilecek bir ürün uzmanıyla konuşun. Veya bir canlı demoyu deneyin!",
+    "en": "Speak with a product specialist who can answer your questions about Coveo and help you decide which Coveo solution is right for you. Or, try a live demo !",
+    "fr": "Contactez-nous pour parler avec un spécialiste de produit qui pourra répondre à vos questions a propos de Coveo. Ou bien, essayer une demonstration !",
+    "cs": "Promluvte si s produktovým specialistou, který vám pomůže vybrat nejvhodnější řešení Coveo a zodpoví vaše dotazy týkající se této platformy. Vyzkoušet můžete rovněž živou ukázku!",
+    "da": "Tal med en produktspecialist, der kan besvare dine spørgsmål om Coveo og hjælpe dig med at beslutte hvilken Coveo-løsning, der passer til dig. Eller prøv en live demo!",
+    "de": "Sprechen Sie mit einem Produktspezialisten, der Ihre Fragen zu Coveo beantworten und Ihnen helfen kann, die für Sie am besten geeignete Coveo-Lösung zu finden. Oder probieren Sie eine Testversion aus!",
+    "el": "Επικοινωνήστε με άτομο εξειδικευμένο στο προϊόν, το οποίο μπορεί να απαντήσει στις ερωτήσεις σας σχετικά με την πλατφόρμα Coveo, το οποίο θα σας βοηθήσει να αποφασίσετε ποια λύση Coveo είναι η κατάλληλη για εσάς. Ή δοκιμάστε μία ζωντανή επίδειξη!",
+    "es-es": "Hable con un especialista en el producto que pueda responder a sus preguntas sobre Coveo y le ayude a decidir qué solución Coveo se adapta a sus necesidades. O pruebe una versión de prueba.",
+    "fi": "Puhu tuoteasiantuntijan kanssa, joka pystyy vastaamaan kysymyksiisi   Coveosta ja auttamaan sinua päättämään, mikä Coveo-ratkaisu on oikea sinulle. Kokeile live-demoa!",
+    "hu": "Beszéljen egy termékszakértővel, aki örömmel válaszol a Coveóval kapcsolatos kérdéseire, és segít Önnek megtalálni az ideális Coveo-megoldást. Vagy próbálja ki az élő demót!",
+    "id": "Bicaralah dengan spesialis produk yang dapat menjawab pertanyaan Anda tentang Coveo dan membantu Anda menentukan solusi Coveo mana yang tepat untuk Anda. Atau, coba demo langsung!",
+    "it": "Rivolgersi a uno specialista del prodotto in grado di rispondere a domande relative a Coveo e di assistere nella scelta della soluzione Coveo più adatta. In alternativa, provare una demo dal vivo,",
+    "ja": "Coveoに関するご質問にお答えし、お客様に合ったCoveoソリューションの選択をお手伝いする製品スペシャリストと話す。または、実践デモをお試しください！",
+    "ko": "Coveo에 관한 질문에 답하고 Coveo 솔루션이 사용자에게 적합한지 알아보는 데 도움을 줄 수 있는 제품 전문가와 상담하십시오. 또는 실제 시연을 이용하십시오!",
+    "nl": "Een productspecialist spreken die uw vragen over Coveo kan beantwoorden en u helpen te beslissen welke Coveo-oplossing geschikt is voor u. Of probeer een live demo!",
+    "no": "Snakk med en produktspesialist som kan besvare dine spørsmål om Coveo og hjelpe deg å avgjøre hvilken Coveo-løsning som er riktig for deg. Eller prøv en live demo!",
+    "pl": "Skontaktuj się ze specjalistą ds. produktów, który odpowie na pytania dotyczące Coveo i pomoże Ci w wyborze odpowiedniego rozwiązania Coveo. Możesz też wypróbować interaktywne demo!",
+    "pt-br": "Fale com um especialista de produto que possa responder suas dúvidas sobre a Coveo e ajudá-lo a decidir qual solução Coveo é adequada para você. Ou experimente uma demonstração ao vivo!",
+    "ru": "Пообщайтесь со специалистом по продукции, который сможет ответить на ваши вопросы о Conveo и поможет решить, какое решение Coveo вам подойдет. Или попробуйте демоверсию с автоматическим обновлением!",
+    "sv": "Tala med en produktspecialist som kan svara på dina frågor om Coveo och hjälpa dig välja vilken Coveolösning som passar dig. Eller, prova en live demo",
+    "th": "พูดคุยกับผู้เชี่ยวชาญด้านผลิตภัณฑ์ซึ่งสามารถตอบคำถามของคุณเกี่ยวกับ Coveo และช่วยคุณตัดสินใจว่าโซลูชัน Coveo ใดที่เหมาะสมกับคุณ หรือทดลองใช้ผลิตภัณฑ์ตัวอย่าง!",
+    "tr": "Coveo hakkındaki sorularınıza cevap verebilecek ve hangi Coveo çözümünün sizin için doğru olduğu konusunda size yardımcı olabilecek bir ürün uzmanıyla konuşun. Veya bir canlı demoyu deneyin!",
     "zh-cn": "咨询能够回答您有关 Coveo 的问题的产品专家，并帮助您确定哪个 Coveo 解决方案适合您。或者，尝试现场演示！",
     "zh-tw": "諮詢能夠回答您有關 Coveo 的問題的產品專家，並幫助您確定哪個 Coveo 解決方案適合您。或者，嘗試現場示範！"
   },
@@ -7389,5 +7368,17 @@
   "RemoveFilterOn": {
     "en": "Remove filter on {0}",
     "fr": "Enlever le filtre sur {0}"
+  },
+  "Select": {
+    "en": "Select",
+    "fr": "Sélectionnez"
+  },
+  "Unselect": {
+    "en": "Unselect",
+    "fr": "Désélectionnez"
+  },
+  "With": {
+    "en": "With",
+    "fr": "Avec"
   }
 }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7369,10 +7369,6 @@
     "en": "Remove filter on {0}",
     "fr": "Enlever le filtre sur {0}"
   },
-  "PressKeyToActivateFacetSearch": {
-    "en": "Press {0} to activate facet search",
-    "fr": "Appuyez sur {0} pour activer la recherche de facette"
-  },
   "Enter": {
     "en": "Enter",
     "fr": "Entrée"

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7380,5 +7380,13 @@
   "With": {
     "en": "With",
     "fr": "Avec"
+  },
+  "ExpandFacetValues": {
+    "en": "Expand facet values",
+    "fr": "Étendre les valeurs de facette"
+  },
+  "CollapseFacetValues": {
+    "en": "Collapse facet values",
+    "fr": "Réduire les valeurs de facette"
   }
 }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7369,18 +7369,6 @@
     "en": "Remove filter on {0}",
     "fr": "Enlever le filtre sur {0}"
   },
-  "Select": {
-    "en": "Select",
-    "fr": "Sélectionnez"
-  },
-  "Unselect": {
-    "en": "Unselect",
-    "fr": "Désélectionnez"
-  },
-  "With": {
-    "en": "With",
-    "fr": "Avec"
-  },
   "ExpandFacetValues": {
     "en": "Expand facet values",
     "fr": "Étendre les valeurs de facette"
@@ -7428,5 +7416,13 @@
   "FacetTitle": {
     "en": "{0} facet",
     "fr": "Facette {0}"
+  },
+  "SelectValueWithResultCount": {
+    "en": "Select {0} with {1}",
+    "fr": "Sélectionnez {0} avec {1}"
+  },
+  "UnselectValueWithResultCount": {
+    "en": "Unselect {0} with {1}",
+    "fr": "Désélectionnez {0} avec {1}"
   }
 }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7424,5 +7424,9 @@
   "DisplayResultsAs": {
     "en": "Display results as {0}",
     "fr": "Afficher les résultats comme {0}"
+  },
+  "FacetTitle": {
+    "en": "{0} facet",
+    "fr": "Facette {0}"
   }
 }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7369,18 +7369,6 @@
     "en": "Remove filter on {0}",
     "fr": "Enlever le filtre sur {0}"
   },
-  "ExpandFacetValues": {
-    "en": "Expand facet values",
-    "fr": "Étendre les valeurs de facette"
-  },
-  "CollapseFacetValues": {
-    "en": "Collapse facet values",
-    "fr": "Réduire les valeurs de facette"
-  },
-  "FacetSearch": {
-    "en": "Facet search",
-    "fr": "Recherche de facette"
-  },
   "PressKeyToActivateFacetSearch": {
     "en": "Press {0} to activate facet search",
     "fr": "Appuyez sur {0} pour activer la recherche de facette"
@@ -7388,14 +7376,6 @@
   "Enter": {
     "en": "Enter",
     "fr": "Entrée"
-  },
-  "ResetFacet": {
-    "en": "Reset facet",
-    "fr": "Réinitialiser la facette"
-  },
-  "FacetSettings": {
-    "en": "Facet settings",
-    "fr": "Paramètres de facette"
   },
   "InsertAQuery": {
     "en": "Insert a query",

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7396,5 +7396,9 @@
   "Enter": {
     "en": "Enter",
     "fr": "Entrée"
+  },
+  "ResetFacet": {
+    "en": "Reset facet",
+    "fr": "Réinitialiser la facette"
   }
 }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7400,5 +7400,9 @@
   "ResetFacet": {
     "en": "Reset facet",
     "fr": "Réinitialiser la facette"
+  },
+  "FacetSettings": {
+    "en": "Facet settings",
+    "fr": "Paramètres de facette"
   }
 }

--- a/unitTests/ui/FacetHeaderTest.ts
+++ b/unitTests/ui/FacetHeaderTest.ts
@@ -42,6 +42,16 @@ export function FacetHeaderTest() {
       expect($$(title).text()).toBe('this is a title');
     });
 
+    it('the title should be accessible', () => {
+      baseOptions.title = 'this is a title';
+      initFacetHeader();
+
+      const title = $$(facetHeader.element).find('.coveo-facet-header-title');
+      expect($$(title).getAttribute('role')).toBe('heading');
+      expect($$(title).getAttribute('aria-level')).toBe('2');
+      expect($$(title).getAttribute('aria-label')).toBeTruthy();
+    });
+
     it('should build an icon if specified', () => {
       baseOptions.icon = 'this-is-an-icon';
       initFacetHeader();

--- a/unitTests/ui/FacetSettingsTest.ts
+++ b/unitTests/ui/FacetSettingsTest.ts
@@ -6,71 +6,77 @@ import { registerCustomMatcher } from '../CustomMatchers';
 import { $$ } from '../../src/utils/Dom';
 
 export function FacetSettingsTest() {
-  describe('FacetSettings', function() {
+  describe('FacetSettings', () => {
     let facet: Facet;
     let facetSettings: FacetSettings;
+    let sorts: string[];
 
-    beforeEach(function() {
+    function initFacetSettings() {
+      facetSettings = new FacetSettings(sorts, facet);
+      facetSettings.build();
+    }
+
+    beforeEach(() => {
       facet = Mock.optionsComponentSetup<Facet, IFacetOptions>(Facet, {
         field: '@field'
       }).cmp;
+      sorts = ['foo', 'bar'];
       registerCustomMatcher();
     });
 
-    afterEach(function() {
+    afterEach(() => {
       facet = null;
       facetSettings = null;
     });
 
     it('allows to save state', () => {
       // settings not enabled : no call to query state
-      facetSettings = new FacetSettings(['foo', 'bar'], facet);
-      facetSettings.build();
+      initFacetSettings();
       facetSettings.saveState();
       expect(facet.queryStateModel.get).not.toHaveBeenCalled();
 
       // settings enabled : 3 calls to query state
       facet.options.enableSettingsFacetState = true;
-      facetSettings = new FacetSettings(['foo', 'bar'], facet);
-      facetSettings.build();
+      initFacetSettings();
       facetSettings.saveState();
       expect(facet.queryStateModel.get).toHaveBeenCalledTimes(3);
     });
 
     it('allows to load state', () => {
       // settings not enabled : no call to query state
-      facetSettings = new FacetSettings(['foo', 'bar'], facet);
-      facetSettings.build();
+      initFacetSettings();
       facetSettings.loadSavedState();
       expect(facet.queryStateModel.setMultiple).not.toHaveBeenCalled();
 
       // settings enabled : 1 call to set multiple
       facet.options.enableSettingsFacetState = true;
-      facetSettings = new FacetSettings(['foo', 'bar'], facet);
-      facetSettings.build();
+      initFacetSettings();
       facetSettings.loadSavedState();
       expect(facet.queryStateModel.setMultiple).toHaveBeenCalled();
     });
 
     it('allow to open and close the popup', () => {
-      facetSettings = new FacetSettings(['foo', 'bar'], facet);
-      var built = facetSettings.build();
-      facet.root.appendChild(built);
+      initFacetSettings();
+
+      facet.root.appendChild(facetSettings.settingsButton);
       expect($$(facetSettings.facet.root).find('.coveo-facet-settings-popup')).toBeNull();
+
       facetSettings.open();
       expect($$(facetSettings.facet.root).find('.coveo-facet-settings-popup')).not.toBeNull();
+
       facetSettings.close();
       expect($$(facetSettings.facet.root).find('.coveo-facet-settings-popup')).toBeNull();
     });
 
     it('should show collapse/expand section if it is not disabled from the facet', () => {
       facet.options.enableCollapse = true;
-      facetSettings = new FacetSettings(['foo', 'bar'], facet);
-      const built = facetSettings.build();
+      initFacetSettings();
+
       facetSettings.open();
-      facet.root.appendChild(built);
+      facet.root.appendChild(facetSettings.settingsButton);
       expect($$(facetSettings.facet.root).find('.coveo-facet-settings-section-hide')).not.toBeNull();
       expect($$(facetSettings.facet.root).find('.coveo-facet-settings-section-show')).not.toBeNull();
+
       facet.collapse();
       facetSettings.open();
       expect($$(facetSettings.facet.root).find('.coveo-facet-settings-section-hide')).not.toBeNull();
@@ -79,12 +85,13 @@ export function FacetSettingsTest() {
 
     it('should not show collapse/expand section if it is disabled from the facet', () => {
       facet.options.enableCollapse = false;
-      facetSettings = new FacetSettings(['foo', 'bar'], facet);
-      const built = facetSettings.build();
+      initFacetSettings();
+
       facetSettings.open();
-      facet.root.appendChild(built);
+      facet.root.appendChild(facetSettings.settingsButton);
       expect($$(facetSettings.facet.root).find('.coveo-facet-settings-section-hide')).toBeNull();
       expect($$(facetSettings.facet.root).find('.coveo-facet-settings-section-show')).toBeNull();
+
       facet.collapse();
       facetSettings.open();
       expect($$(facetSettings.facet.root).find('.coveo-facet-settings-section-hide')).toBeNull();
@@ -92,45 +99,52 @@ export function FacetSettingsTest() {
     });
 
     it("should show direction section if there's two linked parameters that require changing direction", () => {
-      facetSettings = new FacetSettings(['alphaascending', 'alphadescending'], facet);
-      facetSettings.build();
+      sorts = ['alphaascending', 'alphadescending'];
+      initFacetSettings();
       facetSettings.open();
+
       expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-ascending')).not.toBeNull();
       expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-descending')).not.toBeNull();
     });
 
     it("should not show direction section if there's a single ascending or descending parameter", () => {
-      facetSettings = new FacetSettings(['alphaascending'], facet);
-      facetSettings.build();
+      sorts = ['alphaascending'];
+      initFacetSettings();
       facetSettings.open();
+
       expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-ascending')).toBeNull();
       expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-descending')).toBeNull();
     });
 
     it("should not show direction section if there's two parameters allowing changing direction, but both parameters are not linked", () => {
-      facetSettings = new FacetSettings(['alphaascending', 'computedfieldascending'], facet);
-      facetSettings.build();
+      sorts = ['alphaascending', 'computedfieldascending'];
+      initFacetSettings();
       facetSettings.open();
+
       expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-ascending')).toBeNull();
       expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-descending')).toBeNull();
     });
 
     it('should activate direction section when selecting a sort item with a possible direction', () => {
-      facetSettings = new FacetSettings(['score', 'alphaascending', 'alphadescending'], facet);
-      facetSettings.build();
+      sorts = ['score', 'alphaascending', 'alphadescending'];
+      initFacetSettings();
       facetSettings.open();
+
       const ascendingSection = $$(facetSettings.settingsPopup).find('.coveo-facet-settings-item[data-direction="ascending"]');
       expect($$(ascendingSection).hasClass('coveo-selected')).toBe(false);
+
       $$(facetSettings.getSortItem('alphaascending')).trigger('click');
       expect($$(ascendingSection).hasClass('coveo-selected')).toBe(true);
     });
 
     it('should de-activate direction section when selecting a sort item with no possible direction', () => {
-      facetSettings = new FacetSettings(['alphaascending', 'alphadescending', 'score'], facet);
-      facetSettings.build();
+      sorts = ['alphaascending', 'alphadescending', 'score'];
+      initFacetSettings();
       facetSettings.open();
+
       const ascendingSection = $$(facetSettings.settingsPopup).find('.coveo-facet-settings-item[data-direction="ascending"]');
       expect($$(ascendingSection).hasClass('coveo-selected')).toBe(true);
+
       $$(facetSettings.getSortItem('score')).trigger('click');
       expect($$(ascendingSection).hasClass('coveo-selected')).toBe(false);
     });
@@ -138,9 +152,8 @@ export function FacetSettingsTest() {
     describe('when closing the popup', () => {
       beforeEach(() => {
         jasmine.clock().install();
-        facetSettings = new FacetSettings(['foo', 'bar'], facet);
+        initFacetSettings();
         spyOn(facetSettings, 'close');
-        facetSettings.build();
         facetSettings.open();
       });
 

--- a/unitTests/ui/FacetSettingsTest.ts
+++ b/unitTests/ui/FacetSettingsTest.ts
@@ -4,6 +4,8 @@ import { FacetSettings } from '../../src/ui/Facet/FacetSettings';
 import { IFacetOptions } from '../../src/ui/Facet/Facet';
 import { registerCustomMatcher } from '../CustomMatchers';
 import { $$ } from '../../src/utils/Dom';
+import { Simulate } from '../Simulate';
+import { KEYBOARD } from '../../src/Core';
 
 export function FacetSettingsTest() {
   describe('FacetSettings', () => {
@@ -55,17 +57,40 @@ export function FacetSettingsTest() {
       expect(facet.queryStateModel.setMultiple).toHaveBeenCalled();
     });
 
-    it('allow to open and close the popup', () => {
-      initFacetSettings();
+    describe('given the FacetSettings is initialized and appended to a facet', () => {
+      function settingsPopup() {
+        return $$(facetSettings.facet.root).find('.coveo-facet-settings-popup');
+      }
 
-      facet.root.appendChild(facetSettings.settingsButton);
-      expect($$(facetSettings.facet.root).find('.coveo-facet-settings-popup')).toBeNull();
+      beforeEach(() => {
+        initFacetSettings();
+        facet.root.appendChild(facetSettings.settingsButton);
+        expect(settingsPopup()).toBeNull();
+      });
 
-      facetSettings.open();
-      expect($$(facetSettings.facet.root).find('.coveo-facet-settings-popup')).not.toBeNull();
+      it('allow to open and close the popup using the #open and #close methods', () => {
+        facetSettings.open();
+        expect(settingsPopup()).not.toBeNull();
 
-      facetSettings.close();
-      expect($$(facetSettings.facet.root).find('.coveo-facet-settings-popup')).toBeNull();
+        facetSettings.close();
+        expect(settingsPopup()).toBeNull();
+      });
+
+      it('allows open and closing the popup by clicking the facetSetting button', () => {
+        facetSettings.settingsButton.click();
+        expect(settingsPopup()).not.toBeNull();
+
+        facetSettings.settingsButton.click();
+        expect(settingsPopup()).toBeNull();
+      });
+
+      it('allows open and closing the popup by pressing enter on the facetSetting button', () => {
+        Simulate.keyUp(facetSettings.settingsButton, KEYBOARD.ENTER);
+        expect(settingsPopup()).not.toBeNull();
+
+        Simulate.keyUp(facetSettings.settingsButton, KEYBOARD.ENTER);
+        expect(settingsPopup()).toBeNull();
+      });
     });
 
     it('should show collapse/expand section if it is not disabled from the facet', () => {

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -623,14 +623,6 @@ export function FacetTest() {
           test.cmp.searchContainer.checkbox.dispatchEvent(changeEvent);
         }
 
-        function triggerEnterKeyOnListItem() {
-          const enterKeyEvent = new Event('keyup') as any;
-          enterKeyEvent.which = 13;
-          enterKeyEvent.keyCode = 13;
-
-          test.cmp.searchContainer.listItem.dispatchEvent(enterKeyEvent);
-        }
-
         beforeEach(() => {
           const options = { field: '@field', enableFacetSearch: true };
           test = Mock.optionsComponentSetup<Facet, IFacetOptions>(Facet, options);
@@ -647,6 +639,14 @@ export function FacetTest() {
         });
 
         describe(`when triggering an 'Enter' keyup event on the searchContainer listItem`, () => {
+          function triggerEnterKeyOnListItem() {
+            const enterKeyEvent = new Event('keyup') as any;
+            enterKeyEvent.which = 13;
+            enterKeyEvent.keyCode = 13;
+
+            test.cmp.searchContainer.listItem.dispatchEvent(enterKeyEvent);
+          }
+
           beforeEach(triggerEnterKeyOnListItem);
 
           it('activates searching', () => {

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -639,15 +639,15 @@ export function FacetTest() {
         });
 
         describe(`when triggering an 'Enter' keyup event on the searchContainer listItem`, () => {
-          function triggerEnterKeyOnListItem() {
+          function triggerEnterKeyOnAccessibleElement() {
             const enterKeyEvent = new Event('keyup') as any;
             enterKeyEvent.which = 13;
             enterKeyEvent.keyCode = 13;
 
-            test.cmp.searchContainer.listItem.dispatchEvent(enterKeyEvent);
+            test.cmp.searchContainer.accessibleElement.dispatchEvent(enterKeyEvent);
           }
 
-          beforeEach(triggerEnterKeyOnListItem);
+          beforeEach(triggerEnterKeyOnAccessibleElement);
 
           it('activates searching', () => {
             expect(test.cmp.element.className).toContain(searchingCssClass);
@@ -661,7 +661,7 @@ export function FacetTest() {
 
           it(`when triggering a second 'Enter' keyup event,
           it removes the checkbox 'checked' attribute`, () => {
-            triggerEnterKeyOnListItem();
+            triggerEnterKeyOnAccessibleElement();
 
             const checkbox = test.cmp.searchContainer.checkbox;
             const checkedAttribute = checkbox.getAttribute('checked');

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -10,6 +10,7 @@ import { BreadcrumbEvents } from '../../src/events/BreadcrumbEvents';
 import { IPopulateBreadcrumbEventArgs } from '../../src/events/BreadcrumbEvents';
 import { IPopulateOmniboxEventArgs } from '../../src/events/OmniboxEvents';
 import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
+import { KEYBOARD } from '../../src/Core';
 
 export function FacetTest() {
   describe('Facet', () => {
@@ -640,11 +641,7 @@ export function FacetTest() {
 
         describe(`when triggering an 'Enter' keyup event on the searchContainer listItem`, () => {
           function triggerEnterKeyOnAccessibleElement() {
-            const enterKeyEvent = new Event('keyup') as any;
-            enterKeyEvent.which = 13;
-            enterKeyEvent.keyCode = 13;
-
-            test.cmp.searchContainer.accessibleElement.dispatchEvent(enterKeyEvent);
+            Simulate.keyUp(test.cmp.searchContainer.accessibleElement, KEYBOARD.ENTER);
           }
 
           beforeEach(triggerEnterKeyOnAccessibleElement);

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -613,6 +613,64 @@ export function FacetTest() {
         expect(test.cmp.facetSearch).toBeUndefined();
       });
 
+      describe(`given enableFacetSearch is set to 'true',
+      given that searching is not active`, () => {
+        const searchingCssClass = 'coveo-facet-searching';
+        const oneMoreThanNumberOfDisplayedValues = 6;
+
+        function triggerChangeOnCheckbox() {
+          const changeEvent = new Event('change');
+          test.cmp.searchContainer.checkbox.dispatchEvent(changeEvent);
+        }
+
+        function triggerEnterKeyOnListItem() {
+          const enterKeyEvent = new Event('keyup') as any;
+          enterKeyEvent.which = 13;
+          enterKeyEvent.keyCode = 13;
+
+          test.cmp.searchContainer.listItem.dispatchEvent(enterKeyEvent);
+        }
+
+        beforeEach(() => {
+          const options = { field: '@field', enableFacetSearch: true };
+          test = Mock.optionsComponentSetup<Facet, IFacetOptions>(Facet, options);
+          test.cmp['nbAvailableValues'] = oneMoreThanNumberOfDisplayedValues;
+          test.cmp.reset();
+
+          expect(test.cmp.element.className).not.toContain(searchingCssClass);
+        });
+
+        it(`when triggering a 'change' event on the searchContainer checkbox,
+        it actives searching`, () => {
+          triggerChangeOnCheckbox();
+          expect(test.cmp.element.className).toContain(searchingCssClass);
+        });
+
+        describe(`when triggering an 'Enter' keyup event on the searchContainer listItem`, () => {
+          beforeEach(triggerEnterKeyOnListItem);
+
+          it('activates searching', () => {
+            expect(test.cmp.element.className).toContain(searchingCssClass);
+          });
+
+          it(`sets the checkbox 'checked' attribute`, () => {
+            const checkbox = test.cmp.searchContainer.checkbox;
+            const checkedAttribute = checkbox.getAttribute('checked');
+            expect(checkedAttribute).toBeTruthy();
+          });
+
+          it(`when triggering a second 'Enter' keyup event,
+          it removes the checkbox 'checked' attribute`, () => {
+            triggerEnterKeyOnListItem();
+
+            const checkbox = test.cmp.searchContainer.checkbox;
+            const checkedAttribute = checkbox.getAttribute('checked');
+
+            expect(checkedAttribute).toBeFalsy();
+          });
+        });
+      });
+
       it('facetSearchDelay should be passed to the facet search component', function(done) {
         test = Mock.optionsComponentSetup<Facet, IFacetOptions>(Facet, {
           field: '@field',

--- a/unitTests/ui/ValueElementRendererTest.ts
+++ b/unitTests/ui/ValueElementRendererTest.ts
@@ -61,7 +61,7 @@ export function ValueElementRendererTest() {
       facetValue.selected = false;
       valueRenderer = new ValueElementRenderer(facet, facetValue).build();
 
-      const ariaLabel = valueRenderer.stylishCheckbox.getAttribute('aria-label');
+      const ariaLabel = valueRenderer.accessibleElement.getAttribute('aria-label');
       expect(ariaLabel).toContain('Select');
     });
 
@@ -71,7 +71,7 @@ export function ValueElementRendererTest() {
       facetValue.selected = true;
       valueRenderer = new ValueElementRenderer(facet, facetValue).build();
 
-      const ariaLabel = valueRenderer.stylishCheckbox.getAttribute('aria-label');
+      const ariaLabel = valueRenderer.accessibleElement.getAttribute('aria-label');
       expect(ariaLabel).toContain('Unselect');
     });
 

--- a/unitTests/ui/ValueElementRendererTest.ts
+++ b/unitTests/ui/ValueElementRendererTest.ts
@@ -55,6 +55,26 @@ export function ValueElementRendererTest() {
       expect(valueRenderer.build().stylishCheckbox).toBeDefined();
     });
 
+    it(`when the facetValue is not selected,
+    the aria-label attribute contains the word 'Select'`, () => {
+      const facetValue = FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 123));
+      facetValue.selected = false;
+      valueRenderer = new ValueElementRenderer(facet, facetValue).build();
+
+      const ariaLabel = valueRenderer.stylishCheckbox.getAttribute('aria-label');
+      expect(ariaLabel).toContain('Select');
+    });
+
+    it(`when the facetValue is selected,
+    the aria-label attribute contains the word 'Unselect'`, () => {
+      const facetValue = FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 123));
+      facetValue.selected = true;
+      valueRenderer = new ValueElementRenderer(facet, facetValue).build();
+
+      const ariaLabel = valueRenderer.stylishCheckbox.getAttribute('aria-label');
+      expect(ariaLabel).toContain('Unselect');
+    });
+
     it('should build a caption', () => {
       valueRenderer = new ValueElementRenderer(
         facet,

--- a/unitTests/utils/AccessibleButtonTest.ts
+++ b/unitTests/utils/AccessibleButtonTest.ts
@@ -22,6 +22,17 @@ export const AccessibleButtonTest = () => {
       expect(element.getAttribute('aria-label')).toBe('qwerty');
     });
 
+    it('should add the specified title', () => {
+      const title = 'title';
+
+      new AccessibleButton()
+        .withElement(element)
+        .withTitle(title)
+        .build();
+
+      expect(element.getAttribute('title')).toBe(title);
+    });
+
     it('should add the correct role', () => {
       new AccessibleButton().withElement(element).build();
 


### PR DESCRIPTION
- Facet values given role heading level 3 to allow jumping between screen readers.
- Facet search button is now accessible (but no search input/list).
- Facet more/less buttons are now accessible.
- Facet reset button is now accessible.
- Facet Settings button is now accessible (but not list).
- Added unit tests for click and enter key behaviour.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)