### PR TITLE
JSUI-2437 Supporting fields with array values (e.g. multi-value fields) in template conditions using data-field-

### DIFF
--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -208,7 +208,7 @@ export interface IAnalyticsSearchAlertsUpdateMeta extends IAnalyticsSearchAlerts
 
 export interface IAnalyticsSearchAlertsFollowDocumentMeta extends IAnalyticsDocumentViewMeta {
   documentSource: string;
-  documentLanguage: string;
+  documentLanguage: string[];
   contentIDKey: string;
   contentIDValue: string;
 }

--- a/src/ui/Templates/TemplateFieldsEvaluator.ts
+++ b/src/ui/Templates/TemplateFieldsEvaluator.ts
@@ -1,6 +1,6 @@
 import { IQueryResult } from '../../rest/QueryResult';
 import { IFieldsToMatch } from './Template';
-import { each, isArray } from 'underscore';
+import { each } from 'underscore';
 
 export class TemplateFieldsEvaluator {
   public static evaluateFieldsToMatch(toMatches: IFieldsToMatch[], result: IQueryResult): boolean {
@@ -24,15 +24,7 @@ export class TemplateFieldsEvaluator {
   }
 
   private static getFieldValueAsArray(fieldValue: string | string[]): string[] {
-    if (typeof fieldValue === 'string') {
-      return [fieldValue];
-    }
-
-    if (isArray(fieldValue)) {
-      return fieldValue;
-    }
-
-    return [];
+    return typeof fieldValue === 'string' ? [fieldValue] : fieldValue;
   }
 
   private static isMatch(fieldValues: string[], value: string) {

--- a/src/ui/Templates/TemplateFieldsEvaluator.ts
+++ b/src/ui/Templates/TemplateFieldsEvaluator.ts
@@ -1,23 +1,41 @@
 import { IQueryResult } from '../../rest/QueryResult';
 import { IFieldsToMatch } from './Template';
-import * as _ from 'underscore';
+import { each, isArray } from 'underscore';
 
 export class TemplateFieldsEvaluator {
   public static evaluateFieldsToMatch(toMatches: IFieldsToMatch[], result: IQueryResult): boolean {
     let templateShouldBeLoaded = true;
-    _.each(toMatches, (toMatch: IFieldsToMatch) => {
+    each(toMatches, (toMatch: IFieldsToMatch) => {
       let matchAtLeastOnce = false;
       if (!toMatch.values) {
         matchAtLeastOnce = result.raw[toMatch.field] != null;
       } else {
-        _.each(toMatch.values, value => {
+        each(toMatch.values, value => {
           if (!matchAtLeastOnce) {
-            matchAtLeastOnce = result.raw[toMatch.field] && result.raw[toMatch.field].toLowerCase() == value.toLowerCase();
+            const fieldValue: string | string[] = result.raw[toMatch.field];
+            const fieldValues = TemplateFieldsEvaluator.getFieldValueAsArray(fieldValue);
+            matchAtLeastOnce = TemplateFieldsEvaluator.isMatch(fieldValues, value);
           }
         });
       }
       templateShouldBeLoaded = templateShouldBeLoaded && matchAtLeastOnce;
     });
     return templateShouldBeLoaded;
+  }
+
+  private static getFieldValueAsArray(fieldValue: string | string[]): string[] {
+    if (typeof fieldValue === 'string') {
+      return [fieldValue];
+    }
+
+    if (isArray(fieldValue)) {
+      return fieldValue;
+    }
+
+    return [];
+  }
+
+  private static isMatch(fieldValues: string[], value: string) {
+    return fieldValues.map(fieldValue => fieldValue.toLowerCase()).indexOf(value.toLowerCase()) !== -1;
   }
 }

--- a/src/utils/QueryUtils.ts
+++ b/src/utils/QueryUtils.ts
@@ -122,7 +122,7 @@ export class QueryUtils {
     return result.raw['source'];
   }
 
-  static getLanguage(result: IQueryResult): string {
+  static getLanguage(result: IQueryResult): string[] {
     return result.raw['language'];
   }
 

--- a/unitTests/ui/TemplateFieldsEvaluatorTest.ts
+++ b/unitTests/ui/TemplateFieldsEvaluatorTest.ts
@@ -86,6 +86,16 @@ export function TemplateFieldsEvaluatorTest() {
         fieldsToMatch = [{ field: multiValueField, values: ['english'] }];
         expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(false);
       });
+
+      it(`when the result multi-value field has more than one value,
+      when the fieldsToMatch #field is the multi-value field
+      and the #values is a populated array containing the last result field value,
+      it returns 'true'`, () => {
+        result.raw[multiValueField] = ['francais', 'espanol', 'english'];
+        fieldsToMatch = [{ field: multiValueField, values: ['english'] }];
+
+        expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
+      });
     });
   });
 }

--- a/unitTests/ui/TemplateFieldsEvaluatorTest.ts
+++ b/unitTests/ui/TemplateFieldsEvaluatorTest.ts
@@ -54,5 +54,60 @@ export function TemplateFieldsEvaluatorTest() {
       ];
       expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(false);
     });
