### PR TITLE
JSUI-2308 Checking for either open or close bracket on array values in hash

### DIFF
--- a/src/controllers/HistoryController.ts
+++ b/src/controllers/HistoryController.ts
@@ -185,7 +185,8 @@ export class HistoryController extends RootComponent implements IHistoryManager 
     Assert.isNonEmptyString(key);
     let value;
     try {
-      value = this.hashUtils.getValue(key, this.hashUtils.getHash(this.window));
+      const hash = this.hashUtils.getHash(this.window);
+      value = this.hashUtils.getValue(key, hash);
     } catch (error) {
       this.logger.error(`Could not parse parameter ${key} from URI`);
     }

--- a/unitTests/utils/HashUtilsTest.ts
+++ b/unitTests/utils/HashUtilsTest.ts
@@ -32,13 +32,42 @@ export function HashUtilsTest() {
       expect(value).toEqual(expectedValue);
     });
 
-    it('parses arrays correctly', () => {
+    it('parses unencoded arrays correctly', () => {
       const toParse = '#a=[1]';
       const expectedValue = ['1'];
 
       const value = HashUtils.getValue('a', toParse);
 
       expect(value).toEqual(expectedValue);
+    });
+
+    it('parses encoded arrays correctly', () => {
+      const encodedLeftBracket = '%5B';
+      const encodedRightBracket = '%5D';
+      const toParse = `#a=${encodedLeftBracket}1${encodedRightBracket}`;
+      const expectedValue = ['1'];
+
+      const value = HashUtils.getValue('a', toParse);
+
+      expect(value).toEqual(expectedValue);
+    });
+
+    it('parses arrays with only a left bracket correctly', () => {
+      const value = 'value';
+      const toParse = `#f=[${value}`;
+      const expectedValue = [value];
+
+      const result = HashUtils.getValue('f', toParse);
+      expect(result).toEqual(expectedValue);
+    });
+
+    it('parses arrays with only a right bracket correctly', () => {
+      const value = 'value';
+      const toParse = `#f=${value}]`;
+      const expectedValue = [value];
+
+      const result = HashUtils.getValue('f', toParse);
+      expect(result).toEqual(expectedValue);
     });
 
     it('parses strings correctly', () => {
@@ -67,7 +96,7 @@ export function HashUtilsTest() {
       expect(encodedValue).toEqual(expectedEncodedValue);
     });
 
-    it('encodes arrays correcttly', () => {
+    it('encodes arrays correctly', () => {
       const toEncode = [1];
       const expectEncodedValue = 'a=[1]';
 


### PR DESCRIPTION
Problem: the Microsoft Outlook link autoformatter does not include the trailing square bracket `]` as part of the clickable link. A person clicking the link hits a page with a broken state and no results.
 Approach: I chose a looser check on array values, where only the opening or closing bracket needs to present for us to detect the value as an array.

https://coveord.atlassian.net/browse/JSUI-2308





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)