### PR TITLE
Doc 2444 update pipelinecontext doc

### DIFF
--- a/src/ui/PipelineContext/PipelineContext.ts
+++ b/src/ui/PipelineContext/PipelineContext.ts
@@ -35,8 +35,6 @@ export interface IPipelineContextOptions {}
  * // context: {"foo":"bar","foobar":["foo","bar"]}
  * ```
  *
- * **Note:**
- *
  * Configuring the component within a script tag implies you will be able to leverage the interface editor.
  *
  *
@@ -55,7 +53,7 @@ export interface IPipelineContextOptions {}
  * ...
  * ```
  *
- * The data is added to the [Query.Context]{@link IQuery.context} parameter.
+ * Whether you configure the component within a script tag or using JavaScript code, the data is added to the [Query.Context]{@link IQuery.context} parameter.
  *
  * **Note:**
  *

--- a/src/ui/PipelineContext/PipelineContext.ts
+++ b/src/ui/PipelineContext/PipelineContext.ts
@@ -14,16 +14,11 @@ declare const Coveo;
 export interface IPipelineContextOptions {}
 
 /**
- * A PipelineContext is used to add contextual information about the environment inside which the query is executed.
+ * A PipelineContext is used to add custom context information to a query (see [Adding Custom Context Information to Queries](https://docs.coveo.com/en/399])).
  *
- * It allows you to pass arbitrary key values pairs ( think `JSON` ), which can then be leveraged by the [Query Pipeline](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=108),
- * or by Coveo Machine Learning.
+ * This component is meant to be initialized with a script tag, possibly configuring it with JSON content.
  *
- * This can be any arbitrary information that you can use to contextualize the query and help Coveo improve relevance by returning results tailored to a specific context.
- *
- * This component is meant to be created with a script tag, possibly configuring it with JSON content.
- *
- * The values can be either a `string` or an array of `string`.
+ * The values can be either string or string array.
  *
  * ```
  * <script class='CoveoPipelineContext' type='text/context'>
@@ -32,26 +27,11 @@ export interface IPipelineContextOptions {}
  *      "foobar" : ["foo", "bar"]
  *   }
  * </script>
- * // context: {"foo":"bar","foobar":["foo","bar"]}
  * ```
  *
  * Configuring the component within a script tag implies you will be able to leverage the interface editor.
  *
- *
  * Once the component is created, you can also use JavaScript code to set/overwrite context values, using the {@link setContext} and {@link setContextValue} methods.
- *
- * ```
- * ...
- * Coveo.get(Coveo.$$(document).find('.CoveoPipelineContext')).setContext('{}');
- * // context has been erased
- * ...
- * Coveo.get(Coveo.$$(document).find('.CoveoPipelineContext')).setContextValue('{"foo":"foobar"}');
- * // context: {"foo":"foobar"}
- * ...
- * Coveo.get(Coveo.$$(document).find('.CoveoPipelineContext')).setContext('{"myKey1":"myValue1","mykey2":["myValue2","myValue2"],"myKeyN":"myValueN"}')
- * // context: {"myKey1":"myValue1","mykey2":["myValue2","myValue2"],"myKeyN":"myValueN"}
- * ...
- * ```
  *
  * Whether you configure the component within a script tag or using JavaScript code, the data is added to the [Query.Context]{@link IQuery.context} parameter.
  *
@@ -86,7 +66,9 @@ export class PipelineContext extends Component implements IPipelineContextProvid
   }
 
   /**
-   * Set a new context, replacing any value previously set.
+   * **Available since the [December 2017 Release](https://docs.coveo.com/en/373)**
+   *
+   * Sets a new context, replacing the previous one.
    *
    * @param newContext The new context to set, which can be directly passed as a JSON, or as a stringified JSON.
    */
@@ -108,6 +90,8 @@ export class PipelineContext extends Component implements IPipelineContextProvid
   }
 
   /**
+   * **Available since the [December 2017 Release](https://docs.coveo.com/en/373)**
+   *
    * Sets a value for a context key, replacing the previous value if applicable.
    * @param contextKey
    * @param contextValue

--- a/src/ui/PipelineContext/PipelineContext.ts
+++ b/src/ui/PipelineContext/PipelineContext.ts
@@ -68,7 +68,7 @@ export class PipelineContext extends Component implements IPipelineContextProvid
   /**
    * **Available since the [December 2017 Release](https://docs.coveo.com/en/373).**
    *
-   * Sets a new context, replacing the previous one.
+   * Sets a new context, replacing the previous context if applicable.
    *
    * @param newContext The new context to set, which can be directly passed as a JSON, or as a stringified JSON.
    */

