### PR TITLE
JSUI-2389 Not appending OmniboxResultList title and body when no results.

### DIFF
--- a/src/ui/OmniboxResultList/OmniboxResultList.ts
+++ b/src/ui/OmniboxResultList/OmniboxResultList.ts
@@ -213,33 +213,53 @@ export class OmniboxResultList extends ResultList implements IComponentBindings 
    * Creates a result container and appends each element from the received `HTMLElement` array to it. For each element
    * it appends to the result container, this method triggers a `newResultDisplayed` event. Once all elements have been
    * appended to the result container, the method triggers a `newResultsDisplayed` event.
-   * @param resultsElement The array of `HTMLElement` to render.
+   * @param resultElements The array of `HTMLElement` to render.
    * @param append
    */
-  public renderResults(resultsElement: HTMLElement[], append = false) {
+  public renderResults(resultElements: HTMLElement[], append = false) {
     $$(this.options.resultContainer).empty();
-    if (this.lastOmniboxRequest) {
-      if (this.options.headerTitle) {
-        this.options.resultContainer.appendChild(
-          $$(
-            'div',
-            { className: 'coveo-omnibox-result-list-header' },
-            $$('span', { className: 'coveo-icon-omnibox-result-list' }).el,
-            $$('span', { className: 'coveo-caption' }, l(this.options.headerTitle)).el
-          ).el
-        );
-      }
-      _.each(resultsElement, (resultElement: HTMLElement) => {
-        this.options.resultContainer.appendChild(resultElement);
-        this.triggerNewResultDisplayed(Component.getResult(resultElement), resultElement);
-      });
-      this.triggerNewResultsDisplayed();
-      if ($$(this.options.resultContainer).findAll('.coveo-omnibox-selectable').length == 0) {
-        this.lastOmniboxRequest.resolve({ element: null, zIndex: this.options.omniboxZIndex });
-      } else {
-        this.lastOmniboxRequest.resolve({ element: this.options.resultContainer, zIndex: this.options.omniboxZIndex });
-      }
+
+    if (!this.lastOmniboxRequest) {
       return Promise.resolve(null);
+    }
+
+    if (resultElements.length) {
+      this.appendHeaderIfTitleIsSpecified();
+      this.appendResults(resultElements);
+    }
+
+    this.resolveLastOmniboxRequest();
+
+    return Promise.resolve(null);
+  }
+
+  private appendHeaderIfTitleIsSpecified() {
+    if (this.options.headerTitle) {
+      this.options.resultContainer.appendChild(
+        $$(
+          'div',
+          { className: 'coveo-omnibox-result-list-header' },
+          $$('span', { className: 'coveo-icon-omnibox-result-list' }).el,
+          $$('span', { className: 'coveo-caption' }, l(this.options.headerTitle)).el
+        ).el
+      );
+    }
+  }
+
+  private appendResults(resultElements: HTMLElement[]) {
+    _.each(resultElements, (resultElement: HTMLElement) => {
+      this.options.resultContainer.appendChild(resultElement);
+      this.triggerNewResultDisplayed(Component.getResult(resultElement), resultElement);
+    });
+
+    this.triggerNewResultsDisplayed();
+  }
+
+  private resolveLastOmniboxRequest() {
+    if ($$(this.options.resultContainer).findAll('.coveo-omnibox-selectable').length == 0) {
+      this.lastOmniboxRequest.resolve({ element: null, zIndex: this.options.omniboxZIndex });
+    } else {
+      this.lastOmniboxRequest.resolve({ element: this.options.resultContainer, zIndex: this.options.omniboxZIndex });
     }
   }
 

--- a/unitTests/Simulate.ts
+++ b/unitTests/Simulate.ts
@@ -219,7 +219,7 @@ export class Simulate {
     };
   }
 
-  static omnibox(env: IMockEnvironment, options?): IOmniboxData {
+  static populateOmnibox(env: IMockEnvironment, options?): IOmniboxData {
     let expression = {
       word: 'foo',
       regex: /foo/

--- a/unitTests/ui/AnalyticsSuggestionsTest.ts
+++ b/unitTests/ui/AnalyticsSuggestionsTest.ts
@@ -26,7 +26,7 @@ export function AnalyticsSuggestionsTest() {
     });
 
     it('should trigger a call to get top query from the analytics', () => {
-      Simulate.omnibox(test.env);
+      Simulate.populateOmnibox(test.env);
       expect(test.env.usageAnalytics.getTopQueries).toHaveBeenCalled();
     });
 
@@ -38,7 +38,7 @@ export function AnalyticsSuggestionsTest() {
         })
       );
 
-      var simulation = Simulate.omnibox(test.env);
+      var simulation = Simulate.populateOmnibox(test.env);
       simulation.rows[0].deferred.then(elementResolved => {
         expect(simulation.rows.length).toBe(1);
         expect($$(elementResolved.element).text()).toEqual(jasmine.stringMatching('foo'));
@@ -55,7 +55,7 @@ export function AnalyticsSuggestionsTest() {
           resolve(['foo', 'bar', 'baz']);
         })
       );
-      var simulation = Simulate.omnibox(test.env);
+      var simulation = Simulate.populateOmnibox(test.env);
       simulation.rows[0].deferred.then(elementResolved => {
         test.cmp.selectSuggestion(0);
         expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(
@@ -79,19 +79,19 @@ export function AnalyticsSuggestionsTest() {
           resolve(['foo', 'bar', 'baz']);
         })
       );
-      Simulate.omnibox(test.env, {
+      Simulate.populateOmnibox(test.env, {
         completeQueryExpression: {
           word: 't',
           regex: /t/
         }
       });
-      Simulate.omnibox(test.env, {
+      Simulate.populateOmnibox(test.env, {
         completeQueryExpression: {
           word: 'tes',
           regex: /tes/
         }
       });
-      var simulation = Simulate.omnibox(test.env, {
+      var simulation = Simulate.populateOmnibox(test.env, {
         completeQueryExpression: {
           word: 'test',
           regex: /test/
@@ -114,19 +114,19 @@ export function AnalyticsSuggestionsTest() {
           resolve(['foo', 'bar', 'baz']);
         })
       );
-      Simulate.omnibox(test.env, {
+      Simulate.populateOmnibox(test.env, {
         completeQueryExpression: {
           word: 't',
           regex: /t/
         }
       });
-      Simulate.omnibox(test.env, {
+      Simulate.populateOmnibox(test.env, {
         completeQueryExpression: {
           word: 't',
           regex: /t/
         }
       });
-      var simulation = Simulate.omnibox(test.env, {
+      var simulation = Simulate.populateOmnibox(test.env, {
         completeQueryExpression: {
           word: 't',
           regex: /t/
@@ -149,7 +149,7 @@ export function AnalyticsSuggestionsTest() {
           resolve(['foo', 'bar', 'baz']);
         })
       );
-      var simulation = Simulate.omnibox(test.env, {
+      var simulation = Simulate.populateOmnibox(test.env, {
         completeQueryExpression: {
           word: 't;',
           regex: /t;/
@@ -172,7 +172,7 @@ export function AnalyticsSuggestionsTest() {
           resolve(['foo', 'bar', 'baz']);
         })
       );
-      var simulation = Simulate.omnibox(test.env, {
+      var simulation = Simulate.populateOmnibox(test.env, {
         completeQueryExpression: {
           word: _.range(0, 500).join(''),
           regex: /t;/
@@ -196,7 +196,7 @@ export function AnalyticsSuggestionsTest() {
             resolve(['foo', 'bar', 'baz']);
           })
         );
-        let simulation = Simulate.omnibox(test.env, {
+        let simulation = Simulate.populateOmnibox(test.env, {
           completeQueryExpression: {
             word: _.range(0, 500).join(''),
             regex: /t;/
@@ -212,7 +212,7 @@ export function AnalyticsSuggestionsTest() {
         test = Mock.optionsComponentSetup<AnalyticsSuggestions, IAnalyticsSuggestionsOptions>(AnalyticsSuggestions, {
           numberOfSuggestions: 333
         });
-        Simulate.omnibox(test.env);
+        Simulate.populateOmnibox(test.env);
         expect(test.env.usageAnalytics.getTopQueries).toHaveBeenCalledWith(jasmine.objectContaining({ pageSize: 333 }));
       });
     });

--- a/unitTests/ui/FieldSuggestionsTest.ts
+++ b/unitTests/ui/FieldSuggestionsTest.ts
@@ -27,7 +27,7 @@ export function FieldSuggestionsTest() {
     });
 
     it('should do a request on the endpoint', () => {
-      Simulate.omnibox(test.env);
+      Simulate.populateOmnibox(test.env);
       expect(test.env.searchEndpoint.listFieldValues).toHaveBeenCalledWith(
         jasmine.objectContaining({
           field: '@foobar'
@@ -50,7 +50,7 @@ export function FieldSuggestionsTest() {
           resolve([{ value: 'foo' }, { value: 'bar' }, { value: 'baz' }]);
         })
       );
-      var simulation = Simulate.omnibox(test.env);
+      var simulation = Simulate.populateOmnibox(test.env);
       test.cmp.selectSuggestion(0);
       simulation.rows[0].deferred.then(elementResolved => {
         test.cmp.selectSuggestion(0);
@@ -65,7 +65,7 @@ export function FieldSuggestionsTest() {
           field: '@foobar',
           queryOverride: 'some override'
         });
-        Simulate.omnibox(test.env);
+        Simulate.populateOmnibox(test.env);
         expect(test.env.searchEndpoint.listFieldValues).toHaveBeenCalledWith(
           jasmine.objectContaining({
             field: '@foobar',
@@ -85,7 +85,7 @@ export function FieldSuggestionsTest() {
             resolve([{ value: 'foo' }, { value: 'bar' }, { value: 'baz' }]);
           })
         );
-        var simulation = Simulate.omnibox(test.env);
+        var simulation = Simulate.populateOmnibox(test.env);
         test.cmp.selectSuggestion(0);
         simulation.rows[0].deferred.then(elementResolved => {
           expect(elementResolved.zIndex).toBe(333);
@@ -98,7 +98,7 @@ export function FieldSuggestionsTest() {
           field: '@foobar',
           numberOfSuggestions: 333
         });
-        Simulate.omnibox(test.env);
+        Simulate.populateOmnibox(test.env);
         expect(test.env.searchEndpoint.listFieldValues).toHaveBeenCalledWith(
           jasmine.objectContaining({
             field: '@foobar',
@@ -120,7 +120,7 @@ export function FieldSuggestionsTest() {
 
           (<jasmine.Spy>test.env.searchEndpoint.listFieldValues).and.returnValue(fakeListField);
 
-          const simulation = Simulate.omnibox(test.env);
+          const simulation = Simulate.populateOmnibox(test.env);
           simulation.rows[0].deferred.then(elementResolved => {
             expect($$(elementResolved.element).find('.coveo-top-field-suggestion-header')).toBeNull();
             done();
@@ -135,7 +135,7 @@ export function FieldSuggestionsTest() {
 
           (<jasmine.Spy>test.env.searchEndpoint.listFieldValues).and.returnValue(fakeListField);
 
-          const simulation = Simulate.omnibox(test.env);
+          const simulation = Simulate.populateOmnibox(test.env);
           simulation.rows[0].deferred.then(elementResolved => {
             const header = $$(elementResolved.element).find('.coveo-top-field-suggestion-header');
             expect(header).not.toBeNull();

--- a/unitTests/ui/OmniboxResultListTest.ts
+++ b/unitTests/ui/OmniboxResultListTest.ts
@@ -56,7 +56,7 @@ export function OmniboxResultListTest() {
       beforeEach(() => {
         spyOnSelect = jasmine.createSpy('onClick');
         test.cmp.options.onSelect = spyOnSelect;
-        Simulate.omnibox(test.env);
+        Simulate.populateOmnibox(test.env);
       });
 
       it('should call the onSelect option when clicking on each element of the result list', async done => {
@@ -159,16 +159,30 @@ export function OmniboxResultListTest() {
         expect(test.cmp.options.layout).toEqual('list');
       });
 
-      it('headerTitle should output a title', async done => {
-        test = Mock.optionsComponentSetup<OmniboxResultList, IOmniboxResultListOptions>(OmniboxResultList, {
-          headerTitle: 'My title'
+      describe(`when the headerTitle option is specified,
+      when simulating a populate omnibox event`, () => {
+        beforeEach(() => {
+          test = Mock.optionsComponentSetup<OmniboxResultList, IOmniboxResultListOptions>(OmniboxResultList, {
+            headerTitle: 'My title'
+          });
+
+          Simulate.populateOmnibox(test.env);
         });
-        Simulate.omnibox(test.env);
-        const built = await test.cmp.buildResults(results);
-        await test.cmp.renderResults(built);
-        const header = $$(test.cmp.options.resultContainer).find('.coveo-omnibox-result-list-header');
-        expect($$(header).text()).toEqual('My title');
-        done();
+
+        it('when results is a populated array, it appends a title to the result container', async done => {
+          const built = await test.cmp.buildResults(results);
+          await test.cmp.renderResults(built);
+          const header = $$(test.cmp.options.resultContainer).find('.coveo-omnibox-result-list-header');
+          expect($$(header).text()).toEqual('My title');
+          done();
+        });
+
+        it(`when results is an empty array, it does not append a title to the result container`, async done => {
+          await test.cmp.renderResults([]);
+          const header = $$(test.cmp.options.resultContainer).find('.coveo-omnibox-result-list-header');
+          expect(header).toBe(null);
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
I had some difficulty understanding the root cause of why this issue happens on page refresh only.

I used a more pragmatic solution that checks if we have results. If there aren't any, we skip appending the Omnibox result list title/results, and do not trigger the `newResult` and `newResults` events).


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)