### PR TITLE
JSUI-2361 Facet add advanced override when additionnalFilter is passed & no values are selected

### DIFF
--- a/src/controllers/FacetQueryController.ts
+++ b/src/controllers/FacetQueryController.ts
@@ -320,6 +320,10 @@ export class FacetQueryController {
       mergeWith.constant = `${mergeWith.constant} ${this.additionalFilter}`;
     }
 
+    if (!mergeWith.advanced) {
+      mergeWith.advanced = queryBuilder.advancedExpression.build();
+    }
+
     return mergeWith;
   }
 

--- a/unitTests/controllers/FacetQueryControllerTest.ts
+++ b/unitTests/controllers/FacetQueryControllerTest.ts
@@ -92,7 +92,8 @@ export function FacetQueryControllerTest() {
           expect(groupByRequest.advancedQueryOverride).toBeUndefined();
         });
 
-        it("should add a basic query override if the facet is configured with an additional filter and there's a basic expression in the query", () => {
+        it(`when the facet is configured with an additional filter and there's a basic expression in the query
+          it should add a basic query override `, () => {
           mockFacet.options.additionalFilter = 'an additional filter';
           queryBuilder.expression.add('foo');
 
@@ -103,7 +104,21 @@ export function FacetQueryControllerTest() {
           expect(groupByRequest.constantQueryOverride).toBe('an additional filter');
         });
 
-        it("should add the existing constant query override if the facet is configured with an additional filter and there's a constant expression in the query", () => {
+        it(`when the facet is configured with an additional filter and there's an advanced expression in the query
+          it should add an advanced query override`, () => {
+          mockFacet.options.additionalFilter = 'an additional filter';
+          queryBuilder.advancedExpression.add('advanced expression');
+
+          facetQueryController.putGroupByIntoQueryBuilder(queryBuilder);
+          const groupByRequest = queryBuilder.build().groupBy[0];
+
+          expect(groupByRequest.queryOverride).toBeUndefined();
+          expect(groupByRequest.constantQueryOverride).toBe('an additional filter');
+          expect(groupByRequest.advancedQueryOverride).toBe('advanced expression');
+        });
+
+        it(`when the facet is configured with an additional filter and there's a constant expression in the query
+          it should add the existing constant query override`, () => {
           mockFacet.options.additionalFilter = 'an additional filter';
           queryBuilder.constantExpression.add('foo');
 
@@ -153,7 +168,8 @@ export function FacetQueryControllerTest() {
           expect(groupByRequest.advancedQueryOverride).toBe('@uri');
         });
 
-        it("should add a basic query override if the facet is configured with an additional filter and there's a basic expression in the query", () => {
+        it(`when the facet is configured with an additional filter and there's a basic expression in the query
+          should add a basic query override`, () => {
           mockFacet.options.additionalFilter = 'an additional filter';
           queryBuilder.expression.add('foo');
 
@@ -165,7 +181,8 @@ export function FacetQueryControllerTest() {
           expect(groupByRequest.advancedQueryOverride).toBeUndefined();
         });
 
-        it("should add a constant query override if the facet is configured with an additional filter and there's a constant expression in the query", () => {
+        it(`when the facet is configured with an additional filter and there's a constant expression in the query
+          it should add a constant query override`, () => {
           mockFacet.options.additionalFilter = 'an additional filter';
           queryBuilder.constantExpression.add('foo');
 
@@ -175,6 +192,19 @@ export function FacetQueryControllerTest() {
           expect(groupByRequest.queryOverride).toBeUndefined();
           expect(groupByRequest.constantQueryOverride).toBe('foo an additional filter');
           expect(groupByRequest.advancedQueryOverride).toBeUndefined();
+        });
+
+        it(`when the facet is configured with an additional filter and there's an advanced expression in the query
+          it should add an advanced query override`, () => {
+          mockFacet.options.additionalFilter = 'an additional filter';
+          queryBuilder.advancedExpression.add('advanced expression');
+
+          facetQueryController.putGroupByIntoQueryBuilder(queryBuilder);
+          const groupByRequest = queryBuilder.build().groupBy[0];
+
+          expect(groupByRequest.queryOverride).toBeUndefined();
+          expect(groupByRequest.constantQueryOverride).toBe('an additional filter');
+          expect(groupByRequest.advancedQueryOverride).toBe('advanced expression');
         });
       });
 


### PR DESCRIPTION
Add an advanced override when additionnalFilter + advancedQueryExpression are defined & no values are selected in the facet
https://coveord.atlassian.net/browse/JSUI-2361





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)