### PR TITLE
Prevent a term from being highlighted two times

### DIFF
--- a/src/utils/StreamHighlightUtils.ts
+++ b/src/utils/StreamHighlightUtils.ts
@@ -2,7 +2,7 @@ import { Options } from '../misc/Options';
 import { HighlightUtils } from './HighlightUtils';
 import { StringUtils } from './StringUtils';
 import { Utils } from './Utils';
-import { IHighlight } from '../rest/Highlight';
+import { IHighlight, IHighlightTerm, IHighlightPhrase } from '../rest/Highlight';
 import { $$ } from './Dom';
 import * as _ from 'underscore';
 
@@ -36,8 +36,8 @@ export class DefaultStreamHighlightOptions extends Options implements IStreamHig
 export class StreamHighlightUtils {
   static highlightStreamHTML(
     stream: string,
-    termsToHighlight: { [originalTerm: string]: string[] },
-    phrasesToHighlight: { [phrase: string]: { [originalTerm: string]: string[] } },
+    termsToHighlight: IHighlightTerm,
+    phrasesToHighlight: IHighlightPhrase,
     options?: IStreamHighlightOptions
   ) {
     const opts = new DefaultStreamHighlightOptions().merge(options);
@@ -61,8 +61,8 @@ export class StreamHighlightUtils {
 
   static highlightStreamText(
     stream: string,
-    termsToHighlight: { [originalTerm: string]: string[] },
-    phrasesToHighlight: { [phrase: string]: { [originalTerm: string]: string[] } },
+    termsToHighlight: IHighlightTerm,
+    phrasesToHighlight: IHighlightPhrase,
     options?: IStreamHighlightOptions
   ) {
     const opts = new DefaultStreamHighlightOptions().merge(options);
@@ -77,13 +77,21 @@ export class StreamHighlightUtils {
 
 export function getRestHighlightsForAllTerms(
   toHighlight: string,
-  termsToHighlight: { [originalTerm: string]: string[] },
-  phrasesToHighlight: { [phrase: string]: { [originalTerm: string]: string[] } },
+  termsToHighlight: IHighlightTerm,
+  phrasesToHighlight: IHighlightPhrase,
   opts: IStreamHighlightOptions
 ): IHighlight[] {
   const indexes = [];
   const sortedTerms = _.keys(termsToHighlight).sort(termsSorting);
-  _.each(sortedTerms, (term: string) => {
+
+  const phrasesTerms = _.chain(phrasesToHighlight)
+    .values()
+    .map(_.keys)
+    .flatten()
+    .value();
+  const uniqueTerms = _.difference(sortedTerms, phrasesTerms);
+
+  _.each(uniqueTerms, (term: string) => {
     let termsToIterate = _.compact([term].concat(termsToHighlight[term]).sort(termsSorting));
     termsToIterate = _.map(termsToIterate, term => Utils.escapeRegexCharacter(term));
     let regex = regexStart;

--- a/unitTests/ui/CoreHelpersTest.ts
+++ b/unitTests/ui/CoreHelpersTest.ts
@@ -1,5 +1,5 @@
 import { TemplateHelpers } from '../../src/ui/Templates/TemplateHelpers';
-import { IHighlight } from '../../src/rest/Highlight';
+import { IHighlight, IHighlightPhrase, IHighlightTerm } from '../../src/rest/Highlight';
 import { IDateToStringOptions } from '../../src/utils/DateUtils';
 import { ITimeSpanUtilsOptions } from '../../src/utils/TimeSpanUtils';
 import { FakeResults } from '../Fake';
@@ -88,7 +88,7 @@ export function CoreHelperTest() {
 
     it('highlightStreamText should work correctly', () => {
       const toHighlight = 'a b';
-      const terms: { [originalTerm: string]: string[] } = { a: [], b: [] };
+      const terms: IHighlightTerm = { a: [], b: [] };
       expect(TemplateHelpers.getHelper('highlightStreamText')(toHighlight, terms, {})).toEqual(
         '<span class="coveo-highlight" data-highlight-group="1" data-highlight-group-term="a">a</span> <span class="coveo-highlight" data-highlight-group="2" data-highlight-group-term="b">b</span>'
       );
@@ -96,7 +96,7 @@ export function CoreHelperTest() {
 
     it('highlightStreamTextv2 should work correctly', () => {
       const toHighlight = 'a b';
-      const termsToHighlight: { [originalTerm: string]: string[] } = { a: [], b: [] };
+      const termsToHighlight: IHighlightTerm = { a: [], b: [] };
 
       expect(
         TemplateHelpers.getHelper('highlightStreamTextv2')(toHighlight, {
@@ -108,9 +108,22 @@ export function CoreHelperTest() {
       );
     });
 
+    it("highlightStreamTextv2 should only highlight a phrase's term once", () => {
+      const toHighlight = 'A test phrase';
+      const termsToHighlight: IHighlightTerm = { phrase: [], test: [] };
+      const phrasesToHighlight: IHighlightPhrase = { 'test phrase': { phrase: [], test: [] } };
+
+      expect(
+        TemplateHelpers.getHelper('highlightStreamTextv2')(toHighlight, {
+          termsToHighlight,
+          phrasesToHighlight
+        })
+      ).toEqual('A <span class="coveo-highlight" data-highlight-group="3" data-highlight-group-term="test phrase">test phrase</span>');
+    });
+
     it('highlightStreamHTML should work correctly', () => {
       const toHighlight = '<div>a b</div>';
-      const terms: { [originalTerm: string]: string[] } = { a: [], b: [] };
+      const terms: IHighlightTerm = { a: [], b: [] };
       expect(TemplateHelpers.getHelper('highlightStreamHTML')(toHighlight, terms, {})).toEqual(
         '<div><span class="coveo-highlight" data-highlight-group="1" data-highlight-group-term="a">a</span> <span class="coveo-highlight" data-highlight-group="2" data-highlight-group-term="b">b</span></div>'
       );
@@ -118,7 +131,7 @@ export function CoreHelperTest() {
 
     it('highlightStreamHTMLv2 should work correctly', () => {
       const toHighlight = '<div>a b</div>';
-      const termsToHighlight: { [originalTerm: string]: string[] } = { a: [], b: [] };
+      const termsToHighlight: IHighlightTerm = { a: [], b: [] };
       expect(
         TemplateHelpers.getHelper('highlightStreamHTMLv2')(toHighlight, {
           termsToHighlight,
@@ -362,7 +375,7 @@ export function CoreHelperTest() {
         result = FakeResults.createFakeResult();
 
         let spy = jasmine.createSpy('getRawDataStream');
-        spy.and.returnValue(new Promise((resolve, reject) => {}));
+        spy.and.returnValue(new Promise(() => {}));
         endpoint.getRawDataStream = spy;
         SearchEndpoint.endpoints['default'] = endpoint;
       });


### PR DESCRIPTION
When a term was present at the end of a phrase (phrasesToHighlight) and was also a term (termsToHighlight), it was displayed twice

https://coveord.atlassian.net/browse/JSUI-2241

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)