### PR TITLE
Fix responsiveMode feature JSUI-2269

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
@@ -55,13 +55,7 @@ export class ResponsiveFacetColumn implements IResponsiveComponent {
     this.bindDropdownContentEvents();
     this.registerOnCloseHandler();
     this.registerQueryEvents();
-    if (Utils.isNullOrUndefined(options.responsiveBreakpoint)) {
-      this.breakpoint = this.searchInterface
-        ? this.searchInterface.responsiveComponents.getMediumScreenWidth()
-        : new ResponsiveComponents().getMediumScreenWidth();
-    } else {
-      this.breakpoint = options.responsiveBreakpoint;
-    }
+    this.breakpoint = options.responsiveBreakpoint;
   }
 
   public registerComponent(accept: Component) {
@@ -94,15 +88,23 @@ export class ResponsiveFacetColumn implements IResponsiveComponent {
   }
 
   private needSmallMode(): boolean {
-    switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
-      case 'small':
-        return true;
-      case 'auto':
-        break;
-      default:
-        return false;
+    if (this.searchInterface) {
+      switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
+        case 'small':
+          return true;
+        case 'auto':
+          return (
+            this.coveoRoot.width() <=
+            (Utils.isNullOrUndefined(this.breakpoint) ? this.searchInterface.responsiveComponents.getMediumScreenWidth() : this.breakpoint)
+          );
+        default:
+          return false;
+      }
     }
-    return this.coveoRoot.width() <= this.breakpoint;
+    return (
+      this.coveoRoot.width() <=
+      (Utils.isNullOrUndefined(this.breakpoint) ? new ResponsiveComponents().getMediumScreenWidth() : this.breakpoint)
+    );
   }
 
   private changeToSmallMode() {

--- a/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
@@ -94,6 +94,14 @@ export class ResponsiveFacetColumn implements IResponsiveComponent {
   }
 
   private needSmallMode(): boolean {
+    switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
+      case 'small':
+        return true;
+      case 'auto':
+        break;
+      default:
+        return false;
+    }
     return this.coveoRoot.width() <= this.breakpoint;
   }
 

--- a/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
@@ -88,23 +88,23 @@ export class ResponsiveFacetColumn implements IResponsiveComponent {
   }
 
   private needSmallMode(): boolean {
-    if (this.searchInterface) {
-      switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
-        case 'small':
-          return true;
-        case 'auto':
-          return (
-            this.coveoRoot.width() <=
-            (Utils.isNullOrUndefined(this.breakpoint) ? this.searchInterface.responsiveComponents.getMediumScreenWidth() : this.breakpoint)
-          );
-        default:
-          return false;
-      }
+    if (!this.searchInterface) {
+      return (
+        this.coveoRoot.width() <=
+        (Utils.isNullOrUndefined(this.breakpoint) ? new ResponsiveComponents().getMediumScreenWidth() : this.breakpoint)
+      );
     }
-    return (
-      this.coveoRoot.width() <=
-      (Utils.isNullOrUndefined(this.breakpoint) ? new ResponsiveComponents().getMediumScreenWidth() : this.breakpoint)
-    );
+    switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
+      case 'small':
+        return true;
+      case 'auto':
+        return (
+          this.coveoRoot.width() <=
+          (Utils.isNullOrUndefined(this.breakpoint) ? this.searchInterface.responsiveComponents.getMediumScreenWidth() : this.breakpoint)
+        );
+      default:
+        return false;
+    }
   }
 
   private changeToSmallMode() {

--- a/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
@@ -27,6 +27,7 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
   private facetSliders: any[];
   private facets: any[];
   private dropdownHeaderLabel: string;
+  private searchInterface: SearchInterface;
 
   public static init(root: HTMLElement, component, options: IResponsiveComponentOptions) {
     let logger = new Logger('ResponsiveRecommendation');
@@ -35,6 +36,7 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
       logger.info('Recommendation component has no parent interface. Disabling responsive mode for this component.');
       return;
     }
+
     if (!$$(coveoRoot).find('.coveo-results-column')) {
       logger.info('Cannot find element with class coveo-results-column. Disabling responsive mode for this component.');
       return;
@@ -66,6 +68,7 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
     this.recommendationRoot = this.getRecommendationRoot();
     this.dropdownHeaderLabel = options.dropdownHeaderLabel;
     this.breakpoint = this.defineResponsiveBreakpoint(options);
+    this.searchInterface = <SearchInterface>Component.get(this.coveoRoot.el, SearchInterface, false);
     this.dropdown = this.buildDropdown(responsiveDropdown);
     this.facets = this.getFacets();
     this.facetSliders = this.getFacetSliders();
@@ -92,6 +95,14 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
   }
 
   private needSmallMode(): boolean {
+    switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
+      case 'small':
+        return true;
+      case 'auto':
+        break;
+      default:
+        return false;
+    }
     return this.coveoRoot.width() <= this.breakpoint;
   }
 