--- a/src/ui/PipelineContext/PipelineContext.ts
+++ b/src/ui/PipelineContext/PipelineContext.ts
@@ -16,12 +16,12 @@ export interface IPipelineContextOptions {}
 /**
  * A PipelineContext is used to add contextual information about the environment inside which the query is executed.
  *
- * It allows to pass arbitrary key values pairs ( think `JSON` ), which can then be leveraged by the [Query Pipeline](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=108),
+ * It allows you to pass arbitrary key values pairs ( think `JSON` ), which can then be leveraged by the [Query Pipeline](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=108),
  * or by Coveo Machine Learning.
  *
  * This can be any arbitrary information that you can use to contextualize the query and help Coveo improve relevance by returning results tailored to a specific context.
  *
- * This component is meant to be configured using a script tag, with a JSON content.
+ * This component is meant to be created with a script tag, possibly configuring it with JSON content.
  *
  * The values can be either a `string` or an array of `string`.
  *
@@ -32,20 +32,30 @@ export interface IPipelineContextOptions {}
  *      "foobar" : ["foo", "bar"]
  *   }
  * </script>
+ * // context: {"foo":"bar","foobar":["foo","bar"]}
  * ```
  *
- * You can also simply use JavaScript code to pass context values, using the {@link QueryBuilder.addContextValue} method.
+ * **Note:**
  *
- * This means you do not necessarily need to use this component to pass context.
+ * Configuring the component within a script tag implies you will be able to leverage the interface editor.
+ *
+ *
+ * Once the component is created, you can also use JavaScript code to set/overwrite context values, using the {@link setContext} and {@link setContextValue} methods.
+ *
  * ```
- * Coveo.$$(root).on('buildingQuery', function(args) {
- *     args.queryBuilder.addContextValue('foo', 'bar');
- * })
+ * ...
+ * Coveo.get(Coveo.$$(document).find('.CoveoPipelineContext')).setContext('{}');
+ * // context has been erased
+ * ...
+ * Coveo.get(Coveo.$$(document).find('.CoveoPipelineContext')).setContextValue('{"foo":"foobar"}');
+ * // context: {"foo":"foobar"}
+ * ...
+ * Coveo.get(Coveo.$$(document).find('.CoveoPipelineContext')).setContext('{"myKey1":"myValue1","mykey2":["myValue2","myValue2"],"myKeyN":"myValueN"}')
+ * // context: {"myKey1":"myValue1","mykey2":["myValue2","myValue2"],"myKeyN":"myValueN"}
+ * ...
  * ```
  *
- * Using this component as opposed to JavaScript code means you will be able to leverage the interface editor.
- *
- * Regardless of if you use this component or JavaScript to add context, both will add the needed data in the [Query.Context]{@link IQuery.context} parameter.
+ * The data is added to the [Query.Context]{@link IQuery.context} parameter.
  *
  * **Note:**
  *

--- a/src/ui/PipelineContext/PipelineContext.ts
+++ b/src/ui/PipelineContext/PipelineContext.ts
@@ -14,7 +14,7 @@ declare const Coveo;
 export interface IPipelineContextOptions {}
 
 /**
- * A PipelineContext is used to add custom context information to a query (see [Adding Custom Context Information to Queries](https://docs.coveo.com/en/399])).
+ * A PipelineContext is used to add custom context information to a query (see [Adding Custom Context Information to Queries](https://docs.coveo.com/en/399)).
  *
  * This component is meant to be initialized with a script tag, possibly configuring it with JSON content.
  *
@@ -66,7 +66,7 @@ export class PipelineContext extends Component implements IPipelineContextProvid
   }
 
   /**
-   * **Available since the [December 2017 Release](https://docs.coveo.com/en/373)**
+   * **Available since the [December 2017 Release](https://docs.coveo.com/en/373).**
    *
    * Sets a new context, replacing the previous one.
    *
@@ -90,7 +90,7 @@ export class PipelineContext extends Component implements IPipelineContextProvid
   }
 
   /**
-   * **Available since the [December 2017 Release](https://docs.coveo.com/en/373)**
+   * **Available since the [December 2017 Release](https://docs.coveo.com/en/373).**
    *
    * Sets a value for a context key, replacing the previous value if applicable.
    * @param contextKey


### PR DESCRIPTION
Modified the PipelineContext introduction to mention `setContext` and `setContextValue`, and to remove `buildingQuery`.

In the reference doc of `setContext` and `setContextValue` functions, mentioned that they are only available since the december 2017 release.

Also significantly leaned out the introduction. It now only mentions the minimum and links to  https://docs.coveo.com/en/399/javascript-search-framework/adding-custom-context-information-to-queries for more details (btw, this page is currently being updated accordingly).