### PR TITLE
JSUI-2385 Adding #valueCaption option to CategoryFacet

### DIFF
--- a/sass/_CategoryFacet.scss
+++ b/sass/_CategoryFacet.scss
@@ -105,15 +105,18 @@
   }
 }
 
-.coveo-category-facet-more,
-.coveo-category-facet-less {
+.coveo-category-facet-more-less-container {
   width: 100%;
   height: 15px;
   background: $color-blueish-white;
-  cursor: pointer;
   text-align: center;
   border-bottom-left-radius: $default-border-radius;
   border-bottom-right-radius: $default-border-radius;
+}
+
+.coveo-category-facet-more,
+.coveo-category-facet-less {
+  cursor: pointer;
   &:hover,
   &:focus {
     background: $color-light-grey;

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -819,12 +819,8 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
       this.reset();
     };
 
-    const categoryFacetBreadcrumbBuilder = new CategoryFacetBreadcrumb(
-      this.options.title,
-      resetFacet,
-      lastParentValue,
-      this.options.basePath
-    );
+    const categoryFacetBreadcrumbBuilder = new CategoryFacetBreadcrumb(this.options, resetFacet, lastParentValue);
+
     args.breadcrumbs.push({ element: categoryFacetBreadcrumbBuilder.build() });
   }
 

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -406,6 +406,9 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
       $$(facetSearch).insertAfter(this.categoryValueRoot.listRoot.el);
     }
 
+    this.moreLessContainer = $$('div', { className: 'coveo-category-facet-more-less-container' });
+    $$(this.element).append(this.moreLessContainer.el);
+
     if (this.options.enableMoreLess) {
       this.renderMoreLess();
     }
@@ -748,9 +751,6 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   }
 
   private renderMoreLess() {
-    this.moreLessContainer = $$('div', { className: 'coveo-category-facet-more-less-container' });
-    $$(this.element).append(this.moreLessContainer.el);
-
     if (this.numberOfChildValuesCurrentlyDisplayed > this.options.numberOfValues) {
       this.moreLessContainer.append(this.buildLessButton());
     }

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -583,6 +583,17 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
     CategoryFacetDebug.analyzeResults(queryResults.groupByResults[0], this.options.delimitingCharacter);
   }
 
+  /**
+   *
+   * @param value The string to find a caption for.
+   * Returns the caption for a value or the value itself if no caption is available.
+   */
+  public getCaption(value: string) {
+    const valueCaptions = this.options.valueCaption;
+    const caption = valueCaptions[value];
+    return caption ? caption : value;
+  }
+
   public showWaitingAnimation() {
     this.ensureDom();
     if (!this.showingWaitAnimation) {

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -819,7 +819,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
       this.reset();
     };
 
-    const categoryFacetBreadcrumbBuilder = new CategoryFacetBreadcrumb(this.options, resetFacet, lastParentValue);
+    const categoryFacetBreadcrumbBuilder = new CategoryFacetBreadcrumb(this, resetFacet, lastParentValue);
 
     args.breadcrumbs.push({ element: categoryFacetBreadcrumbBuilder.build() });
   }

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -226,6 +226,8 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
      * Specifies a JSON object describing a mapping of facet values to their desired captions. See
      * [Normalizing Facet Value Captions](https://developers.coveo.com/x/jBsvAg).
      *
+     * If this option is specified, the facet search box will be unavailable.
+     *
      * **Examples:**
      *
      * You can set the option in the ['init']{@link init} call:

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -261,7 +261,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
      * **Note:**
      * > Using value captions will disable alphabetical sorts (see the [availableSorts]{@link Facet.options.availableSorts} option).
      */
-    valueCaption: ComponentOptions.buildJsonOption<IStringMap<string>>(),
+    valueCaption: ComponentOptions.buildJsonOption<IStringMap<string>>({ defaultValue: {} }),
     ...ResponsiveFacetOptions
   };
 
@@ -296,7 +296,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
     this.currentPage = 0;
     this.numberOfValues = this.options.numberOfValues;
 
-    if (this.options.enableFacetSearch) {
+    if (this.isFacetSearchAvailable) {
       this.categoryFacetSearch = new CategoryFacetSearch(this);
     }
 
@@ -342,6 +342,23 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
     );
   }
 
