### PR TITLE
Result with no field value should not throw an error when being evaluated against a template

### DIFF
--- a/src/ui/Templates/TemplateFieldsEvaluator.ts
+++ b/src/ui/Templates/TemplateFieldsEvaluator.ts
@@ -1,6 +1,6 @@
 import { IQueryResult } from '../../rest/QueryResult';
 import { IFieldsToMatch } from './Template';
-import { each } from 'underscore';
+import { each, find } from 'underscore';
 
 export class TemplateFieldsEvaluator {
   public static evaluateFieldsToMatch(toMatches: IFieldsToMatch[], result: IQueryResult): boolean {
@@ -28,6 +28,6 @@ export class TemplateFieldsEvaluator {
   }
 
   private static isMatch(fieldValues: string[], value: string) {
-    return fieldValues.map(fieldValue => fieldValue.toLowerCase()).indexOf(value.toLowerCase()) !== -1;
+    return find(fieldValues, fieldValue => fieldValue.toLowerCase() == value.toLowerCase()) != undefined;
   }
 }

--- a/unitTests/ui/TemplateFieldsEvaluatorTest.ts
+++ b/unitTests/ui/TemplateFieldsEvaluatorTest.ts
@@ -24,6 +24,11 @@ export function TemplateFieldsEvaluatorTest() {
       expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(true);
     });
 
+    it('should not throw an error for a result with no value for a given field', () => {
+      fieldsToMatch = [{ field: 'doesNotExists', values: ['does not matter'] }];
+      expect(() => TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).not.toThrow();
+    });
+
     it('should be able to evaluate fields that do not match', () => {
       fieldsToMatch = [{ field: 'foo', values: ['brak'] }];
       expect(TemplateFieldsEvaluator.evaluateFieldsToMatch(fieldsToMatch, result)).toBe(false);


### PR DESCRIPTION
Native map function throws an error on an undefined value, whereas underscore has built-in protection against that.

https://coveord.atlassian.net/browse/JSUI-2459





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)