### PR TITLE
Change "search as you type" to "search-as-you-type" in docs & warnings

### DIFF
--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -41,7 +41,7 @@ export interface IQueryOptions {
    */
   ignoreWarningSearchEvent?: boolean;
   /**
-   * Specify that the query to execute is a search as you type. This information will be passed down in the query events for component and external code to determine their behavior
+   * Whether the query to execute is a search-as-you-type. This information will be passed down in the query events for component and external code to determine their behavior
    */
   searchAsYouType?: boolean;
   /**

--- a/src/events/QueryEvents.ts
+++ b/src/events/QueryEvents.ts
@@ -10,7 +10,7 @@ import { QueryBuilder } from '../ui/Base/QueryBuilder';
  */
 export interface INewQueryEventArgs {
   /**
-   * Determine if the query is a "search as you type"
+   * Whether the query is a search-as-you-type
    */
   searchAsYouType: boolean;
   /**
@@ -30,7 +30,7 @@ export interface IBuildingQueryEventArgs {
    */
   queryBuilder: QueryBuilder;
   /**
-   * Determine if the query is a "search as you type"
+   * Determine if the query is a "search-as-you-type"
    */
   searchAsYouType: boolean;
   /**
@@ -48,7 +48,7 @@ export interface IDoneBuildingQueryEventArgs {
    */
   queryBuilder: QueryBuilder;
   /**
-   * Determine if the query is a "search as you type"
+   * Whether the query is a search-as-you-type
    */
   searchAsYouType: boolean;
   /**
@@ -74,7 +74,7 @@ export interface IDuringQueryEventArgs {
    */
   promise: Promise<IQueryResults>;
   /**
-   * Determine if the query is a "search as you type"
+   * Whether the query is a search-as-you-type
    */
   searchAsYouType: boolean;
 }
@@ -96,7 +96,7 @@ export interface IQuerySuccessEventArgs {
    */
   queryBuilder: QueryBuilder;
   /**
-   * Determine if the query is a "search as you type"
+   * Whether the query is a search-as-you-type
    */
   searchAsYouType: boolean;
 }
@@ -118,7 +118,7 @@ export interface IFetchMoreSuccessEventArgs {
    */
   queryBuilder: QueryBuilder;
   /**
-   * Determine if the query is a "search as you type"
+   * Whether the query is a search-as-you-type
    */
   searchAsYouType: boolean;
 }
@@ -144,7 +144,7 @@ export interface IQueryErrorEventArgs {
    */
   error: IEndpointError;
   /**
-   * Determine if the query is a "search as you type"
+   * Whether the query is a search-as-you-type
    */
   searchAsYouType: boolean;
 }
@@ -166,7 +166,7 @@ export interface IPreprocessResultsEventArgs {
    */
   results: IQueryResults;
   /**
-   * Determine if the query is a "search as you type"
+   * Whether the query is a search-as-you-type
    */
   searchAsYouType: boolean;
 }
@@ -198,7 +198,7 @@ export interface INoResultsEventArgs {
    */
   results: IQueryResults;
   /**
-   * Determine if the query is a "search as you type"
+   * Whether the query is a search-as-you-type
    */
   searchAsYouType: boolean;
   /**

--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -308,7 +308,7 @@ export var analyticsActionCauseList = {
     type: 'search box'
   },
   /**
-   * Identifies the search as you type event that gets logged when a query is automatically generated, and results are displayed while a user is entering text in the search box before they voluntarily submit the query.
+   * The search-as-you-type event that gets logged when a query is automatically generated, and results are displayed while a user is entering text in the search box before they voluntarily submit the query.
    *
    * `actionCause`: `'searchboxAsYouType'`
    * `actionType`: `'search box'`
@@ -318,7 +318,7 @@ export var analyticsActionCauseList = {
     type: 'search box'
   },
   /**
-   * Identifies the search as you type event that gets logged when a breadcrumb facet is selected and the query is updated.
+   * The search-as-you-type event that gets logged when a breadcrumb facet is selected and the query is updated.
    *
    * `actionCause`: `'breadcrumbFacet'`
    * `actionType`: `'breadcrumb'`

--- a/src/ui/Querybox/Querybox.ts
+++ b/src/ui/Querybox/Querybox.ts
@@ -59,7 +59,7 @@ export class Querybox extends Component {
    */
   public static options: IQueryboxOptions = {
     /**
-     * Specifies whether to enable the search-as-you-type feature.
+     * Whether to enable the search-as-you-type feature.
      *
      * Default value is `false`.
      */

--- a/src/ui/Querybox/QueryboxOptionsProcessing.ts
+++ b/src/ui/Querybox/QueryboxOptionsProcessing.ts
@@ -35,7 +35,7 @@ export class QueryboxOptionsProcessing {
       this.options.triggerQueryOnClear === false &&
       this.options.enableSearchAsYouType === true
     ) {
-      this.owner.logger.warn('Forcing option triggerQueryOnClear to true, since search as you type is enabled', this.owner);
+      this.owner.logger.warn('Forcing option triggerQueryOnClear to true, since search-as-you-type is enabled', this.owner);
       this.options.triggerQueryOnClear = true;
     }
   }


### PR DESCRIPTION



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)