+  private get isFacetSearchAvailable() {
+    if (this.areValueCaptionsSpecified) {
+      return false;
+    }
+
+    if (!this.options.enableFacetSearch) {
+      return false;
+    }
+
+    return true;
+  }
+
+  private get areValueCaptionsSpecified() {
+    const valueCaptions = this.options.valueCaption;
+    return Object.keys(valueCaptions).length !== 0;
+  }
+
   private handleNoResults() {
     if (this.isPristine()) {
       this.hide();
@@ -384,7 +401,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
     }
 
     this.renderValues(categoryFacetResult, numberOfRequestedValues);
-    if (this.options.enableFacetSearch) {
+    if (this.isFacetSearchAvailable) {
       const facetSearch = this.categoryFacetSearch.build();
       $$(facetSearch).insertAfter(this.categoryValueRoot.listRoot.el);
     }
@@ -745,7 +762,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
 
   private clear() {
     this.categoryValueRoot.clear();
-    if (this.options.enableFacetSearch) {
+    if (this.isFacetSearchAvailable) {
       this.categoryFacetSearch.clear();
     }
     this.moreLessContainer && this.moreLessContainer.detach();

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -33,6 +33,7 @@ import { IResponsiveComponentOptions } from '../ResponsiveComponents/ResponsiveC
 import { ResponsiveFacetOptions } from '../ResponsiveComponents/ResponsiveFacetOptions';
 import { CategoryFacetHeader } from './CategoryFacetHeader';
 import { AccessibleButton } from '../../utils/AccessibleButton';
+import { IStringMap } from '../../rest/GenericParam';
 
 export interface ICategoryFacetOptions extends IResponsiveComponentOptions {
   field: IFieldOption;
@@ -49,6 +50,7 @@ export interface ICategoryFacetOptions extends IResponsiveComponentOptions {
   debug?: boolean;
   basePath?: string[];
   maximumDepth?: number;
+  valueCaption?: IStringMap<string>;
 }
 
 export type CategoryValueDescriptor = {
@@ -220,6 +222,46 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
      * This option can have negative effects on performance, and should only be activated when debugging.
      */
     debug: ComponentOptions.buildBooleanOption({ defaultValue: false }),
+    /**
+     * Specifies a JSON object describing a mapping of facet values to their desired captions. See
+     * [Normalizing Facet Value Captions](https://developers.coveo.com/x/jBsvAg).
+     *
+     * **Examples:**
+     *
+     * You can set the option in the ['init']{@link init} call:
+     * ```javascript
+     * var myValueCaptions = {
+     *   "txt" : "Text files",
+     *   "html" : "Web page",
+     *   [ ... ]
+     * };
+     *
+     * Coveo.init(document.querySelector("#search"), {
+     *   Facet : {
+     *     valueCaption : myValueCaptions
+     *   }
+     * });
+     * ```
+     *
+     * Or before the `init` call, using the ['options']{@link options} top-level function:
+     * ```javascript
+     * Coveo.options(document.querySelector("#search"), {
+     *   Facet : {
+     *     valueCaption : myValueCaptions
+     *   }
+     * });
+     * ```
+     *
+     * Or directly in the markup:
+     * ```html
+     * <!-- Ensure that the double quotes are properly handled in data-value-caption. -->
+     * <div class='CoveoCategoryFacet' data-field='@myotherfield' data-value-caption='{"txt":"Text files","html":"Web page"}'></div>
+     * ```
+     *
+     * **Note:**
+     * > Using value captions will disable alphabetical sorts (see the [availableSorts]{@link Facet.options.availableSorts} option).
+     */
+    valueCaption: ComponentOptions.buildJsonOption<IStringMap<string>>(),
     ...ResponsiveFacetOptions
   };
 

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -15,7 +15,7 @@ import 'styling/_CategoryFacet';
 import { IAttributesChangedEventArg, MODEL_EVENTS } from '../../models/Model';
 import { Utils } from '../../utils/Utils';
 import { CategoryValue, CategoryValueParent } from './CategoryValue';
-import { pluck, reduce, find, first, last, contains, isArray } from 'underscore';
+import { pluck, reduce, find, first, last, contains, isArray, keys } from 'underscore';
 import { Assert } from '../../misc/Assert';
 import { QueryEvents, IBuildingQueryEventArgs, IQuerySuccessEventArgs } from '../../events/QueryEvents';
 import { CategoryFacetSearch } from './CategoryFacetSearch';
@@ -358,7 +358,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
 
   private get areValueCaptionsSpecified() {
     const valueCaptions = this.options.valueCaption;
-    return Object.keys(valueCaptions).length !== 0;
+    return keys(valueCaptions).length !== 0;
   }
 
   private handleNoResults() {

--- a/src/ui/CategoryFacet/CategoryFacetBreadcrumb.ts
+++ b/src/ui/CategoryFacet/CategoryFacetBreadcrumb.ts
@@ -24,7 +24,7 @@ export class CategoryFacetBreadcrumb {
 
     SVGDom.addClassToSVGInContainer(clear.el, 'coveo-facet-breadcrumb-clear-svg');
     const pathToRender = without(this.categoryValueDescriptor.path, ...this.categoryFacet.options.basePath);
-    const captionLabel = pathToRender.join('/');
+    const captionLabel = pathToRender.map(pathPart => this.categoryFacet.getCaption(pathPart)).join('/');
 
     const breadcrumbTitle = $$('span', { className: 'coveo-category-facet-breadcrumb-title' }, `${this.categoryFacet.options.title}: `);
     const valuesContainer = $$('span', { className: 'coveo-category-facet-breadcrumb-values' }, captionLabel, clear);

--- a/src/ui/CategoryFacet/CategoryFacetBreadcrumb.ts
+++ b/src/ui/CategoryFacet/CategoryFacetBreadcrumb.ts
@@ -1,17 +1,16 @@
 import { $$ } from '../../utils/Dom';
 import { SVGDom } from '../../utils/SVGDom';
 import { SVGIcons } from '../../utils/SVGIcons';
-import { CategoryValueDescriptor } from './CategoryFacet';
+import { CategoryValueDescriptor, ICategoryFacetOptions } from './CategoryFacet';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import { l } from '../../strings/Strings';
 import { without } from 'underscore';
 
 export class CategoryFacetBreadcrumb {
   constructor(
-    private categoryFacetTitle: string,
+    private categoryFacetOptions: ICategoryFacetOptions,
     private onClickHandler: (e: MouseEvent) => void,
-    private categoryValueDescriptor: CategoryValueDescriptor,
-    private basePath: string[]
+    private categoryValueDescriptor: CategoryValueDescriptor
   ) {}
 
   public build(): HTMLElement {
@@ -24,10 +23,10 @@ export class CategoryFacetBreadcrumb {
     );
 
     SVGDom.addClassToSVGInContainer(clear.el, 'coveo-facet-breadcrumb-clear-svg');
-    const pathToRender = without(this.categoryValueDescriptor.path, ...this.basePath);
+    const pathToRender = without(this.categoryValueDescriptor.path, ...this.categoryFacetOptions.basePath);
     const captionLabel = pathToRender.join('/');
 
-    const breadcrumbTitle = $$('span', { className: 'coveo-category-facet-breadcrumb-title' }, `${this.categoryFacetTitle}: `);
+    const breadcrumbTitle = $$('span', { className: 'coveo-category-facet-breadcrumb-title' }, `${this.categoryFacetOptions.title}: `);
     const valuesContainer = $$('span', { className: 'coveo-category-facet-breadcrumb-values' }, captionLabel, clear);
 
     new AccessibleButton()

--- a/src/ui/CategoryFacet/CategoryFacetBreadcrumb.ts
+++ b/src/ui/CategoryFacet/CategoryFacetBreadcrumb.ts
@@ -1,14 +1,14 @@
 import { $$ } from '../../utils/Dom';
 import { SVGDom } from '../../utils/SVGDom';
 import { SVGIcons } from '../../utils/SVGIcons';
-import { CategoryValueDescriptor, ICategoryFacetOptions } from './CategoryFacet';
+import { CategoryValueDescriptor, CategoryFacet } from './CategoryFacet';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import { l } from '../../strings/Strings';
 import { without } from 'underscore';
 
 export class CategoryFacetBreadcrumb {
   constructor(
-    private categoryFacetOptions: ICategoryFacetOptions,
+    private categoryFacet: CategoryFacet,
     private onClickHandler: (e: MouseEvent) => void,
     private categoryValueDescriptor: CategoryValueDescriptor
   ) {}
@@ -23,10 +23,10 @@ export class CategoryFacetBreadcrumb {
     );
 
     SVGDom.addClassToSVGInContainer(clear.el, 'coveo-facet-breadcrumb-clear-svg');
-    const pathToRender = without(this.categoryValueDescriptor.path, ...this.categoryFacetOptions.basePath);
+    const pathToRender = without(this.categoryValueDescriptor.path, ...this.categoryFacet.options.basePath);
     const captionLabel = pathToRender.join('/');
 
-    const breadcrumbTitle = $$('span', { className: 'coveo-category-facet-breadcrumb-title' }, `${this.categoryFacetOptions.title}: `);
+    const breadcrumbTitle = $$('span', { className: 'coveo-category-facet-breadcrumb-title' }, `${this.categoryFacet.options.title}: `);
     const valuesContainer = $$('span', { className: 'coveo-category-facet-breadcrumb-values' }, captionLabel, clear);
 
     new AccessibleButton()

--- a/src/ui/CategoryFacet/CategoryValue.ts
+++ b/src/ui/CategoryFacet/CategoryValue.ts
@@ -84,7 +84,7 @@ export class CategoryValue implements CategoryValueParent {
     element.addClass('coveo-selectable');
 
     const countLabel = l('ResultCount', this.categoryValueDescriptor.count.toString());
-    const label = l('SelectValueWithResultCount', this.categoryValueDescriptor.value, countLabel);
+    const label = l('SelectValueWithResultCount', this.captionedValueDescriptorValue, countLabel);
 
     new AccessibleButton()
       .withElement(element)

--- a/src/ui/CategoryFacet/CategoryValue.ts
+++ b/src/ui/CategoryFacet/CategoryValue.ts
@@ -105,10 +105,8 @@ export class CategoryValue implements CategoryValueParent {
   }
 
   private get captionedValueDescriptorValue() {
-    const valueCaptions = this.categoryFacet.options.valueCaption;
     const value = this.categoryValueDescriptor.value;
-    const caption = valueCaptions[value];
-    return caption ? caption : value;
+    return this.categoryFacet.getCaption(value);
   }
 
   private onSelect() {

--- a/src/ui/CategoryFacet/CategoryValue.ts
+++ b/src/ui/CategoryFacet/CategoryValue.ts
@@ -17,7 +17,6 @@ export interface CategoryValueParent {
 
 export class CategoryValue implements CategoryValueParent {
   private collapseArrow: Dom;
-  private label: Dom;
 
   public path: string[];
   public element: Dom;
@@ -31,7 +30,7 @@ export class CategoryValue implements CategoryValueParent {
     private categoryFacet: CategoryFacet
   ) {
     this.element = this.categoryFacetTemplates.buildListElement({
-      value: this.categoryValueDescriptor.value,
+      value: this.captionedValueDescriptorValue,
       count: this.categoryValueDescriptor.count
     });
     this.collapseArrow = this.categoryFacetTemplates.buildCollapseArrow();
@@ -81,14 +80,14 @@ export class CategoryValue implements CategoryValueParent {
   }
 
   public makeSelectable() {
-    this.label = $$(this.element.find('.coveo-category-facet-value-label'));
-    this.label.addClass('coveo-selectable');
+    const element = $$(this.element.find('.coveo-category-facet-value-label'));
+    element.addClass('coveo-selectable');
 
     const countLabel = l('ResultCount', this.categoryValueDescriptor.count.toString());
     const label = l('SelectValueWithResultCount', this.categoryValueDescriptor.value, countLabel);
 
     new AccessibleButton()
-      .withElement(this.label)
+      .withElement(element)
       .withSelectAction(() => this.onSelect())
       .withLabel(label)
       .build();
@@ -103,6 +102,13 @@ export class CategoryValue implements CategoryValueParent {
     }
 
     return this;
+  }
+
+  private get captionedValueDescriptorValue() {
+    const valueCaptions = this.categoryFacet.options.valueCaption;
+    const value = this.categoryValueDescriptor.value;
+    const caption = valueCaptions[value];
+    return caption ? caption : value;
   }
 
   private onSelect() {

--- a/unitTests/ui/CategoryFacet/CategoryFacetBreadcrumbTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetBreadcrumbTest.ts
@@ -1,14 +1,20 @@
 import { CategoryFacetBreadcrumb } from '../../../src/ui/CategoryFacet/CategoryFacetBreadcrumb';
 import { $$ } from '../../../src/Core';
-import { CategoryValueDescriptor, ICategoryFacetOptions } from '../../../src/ui/CategoryFacet/CategoryFacet';
+import { CategoryValueDescriptor, ICategoryFacetOptions, CategoryFacet } from '../../../src/ui/CategoryFacet/CategoryFacet';
+import { optionsComponentSetup } from '../../MockEnvironment';
 
 export function CategoryFacetBreadcrumbTest() {
   describe('CategoryFacetBreadcrumb', () => {
+    let categoryFacet: CategoryFacet;
     let categoryValueDescriptor: CategoryValueDescriptor;
     let categoryFacetOptions: ICategoryFacetOptions;
 
     function buildCategoryFacetBreadcrumb() {
-      return new CategoryFacetBreadcrumb(categoryFacetOptions, () => {}, categoryValueDescriptor).build();
+      return new CategoryFacetBreadcrumb(categoryFacet, () => {}, categoryValueDescriptor).build();
+    }
+
+    function initCategoryFacet() {
+      categoryFacet = optionsComponentSetup<CategoryFacet, ICategoryFacetOptions>(CategoryFacet, categoryFacetOptions).cmp;
     }
 
     beforeEach(() => {
@@ -18,6 +24,8 @@ export function CategoryFacetBreadcrumbTest() {
         title: 'title',
         basePath: []
       };
+
+      initCategoryFacet();
     });
 
     it('build a breadcrumb', () => {
@@ -36,7 +44,7 @@ export function CategoryFacetBreadcrumbTest() {
 
     it('calls the given click handler on click', () => {
       const clickHandler = jasmine.createSpy('handler');
-      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacetOptions, clickHandler, categoryValueDescriptor).build();
+      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacet, clickHandler, categoryValueDescriptor).build();
 
       $$(breadcrumb)
         .find('.coveo-category-facet-breadcrumb-values')

--- a/unitTests/ui/CategoryFacet/CategoryFacetBreadcrumbTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetBreadcrumbTest.ts
@@ -33,15 +33,6 @@ export function CategoryFacetBreadcrumbTest() {
       expect($$(breadcrumb).hasClass('coveo-category-facet-breadcrumb')).toBe(true);
     });
 
-    it('has the right accessibility attributes', () => {
-      categoryValueDescriptor.path = ['path_one', 'path_two'];
-      const breadcrumb = buildCategoryFacetBreadcrumb();
-      const breadcrumbValues = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
-      expect(breadcrumbValues.getAttribute('aria-label')).toBe('Remove filter on path_one/path_two');
-      expect(breadcrumbValues.getAttribute('role')).toBe('button');
-      expect(breadcrumbValues.getAttribute('tabindex')).toBe('0');
-    });
-
     it('calls the given click handler on click', () => {
       const clickHandler = jasmine.createSpy('handler');
       const breadcrumb = new CategoryFacetBreadcrumb(categoryFacet, clickHandler, categoryValueDescriptor).build();
@@ -53,20 +44,44 @@ export function CategoryFacetBreadcrumbTest() {
       expect(clickHandler).toHaveBeenCalled();
     });
 
-    it('build a breadcrumb with the full path if there is no base path', () => {
-      categoryValueDescriptor.path = ['path_one', 'path_two'];
-      const breadcrumb = buildCategoryFacetBreadcrumb();
-      const values = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
-      expect($$(values).text()).toEqual('path_one/path_two');
-    });
+    describe(`when the categoryValueDescriptor #path is a populated array`, () => {
+      beforeEach(() => (categoryValueDescriptor.path = ['path_one', 'path_two']));
 
-    it('build a breadcrumb without the full path if there is a base path', () => {
-      categoryValueDescriptor.path = ['path_one', 'path_two'];
-      categoryFacetOptions.basePath = ['path_one'];
+      it('has the right accessibility attributes', () => {
+        const breadcrumb = buildCategoryFacetBreadcrumb();
+        const breadcrumbValues = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
+        expect(breadcrumbValues.getAttribute('aria-label')).toBe('Remove filter on path_one/path_two');
+        expect(breadcrumbValues.getAttribute('role')).toBe('button');
+        expect(breadcrumbValues.getAttribute('tabindex')).toBe('0');
+      });
 
-      const breadcrumb = buildCategoryFacetBreadcrumb();
-      const values = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
-      expect($$(values).text()).toEqual('path_two');
+      it('build a breadcrumb with the full path if there is no base path', () => {
+        const breadcrumb = buildCategoryFacetBreadcrumb();
+        const values = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
+        expect($$(values).text()).toEqual('path_one/path_two');
+      });
+
+      it('build a breadcrumb without the full path if there is a base path', () => {
+        categoryFacetOptions.basePath = ['path_one'];
+
+        const breadcrumb = buildCategoryFacetBreadcrumb();
+        const values = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
+        expect($$(values).text()).toEqual('path_two');
+      });
+
+      it(`when the categoryFacet has the valueCaption option configured,
+      it renders a path whose parts are captioned`, () => {
+        const firstPartOfPath = categoryValueDescriptor.path[0];
+        const caption = `${firstPartOfPath}_caption`;
+
+        categoryFacetOptions.valueCaption = { [firstPartOfPath]: caption };
+        initCategoryFacet();
+
+        const breadcrumb = buildCategoryFacetBreadcrumb();
+        const values = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
+
+        expect(values.textContent).toContain(caption);
+      });
     });
   });
 }

--- a/unitTests/ui/CategoryFacet/CategoryFacetBreadcrumbTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetBreadcrumbTest.ts
@@ -1,10 +1,15 @@
 import { CategoryFacetBreadcrumb } from '../../../src/ui/CategoryFacet/CategoryFacetBreadcrumb';
 import { $$ } from '../../../src/Core';
 import { CategoryValueDescriptor, ICategoryFacetOptions } from '../../../src/ui/CategoryFacet/CategoryFacet';
+
 export function CategoryFacetBreadcrumbTest() {
   describe('CategoryFacetBreadcrumb', () => {
     let categoryValueDescriptor: CategoryValueDescriptor;
     let categoryFacetOptions: ICategoryFacetOptions;
+
+    function buildCategoryFacetBreadcrumb() {
+      return new CategoryFacetBreadcrumb(categoryFacetOptions, () => {}, categoryValueDescriptor).build();
+    }
 
     beforeEach(() => {
       categoryValueDescriptor = { value: 'value', count: 1, path: [] };
@@ -16,13 +21,13 @@ export function CategoryFacetBreadcrumbTest() {
     });
 
     it('build a breadcrumb', () => {
-      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacetOptions, () => {}, categoryValueDescriptor).build();
+      const breadcrumb = buildCategoryFacetBreadcrumb();
       expect($$(breadcrumb).hasClass('coveo-category-facet-breadcrumb')).toBe(true);
     });
 
     it('has the right accessibility attributes', () => {
       categoryValueDescriptor.path = ['path_one', 'path_two'];
-      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacetOptions, () => {}, categoryValueDescriptor).build();
+      const breadcrumb = buildCategoryFacetBreadcrumb();
       const breadcrumbValues = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
       expect(breadcrumbValues.getAttribute('aria-label')).toBe('Remove filter on path_one/path_two');
       expect(breadcrumbValues.getAttribute('role')).toBe('button');
@@ -42,7 +47,7 @@ export function CategoryFacetBreadcrumbTest() {
 
     it('build a breadcrumb with the full path if there is no base path', () => {
       categoryValueDescriptor.path = ['path_one', 'path_two'];
-      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacetOptions, () => {}, categoryValueDescriptor).build();
+      const breadcrumb = buildCategoryFacetBreadcrumb();
       const values = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
       expect($$(values).text()).toEqual('path_one/path_two');
     });
@@ -51,7 +56,7 @@ export function CategoryFacetBreadcrumbTest() {
       categoryValueDescriptor.path = ['path_one', 'path_two'];
       categoryFacetOptions.basePath = ['path_one'];
 
-      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacetOptions, () => {}, categoryValueDescriptor).build();
+      const breadcrumb = buildCategoryFacetBreadcrumb();
       const values = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
       expect($$(values).text()).toEqual('path_two');
     });

--- a/unitTests/ui/CategoryFacet/CategoryFacetBreadcrumbTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetBreadcrumbTest.ts
@@ -1,22 +1,28 @@
 import { CategoryFacetBreadcrumb } from '../../../src/ui/CategoryFacet/CategoryFacetBreadcrumb';
 import { $$ } from '../../../src/Core';
-import { CategoryValueDescriptor } from '../../../src/ui/CategoryFacet/CategoryFacet';
+import { CategoryValueDescriptor, ICategoryFacetOptions } from '../../../src/ui/CategoryFacet/CategoryFacet';
 export function CategoryFacetBreadcrumbTest() {
   describe('CategoryFacetBreadcrumb', () => {
     let categoryValueDescriptor: CategoryValueDescriptor;
+    let categoryFacetOptions: ICategoryFacetOptions;
 
     beforeEach(() => {
       categoryValueDescriptor = { value: 'value', count: 1, path: [] };
+      categoryFacetOptions = {
+        field: '@field',
+        title: 'title',
+        basePath: []
+      };
     });
 
     it('build a breadcrumb', () => {
-      const breadcrumb = new CategoryFacetBreadcrumb('title', () => {}, categoryValueDescriptor, []).build();
+      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacetOptions, () => {}, categoryValueDescriptor).build();
       expect($$(breadcrumb).hasClass('coveo-category-facet-breadcrumb')).toBe(true);
     });
 
     it('has the right accessibility attributes', () => {
       categoryValueDescriptor.path = ['path_one', 'path_two'];
-      const breadcrumb = new CategoryFacetBreadcrumb('title', () => {}, categoryValueDescriptor, []).build();
+      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacetOptions, () => {}, categoryValueDescriptor).build();
       const breadcrumbValues = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
       expect(breadcrumbValues.getAttribute('aria-label')).toBe('Remove filter on path_one/path_two');
       expect(breadcrumbValues.getAttribute('role')).toBe('button');
@@ -25,7 +31,7 @@ export function CategoryFacetBreadcrumbTest() {
 
     it('calls the given click handler on click', () => {
       const clickHandler = jasmine.createSpy('handler');
-      const breadcrumb = new CategoryFacetBreadcrumb('title', clickHandler, categoryValueDescriptor, []).build();
+      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacetOptions, clickHandler, categoryValueDescriptor).build();
 
       $$(breadcrumb)
         .find('.coveo-category-facet-breadcrumb-values')
@@ -36,14 +42,16 @@ export function CategoryFacetBreadcrumbTest() {
 
     it('build a breadcrumb with the full path if there is no base path', () => {
       categoryValueDescriptor.path = ['path_one', 'path_two'];
-      const breadcrumb = new CategoryFacetBreadcrumb('title', () => {}, categoryValueDescriptor, []).build();
+      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacetOptions, () => {}, categoryValueDescriptor).build();
       const values = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
       expect($$(values).text()).toEqual('path_one/path_two');
     });
 
     it('build a breadcrumb without the full path if there is a base path', () => {
       categoryValueDescriptor.path = ['path_one', 'path_two'];
-      const breadcrumb = new CategoryFacetBreadcrumb('title', () => {}, categoryValueDescriptor, ['path_one']).build();
+      categoryFacetOptions.basePath = ['path_one'];
+
+      const breadcrumb = new CategoryFacetBreadcrumb(categoryFacetOptions, () => {}, categoryValueDescriptor).build();
       const values = $$(breadcrumb).find('.coveo-category-facet-breadcrumb-values');
       expect($$(values).text()).toEqual('path_two');
     });

--- a/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
@@ -289,6 +289,29 @@ export function CategoryFacetTest() {
       );
     });
 
+    it(`when the #valueCaption option is an empty object,
+    it displays the facet search box`, () => {
+      test = Mock.optionsComponentSetup<CategoryFacet, ICategoryFacetOptions>(CategoryFacet, {
+        field: '@field',
+        valueCaption: {}
+      });
+
+      expect(test.cmp.categoryFacetSearch).toBeTruthy();
+    });
+
+    describe(`when the #valueCaption option is defined`, () => {
+      beforeEach(() => {
+        test = Mock.optionsComponentSetup<CategoryFacet, ICategoryFacetOptions>(CategoryFacet, {
+          field: '@field',
+          valueCaption: { value: 'caption' }
+        });
+      });
+
+      it(`does not render the facet search box`, () => {
+        expect(test.cmp.categoryFacetSearch).toBe(undefined);
+      });
+    });
+
     describe('renders', () => {
       function removeAllCategoriesButton(element) {
         const allCategoriesButton = $$(element).find('.coveo-category-facet-all-categories');

--- a/unitTests/ui/CategoryFacet/CategoryValueTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryValueTest.ts
@@ -6,41 +6,58 @@ import { $$, KEYBOARD } from '../../../src/Core';
 import { Simulate } from '../../Simulate';
 export function CategoryValueTest() {
   describe('CategoryValue', () => {
-    let categoryValueDescriptor: CategoryValueDescriptor = {
-      value: 'value',
-      count: 3,
-      path: ['1', '2', '3']
-    };
-
+    let categoryValueDescriptor: CategoryValueDescriptor;
     let categoryFacet: CategoryFacet;
+    let categoryFacetOptions: ICategoryFacetOptions;
 
-    const makeCategoryValue = (path = categoryValueDescriptor.path) => {
-      categoryValueDescriptor.path = path;
-      categoryFacet = optionsComponentSetup<CategoryFacet, ICategoryFacetOptions>(CategoryFacet, {
+    function initCategoryValueDescriptor() {
+      categoryValueDescriptor = {
+        value: 'value',
+        count: 3,
+        path: ['1', '2', '3']
+      };
+    }
+
+    function initCategoryFacetOptions() {
+      categoryFacetOptions = {
         field: '@field',
         maximumDepth: 3
-      }).cmp;
+      };
+    }
 
+    function initCategoryFacet() {
+      categoryFacet = optionsComponentSetup<CategoryFacet, ICategoryFacetOptions>(CategoryFacet, categoryFacetOptions).cmp;
+    }
+
+    function buildCategoryValue() {
       return new CategoryValue($$('div'), categoryValueDescriptor, new CategoryFacetTemplates(), categoryFacet);
-    };
+    }
 
-    describe('when it is selectable', () => {
-      it('does not call changeActivePath if we reached maximumDepth', () => {
-        const categoryValue = makeCategoryValue().makeSelectable();
-        spyOn(categoryFacet, 'changeActivePath');
-        $$($$(categoryValue.element).find('.coveo-category-facet-value-label')).trigger('click');
-        expect(categoryFacet.changeActivePath).not.toHaveBeenCalled();
-      });
+    beforeEach(() => {
+      initCategoryValueDescriptor();
+      initCategoryFacetOptions();
+      initCategoryFacet();
+    });
 
-      it('calls changeActivePath on click when below or equal maximumDepth', () => {
-        const categoryValue = makeCategoryValue(['1', '2']).makeSelectable();
+    it('when at maximumDepth, it does not call changeActivePath', () => {
+      const categoryValue = buildCategoryValue().makeSelectable();
+      spyOn(categoryFacet, 'changeActivePath');
+      $$($$(categoryValue.element).find('.coveo-category-facet-value-label')).trigger('click');
+      expect(categoryFacet.changeActivePath).not.toHaveBeenCalled();
+    });
+
+    describe('when below maximumDepth, when it is selectable', () => {
+      beforeEach(() => (categoryValueDescriptor.path = ['1', '2']));
+
+      it('calls changeActivePath on click', () => {
+        const categoryValue = buildCategoryValue().makeSelectable();
         spyOn(categoryFacet, 'changeActivePath');
         $$($$(categoryValue.element).find('.coveo-category-facet-value-label')).trigger('click');
         expect(categoryFacet.changeActivePath).toHaveBeenCalled();
       });
 
-      it('calls changeActivePath on enter keyup when below or equal maximumDepth', () => {
-        const categoryValue = makeCategoryValue(['1', '2']).makeSelectable();
+      it('calls changeActivePath on enter keyup', () => {
+        const categoryValue = buildCategoryValue().makeSelectable();
         spyOn(categoryFacet, 'changeActivePath');
         Simulate.keyUp($$(categoryValue.element).find('.coveo-category-facet-value-label'), KEYBOARD.ENTER);
         expect(categoryFacet.changeActivePath).toHaveBeenCalled();
@@ -48,14 +65,14 @@ export function CategoryValueTest() {
     });
 
     it('does not call changeActivePath on click by default', () => {
-      const categoryValue = makeCategoryValue();
+      const categoryValue = buildCategoryValue();
       spyOn(categoryFacet, 'changeActivePath');
       $$($$(categoryValue.element).find('.coveo-category-facet-value-label')).trigger('click');
       expect(categoryFacet.changeActivePath).not.toHaveBeenCalled();
     });
 
     it('does not call changeActivePath on enter keyup by default', () => {
-      const categoryValue = makeCategoryValue();
+      const categoryValue = buildCategoryValue();
       spyOn(categoryFacet, 'changeActivePath');
       Simulate.keyUp($$(categoryValue.element).find('.coveo-category-facet-value-label'), KEYBOARD.ENTER);
       expect(categoryFacet.changeActivePath).not.toHaveBeenCalled();

--- a/unitTests/ui/CategoryFacet/CategoryValueTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryValueTest.ts
@@ -84,16 +84,29 @@ export function CategoryValueTest() {
       expect(facetValue).toBe(categoryValueDescriptor.value);
     });
 
-    it(`when the categoryFacet #valueCaption option has a key that matches the categoryValueDescriptor #value,
-    it displays the caption instead of the original value`, () => {
+    describe(`when the categoryFacet #valueCaption option has a key that matches the categoryValueDescriptor #value`, () => {
       const caption = 'caption';
-      const valueCaption = { [categoryValueDescriptor.value]: caption };
-      categoryFacetOptions.valueCaption = valueCaption;
-      initCategoryFacet();
 
-      const categoryValue = buildCategoryValue();
-      const facetValue = categoryValue.element.find('.coveo-category-facet-value-caption').textContent;
-      expect(facetValue).toBe(caption);
+      beforeEach(() => {
+        const valueCaption = { [categoryValueDescriptor.value]: caption };
+        categoryFacetOptions.valueCaption = valueCaption;
+        initCategoryFacet();
+      });
+
+      it(`displays the caption instead of the original value`, () => {
+        const categoryValue = buildCategoryValue();
+        const facetValue = categoryValue.element.find('.coveo-category-facet-value-caption').textContent;
+        expect(facetValue).toBe(caption);
+      });
+
+      it(`when the categoryValue is selectable,
+      it adds a label containing the captioned value`, () => {
+        const categoryValue = buildCategoryValue().makeSelectable();
+        const labelElement = categoryValue.element.find('.coveo-category-facet-value-label');
+        const labelAttribute = labelElement.attributes['aria-label'];
+
+        expect(labelAttribute.value).toContain(caption);
+      });
     });
   });
 }

--- a/unitTests/ui/CategoryFacet/CategoryValueTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryValueTest.ts
@@ -77,5 +77,23 @@ export function CategoryValueTest() {
       Simulate.keyUp($$(categoryValue.element).find('.coveo-category-facet-value-label'), KEYBOARD.ENTER);
       expect(categoryFacet.changeActivePath).not.toHaveBeenCalled();
     });
+
+    it('displays the categoryValueDescriptor #value by default', () => {
+      const categoryValue = buildCategoryValue();
+      const facetValue = categoryValue.element.find('.coveo-category-facet-value-caption').textContent;
+      expect(facetValue).toBe(categoryValueDescriptor.value);
+    });
+
+    it(`when the categoryFacet #valueCaption option has a key that matches the categoryValueDescriptor #value,
+    it displays the caption instead of the original value`, () => {
+      const caption = 'caption';
+      const valueCaption = { [categoryValueDescriptor.value]: caption };
+      categoryFacetOptions.valueCaption = valueCaption;
+      initCategoryFacet();
+
+      const categoryValue = buildCategoryValue();
+      const facetValue = categoryValue.element.find('.coveo-category-facet-value-caption').textContent;
+      expect(facetValue).toBe(caption);
+    });
   });
 }


### PR DESCRIPTION
- Adding the valueCaption option to the CategoryFacet values and breadcrumbs.
- Not creating a CategoryFacetSearchbox when value captions are specified.
- Fixing a bug where no footer is rendered when the logic dictates not to render the more/less buttons.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)