### PR TITLE
Add notes stating that result rating is obsolete in Cloud V2

### DIFF
--- a/src/rest/QueryResult.ts
+++ b/src/rest/QueryResult.ts
@@ -68,6 +68,10 @@ export interface IQueryResult {
   rankingInfo: string;
 
   /**
+   * **Note:**
+   *
+   * > The Coveo Cloud V2 platform does not support collaborative rating. Therefore, this property is obsolete in Coveo Cloud V2.
+   *
    * Contains the collaborative rating value for the item.
    *
    * See the [`ResultRating`]{@link ResultRating} component.

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -705,6 +705,10 @@ export class SearchEndpoint implements ISearchEndpoint {
   }
 
   /**
+   * **Note:**
+   *
+   * > The Coveo Cloud V2 platform does not support collaborative rating. Therefore, this method is obsolete in Coveo Cloud V2.
+   *
    * Rates a single item in the index (granted that collaborative rating is enabled on your index)
    * @param ratingRequest The item id, and the rating to add.
    * @param callOptions An additional set of options to use for this call.

--- a/src/ui/Base/QueryBuilder.ts
+++ b/src/ui/Base/QueryBuilder.ts
@@ -241,6 +241,10 @@ export class QueryBuilder {
    */
   public enableDebug: boolean = false;
   /**
+   * **Note:**
+   *
+   * > The Coveo Cloud V2 platform does not support collaborative rating. Therefore, this property is obsolete in Coveo Cloud V2.
+   *
    * Whether the index should take collaborative rating in account when ranking result (see : {@link ResultRating}).
    */
   public enableCollaborativeRating: boolean;

--- a/src/ui/ResultRating/ResultRating.ts
+++ b/src/ui/ResultRating/ResultRating.ts
@@ -23,6 +23,10 @@ export enum RatingValues {
 
 export interface IResultRatingOptions {}
 /**
+ * **Note:**
+ *
+ * > The Coveo Cloud V2 platform does not support collaborative rating. Therefore, this component is obsolete in Coveo Cloud V2.
+ *
  * The `ResultRating` component renders a 5-star rating widget. Interactive rating is possible if
  * the [`enableCollaborativeRating`]{@link SearchInterface.options.enableCollaborativeRating} option of your
  * search interface is `true`, and if collaborative rating is enabled on your Coveo index.

--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -350,6 +350,10 @@ export class SearchInterface extends RootComponent implements IComponentBindings
     enableDebugInfo: ComponentOptions.buildBooleanOption({ defaultValue: true }),
 
     /**
+     * **Note:**
+     *
+     * > The Coveo Cloud V2 platform does not support collaborative rating. Therefore, this option is obsolete in Coveo Cloud V2.
+     *
      * Specifies whether to enable collaborative rating, which you can leverage using the
      * [`ResultRating`]{@link ResultRating} component.
      *


### PR DESCRIPTION



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)