### PR TITLE
[DOC-4043] - removed note about learning from refinedKeywords

### DIFF
--- a/src/ui/Analytics/PendingSearchEvent.ts
+++ b/src/ui/Analytics/PendingSearchEvent.ts
@@ -163,8 +163,6 @@ export class PendingSearchEvent {
       });
     }
 
-    // The refinedKeywords field is important for Coveo Machine Learning in order to learn properly on query
-    // made based on the long query.
     if (queryResults.refinedKeywords != undefined && queryResults.refinedKeywords.length != 0) {
       searchEvent.customData['refinedKeywords'] = queryResults.refinedKeywords;
     }


### PR DESCRIPTION

This code block was referenced in the following discuss post: https://discuss.coveo.com/t/how-to-track-long-queries-lq-in-usage-analytics/2123

I asked Marie Beaulieu and it turns out ML actually doesn't learn from refinedKeywords. Hence, I suggest deleting the comment.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)