### PR TITLE
JSUI-2386 Using non-momentjs locale code when retrieving Globalize calendar

### DIFF
--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -429,11 +429,15 @@ export class DateUtils {
   }
 
   static get currentGlobalizeCalendar(): GlobalizeCalendar {
-    return Globalize.culture(DateUtils.momentjsCompatibleLocale).calendar as GlobalizeCalendar;
+    return Globalize.culture(DateUtils.currentLocale).calendar as GlobalizeCalendar;
+  }
+
+  static get currentLocale() {
+    return String['locale'];
   }
 
   static get momentjsCompatibleLocale(): string {
-    let currentLocale = String['locale'];
+    let currentLocale = DateUtils.currentLocale;
 
     // Our cultures.js directory contains 'no' which is the equivalent to 'nn' for momentJS
     if (currentLocale.toLowerCase() == 'no') {


### PR DESCRIPTION
Norwegian calendar retrieval using Globalize was failing because we were passing the momentjs locale `nn` instead of `no`.

https://coveord.atlassian.net/browse/JSUI-2386





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)