### PR TITLE
Revert method signature to old version + UT

### DIFF
--- a/src/ui/Templates/Template.ts
+++ b/src/ui/Templates/Template.ts
@@ -180,7 +180,7 @@ export class Template implements ITemplateProperties {
     return _.compact(allComponentsInsideCurrentTemplate);
   }
 
-  public async instantiateToElement(result: IQueryResult, templateOptions: IInstantiateTemplateOptions = {}): Promise<HTMLElement> {
+  public instantiateToElement(result: IQueryResult, templateOptions: IInstantiateTemplateOptions = {}): Promise<HTMLElement> | null {
     const mergedOptions = new DefaultInstantiateTemplateOptions().merge(templateOptions);
     const html = this.instantiateToString(result, mergedOptions);
 
@@ -188,12 +188,11 @@ export class Template implements ITemplateProperties {
       return null;
     }
 
-    await this.ensureComponentsInHtmlStringHaveLoaded(html);
-
-    const template = this.buildTemplate(html, mergedOptions);
-    this.logger.trace('Instantiated result template', result, template);
-
-    return template;
+    return this.ensureComponentsInHtmlStringHaveLoaded(html).then(() => {
+      const template = this.buildTemplate(html, mergedOptions);
+      this.logger.trace('Instantiated result template', result, template);
+      return template;
+    });
   }
 
   public toHtmlElement(): HTMLElement {

--- a/unitTests/ui/TemplateTest.ts
+++ b/unitTests/ui/TemplateTest.ts
@@ -72,6 +72,11 @@ export function TemplateTest() {
         });
       });
 
+      it('should return null when calling instantiate to element with a false condition', () => {
+        tmpl.condition = () => false;
+        expect(tmpl.instantiateToElement(result)).toBeNull();
+      });
+
       it('should correctly return the root HTMLElement when not wrapping in a div', done => {
         tmpl = new Template(() => '<div class="my-stuff"></div>');
         tmpl.instantiateToElement(result, { wrapInDiv: false }).then(created => {


### PR DESCRIPTION
Upstream code assert that if this function returns null, if it was not a "valid" condition/template that match the current result.

It was always currently returning a Promise (never null) since it was now an async function.

Added UT to ensure this behaviour.

https://coveord.atlassian.net/browse/JSUI-2272





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)