### PR TITLE
Add more documentation on how to specify the option/format for CategoryFacet basePath

### DIFF
--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -201,9 +201,9 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
      * ```
      * Setting the `basePath` to `c` would display `folder1` and `folder2` in the `CategoryFacet`, but omit `c`.
      *
-     * This options accepts an array of values. To specify a "deeper" starting path in your tree, you need to use comma separated values.
+     * This options accepts an array of values. To specify a "deeper" starting path in your tree, you need to use comma-separated values.
      *
-     * For example, setting `data-base-path="c,folder2"` on the component markup would display `folder3` in the `CategoryFacet`, but omit `c` and `folder1`.
+     * For example, setting `data-base-path="c,folder1"` on the component markup would display `folder3` in the `CategoryFacet`, but omit `c` and `folder1`.
      *
      */
     basePath: ComponentOptions.buildListOption<string>({ defaultValue: [] }),

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -201,6 +201,10 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
      * ```
      * Setting the `basePath` to `c` would display `folder1` and `folder2` in the `CategoryFacet`, but omit `c`.
      *
+     * This options accepts an array of values. To specify a "deeper" starting path in your tree, you need to use comma separated values.
+     *
+     * For example, setting `data-base-path="c,folder2"` on the component markup would display `folder3` in the `CategoryFacet`, but omit `c` and `folder1`.
+     *
      */
     basePath: ComponentOptions.buildListOption<string>({ defaultValue: [] }),
     /**


### PR DESCRIPTION
Bug initially reported because of a misunderstanding on how to specify a "deeper" base path in the component.

I did not want to go into the whole option validation aspect, because that's another whole level of work. We'll see if we need it in the future.

I simply added more precision in the documentation.

https://coveord.atlassian.net/browse/JSUI-2342





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)