### PR TITLE
Escape recommendations history element title

### DIFF
--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -271,7 +271,7 @@ export class Recommendation extends SearchInterface implements IComponentBinding
       name: 'PageView',
       value: document.location.toString(),
       time: JSON.stringify(new Date()),
-      title: document.title
+      title: _.escape(document.title)
     };
     this.historyStore.addElement(historyElement);
   }


### PR DESCRIPTION
Escape recommendations history element title before storing it to fix 500 error when special characters exist https://answers.coveo.com/questions/19799/500-error-when-special-characters-exist-on-title-i.html