+
+    describe(`when the result raw has a field that has an array of values (e.g. a multi-value field)`, () => {
+      const multiValueField = 'language';
+      const multiValueFieldValues = ['francais'];
+
+      beforeEach(() => {
+        result.raw[multiValueField] = multiValueFieldValues;
+      });
+
+      it(`when the fieldsToMatch #field is the multi-value field, it returns true`, () => {
+        fieldsToMatch = [{ field: multiValueField }];
+        expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
+      });
+
+      it(`when the fieldsToMatch #field is the multi-value field
+      and the #values is an empty array, it returns false`, () => {
+        fieldsToMatch = [{ field: multiValueField, values: [] }];
+        expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(false);
+      });
+
+      it(`when the fieldsToMatch #field is the multi-value field
+      and the #values is an array containing the multi-value field value,
+      it returns true`, () => {
+        fieldsToMatch = [{ field: multiValueField, values: [...multiValueFieldValues] }];
+        expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
+      });
+
+      it(`when the fieldsToMatch #field is the multi-value field
+      and the #values is a populated array not containing the multi-value field value,
+      it returns false`, () => {
+        fieldsToMatch = [{ field: multiValueField, values: ['english'] }];
+        expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(false);
+      });
+
+      it(`when the fieldsToMatch #field is the multi-value field
+      and the #values is an array containing the multi-value field value as uppercase,
+      it returns true`, () => {
+        const uppercaseValues = multiValueFieldValues.map(val => val.toUpperCase());
+        fieldsToMatch = [{ field: multiValueField, values: uppercaseValues }];
+        expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
+      });
+
+      it(`given the result raw multi-value field has uppercase values,
+      when the fieldsToMatch #field is the multi-value field
+      and the #values is an array containing the multi-value field value as lowercase,
+      it returns true`, () => {
+        const uppercaseValues = multiValueFieldValues.map(val => val.toUpperCase());
+        const lowercaseValues = multiValueFieldValues.map(val => val.toLowerCase());
+
+        result.raw[multiValueField] = uppercaseValues;
+        fieldsToMatch = [{ field: multiValueField, values: lowercaseValues }];
+
+        expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
+      });
+    });
   });
 }

--- a/unitTests/ui/TemplateFieldsEvaluatorTest.ts
+++ b/unitTests/ui/TemplateFieldsEvaluatorTest.ts
@@ -6,10 +6,12 @@ export function TemplateFieldsEvaluatorTest() {
   describe('TemplateFieldsEvaluatorTest', () => {
     let result: IQueryResult;
     let fieldsToMatch: IFieldsToMatch[];
+    const field = 'foo';
+    const fieldValue = 'bar';
 
     beforeEach(() => {
       result = FakeResults.createFakeResult();
-      result.raw['foo'] = 'bar';
+      result.raw[field] = fieldValue;
     });
 
     afterEach(() => {
@@ -18,41 +20,38 @@ export function TemplateFieldsEvaluatorTest() {
     });
 
     it('should be able to evaluate fields to match', () => {
-      fieldsToMatch = [
-        {
-          field: 'foo',
-          values: ['bar', 'baz']
-        }
-      ];
+      fieldsToMatch = [{ field, values: [fieldValue, 'baz'] }];
       expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
     });
 
     it('should be able to evaluate fields that do not match', () => {
-      fieldsToMatch = [
-        {
-          field: 'foo',
-          values: ['brak']
-        }
-      ];
+      fieldsToMatch = [{ field: 'foo', values: ['brak'] }];
       expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(false);
     });
 
     it('should be able to evaluate fields that are not null', () => {
-      fieldsToMatch = [
-        {
-          field: 'foo'
-        }
-      ];
+      fieldsToMatch = [{ field }];
       expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
     });
 
     it('should be able to evaluate fields that are null', () => {
-      fieldsToMatch = [
-        {
-          field: 'bar'
-        }
-      ];
+      fieldsToMatch = [{ field: 'bar' }];
       expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(false);
+    });
+
+    it(`when the fieldsToMatch #values is an array containing the field value as uppercase,
+    it returns true`, () => {
+      fieldsToMatch = [{ field, values: [fieldValue.toUpperCase()] }];
+      expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
+    });
+
+    it(`given the result raw field has an uppercase value,
+    when the fieldsToMatch #values is an array containing the field value as lowercase,
+    it returns true`, () => {
+      result.raw[field] = fieldValue.toUpperCase();
+      fieldsToMatch = [{ field, values: [fieldValue.toLowerCase()] }];
+
+      expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
     });
 
     describe(`when the result raw has a field that has an array of values (e.g. a multi-value field)`, () => {
@@ -86,27 +85,6 @@ export function TemplateFieldsEvaluatorTest() {
       it returns false`, () => {
         fieldsToMatch = [{ field: multiValueField, values: ['english'] }];
         expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(false);
-      });
-
-      it(`when the fieldsToMatch #field is the multi-value field
-      and the #values is an array containing the multi-value field value as uppercase,
-      it returns true`, () => {
-        const uppercaseValues = multiValueFieldValues.map(val => val.toUpperCase());
-        fieldsToMatch = [{ field: multiValueField, values: uppercaseValues }];
-        expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
-      });
-
-      it(`given the result raw multi-value field has uppercase values,
-      when the fieldsToMatch #field is the multi-value field
-      and the #values is an array containing the multi-value field value as lowercase,
-      it returns true`, () => {
-        const uppercaseValues = multiValueFieldValues.map(val => val.toUpperCase());
-        const lowercaseValues = multiValueFieldValues.map(val => val.toLowerCase());
-
-        result.raw[multiValueField] = uppercaseValues;
-        fieldsToMatch = [{ field: multiValueField, values: lowercaseValues }];
-
-        expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
       });
     });
   });


### PR DESCRIPTION
Normally, the field values we receive are strings. However, when specifying a multi-value field, the value is a string array. The logic uses a `.toLowercase()` call which fails on an array, causing the condition to fail.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)