### PR TITLE
JSUI-2408 Making "Search All" button accessible

### DIFF
--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -298,13 +298,13 @@ export class FacetSearch implements IFacetSearch {
     if (!facetSearchParameters.fetchMore) {
       $$(this.searchResults).empty();
     }
-    let selectAll = document.createElement('li');
-    if (Utils.isNonEmptyString(facetSearchParameters.valueToSearch)) {
-      $$(selectAll).addClass(['coveo-facet-selectable', 'coveo-facet-search-selectable', 'coveo-facet-search-select-all']);
-      $$(selectAll).text(l('SelectAll'));
-      $$(selectAll).on('click', () => this.selectAllValuesMatchingSearch());
-      this.facetSearchElement.appendToSearchResults(selectAll);
+
+    const facetSearchHasQuery = Utils.isNonEmptyString(facetSearchParameters.valueToSearch);
+
+    if (facetSearchHasQuery) {
+      this.appendSelectAllResultsButton();
     }
+
     let facetValues = map(fieldValues, fieldValue => {
       return FacetValue.create(fieldValue);
     });
@@ -323,6 +323,14 @@ export class FacetSearch implements IFacetSearch {
       $$(elem).setAttribute('aria-selected', 'false');
       $$(elem).addClass('coveo-facet-search-selectable');
     });
+  }
+
+  private appendSelectAllResultsButton() {
+    const selectAll = document.createElement('li');
+    $$(selectAll).addClass(['coveo-facet-selectable', 'coveo-facet-search-selectable', 'coveo-facet-search-select-all']);
+    $$(selectAll).text(l('SelectAll'));
+    $$(selectAll).on('click', () => this.selectAllValuesMatchingSearch());
+    this.facetSearchElement.appendToSearchResults(selectAll);
   }
 
   private buildParamsForNormalSearch() {

--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -329,6 +329,7 @@ export class FacetSearch implements IFacetSearch {
     const selectAll = document.createElement('li');
     $$(selectAll).addClass(['coveo-facet-selectable', 'coveo-facet-search-selectable', 'coveo-facet-search-select-all']);
     $$(selectAll).text(l('SelectAll'));
+    $$(selectAll).setAttribute('aria-hidden', 'true');
     $$(selectAll).on('click', () => this.selectAllValuesMatchingSearch());
     this.facetSearchElement.appendToSearchResults(selectAll);
   }

--- a/src/ui/Facet/FacetSearchDropdownNavigation/FacetSearchDropdownNavigator.ts
+++ b/src/ui/Facet/FacetSearchDropdownNavigation/FacetSearchDropdownNavigator.ts
@@ -54,11 +54,11 @@ export class FacetSearchDropdownNavigator implements ISearchDropdownNavigator {
     this.defaultDropdownNavigator.moveCurrentResultUp();
 
     if (this.isCurrentResultSelectAllButton) {
-      return;
+      this.announceCurrentResultCanBeSelected();
+    } else {
+      this.toggleCanExcludeCurrentResult();
+      this.announceCurrentResultCanBeExcluded();
     }
-
-    this.toggleCanExcludeCurrentResult();
-    this.announceCurrentResultCanBeExcluded();
   }
 
   private get isCurrentResultSelectAllButton() {
@@ -83,12 +83,16 @@ export class FacetSearchDropdownNavigator implements ISearchDropdownNavigator {
   }
 
   private announceCurrentResultCanBeSelected() {
+    const message = this.currentResultSelectMessage;
+    this.config.facetSearch.updateAriaLive(message);
+  }
+
+  private get currentResultSelectMessage() {
     if (this.isCurrentResultSelectAllButton) {
-      return;
+      return this.currentResult.text();
     }
 
     const checkbox = this.currentResult.find('.coveo-facet-value-checkbox');
-    const checkboxLabel = checkbox.getAttribute('aria-label');
-    this.config.facetSearch.updateAriaLive(checkboxLabel);
+    return checkbox.getAttribute('aria-label');
   }
 }

--- a/src/ui/Facet/FacetSearchDropdownNavigation/FacetSearchDropdownNavigator.ts
+++ b/src/ui/Facet/FacetSearchDropdownNavigation/FacetSearchDropdownNavigator.ts
@@ -25,10 +25,11 @@ export class FacetSearchDropdownNavigator implements ISearchDropdownNavigator {
   }
 
   public focusNextElement() {
-    if (this.canExcludeCurrentResult) {
+    if (this.isCurrentResultSelectAllButton) {
+      this.moveResultDownAndAnnounce();
+    } else if (this.canExcludeCurrentResult) {
       this.toggleCanExcludeCurrentResult();
-      this.defaultDropdownNavigator.moveCurrentResultDown();
-      this.announceCurrentResultCanBeSelected();
+      this.moveResultDownAndAnnounce();
     } else {
       this.toggleCanExcludeCurrentResult();
       this.announceCurrentResultCanBeExcluded();
@@ -37,21 +38,39 @@ export class FacetSearchDropdownNavigator implements ISearchDropdownNavigator {
 
   public focusPreviousElement() {
     if (!this.canExcludeCurrentResult) {
-      this.defaultDropdownNavigator.moveCurrentResultUp();
-      this.toggleCanExcludeCurrentResult();
-      this.announceCurrentResultCanBeExcluded();
+      this.moveResultUpAndAnnounce();
     } else {
       this.toggleCanExcludeCurrentResult();
       this.announceCurrentResultCanBeSelected();
     }
   }
 
+  private moveResultDownAndAnnounce() {
+    this.defaultDropdownNavigator.moveCurrentResultDown();
+    this.announceCurrentResultCanBeSelected();
+  }
+
+  private moveResultUpAndAnnounce() {
+    this.defaultDropdownNavigator.moveCurrentResultUp();
+
+    if (this.isCurrentResultSelectAllButton) {
+      return;
+    }
+
+    this.toggleCanExcludeCurrentResult();
+    this.announceCurrentResultCanBeExcluded();
+  }
+
+  private get isCurrentResultSelectAllButton() {
+    return this.currentResult.hasClass('coveo-facet-search-select-all');
+  }
+
   private get canExcludeCurrentResult() {
-    return this.defaultDropdownNavigator.currentResult.hasClass('coveo-facet-value-will-exclude');
+    return this.currentResult.hasClass('coveo-facet-value-will-exclude');
   }
 
   private toggleCanExcludeCurrentResult() {
-    this.defaultDropdownNavigator.currentResult.toggleClass('coveo-facet-value-will-exclude', !this.canExcludeCurrentResult);
+    this.currentResult.toggleClass('coveo-facet-value-will-exclude', !this.canExcludeCurrentResult);
   }
 
   private announceCurrentResultAction() {
@@ -64,6 +83,10 @@ export class FacetSearchDropdownNavigator implements ISearchDropdownNavigator {
   }
 
   private announceCurrentResultCanBeSelected() {
+    if (this.isCurrentResultSelectAllButton) {
+      return;
+    }
+
     const checkbox = this.currentResult.find('.coveo-facet-value-checkbox');
     const checkboxLabel = checkbox.getAttribute('aria-label');
     this.config.facetSearch.updateAriaLive(checkboxLabel);


### PR DESCRIPTION
When there is a query in the facet search box, a "Search All" element is added to the result list. This element has a different mark-up from a normal result. This caused the dropdown navigation logic to throw an error in the console. It also cannot be excluded, requiring an exception in the navigation logic. 

https://coveord.atlassian.net/browse/JSUI-2408


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)