### PR TITLE
JSUI-2436 Transforming documented date format to momentjs format

### DIFF
--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -253,8 +253,33 @@ export class DateUtils {
   }
 
   private static getMomentJsFormat(format: string) {
-    // yyyy was used to format dates before implementing moment.js, which only recognizes YYYY.
-    return format.replace(/yyyy/g, 'YYYY');
+    let correctedFormat = format;
+
+    const fourLowercaseY = DateUtils.buildRegexMatchingExactCharSequence('y', 4);
+    correctedFormat = correctedFormat.replace(fourLowercaseY, 'YYYY');
+
+    const twoLowercaseY = DateUtils.buildRegexMatchingExactCharSequence('y', 2);
+    correctedFormat = correctedFormat.replace(twoLowercaseY, 'YY');
+
+    const twoLowercaseD = DateUtils.buildRegexMatchingExactCharSequence('d', 2);
+    correctedFormat = correctedFormat.replace(twoLowercaseD, 'DD');
+
+    const oneLowercaseD = DateUtils.buildRegexMatchingExactCharSequence('d', 1);
+    correctedFormat = correctedFormat.replace(oneLowercaseD, 'D');
+
+    const twoLowercaseH = DateUtils.buildRegexMatchingExactCharSequence('h', 2);
+    correctedFormat = correctedFormat.replace(twoLowercaseH, 'H');
+
+    return correctedFormat;
+  }
+
+  private static buildRegexMatchingExactCharSequence(char: string, sequenceLength: number) {
+    const negativeLookBehind = `(?<!${char})`;
+    const charSequence = `${char}{${sequenceLength}}`;
+    const negativeLookAhead = `(?!${char})`;
+    const exactSequence = `${negativeLookBehind}${charSequence}${negativeLookAhead}`;
+
+    return new RegExp(exactSequence, 'g');
   }
 
   /**

--- a/unitTests/ui/DateUtilsTest.ts
+++ b/unitTests/ui/DateUtilsTest.ts
@@ -10,6 +10,10 @@ export function DateUtilsTest() {
       return /am/i.test(result) || /pm/i.test(result);
     };
 
+    function testDate() {
+      return DateUtils.convertToStandardDate('1980-02-11');
+    }
+
     beforeEach(() => {
       options = {
         now: moment('1980-02-11').toDate(),
@@ -21,31 +25,31 @@ export function DateUtilsTest() {
     it('should use the correct locale if the locale is `no`', () => {
       String['locale'] = 'no';
       DateUtils.setLocale();
-      expect(DateUtils.dateToString(DateUtils.convertToStandardDate('1980-02-11'), options)).toEqual(l('Today'));
+      expect(DateUtils.dateToString(testDate(), options)).toEqual(l('Today'));
     });
 
     it('should use the correct locale if the locale is `id`', () => {
       String['locale'] = 'id';
       DateUtils.setLocale();
-      expect(DateUtils.dateToString(DateUtils.convertToStandardDate('1980-02-11'), options)).toEqual(l('Today'));
+      expect(DateUtils.dateToString(testDate(), options)).toEqual(l('Today'));
     });
 
     it('should use the correct locale if the locale is `es-ES`', () => {
       String['locale'] = 'es-ES';
       DateUtils.setLocale();
-      expect(DateUtils.dateToString(DateUtils.convertToStandardDate('1980-02-11'), options)).toEqual(l('Today'));
+      expect(DateUtils.dateToString(testDate(), options)).toEqual(l('Today'));
     });
 
     it('should use the correct locale if the locale is `zh-cn`', () => {
       String['locale'] = 'zh-tw';
       DateUtils.setLocale();
-      expect(DateUtils.dateToString(DateUtils.convertToStandardDate('1980-02-11'), options)).toEqual(l('Today'));
+      expect(DateUtils.dateToString(testDate(), options)).toEqual(l('Today'));
     });
 
     it('should default to `en` if the locale is invalid', () => {
       String['locale'] = 'foobar';
       DateUtils.setLocale();
-      expect(DateUtils.dateToString(DateUtils.convertToStandardDate('1980-02-11'), options)).toEqual(l('Today'));
+      expect(DateUtils.dateToString(testDate(), options)).toEqual(l('Today'));
     });
 
     it('should return an empty string if the date entry is null or undefined', () => {
@@ -64,7 +68,7 @@ export function DateUtilsTest() {
 
     it('should display the correct predefinedFormat if the YYYY is lowercase', () => {
       options.predefinedFormat = 'MM/DD/yyyy';
-      expect(DateUtils.dateToString(DateUtils.convertToStandardDate('1980-02-11'), options)).toEqual(l('02/11/1980'));
+      expect(DateUtils.dateToString(testDate(), options)).toEqual(l('02/11/1980'));
     });
 
     it('should return `Invalid Date` if the date input is incorrect', () => {
@@ -120,16 +124,114 @@ export function DateUtilsTest() {
       expect(result).toContain(':00');
     });
 
-    it('dateTimeToString should work with the predefinedFormat yyyy (lowercase)', () => {
-      const now = moment(new Date()).toDate();
-      const result = DateUtils.dateTimeToString(now, { predefinedFormat: 'yyyy' });
-      expect(result).toBe(moment(now).format('YYYY'));
+    it(`when the #predefinedFormat is 'yy', it displays the last two digits of the year`, () => {
+      options.predefinedFormat = 'yy';
+      expect(DateUtils.dateTimeToString(testDate(), options)).toBe('80');
+    });
+
+    it(`when the #predefinedFormat is 'yyy', it does not recognize the sequence`, () => {
+      options.predefinedFormat = 'yyy';
+      expect(DateUtils.dateTimeToString(testDate(), options)).toBe('yyy');
+    });
+
+    it(`when the #predefinedFormat is 'yyyy', it displays the four digits of the year`, () => {
+      options.predefinedFormat = 'yyyy';
+      expect(DateUtils.dateTimeToString(testDate(), options)).toBe('1980');
+    });
+
+    it(`when the #predefinedFormat is 'yy yy', it displays the last two digits of the year twice`, () => {
+      options.predefinedFormat = 'yy yy';
+      expect(DateUtils.dateTimeToString(testDate(), options)).toBe('80 80');
     });
 
     it('dateTimeToString should work with the predefinedFormat YYYY (uppercase)', () => {
       const now = moment(new Date()).toDate();
       const result = DateUtils.dateTimeToString(now, { predefinedFormat: 'YYYY' });
       expect(result).toBe(moment(now).format('YYYY'));
+    });
+
+    it(`when the #predefined format is 'MMMN', it displays the full month name`, () => {
+      const date = DateUtils.convertToStandardDate('2019-01-09');
+      options.predefinedFormat = 'MMMM';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('January');
+    });
+
+    it(`when the #predefined format is 'MMM', it displays a shortened month name`, () => {
+      const date = DateUtils.convertToStandardDate('2019-01-09');
+      options.predefinedFormat = 'MMM';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('Jan');
+    });
+
+    it(`when the #predefined format is 'MM', it displays a double-digit month number`, () => {
+      const date = DateUtils.convertToStandardDate('2019-01-09');
+      options.predefinedFormat = 'MM';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('01');
+    });
+
+    it(`when the #predefined format is 'M', it displays a single-digit month number`, () => {
+      const date = DateUtils.convertToStandardDate('2019-01-09');
+      options.predefinedFormat = 'M';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('1');
+    });
+
+    it(`when the #predefined format is 'dddd', it displays the full day name`, () => {
+      const date = DateUtils.convertToStandardDate('2019-01-09');
+      options.predefinedFormat = 'dddd';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('Wednesday');
+    });
+
+    it(`when the #predefined format is 'ddd', it displays the shortened day name`, () => {
+      const date = DateUtils.convertToStandardDate('2019-01-09');
+      options.predefinedFormat = 'ddd';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('Wed');
+    });
+
+    it(`when the #predefined format is 'dd', it displays a double digit day of month number`, () => {
+      const date = DateUtils.convertToStandardDate('2019-01-09');
+      options.predefinedFormat = 'dd';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('09');
+    });
+
+    it(`when the #predefined format is 'd', it displays a single digit day of month number`, () => {
+      const dateNotInFirstWeek = DateUtils.convertToStandardDate('2019-01-09');
+      options.predefinedFormat = 'd';
+
+      expect(DateUtils.dateTimeToString(dateNotInFirstWeek, options)).toBe('9');
+    });
+
+    it(`when the #predefined format is 'hh', it displays the hour using 24-hour format`, () => {
+      const date = moment('2019-01-01 14:00').toDate();
+      options.predefinedFormat = 'hh';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('14');
+    });
+
+    it(`when the #predefined format is 'h', it displays the hour using a single-digit 12-hour format`, () => {
+      const date = moment('2019-01-01 14:00').toDate();
+      options.predefinedFormat = 'h';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('2');
+    });
+
+    it(`when the #predefined format is 'mm', it displays the minutes`, () => {
+      const date = moment('2019-01-01 14:35').toDate();
+      options.predefinedFormat = 'mm';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('35');
+    });
+
+    it(`when the #predefined format is 'ss', it displays the seconds`, () => {
+      const date = moment('2019-01-01 14:35:26').toDate();
+      options.predefinedFormat = 'ss';
+
+      expect(DateUtils.dateTimeToString(date, options)).toBe('26');
     });
 
     it('dateTimeToString should properly return an empty string when the date is null', () => {

--- a/unitTests/ui/DateUtilsTest.ts
+++ b/unitTests/ui/DateUtilsTest.ts
@@ -185,28 +185,28 @@ export function DateUtilsTest() {
       expect(DateUtils.dateTimeToString(date, options)).toBe('Wednesday');
     });
 
-    it(`when the #predefined format is 'ddd', it displays the shortened day name`, () => {
+    it(`when the #predefined format is 'ddd', it displays a shortened day name`, () => {
       const date = DateUtils.convertToStandardDate('2019-01-09');
       options.predefinedFormat = 'ddd';
 
       expect(DateUtils.dateTimeToString(date, options)).toBe('Wed');
     });
 
-    it(`when the #predefined format is 'dd', it displays a double digit day of month number`, () => {
+    it(`when the #predefined format is 'dd', it displays a double digit number for the day of month`, () => {
       const date = DateUtils.convertToStandardDate('2019-01-09');
       options.predefinedFormat = 'dd';
 
       expect(DateUtils.dateTimeToString(date, options)).toBe('09');
     });
 
-    it(`when the #predefined format is 'd', it displays a single digit day of month number`, () => {
+    it(`when the #predefined format is 'd', it displays a single digit number for the day of month`, () => {
       const dateNotInFirstWeek = DateUtils.convertToStandardDate('2019-01-09');
       options.predefinedFormat = 'd';
 
       expect(DateUtils.dateTimeToString(dateNotInFirstWeek, options)).toBe('9');
     });
 
-    it(`when the #predefined format is 'hh', it displays the hour using 24-hour format`, () => {
+    it(`when the #predefined format is 'hh', it displays the hour using a 24-hour format`, () => {
       const date = moment('2019-01-01 14:00').toDate();
       options.predefinedFormat = 'hh';
 


### PR DESCRIPTION
Our documentation for formatting dates was not in sync with the syntax of our formatting library (momentjs). This PR transforms user-specified formats to align with momentjs syntax and give the outputs detailed in our documentation.

https://coveord.atlassian.net/browse/JSUI-2436





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)