### PR TITLE
Fix a couple of typos in ResutLink documentation

### DIFF
--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -26,7 +26,7 @@ import { AccessibleButton } from '../../utils/AccessibleButton';
  * The `ResultLink` component automatically transform a search result title into a clickable link pointing to the
  * original item.
  *
- * This component is a result template component (see [Result Templates](https://developers.coveo.com/x/aIGfAQ)).
+ * This component is a result template component (see [Result Templates](https://docs.coveo.com/en/413/)).
  */
 export class ResultLink extends Component {
   static ID = 'ResultLink';
@@ -54,7 +54,7 @@ export class ResultLink extends Component {
      * default field):
      *
      * ```html
-     * <a class="CoveoResultLink" field="@uri"></a>
+     * <a class="CoveoResultLink" data-field="@uri"></a>
      * ```
      *
      * - In the following result template, the custom `getMyKBUri()` function provides the `href` value:
@@ -100,7 +100,7 @@ export class ResultLink extends Component {
      *
      * If this option is `true`, clicking the `ResultLink` calls the
      * [`openLinkInNewWindow`]{@link ResultLink.openLinkInNewWindow} method instead of the
-     * [ `openLink`]{@link ResultLink.openLink} method.
+     * [`openLink`]{@link ResultLink.openLink} method.
      *
      * **Note:**
      * > If a search page contains a [`ResultPreferences`]{@link ResultsPreferences} component whose
@@ -196,9 +196,6 @@ export class ResultLink extends Component {
      *
      * **Example:**
      * ```javascript
-     *
-     *
-     *
      * // You can set the option in the 'init' call:
      * Coveo.init(document.querySelector("#search"), {
      *   ResultLink : {


### PR DESCRIPTION
Also update old link


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)