### PR TITLE
Support suggestions in LockerService SFINT-2110

### DIFF
--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -65,8 +65,8 @@ export class SuggestionsManager {
     let target = $$(<HTMLElement>e.target);
     let targetParents = target.parents(this.options.selectableClass);
 
-    //e.relatedTarget is not available if moving off the browser window
-    if (e.relatedTarget) {
+    //e.relatedTarget is not available if moving off the browser window or is an empty object `{}` when moving out of namespace in LockerService.
+    if (e.relatedTarget && e.relatedTarget.getAttribute != undefined) {
       let relatedTargetParents = $$(<HTMLElement>e.relatedTarget).parents(this.options.selectableClass);
       if (target.hasClass(this.options.selectedClass) && !$$(<HTMLElement>e.relatedTarget).hasClass(this.options.selectableClass)) {
         this.removeSelectedStatus(target.el);

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -66,7 +66,7 @@ export class SuggestionsManager {
     let targetParents = target.parents(this.options.selectableClass);
 
     //e.relatedTarget is not available if moving off the browser window or is an empty object `{}` when moving out of namespace in LockerService.
-    if (e.relatedTarget && e.relatedTarget.getAttribute != undefined) {
+    if (e.relatedTarget && $$(e.relatedTarget).isValid()) {
       let relatedTargetParents = $$(<HTMLElement>e.relatedTarget).parents(this.options.selectableClass);
       if (target.hasClass(this.options.selectedClass) && !$$(<HTMLElement>e.relatedTarget).hasClass(this.options.selectableClass)) {
         this.removeSelectedStatus(target.el);

--- a/src/utils/Dom.ts
+++ b/src/utils/Dom.ts
@@ -595,6 +595,14 @@ export class Dom {
   }
 
   /**
+   * Check if the element is not a locked node (`{ toString(): string }`) and thus have base element properties.
+   * @returns {boolean}
+   */
+  public isValid(): boolean {
+    return this.el != null && this.el.getAttribute != undefined;
+  }
+
+  /**
    * Check if the element is a descendant of parent
    * @param other
    */

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -136,6 +136,19 @@ export function SuggestionsManagerTest() {
       expect(suggestion.getAttribute('aria-selected')).toBe('false');
     });
 
+    it('removes selected class and sets aria-selected to false when moving off a selected element in LockerService', () => {
+      suggestion.addClass(selectedClass);
+      suggestion.setAttribute('aria-selected', 'true');
+
+      suggestionManager.handleMouseOut({
+        target: suggestion.el,
+        relatedTarget: {}
+      });
+
+      expect(suggestion.hasClass(selectedClass)).toBe(false);
+      expect(suggestion.getAttribute('aria-selected')).toBe('false');
+    });
+
     it('removes selected class and sets aria-selected to false when moving off an element that is inside a selected element', () => {
       suggestion.addClass(selectedClass);
       suggestion.setAttribute('aria-selected', 'true');
@@ -143,6 +156,19 @@ export function SuggestionsManagerTest() {
       suggestionManager.handleMouseOut({
         target: elementInsideSuggestion.el,
         relatedTarget: container.el
+      });
+
+      expect(suggestion.hasClass(selectedClass)).toBe(false);
+      expect(suggestion.getAttribute('aria-selected')).toBe('false');
+    });
+
+    it('removes selected class and sets aria-selected to false when moving off an element that is inside a selected element in LockerService', () => {
+      suggestion.addClass(selectedClass);
+      suggestion.setAttribute('aria-selected', 'true');
+
+      suggestionManager.handleMouseOut({
+        target: elementInsideSuggestion.el,
+        relatedTarget: {}
       });
 
       expect(suggestion.hasClass(selectedClass)).toBe(false);

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -6,6 +6,7 @@ import { MagicBoxInstance } from '../../src/magicbox/MagicBox';
 
 export function SuggestionsManagerTest() {
   describe('Suggestions manager', () => {
+    const LOCKED_LOCKER_SERVICE_ELEMENT = {};
     let container: Dom;
     let suggestionContainer: Dom;
     let suggestionManager: SuggestionsManager;
@@ -142,7 +143,7 @@ export function SuggestionsManagerTest() {
 
       suggestionManager.handleMouseOut({
         target: suggestion.el,
-        relatedTarget: {}
+        relatedTarget: LOCKED_LOCKER_SERVICE_ELEMENT
       });
 
       expect(suggestion.hasClass(selectedClass)).toBe(false);
@@ -168,7 +169,7 @@ export function SuggestionsManagerTest() {
 
       suggestionManager.handleMouseOut({
         target: elementInsideSuggestion.el,
-        relatedTarget: {}
+        relatedTarget: LOCKED_LOCKER_SERVICE_ELEMENT
       });
 
       expect(suggestion.hasClass(selectedClass)).toBe(false);

--- a/unitTests/utils/DomTest.ts
+++ b/unitTests/utils/DomTest.ts
@@ -31,6 +31,23 @@ export function DomTests() {
         Simulate.removeJQuery();
       });
 
+      describe('when calling #isValidElement', () => {
+        it('should respond true when a valid element is given', () => {
+          const NORMAL_ELEMENT = document.createElement('div');
+          expect($$(NORMAL_ELEMENT).isValid()).toBeTruthy;
+        });
+
+        it('should respond false when a invalid element is given', () => {
+          const NOT_AN_ELEMENT = new Event('resize') as any;
+          expect($$(NOT_AN_ELEMENT).isValid()).toBeFalsy;
+        });
+
+        it('should respond false when a locked element is given such as in a LockerService context', () => {
+          const LOCKED_LOCKER_SERVICE_ELEMENT = {} as any;
+          expect($$(LOCKED_LOCKER_SERVICE_ELEMENT).isValid()).toBeFalsy;
+        });
+      });
+
       describe('without custom event (IE11)', () => {
         let customEvent;
         beforeAll(() => {


### PR DESCRIPTION
See the issue by the jira number.

tl;dr e.relatedTarget should be null in LockerService but is `{}` instead.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)