### PR TITLE
Fix ResultsPerPage for configuration with initial choice

### DIFF
--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -11,6 +11,7 @@ import * as _ from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 import { l } from '../../strings/Strings';
 import { AccessibleButton } from '../../utils/AccessibleButton';
+import { Defer } from '../../misc/Defer';
 
 import 'styling/_ResultsPerPage';
 import { MODEL_EVENTS, IAttributeChangedEventArg } from '../../models/Model';
@@ -155,7 +156,14 @@ export class ResultsPerPage extends Component {
   }
 
   private handleQueryStateModelChanged(args: IAttributeChangedEventArg) {
-    this.updateResultsPerPage(args.value);
+    const valueToSet = args.value;
+
+    if (!this.isValidChoice(valueToSet)) {
+      this.logInvalidConfiguredChoiceWarning(valueToSet);
+      Defer.defer(() => this.resolveInitialState());
+    } else {
+      this.updateResultsPerPage(valueToSet);
+    }
   }
 
   private addAlwaysActiveListeners() {
@@ -184,7 +192,7 @@ export class ResultsPerPage extends Component {
       if (this.isValidChoice(configuredChoice)) {
         return configuredChoice;
       }
-      this.logInvalidConfiguredChoiceWarning();
+      this.logInvalidConfiguredChoiceWarning(configuredChoice);
     }
 
     return firstDisplayedChoice;
@@ -194,8 +202,7 @@ export class ResultsPerPage extends Component {
     return this.options.choicesDisplayed.indexOf(choice) !== -1;
   }
 
-  private logInvalidConfiguredChoiceWarning() {
-    const configuredChoice = this.options.initialChoice;
+  private logInvalidConfiguredChoiceWarning(configuredChoice: number) {
     const validChoices = this.options.choicesDisplayed;
 
     this.logger.warn(

--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -1,24 +1,22 @@
+import 'styling/_ResultsPerPage';
+import * as _ from 'underscore';
+import { InitializationEvents } from '../../events/InitializationEvents';
+import { INoResultsEventArgs, IQuerySuccessEventArgs, QueryEvents } from '../../events/QueryEvents';
+import { ResultListEvents } from '../../events/ResultListEvents';
+import { exportGlobally } from '../../GlobalExports';
+import { Assert } from '../../misc/Assert';
+import { IAttributeChangedEventArg, MODEL_EVENTS } from '../../models/Model';
+import { QueryStateModel, QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
+import { l } from '../../strings/Strings';
+import { AccessibleButton } from '../../utils/AccessibleButton';
+import { DeviceUtils } from '../../utils/DeviceUtils';
+import { $$ } from '../../utils/Dom';
+import { ResultListUtils } from '../../utils/ResultListUtils';
+import { analyticsActionCauseList, IAnalyticsActionCause, IAnalyticsResultsPerPageMeta } from '../Analytics/AnalyticsActionListMeta';
 import { Component } from '../Base/Component';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { ComponentOptions } from '../Base/ComponentOptions';
 import { Initialization } from '../Base/Initialization';
-import { QueryEvents, IQuerySuccessEventArgs, INoResultsEventArgs } from '../../events/QueryEvents';
-import { analyticsActionCauseList, IAnalyticsResultsPerPageMeta, IAnalyticsActionCause } from '../Analytics/AnalyticsActionListMeta';
-import { Assert } from '../../misc/Assert';
-import { $$ } from '../../utils/Dom';
-import { DeviceUtils } from '../../utils/DeviceUtils';
-import * as _ from 'underscore';
-import { exportGlobally } from '../../GlobalExports';
-import { l } from '../../strings/Strings';
-import { AccessibleButton } from '../../utils/AccessibleButton';
-import { Defer } from '../../misc/Defer';
-
-import 'styling/_ResultsPerPage';
-import { MODEL_EVENTS, IAttributeChangedEventArg } from '../../models/Model';
-import { QUERY_STATE_ATTRIBUTES, QueryStateModel } from '../../models/QueryStateModel';
-import { ResultListEvents } from '../../events/ResultListEvents';
-import { ResultListUtils } from '../../utils/ResultListUtils';
-import { InitializationEvents } from '../../events/InitializationEvents';
 
 export interface IResultsPerPageOptions {
   choicesDisplayed?: number[];
@@ -160,7 +158,7 @@ export class ResultsPerPage extends Component {
 
     if (!this.isValidChoice(valueToSet)) {
       this.logInvalidConfiguredChoiceWarning(valueToSet);
-      Defer.defer(() => this.resolveInitialState());
+      this.resolveInitialState();
     } else {
       this.updateResultsPerPage(valueToSet);
     }

--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -129,6 +129,7 @@ export class ResultsPerPage extends Component {
   }
 
   private updateResultsPerPage(resultsPerPage: number) {
+    this.queryController.options.resultsPerPage = resultsPerPage;
     this.searchInterface.resultsPerPage = resultsPerPage;
     this.currentResultsPerPage = resultsPerPage;
   }
@@ -171,8 +172,7 @@ export class ResultsPerPage extends Component {
   }
 
   private resolveInitialState() {
-    this.currentResultsPerPage = this.getInitialChoice();
-    this.queryController.options.resultsPerPage = this.currentResultsPerPage;
+    this.updateResultsPerPage(this.getInitialChoice());
     this.updateQueryStateModelResultsPerPage();
   }
 

--- a/unitTests/Simulate.ts
+++ b/unitTests/Simulate.ts
@@ -28,6 +28,7 @@ import ModalBox = Coveo.ModalBox.ModalBox;
 import { NoopComponent } from '../src/ui/NoopComponent/NoopComponent';
 import { Component } from '../src/ui/Base/Component';
 import { QueryError } from '../src/rest/QueryError';
+import { InitializationEvents } from '../src/Core';
 
 export interface ISimulateQueryData {
   query?: IQuery;
@@ -189,6 +190,13 @@ export class Simulate {
     }
 
     return options;
+  }
+
+  static initialization(env: IMockEnvironment) {
+    $$(env.root).trigger(InitializationEvents.beforeInitialization);
+    $$(env.root).trigger(InitializationEvents.afterComponentsInitialization);
+    $$(env.root).trigger(InitializationEvents.restoreHistoryState);
+    $$(env.root).trigger(InitializationEvents.afterInitialization);
   }
 
   static modalBoxModule(): ModalBox {

--- a/unitTests/ui/ResultsPerPageTest.ts
+++ b/unitTests/ui/ResultsPerPageTest.ts
@@ -71,28 +71,25 @@ export function ResultsPerPageTest() {
 
         test = Mock.advancedComponentSetup<ResultsPerPage>(ResultsPerPage, advancedSetup);
         Simulate.initialization(test.env);
+        verifyStateForNumberOfResults(25);
       });
 
       it('should accept setting the value to the original default 10', () => {
-        verifyStateForNumberOfResults(25);
         setQueryStateModelValue(10);
         verifyStateForNumberOfResults(10);
       });
 
       it('should accept setting the value to the a different value than the original', () => {
-        verifyStateForNumberOfResults(25);
         setQueryStateModelValue(50);
         verifyStateForNumberOfResults(50);
       });
 
       it('should revert to the initial state when setting an invalid value', () => {
-        verifyStateForNumberOfResults(25);
         setQueryStateModelValue(123);
         verifyStateForNumberOfResults(25);
       });
 
       it('should revert to the initial state when setting a NaN', () => {
-        verifyStateForNumberOfResults(25);
         setQueryStateModelValue('foo');
         verifyStateForNumberOfResults(25);
       });

--- a/unitTests/ui/ResultsPerPageTest.ts
+++ b/unitTests/ui/ResultsPerPageTest.ts
@@ -107,6 +107,7 @@ export function ResultsPerPageTest() {
         test = Mock.optionsComponentSetup<ResultsPerPage, IResultsPerPageOptions>(ResultsPerPage, {
           choicesDisplayed: [15, 25, 35, 75]
         });
+        Simulate.initialization(test.env);
         Simulate.query(test.env, {
           results: FakeResults.createFakeResults(100)
         });
@@ -132,6 +133,7 @@ export function ResultsPerPageTest() {
           initialChoice: 13,
           choicesDisplayed: [3, 5, 7, 13]
         });
+        Simulate.initialization(test.env);
         Simulate.query(test.env, {
           results: FakeResults.createFakeResults(100)
         });
@@ -144,6 +146,7 @@ export function ResultsPerPageTest() {
           initialChoice: undefined,
           choicesDisplayed: [firstChoice, 5, 7, 13]
         });
+        Simulate.initialization(test.env);
         Simulate.query(test.env, {
           results: FakeResults.createFakeResults(100)
         });
@@ -157,6 +160,7 @@ export function ResultsPerPageTest() {
           initialChoice: aChoiceNotDisplayed,
           choicesDisplayed: [firstChoice, 5, 7, 13]
         });
+        Simulate.initialization(test.env);
         Simulate.query(test.env, {
           results: FakeResults.createFakeResults(100)
         });

--- a/unitTests/ui/ResultsPerPageTest.ts
+++ b/unitTests/ui/ResultsPerPageTest.ts
@@ -6,6 +6,7 @@ import { Simulate } from '../Simulate';
 import { FakeResults } from '../Fake';
 import { $$ } from '../../src/utils/Dom';
 import { QueryStateModel } from '../../src/Core';
+import { QUERY_STATE_ATTRIBUTES } from '../../src/models/QueryStateModel';
 
 export function ResultsPerPageTest() {
   describe('ResultsPerPage', () => {
@@ -45,6 +46,55 @@ export function ResultsPerPageTest() {
           { currentResultsPerPage: numOfResults },
           test.cmp.element
         );
+      });
+    });
+
+    describe('when modifying the query state model', () => {
+      const setQueryStateModelValue = (value: any) => {
+        test.env.queryStateModel.set(QUERY_STATE_ATTRIBUTES.NUMBER_OF_RESULTS, value);
+      };
+
+      const verifyStateForNumberOfResults = (value: any) => {
+        expect(test.cmp.resultsPerPage).toBe(value);
+        expect(test.env.queryStateModel.get(QUERY_STATE_ATTRIBUTES.NUMBER_OF_RESULTS)).toBe(value);
+      };
+
+      beforeEach(() => {
+        const advancedOptions = <IResultsPerPageOptions>{
+          choicesDisplayed: [10, 25, 50, 100],
+          initialChoice: 25
+        };
+
+        const advancedSetup = new Mock.AdvancedComponentSetupOptions(null, advancedOptions, builder => {
+          return builder.withLiveQueryStateModel();
+        });
+
+        test = Mock.advancedComponentSetup<ResultsPerPage>(ResultsPerPage, advancedSetup);
+        Simulate.initialization(test.env);
+      });
+
+      it('should accept setting the value to the original default 10', () => {
+        verifyStateForNumberOfResults(25);
+        setQueryStateModelValue(10);
+        verifyStateForNumberOfResults(10);
+      });
+
+      it('should accept setting the value to the a different value than the original', () => {
+        verifyStateForNumberOfResults(25);
+        setQueryStateModelValue(50);
+        verifyStateForNumberOfResults(50);
+      });
+
+      it('should revert to the initial state when setting an invalid value', () => {
+        verifyStateForNumberOfResults(25);
+        setQueryStateModelValue(123);
+        verifyStateForNumberOfResults(25);
+      });
+
+      it('should revert to the initial state when setting a NaN', () => {
+        verifyStateForNumberOfResults(25);
+        setQueryStateModelValue('foo');
+        verifyStateForNumberOfResults(25);
       });
     });
 


### PR DESCRIPTION
Initial choice would override the user selection in some case, because the initial state was not properly setup on load (after afterInitialization).

https://coveord.atlassian.net/browse/JSUI-2421


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)