### PR TITLE
JSUI-2456 Add the search interface root for popper elements

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent.ts
@@ -50,7 +50,12 @@ export class ResponsiveDropdownContent implements IResponsiveDropdownContent {
 
     this.popperReference = new PopperJs(referenceElement, this.element.el, {
       placement: 'bottom-end',
-      positionFixed: true
+      positionFixed: true,
+      modifiers: {
+        preventOverflow: {
+          boundariesElement: this.coveoRoot.el
+        }
+      }
     });
   }
 

--- a/src/ui/Settings/Settings.ts
+++ b/src/ui/Settings/Settings.ts
@@ -93,7 +93,7 @@ export class Settings extends Component {
           offset: '0, 5'
         },
         preventOverflow: {
-          boundariesElement: $$(this.root).el
+          boundariesElement: this.root
         }
       }
     });

--- a/src/ui/Settings/Settings.ts
+++ b/src/ui/Settings/Settings.ts
@@ -91,6 +91,9 @@ export class Settings extends Component {
       modifiers: {
         offset: {
           offset: '0, 5'
+        },
+        preventOverflow: {
+          boundariesElement: $$(this.root).el
         }
       }
     });


### PR DESCRIPTION
For this, we agreed that the facets should take all the space when it's available. The problem is that popper when at the root of the window, outside the Coveo Search Interface. Adding a boundariesElement fixes that. See JIRA for example

https://coveord.atlassian.net/browse/JSUI-2456





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)