### PR TITLE
Support Responsive Mode option inside the ResponsiveModeManager SFINT-2135

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
@@ -124,7 +124,7 @@ export class ResponsiveComponentsManager {
     this.searchBoxElement = this.getSearchBoxElement();
     this.logger = new Logger(this);
     this.resizeListener = debounce(() => {
-      if (this.coveoRoot.width() != 0) {
+      if (this.coveoRoot.width() != 0 || this.searchInterface.options.responsiveMode !== 'auto') {
         this.addDropdownHeaderWrapperIfNeeded();
         if (this.shouldSwitchToSmallMode()) {
           this.coveoRoot.addClass('coveo-small-interface');

--- a/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
@@ -124,7 +124,7 @@ export class ResponsiveComponentsManager {
     this.searchBoxElement = this.getSearchBoxElement();
     this.logger = new Logger(this);
     this.resizeListener = debounce(() => {
-      if (this.coveoRoot.width() != 0 || this.searchInterface.options.responsiveMode !== 'auto') {
+      if (this.isAbleToDetermineMode()) {
         this.addDropdownHeaderWrapperIfNeeded();
         if (this.shouldSwitchToSmallMode()) {
           this.coveoRoot.addClass('coveo-small-interface');
@@ -245,5 +245,9 @@ export class ResponsiveComponentsManager {
         manager => manager.coveoRoot.el != this.coveoRoot.el
       );
     });
+  }
+
+  private isAbleToDetermineMode() {
+    return this.coveoRoot.width() != 0 || this.searchInterface.options.responsiveMode !== 'auto';
   }
 }

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -6,6 +6,7 @@ import { Component } from '../../../src/ui/Base/Component';
 import { ValidResponsiveMode } from '../../../src/ui/ResponsiveComponents/ResponsiveComponents';
 
 export function ResponsiveComponentsManagerTest() {
+  const SMALL_RESPONSIVE_MODE = 'small';
   let root: Dom;
   let handleResizeEvent: any;
   let registerComponent: any;
@@ -73,7 +74,7 @@ export function ResponsiveComponentsManagerTest() {
 
     describe('when the search interface responsive mode is not set to *auto*', () => {
       beforeEach(() => {
-        setResponsiveMode('small');
+        setResponsiveMode(SMALL_RESPONSIVE_MODE);
       });
 
       describe('and the root element width is zero', () => {

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -12,13 +12,8 @@ export function ResponsiveComponentsManagerTest() {
   let responsiveComponentsManager: ResponsiveComponentsManager;
   let responsiveComponent: any;
   let component: any;
-  const setupHandleResizeEventTest = (mode?: ValidResponsiveMode) => {
-    if (mode) {
-      (Component.get(root.el, SearchInterface) as SearchInterface).options.responsiveMode = mode;
-    }
-    responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
-    responsiveComponentsManager.resizeListener();
-    jasmine.clock().tick(250);
+  const setResponsiveMode = (mode: ValidResponsiveMode) => {
+    (Component.get(root.el, SearchInterface) as SearchInterface).options.responsiveMode = mode;
   };
 
   describe('ResponsiveComponentsManager', () => {
@@ -44,30 +39,55 @@ export function ResponsiveComponentsManagerTest() {
       jasmine.clock().uninstall();
     });
 
-    it('calls handle resize event when resize listener is called', () => {
-      root.width = () => 400;
-      setupHandleResizeEventTest();
-      expect(handleResizeEvent).toHaveBeenCalled();
-    });
+    describe('when the search interface responsive mode is set to *auto*', () => {
+      beforeEach(() => {
+        setResponsiveMode('auto');
+      });
 
-    it('does not calls handle resize event when resize listener is called and width is zero', () => {
-      root.width = () => 0;
-      setupHandleResizeEventTest();
-      expect(handleResizeEvent).not.toHaveBeenCalled();
-    });
-
-    ['small', 'medium', 'large'].forEach((responsiveMode: ValidResponsiveMode) => {
-      it(`calls handle resize event when resize listener is called even if the width is zero when the responsiveMode is set to ${responsiveMode}`, () => {
-        root.width = () => 0;
-        setupHandleResizeEventTest(responsiveMode);
+      it('should calls handle resize event when resize listener is called', () => {
+        root.width = () => 400;
+        responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+        responsiveComponentsManager.resizeListener();
+        jasmine.clock().tick(250);
         expect(handleResizeEvent).toHaveBeenCalled();
+      });
+
+      describe('and the root element width is zero', () => {
+        beforeEach(() => {
+          root.width = () => 0;
+        });
+
+        it('should  not calls handle resize event when resize listener is called', () => {
+          responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+          responsiveComponentsManager.resizeListener();
+          jasmine.clock().tick(250);
+          expect(handleResizeEvent).not.toHaveBeenCalled();
+        });
+
+        it('should  not calls handle resize event when it registers component', () => {
+          responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+          expect(handleResizeEvent).not.toHaveBeenCalled();
+        });
       });
     });
 
-    it('does not calls handle resize event when resize listener is called and the width is zero and the responsiveMode is set to auto', () => {
-      root.width = () => 0;
-      setupHandleResizeEventTest('auto');
-      expect(handleResizeEvent).not.toHaveBeenCalled();
+    describe('when the search interface responsive mode is not set to *auto*', () => {
+      beforeEach(() => {
+        setResponsiveMode('small');
+      });
+
+      describe('and the root element width is zero', () => {
+        beforeEach(() => {
+          root.width = () => 0;
+        });
+
+        it('should calls handle resize event when resize listener is called', () => {
+          responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+          responsiveComponentsManager.resizeListener();
+          jasmine.clock().tick(250);
+          expect(handleResizeEvent).toHaveBeenCalled();
+        });
+      });
     });
 
     it('registers component even when the corresponding responsive class has already been instanciated', () => {

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -2,6 +2,8 @@ import { $$, Dom } from '../../../src/utils/Dom';
 import { ResponsiveComponentsManager } from '../../../src/ui/ResponsiveComponents/ResponsiveComponentsManager';
 import * as Mock from '../../MockEnvironment';
 import { SearchInterface, ISearchInterfaceOptions } from '../../../src/ui/SearchInterface/SearchInterface';
+import { Component } from '../../../src/ui/Base/Component';
+import { ValidResponsiveMode } from '../../../src/ui/ResponsiveComponents/ResponsiveComponents';
 
 export function ResponsiveComponentsManagerTest() {
   let root: Dom;
@@ -10,6 +12,14 @@ export function ResponsiveComponentsManagerTest() {
   let responsiveComponentsManager: ResponsiveComponentsManager;
   let responsiveComponent: any;
   let component: any;
+  const setupHandleResizeEventTest = (mode?: ValidResponsiveMode) => {
+    if (mode) {
+      (Component.get(root.el, SearchInterface) as SearchInterface).options.responsiveMode = mode;
+    }
+    responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+    responsiveComponentsManager.resizeListener();
+    jasmine.clock().tick(250);
+  };
 
   describe('ResponsiveComponentsManager', () => {
     beforeEach(() => {
@@ -36,19 +46,27 @@ export function ResponsiveComponentsManagerTest() {
 
     it('calls handle resize event when resize listener is called', () => {
       root.width = () => 400;
-      responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
-      responsiveComponentsManager.resizeListener();
-      jasmine.clock().tick(250);
+      setupHandleResizeEventTest();
       expect(handleResizeEvent).toHaveBeenCalled();
     });
 
     it('does not calls handle resize event when resize listener is called and width is zero', () => {
       root.width = () => 0;
-      responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
-      jasmine.clock().tick(250);
+      setupHandleResizeEventTest();
+      expect(handleResizeEvent).not.toHaveBeenCalled();
+    });
 
-      responsiveComponentsManager.resizeListener();
+    ['small', 'medium', 'large'].forEach((responsiveMode: ValidResponsiveMode) => {
+      it(`calls handle resize event when resize listener is called even if the width is zero when the responsiveMode is set to ${responsiveMode}`, () => {
+        root.width = () => 0;
+        setupHandleResizeEventTest(responsiveMode);
+        expect(handleResizeEvent).toHaveBeenCalled();
+      });
+    });
 
+    it('does not calls handle resize event when resize listener is called and the width is zero and the responsiveMode is set to auto', () => {
+      root.width = () => 0;
+      setupHandleResizeEventTest('auto');
       expect(handleResizeEvent).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
The goal of this PR is to support the responsive mode override feature even when the component is hidden.
When the responsive mode is set to a value other than auto, the width check is no longer require because we no longer needs to detect the appropriate responsive mode.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)