### PR TITLE
JSUI-2221 Adding optional #result arg to logCustomEvent

### DIFF
--- a/src/ui/Analytics/Analytics.ts
+++ b/src/ui/Analytics/Analytics.ts
@@ -291,8 +291,8 @@ export class Analytics extends Component {
    * @param element The HTMLElement that the user has interacted with for this custom event. Default value is the
    * element on which the `Analytics` component is bound.
    */
-  public logCustomEvent<T>(actionCause: IAnalyticsActionCause, meta: T, element: HTMLElement = this.element) {
-    this.client.logCustomEvent(actionCause, meta, element);
+  public logCustomEvent<T>(actionCause: IAnalyticsActionCause, meta: T, element: HTMLElement = this.element, result?: IQueryResult) {
+    this.client.logCustomEvent(actionCause, meta, element, result);
   }
 
   /**

--- a/src/ui/Analytics/AnalyticsClient.ts
+++ b/src/ui/Analytics/AnalyticsClient.ts
@@ -124,7 +124,12 @@ export interface IAnalyticsClient {
    * @param element The HTMLElement that the user has interacted with for this custom event. Default value is the
    * element on which the `Analytics` component is bound.
    */
-  logCustomEvent<TMeta>(actionCause: IAnalyticsActionCause, meta: TMeta, element: HTMLElement): Promise<IAPIAnalyticsEventResponse>;
+  logCustomEvent<TMeta>(
+    actionCause: IAnalyticsActionCause,
+    meta: TMeta,
+    element: HTMLElement,
+    result?: IQueryResult
+  ): Promise<IAPIAnalyticsEventResponse>;
 
   /**
    * Gets suggested queries from the Coveo Usage Analytics service.

--- a/src/ui/Analytics/LiveAnalyticsClient.ts
+++ b/src/ui/Analytics/LiveAnalyticsClient.ts
@@ -116,7 +116,7 @@ export class LiveAnalyticsClient implements IAnalyticsClient {
     element: HTMLElement,
     result?: IQueryResult
   ): Promise<IAPIAnalyticsEventResponse> {
-    var metaObject = this.buildMetaObject(meta, result);
+    const metaObject = this.buildMetaObject(meta, result);
     return this.pushCustomEvent(actionCause, metaObject, element);
   }
 

--- a/src/ui/Analytics/LiveAnalyticsClient.ts
+++ b/src/ui/Analytics/LiveAnalyticsClient.ts
@@ -110,8 +110,13 @@ export class LiveAnalyticsClient implements IAnalyticsClient {
     return this.pushClickEvent(actionCause, metaObject, result, element);
   }
 
-  public logCustomEvent<TMeta>(actionCause: IAnalyticsActionCause, meta: TMeta, element: HTMLElement): Promise<IAPIAnalyticsEventResponse> {
-    var metaObject = this.buildMetaObject(meta);
+  public logCustomEvent<TMeta>(
+    actionCause: IAnalyticsActionCause,
+    meta: TMeta,
+    element: HTMLElement,
+    result?: IQueryResult
+  ): Promise<IAPIAnalyticsEventResponse> {
+    var metaObject = this.buildMetaObject(meta, result);
     return this.pushCustomEvent(actionCause, metaObject, element);
   }
 

--- a/unitTests/ui/LiveAnalyticsClientTest.ts
+++ b/unitTests/ui/LiveAnalyticsClientTest.ts
@@ -428,6 +428,30 @@ export function LiveAnalyticsClientTest() {
       );
     });
 
+    it(`when specifying a result having a #permanentid as an argument for #logCustomEvent,
+    it adds the result contentIDKey and contentIDValue to the metadata object`, () => {
+      const spy = jasmine.createSpy('spy');
+      $$(env.root).on(AnalyticsEvents.changeAnalyticsCustomData, spy);
+
+      const id = {
+        key: 'permanentid',
+        value: '123'
+      };
+      const result = FakeResults.createFakeResult();
+      result[id.key] = id.value;
+      client.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.documentOpen, {}, document.createElement('div'), result);
+
+      expect(spy).toHaveBeenCalledWith(
+        jasmine.any(Object),
+        jasmine.objectContaining({
+          metaObject: jasmine.objectContaining({
+            contentIDKey: id.key,
+            contentIDValue: id.value
+          })
+        })
+      );
+    });
+
     describe('with click event', () => {
       let spy: jasmine.Spy;
       let fakeResult: IQueryResult;


### PR DESCRIPTION
Background:
SFINT team wants to send interactions with a result to analytics. They want to use `logCustomEvent` rather than `logClickEvent` because the latter calls are used by ML to build their models.

Problem:
It is not possible to specify a result when using `logCustomEvent`, so the metadata does not have contentIDKey or contentIDValue properties. When usage analytics receives an event without these properties, they look at the most recent search event to determine them. In some cases however, a pending searchAsYouType event is sent prior to sending the custom event, causing the custom event to be linked to the wrong search.

Solution:
Adding an optional `result` argument to `logCustomEvent` so that the metadata contains the properties in question and UA does not need to guess what they should be.



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)