--- a/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
@@ -95,17 +95,19 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
   }
 
   private needSmallMode(): boolean {
-    if (this.searchInterface) {
-      switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
-        case 'small':
-          return true;
-        case 'auto':
-          break;
-        default:
-          return false;
-      }
+    const isWidthSmallerThanBreakpoint = this.coveoRoot.width() <= this.breakpoint;
+    if (!this.searchInterface) {
+      return isWidthSmallerThanBreakpoint;
     }
-    return this.coveoRoot.width() <= this.breakpoint;
+
+    switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
+      case 'small':
+        return true;
+      case 'auto':
+        return isWidthSmallerThanBreakpoint;
+      default:
+        return false;
+    }
   }
 
   private changeToSmallMode() {

--- a/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
@@ -95,13 +95,15 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
   }
 
   private needSmallMode(): boolean {
-    switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
-      case 'small':
-        return true;
-      case 'auto':
-        break;
-      default:
-        return false;
+    if (this.searchInterface) {
+      switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
+        case 'small':
+          return true;
+        case 'auto':
+          break;
+        default:
+          return false;
+      }
     }
     return this.coveoRoot.width() <= this.breakpoint;
   }

--- a/src/ui/ResponsiveComponents/ResponsiveResultLayout.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveResultLayout.ts
@@ -51,10 +51,26 @@ export class ResponsiveResultLayout implements IResponsiveComponent {
   }
 
   private needSmallMode(): boolean {
+    switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
+      case 'small':
+        return true;
+      case 'auto':
+        break;
+      default:
+        return false;
+    }
     return this.coveoRoot.width() <= this.searchInterface.responsiveComponents.getSmallScreenWidth();
   }
 
   private needMediumMode(): boolean {
+    switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
+      case 'medium':
+        return true;
+      case 'auto':
+        break;
+      default:
+        return false;
+    }
     return this.coveoRoot.width() <= this.searchInterface.responsiveComponents.getMediumScreenWidth();
   }
 }

--- a/src/ui/ResponsiveComponents/ResponsiveResultLayout.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveResultLayout.ts
@@ -55,11 +55,10 @@ export class ResponsiveResultLayout implements IResponsiveComponent {
       case 'small':
         return true;
       case 'auto':
-        break;
+        return this.coveoRoot.width() <= this.searchInterface.responsiveComponents.getSmallScreenWidth();
       default:
         return false;
     }
-    return this.coveoRoot.width() <= this.searchInterface.responsiveComponents.getSmallScreenWidth();
   }
 
   private needMediumMode(): boolean {
@@ -67,10 +66,9 @@ export class ResponsiveResultLayout implements IResponsiveComponent {
       case 'medium':
         return true;
       case 'auto':
-        break;
+        return this.coveoRoot.width() <= this.searchInterface.responsiveComponents.getMediumScreenWidth();
       default:
         return false;
     }
-    return this.coveoRoot.width() <= this.searchInterface.responsiveComponents.getMediumScreenWidth();
   }
 }

--- a/src/ui/ResponsiveComponents/ResponsiveTabs.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveTabs.ts
@@ -70,6 +70,17 @@ export class ResponsiveTabs implements IResponsiveComponent {
   }
 
   private needSmallMode(): boolean {
+    // Ignore everything if the responsiveMode is not auto.
+    if (this.searchInterface) {
+      switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
+        case 'small':
+          return true;
+        case 'auto':
+          break;
+        default:
+          return false;
+      }
+    }
     const mediumWidth = this.searchInterface
       ? this.searchInterface.responsiveComponents.getMediumScreenWidth()
       : new ResponsiveComponents().getMediumScreenWidth();

