### PR TITLE
Remove veracode from PR  JSUI-2270

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
   - node_modules
 before_install:
   - npm install -g npm@5.5.1
-  - wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$VERACODE_WRAPPER_VERSION/vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$VERACODE_WRAPPER_VERSION/vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar; fi
 script:
 - source read.version.sh
 - echo $PACKAGE_JSON_VERSION
@@ -30,8 +30,8 @@ after_success:
 - if [ "x$TRAVIS_TAG" != "x" ]; then bash ./deploy.doc.sh ; fi
 - yarn run docsitemap
 - yarn run zipForGitReleases
-- yarn run zipForVeracode
-- java -jar vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar -vid $VERACODE_KEY_ID  -vkey $VERACODE_SECRET -action uploadandscan -appname Coveo -sandboxname "JS UI" -createprofile true -filepath veracode.zip -version "Travis build [ $TRAVIS_JOB_NUMBER ] on branch [ $TRAVIS_BRANCH ]"
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; yarn run zipForVeracode ; fi
+- if [ "$TRAVIS_PULL_REQUEST" = "false" ]; java -jar vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar -vid $VERACODE_KEY_ID  -vkey $VERACODE_SECRET -action uploadandscan -appname Coveo -sandboxname "JS UI" -createprofile true -filepath veracode.zip -version "Travis build [ $TRAVIS_JOB_NUMBER ] on branch [ $TRAVIS_BRANCH ]" ; fi
 env:
   global:
   - COMMIT_AUTHOR_EMAIL: sandbox_JSUI@coveo.com


### PR DESCRIPTION
The issue: Travis PR builds from a fork will fail because the secrets are not shared, which is fine.
So I applied this workaround suggested by Travis-CI itself: https://docs.travis-ci.com/user/pull-requests/#pull-requests-and-security-restrictions

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)