### PR TITLE
JSUI-2240 Hiding overflow and adding ellipses when small tabs are active

### DIFF
--- a/sass/_ResponsiveTabs.scss
+++ b/sass/_ResponsiveTabs.scss
@@ -29,6 +29,12 @@
         border-bottom: 2px solid $color-greyish-dark-blue;
       }
     }
+
+    p {
+      max-width: 240px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
   }
   .coveo-tab-list {
     list-style: none;


### PR DESCRIPTION
On small screen sizes, a tab with a long caption causes problems. It displaces the "more" button creating overflow. Also, when choosing another tab from the "more" dropdown, the tab that moves into the dropdown will have 0 opacity. The selected tab will also not appear in the tab-section.

The simplest solution I found that solves these different issues was to limit the caption width and add ellipses when small-tabs are active (i.e. when the tabs are not able to fit on the screen).

https://coveord.atlassian.net/browse/JSUI-2240





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)