### PR TITLE
Date/datetime values displayed on result templates ignore the current locale.

### DIFF
--- a/gulpTasks/definition.js
+++ b/gulpTasks/definition.js
@@ -39,6 +39,7 @@ gulp.task('cleanDefs', function() {
       .pipe(replace(/agGridModule\.[a-zA-Z]+/g, 'any'))
       .pipe(replace(/\(this: [A-Za-z_-]+, /gm, '('))
       .pipe(replace(/\| null/gm, '| void'))
+      .pipe(replace(/moment\.[a-zA-Z]+/g, 'any'))
       .pipe(gulp.dest('bin/ts/')) );
 });
 

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -207,18 +207,8 @@ export class DateUtils {
   }
 
   public static setLocale(): void {
-    let currentLocale = String['locale'];
-
-    // Our cultures.js directory contains 'no' which is the equivalent to 'nn' for momentJS
-    if (currentLocale.toLowerCase() == 'no') {
-      currentLocale = 'nn';
-    } else if (currentLocale.toLowerCase() == 'es-es') {
-      // Our cultures.js directory contains 'es-es' which is the equivalent to 'es' for momentJS
-      currentLocale = 'es';
-    }
-
-    moment.updateLocale(currentLocale, DateUtils.transformGlobalizeCalendarToMomentCalendar());
-    moment.locale(currentLocale);
+    moment.updateLocale(DateUtils.currentLocale, DateUtils.transformGlobalizeCalendarToMomentCalendar());
+    moment.locale(DateUtils.currentLocale);
   }
 
   /**
@@ -452,20 +442,23 @@ export class DateUtils {
   }
 
   static transformGlobalizeCalendarToMomentCalendar(): moment.LocaleSpecification {
+    const cldrToMomentFormat = (cldrFormat: string) => {
+      return cldrFormat.replace(/y/g, 'Y').replace(/d/g, 'D');
+    };
+
     return {
       months: DateUtils.currentGlobalizeCalendar.months.names,
       monthsShort: DateUtils.currentGlobalizeCalendar.months.namesAbbr,
-      monthsParseExact: true,
       weekdays: DateUtils.currentGlobalizeCalendar.days.names,
       weekdaysShort: DateUtils.currentGlobalizeCalendar.days.namesAbbr,
       weekdaysMin: DateUtils.currentGlobalizeCalendar.days.namesShort,
       longDateFormat: {
-        LT: DateUtils.currentGlobalizeCalendar.patterns.t.replace(/y/g, 'Y').replace(/d/g, 'D'),
-        LTS: DateUtils.currentGlobalizeCalendar.patterns.T.replace(/y/g, 'Y').replace(/d/g, 'D'),
-        L: DateUtils.currentGlobalizeCalendar.patterns.d.replace(/y/g, 'Y').replace(/d/g, 'D'),
-        LL: DateUtils.currentGlobalizeCalendar.patterns.M.replace(/y/g, 'Y').replace(/d/g, 'D'),
-        LLL: DateUtils.currentGlobalizeCalendar.patterns.f.replace(/y/g, 'Y'),
-        LLLL: DateUtils.currentGlobalizeCalendar.patterns.F.replace(/y/g, 'Y').replace(/d/g, 'D')
+        LT: cldrToMomentFormat(DateUtils.currentGlobalizeCalendar.patterns.t),
+        LTS: cldrToMomentFormat(DateUtils.currentGlobalizeCalendar.patterns.T),
+        L: cldrToMomentFormat(DateUtils.currentGlobalizeCalendar.patterns.d),
+        LL: cldrToMomentFormat(DateUtils.currentGlobalizeCalendar.patterns.M),
+        LLL: cldrToMomentFormat(DateUtils.currentGlobalizeCalendar.patterns.f),
+        LLLL: cldrToMomentFormat(DateUtils.currentGlobalizeCalendar.patterns.F)
       },
       calendar: {
         lastDay: `[${l('Yesterday')}]`,

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -4,6 +4,9 @@ import { l } from '../strings/Strings';
 import * as _ from 'underscore';
 import * as moment from 'moment';
 import { Logger } from '../misc/Logger';
+
+declare const Globalize;
+
 /**
  * The `IDateToStringOptions` interface describes a set of options to use when converting a standard Date object to a
  * string using the [ `dateToString` ]{@link DateUtils.dateToString}, or the
@@ -214,15 +217,8 @@ export class DateUtils {
       currentLocale = 'es';
     }
 
+    moment.updateLocale(currentLocale, DateUtils.transformGlobalizeCalendarToMomentCalendar());
     moment.locale(currentLocale);
-
-    moment.updateLocale(currentLocale, {
-      calendar: {
-        lastDay: `[${l('Yesterday')}]`,
-        sameDay: `[${l('Today')}]`,
-        nextDay: `[${l('Tomorrow')}]`
-      }
-    });
   }
 
   /**
@@ -303,23 +299,23 @@ export class DateUtils {
 
     if (options.useWeekdayIfThisWeek && isThisWeek) {
       if (dateOnly.valueOf() > today.valueOf()) {
-        return l('NextDay', dateOnly.format('dddd'));
+        return l('NextDay', l(dateOnly.format('dddd')));
       } else if (dateOnly.valueOf() < today.valueOf()) {
-        return l('LastDay', dateOnly.format('dddd'));
+        return l('LastDay', l(dateOnly.format('dddd')));
       } else {
         return dateOnly.format('dddd');
       }
     }
 
     if (options.omitYearIfCurrentOne && dateOnly.year() === today.year()) {
-      return dateOnly.format('MMMM DD');
+      return dateOnly.format('LL');
     }
 
     if (options.useLongDateFormat) {
-      return dateOnly.format('dddd, MMMM DD, YYYY');
+      return `${dateOnly.format('dddd')} ${dateOnly.format('LL')} ${dateOnly.format('YYYY')}`;
     }
 
-    return dateOnly.format('M/D/YYYY');
+    return dateOnly.format('L');
   }
 
   /**
@@ -436,5 +432,46 @@ export class DateUtils {
       ':' +
       ('0' + (((moment(to).valueOf() - moment(from).valueOf()) % (1000 * 60)) / 1000).toFixed()).slice(-2)
     );
+  }
+
+  static get currentGlobalizeCalendar(): GlobalizeCalendar {
+    return Globalize.culture(DateUtils.currentLocale).calendar as GlobalizeCalendar;
+  }
+
+  static get currentLocale(): string {
+    let currentLocale = String['locale'];
+
+    // Our cultures.js directory contains 'no' which is the equivalent to 'nn' for momentJS
+    if (currentLocale.toLowerCase() == 'no') {
+      currentLocale = 'nn';
+    } else if (currentLocale.toLowerCase() == 'es-es') {
+      // Our cultures.js directory contains 'es-es' which is the equivalent to 'es' for momentJS
+      currentLocale = 'es';
+    }
+    return currentLocale;
+  }
+
+  static transformGlobalizeCalendarToMomentCalendar(): moment.LocaleSpecification {
+    return {
+      months: DateUtils.currentGlobalizeCalendar.months.names,
+      monthsShort: DateUtils.currentGlobalizeCalendar.months.namesAbbr,
+      monthsParseExact: true,
+      weekdays: DateUtils.currentGlobalizeCalendar.days.names,
+      weekdaysShort: DateUtils.currentGlobalizeCalendar.days.namesAbbr,
+      weekdaysMin: DateUtils.currentGlobalizeCalendar.days.namesShort,
+      longDateFormat: {
+        LT: DateUtils.currentGlobalizeCalendar.patterns.t.replace(/y/g, 'Y').replace(/d/g, 'D'),
+        LTS: DateUtils.currentGlobalizeCalendar.patterns.T.replace(/y/g, 'Y').replace(/d/g, 'D'),
+        L: DateUtils.currentGlobalizeCalendar.patterns.d.replace(/y/g, 'Y').replace(/d/g, 'D'),
+        LL: DateUtils.currentGlobalizeCalendar.patterns.M.replace(/y/g, 'Y').replace(/d/g, 'D'),
+        LLL: DateUtils.currentGlobalizeCalendar.patterns.f.replace(/y/g, 'Y'),
+        LLLL: DateUtils.currentGlobalizeCalendar.patterns.F.replace(/y/g, 'Y').replace(/d/g, 'D')
+      },
+      calendar: {
+        lastDay: `[${l('Yesterday')}]`,
+        sameDay: `[${l('Today')}]`,
+        nextDay: `[${l('Tomorrow')}]`
+      }
+    };
   }
 }

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -207,8 +207,8 @@ export class DateUtils {
   }
 
   public static setLocale(): void {
-    moment.updateLocale(DateUtils.currentLocale, DateUtils.transformGlobalizeCalendarToMomentCalendar());
-    moment.locale(DateUtils.currentLocale);
+    moment.updateLocale(DateUtils.momentjsCompatibleLocale, DateUtils.transformGlobalizeCalendarToMomentCalendar());
+    moment.locale(DateUtils.momentjsCompatibleLocale);
   }
 
   /**
@@ -425,10 +425,10 @@ export class DateUtils {
   }
 
   static get currentGlobalizeCalendar(): GlobalizeCalendar {
-    return Globalize.culture(DateUtils.currentLocale).calendar as GlobalizeCalendar;
+    return Globalize.culture(DateUtils.momentjsCompatibleLocale).calendar as GlobalizeCalendar;
   }
 
-  static get currentLocale(): string {
+  static get momentjsCompatibleLocale(): string {
     let currentLocale = String['locale'];
 
     // Our cultures.js directory contains 'no' which is the equivalent to 'nn' for momentJS

--- a/unitTests/ui/CoreHelpersTest.ts
+++ b/unitTests/ui/CoreHelpersTest.ts
@@ -218,7 +218,7 @@ export function CoreHelperTest() {
 
         it('should work correctly with useLongDateFormat', () => {
           options.useLongDateFormat = true;
-          expect(TemplateHelpers.getHelper('date')(new Date(1981, 3, 11), options)).toEqual('Saturday, April 11, 1981');
+          expect(TemplateHelpers.getHelper('date')(new Date(1981, 3, 11), options)).toEqual('Saturday April 11 1981');
         });
 
         it('should work correctly with correct default options ', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2326


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)