--- a/src/ui/ResponsiveComponents/ResponsiveTabs.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveTabs.ts
@@ -71,16 +71,20 @@ export class ResponsiveTabs implements IResponsiveComponent {
 
   private needSmallMode(): boolean {
     // Ignore everything if the responsiveMode is not auto.
-    if (this.searchInterface) {
-      switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
-        case 'small':
-          return true;
-        case 'auto':
-          break;
-        default:
-          return false;
-      }
+    if (!this.searchInterface) {
+      return this.shouldAutoModeResolveToSmall();
     }
+    switch (this.searchInterface.responsiveComponents.getResponsiveMode()) {
+      case 'small':
+        return true;
+      case 'auto':
+        return this.shouldAutoModeResolveToSmall();
+      default:
+        return false;
+    }
+  }
+
+  private shouldAutoModeResolveToSmall() {
     const mediumWidth = this.searchInterface
       ? this.searchInterface.responsiveComponents.getMediumScreenWidth()
       : new ResponsiveComponents().getMediumScreenWidth();

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -235,6 +235,7 @@ export function mockResponsiveComponents(): ResponsiveComponents {
   m.isSmallScreenWidth = () => false;
   m.isMediumScreenWidth = () => false;
   m.isLargeScreenWidth = () => true;
+  m.getResponsiveMode = () => 'auto';
   return m;
 }
 

--- a/unitTests/ui/ResponsiveComponents/ResponsiveFacetsTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveFacetsTest.ts
@@ -221,6 +221,30 @@ export function ResponsiveFacetsTest() {
       expect(responsiveFacets.needDropdownWrapper()).toBe(false);
     });
 
+    it('should need the dropdown wrapper when the responsiveMode of the search interface is small even if the screen is large', () => {
+      const mediumBreakpoint = 481;
+      new SearchInterface(root.el, {
+        responsiveMediumBreakpoint: mediumBreakpoint,
+        responsiveMode: 'small'
+      });
+      responsiveFacets = new ResponsiveFacets(root, '', {});
+      root.width = jasmine.createSpy('width').and.returnValue(mediumBreakpoint + 1) as any;
+
+      expect(responsiveFacets.needDropdownWrapper()).toBe(true);
+    });
+
+    it('should not need the dropdown wrapper when the responsiveMode of the search interface is medium even if the screen is small', () => {
+      const smallBreakpoint = 481;
+      new SearchInterface(root.el, {
+        responsiveSmallBreakpoint: smallBreakpoint,
+        responsiveMode: 'medium'
+      });
+      responsiveFacets = new ResponsiveFacets(root, '', {});
+      root.width = jasmine.createSpy('width').and.returnValue(smallBreakpoint - 1) as any;
+
+      expect(responsiveFacets.needDropdownWrapper()).toBe(false);
+    });
+
     it('should use the breakpoint set from the search interface if not specified explicitely', () => {
       new SearchInterface(root.el, {
         responsiveMediumBreakpoint: 1234567

--- a/unitTests/ui/ResponsiveComponents/ResponsiveRecommendationTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveRecommendationTest.ts
@@ -10,6 +10,7 @@ import { $$, Dom } from '../../../src/utils/Dom';
 import { QueryEvents } from '../../../src/events/QueryEvents';
 import { mockComponent } from '../../MockEnvironment';
 import { FakeResults } from '../../Fake';
+import { SearchInterface } from '../../../src/ui/SearchInterface/SearchInterface';
 
 export function ResponsiveRecommendationTest() {
   describe('ResponsiveRecommendation', () => {
@@ -68,6 +69,26 @@ export function ResponsiveRecommendationTest() {
       responsiveDropdown.isOpened = true;
       responsiveRecommendation.handleResizeEvent();
       expect(responsiveDropdownContent.positionDropdown).toHaveBeenCalled();
+    });
+
+    describe('when it should switch to small mode but the responsiveMode is on medium (or large)', () => {
+      it('returns false when needDropdownWrapper is called', () => {
+        new SearchInterface(root.el, { responsiveMode: 'medium' });
+        responsiveRecommendation = new ResponsiveRecommendation(root, '', { dropdownHeaderLabel: 'label' }, responsiveDropdown);
+        shouldSwitchToSmallMode();
+        expect(responsiveRecommendation.needDropdownWrapper()).toBe(false);
+      });
+    });
+
+    describe('when it should switch to small mode but the responsiveMode is on small', () => {
+      it('returns false when needDropdownWrapper is called', () => {
+        new SearchInterface(root.el, { responsiveMode: 'medium' });
+        responsiveRecommendation = new ResponsiveRecommendation(root, '', { dropdownHeaderLabel: 'label' }, responsiveDropdown);
+        shouldSwitchToLargeMode();
+        ResponsiveComponentsUtils.activateSmallRecommendation(root);
+
+        expect(responsiveRecommendation.needDropdownWrapper()).toBe(false);
+      });
     });
 
     describe('when it should switch to small mode', () => {

--- a/unitTests/ui/ResponsiveComponents/ResponsiveTabsTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveTabsTest.ts
@@ -5,6 +5,7 @@ import { ResponsiveComponentsUtils } from '../../../src/ui/ResponsiveComponents/
 import { ResponsiveTabs } from '../../../src/ui/ResponsiveComponents/ResponsiveTabs';
 import { Tab } from '../../../src/ui/Tab/Tab';
 import { $$, Dom } from '../../../src/utils/Dom';
+import { SearchInterface } from '../../../src/ui/SearchInterface/SearchInterface';
 
 export function ResponsiveTabsTest() {
   let root: Dom;
@@ -40,6 +41,18 @@ export function ResponsiveTabsTest() {
       expect(ResponsiveComponentsUtils.activateSmallTabs).toHaveBeenCalled();
     });
 
+    it("doesn't activates small tabs when the screen is narrow and the responsiveMode is medium (or large)", () => {
+      const mediumBreakpoint = 800;
+      new SearchInterface(root.el, { responsiveMode: 'medium', responsiveMediumBreakpoint: mediumBreakpoint });
+      responsiveTabs = new ResponsiveTabs(root, Tab.ID);
+      spyOn(ResponsiveComponentsUtils, 'activateSmallTabs');
+      spyOn(root, 'width').and.returnValue(mediumBreakpoint - 1);
+
+      responsiveTabs.handleResizeEvent();
+
+      expect(ResponsiveComponentsUtils.activateSmallTabs).not.toHaveBeenCalled();
+    });
+
     it('deactivates small tabs when it should switch to large mode', () => {
       spyOn(ResponsiveComponentsUtils, 'deactivateSmallTabs');
       spyOn(root, 'width').and.returnValue(new ResponsiveComponents().getMediumScreenWidth() + 1);
@@ -48,6 +61,20 @@ export function ResponsiveTabsTest() {
       responsiveTabs.handleResizeEvent();
 
       expect(ResponsiveComponentsUtils.deactivateSmallTabs).toHaveBeenCalled();
+    });
+
+    it("doesn't deactivates small tabs when the screen is wide and the responsiveMode is small", () => {
+      const mediumBreakpoint = 800;
+      new SearchInterface(root.el, { responsiveMode: 'small', responsiveMediumBreakpoint: mediumBreakpoint });
+      responsiveTabs = new ResponsiveTabs(root, Tab.ID);
+
+      spyOn(ResponsiveComponentsUtils, 'deactivateSmallTabs');
+      spyOn(root, 'width').and.returnValue(mediumBreakpoint + 1);
+      ResponsiveComponentsUtils.activateSmallTabs(root);
+
+      responsiveTabs.handleResizeEvent();
+
+      expect(ResponsiveComponentsUtils.deactivateSmallTabs).not.toHaveBeenCalled();
     });
 
     describe('when moving tabs to different section', () => {


### PR DESCRIPTION
The issue was that the `needSmallMode` didn't use the responsive component and so didn't care about what was the responsive mode. Now if the responsive mode is set, then it'll be used before any breakpoints.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)