### PR TITLE
Wait for result to be displayed in ResultList.handleQuerySuccess

### DIFF
--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -468,7 +468,7 @@ export class ResultList extends Component {
       this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.pagerScrolling, {}, this.element);
       const results = data.results;
       this.reachedTheEndOfResults = count > data.results.length;
-      this.buildResults(data).then((elements: HTMLElement[]) => {
+      this.buildResults(data).then(async (elements: HTMLElement[]) => {
         this.renderResults(elements, true);
         each(results, result => {
           this.currentlyDisplayedResults.push(result);
@@ -578,8 +578,8 @@ export class ResultList extends Component {
     this.reachedTheEndOfResults = data.query.numberOfResults > data.results.results.length;
 
     this.currentlyDisplayedResults = [];
-    this.buildResults(data.results).then((elements: HTMLElement[]) => {
-      this.renderResults(elements);
+    this.buildResults(data.results).then(async (elements: HTMLElement[]) => {
+      await this.renderResults(elements);
 
       this.showOrHideElementsDependingOnState(true, this.currentlyDisplayedResults.length != 0);
 
@@ -666,7 +666,7 @@ export class ResultList extends Component {
           new InitializationPlaceholder(this.root).withVisibleRootElement().withPlaceholderForResultList();
         }
         Defer.defer(() => {
-          this.buildResults(args.results).then((elements: HTMLElement[]) => {
+          this.buildResults(args.results).then(async (elements: HTMLElement[]) => {
             this.renderResults(elements);
           });
         });

--- a/unitTests/ui/ResultListTest.ts
+++ b/unitTests/ui/ResultListTest.ts
@@ -38,7 +38,7 @@ export function ResultListTest() {
       describe('when returning less than 10 results', () => {
         let promiseResults: Promise<IQueryResults>;
         beforeEach(() => {
-          promiseResults = new Promise((resolve, reject) => {
+          promiseResults = new Promise(resolve => {
             resolve(FakeResults.createFakeResults(5));
           });
 
@@ -70,7 +70,7 @@ export function ResultListTest() {
       describe('when returning 10 or more results', () => {
         let promiseResults: Promise<IQueryResults>;
         beforeEach(() => {
-          promiseResults = new Promise((resolve, reject) => {
+          promiseResults = new Promise(resolve => {
             resolve(FakeResults.createFakeResults(10));
           });
 
@@ -403,6 +403,19 @@ export function ResultListTest() {
       });
     });
 
+    it('should not ask for more data when infiniteScrolling is enable and the container is not a window', () => {
+      const infiniteScrollContainer = $$('div');
+      infiniteScrollContainer.setAttribute('style', 'height: 400px;');
+      const option: IResultListOptions = {
+        enableInfiniteScroll: true,
+        infiniteScrollContainer: infiniteScrollContainer.el
+      };
+      test = Mock.basicComponentSetup<ResultList>(ResultList, option);
+      spyOn(test.cmp, 'displayMoreResults');
+      Simulate.query(test.env);
+      expect(test.cmp.displayMoreResults).not.toHaveBeenCalled();
+    });
+
     describe('exposes options', () => {
       it('resultContainer allow to specify where to render results', done => {
         const aNewContainer = document.createElement('div');
@@ -461,7 +474,7 @@ export function ResultListTest() {
       it('resultTemplate allow to specify a template manually', done => {
         const tmpl: UnderscoreTemplate = Mock.mock<UnderscoreTemplate>(UnderscoreTemplate);
         const asSpy = <any>tmpl;
-        asSpy.instantiateToElement.and.returnValue(new Promise((resolve, reject) => resolve(document.createElement('div'))));
+        asSpy.instantiateToElement.and.returnValue(new Promise(resolve => resolve(document.createElement('div'))));
         test = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, {
           resultTemplate: tmpl
         });


### PR DESCRIPTION
Wait for the result to be actually rendered before checking if we need more result in the case of an infiniteScroll resultList.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)