### PR TITLE
JSUI-2383 Calling shouldExecuteQuery before updating this.lastQuery

### DIFF
--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -740,13 +740,14 @@ export class Omnibox extends Component {
 
   private triggerNewQuery(searchAsYouType: boolean, analyticsEvent: () => void) {
     clearTimeout(this.searchAsYouTypeTimeout);
+    const shouldExecuteQuery = this.shouldExecuteQuery(searchAsYouType);
     this.lastQuery = this.getQuery(searchAsYouType);
-    analyticsEvent();
+    shouldExecuteQuery && analyticsEvent();
 
     this.queryController.executeQuery({
       searchAsYouType: searchAsYouType,
       logInActionsHistory: true,
-      cancel: !this.shouldExecuteQuery(searchAsYouType)
+      cancel: !shouldExecuteQuery
     });
   }
 

--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -740,15 +740,14 @@ export class Omnibox extends Component {
 
   private triggerNewQuery(searchAsYouType: boolean, analyticsEvent: () => void) {
     clearTimeout(this.searchAsYouTypeTimeout);
-    const text = this.getQuery(searchAsYouType);
-    if (this.shouldExecuteQuery(searchAsYouType)) {
-      this.lastQuery = text;
-      analyticsEvent();
-      this.queryController.executeQuery({
-        searchAsYouType: searchAsYouType,
-        logInActionsHistory: true
-      });
-    }
+    this.lastQuery = this.getQuery(searchAsYouType);
+    analyticsEvent();
+
+    this.queryController.executeQuery({
+      searchAsYouType: searchAsYouType,
+      logInActionsHistory: true,
+      cancel: !this.shouldExecuteQuery(searchAsYouType)
+    });
   }
 
   private getQuery(searchAsYouType: boolean) {

--- a/unitTests/ui/OmniboxTest.ts
+++ b/unitTests/ui/OmniboxTest.ts
@@ -37,6 +37,13 @@ export function OmniboxTest() {
       expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.searchboxSubmit, {});
     });
 
+    it(`when the magicbox text is equal to the #lastQuery property,
+    when calling #submit, it triggers a query`, () => {
+      test.cmp.submit();
+      test.cmp.submit();
+      expect(test.env.queryController.executeQuery).toHaveBeenCalledTimes(2);
+    });
+
     describe('exposes options', () => {
       it('inline should be passed down to magic box', () => {
         test = Mock.optionsComponentSetup<Omnibox, IOmniboxOptions>(Omnibox, {


### PR DESCRIPTION
I introduced a regression with my last PR for this jira. I was updating `lastQuery` before calling `shouldExecuteQuery` causing the `cancel` property to be set to true all the time. This prevents sending a query for a regular search that does not use search-as-you-type.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)