### PR TITLE
Use beacon to send click event

### DIFF
--- a/src/rest/AnalyticsEndpoint.ts
+++ b/src/rest/AnalyticsEndpoint.ts
@@ -3,7 +3,8 @@ import { Assert } from '../misc/Assert';
 import { Logger } from '../misc/Logger';
 import { IAPIAnalyticsSearchEventsResponse } from '../rest/APIAnalyticsSearchEventsResponse';
 import { IClickEvent } from '../rest/ClickEvent';
-import { EndpointCaller, IEndpointCallerOptions, IErrorResponse, ISuccessResponse } from '../rest/EndpointCaller';
+import { IEndpointCallerOptions, IErrorResponse, ISuccessResponse } from '../rest/EndpointCaller';
+import { AnalyticsEndpointCaller } from '../rest/AnalyticsEndpointCaller';
 import { IStringMap } from '../rest/GenericParam';
 import { ISearchEvent } from '../rest/SearchEvent';
 import { Cookie } from '../utils/CookieUtils';
@@ -33,7 +34,7 @@ export class AnalyticsEndpoint {
 
   private visitId: string;
   private organization: string;
-  public endpointCaller: EndpointCaller;
+  public endpointCaller: AnalyticsEndpointCaller;
 
   constructor(public options: IAnalyticsEndpointOptions) {
     this.logger = new Logger(this);
@@ -42,7 +43,7 @@ export class AnalyticsEndpoint {
       accessToken: this.options.accessToken.token
     };
 
-    this.endpointCaller = new EndpointCaller(endpointCallerOptions);
+    this.endpointCaller = new AnalyticsEndpointCaller(endpointCallerOptions);
     this.organization = options.organization;
   }
 

--- a/src/rest/AnalyticsEndpoint.ts
+++ b/src/rest/AnalyticsEndpoint.ts
@@ -8,7 +8,7 @@ import { AnalyticsEndpointCaller } from '../rest/AnalyticsEndpointCaller';
 import { IStringMap } from '../rest/GenericParam';
 import { ISearchEvent } from '../rest/SearchEvent';
 import { Cookie } from '../utils/CookieUtils';
-import { UrlUtils } from '../utils/UrlUtils';
+import { UrlUtils, IUrlNormalizedParts } from '../utils/UrlUtils';
 import { Utils } from '../utils/Utils';
 import { AccessToken } from './AccessToken';
 import { IAPIAnalyticsEventResponse } from './APIAnalyticsEventResponse';
@@ -72,7 +72,7 @@ export class AnalyticsEndpoint {
   public sendSearchEvents(searchEvents: ISearchEvent[]): Promise<IAPIAnalyticsSearchEventsResponse> {
     if (searchEvents.length > 0) {
       this.logger.info('Logging analytics search events', searchEvents);
-      return this.sendToService<ISearchEvent[], IAPIAnalyticsSearchEventsResponse>(searchEvents, 'searches', 'searchEvents');
+      return this.sendToService(searchEvents, 'searches', 'searchEvents');
     }
   }
 
@@ -93,34 +93,15 @@ export class AnalyticsEndpoint {
     return this.getFromService<string[]>(url, params);
   }
 
-  private async sendToService<D, R>(data: D, path: string, paramName: string): Promise<R> {
-    const versionToCall = AnalyticsEndpoint.CUSTOM_ANALYTICS_VERSION || AnalyticsEndpoint.DEFAULT_ANALYTICS_VERSION;
-    const urlNormalized = UrlUtils.normalizeAsParts({
-      paths: [this.options.serviceUrl, '/rest/', versionToCall, '/analytics/', path],
-      query: {
-        org: this.organization,
-        visitor: Cookie.get('visitorId')
-      }
-    });
+  private async sendToService(data: Record<string, any>, path: string, paramName: string): Promise<any> {
     // We use pendingRequest because we don't want to have 2 request to analytics at the same time.
     // Otherwise the cookie visitId won't be set correctly.
     if (AnalyticsEndpoint.pendingRequest != null) {
-      try {
-        await AnalyticsEndpoint.pendingRequest;
-      } finally {
-        return this.sendToService<D, R>(data, path, paramName);
-      }
+      await AnalyticsEndpoint.pendingRequest;
     }
 
-    const request: Promise<any> = (AnalyticsEndpoint.pendingRequest = this.endpointCaller.call<R>({
-      errorsAsSuccess: false,
-      method: 'POST',
-      queryString: urlNormalized.queryNormalized,
-      requestData: data,
-      url: urlNormalized.path,
-      responseType: 'text',
-      requestDataType: 'application/json'
-    }));
+    const url = this.getURL(path);
+    const request = this.executeRequest(url, data);
 
     try {
       const results = await request;
@@ -132,12 +113,54 @@ export class AnalyticsEndpoint {
       if (this.options.accessToken.isExpired(error)) {
         const successfullyRenewed = await this.options.accessToken.doRenew();
         if (successfullyRenewed) {
-          return this.sendToService<D, R>(data, path, paramName);
+          return this.sendToService(data, path, paramName);
         }
       }
 
       throw error;
     }
+  }
+
+  private executeRequest(
+    urlNormalized: IUrlNormalizedParts,
+    data: Record<string, any>
+  ): Promise<ISuccessResponse<IAPIAnalyticsEventResponse>> {
+    const request = this.endpointCaller.call<IAPIAnalyticsEventResponse>({
+      errorsAsSuccess: false,
+      method: 'POST',
+      queryString: urlNormalized.queryNormalized,
+      requestData: data,
+      url: urlNormalized.path,
+      responseType: 'text',
+      requestDataType: 'application/json'
+    });
+
+    if (request) {
+      AnalyticsEndpoint.pendingRequest = request;
+      return request;
+    }
+
+    // In some case, (eg: using navigator.sendBeacon), there won't be any response to read from the service
+    // In those case, send back an empty object upstream.
+    return Promise.resolve({
+      data: {
+        visitId: '',
+        visitorId: ''
+      },
+      duration: 0
+    });
+  }
+
+  private getURL(path: string): IUrlNormalizedParts {
+    const versionToCall = AnalyticsEndpoint.CUSTOM_ANALYTICS_VERSION || AnalyticsEndpoint.DEFAULT_ANALYTICS_VERSION;
+    const urlNormalized = UrlUtils.normalizeAsParts({
+      paths: [this.options.serviceUrl, '/rest/', versionToCall, '/analytics/', path],
+      query: {
+        org: this.organization,
+        visitor: Cookie.get('visitorId')
+      }
+    });
+    return urlNormalized;
   }
 
   private getFromService<T>(url: string, params: IStringMap<string>): Promise<T> {

--- a/src/rest/AnalyticsEndpointCaller.ts
+++ b/src/rest/AnalyticsEndpointCaller.ts
@@ -8,7 +8,7 @@ export class AnalyticsEndpointCaller implements IEndpointCaller {
     this.passthrough = new EndpointCaller(options);
   }
 
-  public call<T>(params: IEndpointCallParameters): Promise<ISuccessResponse<T>> | null {
+  public call<T>(params: IEndpointCallParameters): Promise<ISuccessResponse<T>> {
     if (this.shouldSendAsBeacon(params)) {
       this.sendBeacon(params);
       return;

--- a/src/rest/AnalyticsEndpointCaller.ts
+++ b/src/rest/AnalyticsEndpointCaller.ts
@@ -8,7 +8,7 @@ export class AnalyticsEndpointCaller implements IEndpointCaller {
     this.passthrough = new EndpointCaller(options);
   }
 
-  public call<T>(params: IEndpointCallParameters): Promise<ISuccessResponse<T>> {
+  public call<T>(params: IEndpointCallParameters): Promise<ISuccessResponse<T>> | null {
     if (this.shouldSendAsBeacon(params)) {
       this.sendBeacon(params);
       return;
@@ -24,10 +24,9 @@ export class AnalyticsEndpointCaller implements IEndpointCaller {
   private sendBeacon(params: IEndpointCallParameters) {
     const url = UrlUtils.normalizeAsString({
       paths: params.url,
-      queryAsString: params.queryString
+      queryAsString: params.queryString.concat(`access_token=${this.options.accessToken}`)
     });
-    const data = EndpointCaller.convertJsonToFormBody(params.requestData);
-
+    const data = EndpointCaller.convertJsonToFormBody({ clickEvent: params.requestData });
     navigator.sendBeacon(url, new Blob([data], { type: 'application/x-www-form-urlencoded' }));
   }
 

--- a/src/rest/AnalyticsEndpointCaller.ts
+++ b/src/rest/AnalyticsEndpointCaller.ts
@@ -1,0 +1,37 @@
+import { IEndpointCaller, IEndpointCallerOptions, ISuccessResponse, IEndpointCallParameters, EndpointCaller } from './EndpointCaller';
+import { UrlUtils } from '../utils/UrlUtils';
+
+export class AnalyticsEndpointCaller implements IEndpointCaller {
+  private passthrough: EndpointCaller;
+
+  constructor(public options: IEndpointCallerOptions = {}) {
+    this.passthrough = new EndpointCaller(options);
+  }
+
+  public call<T>(params: IEndpointCallParameters): Promise<ISuccessResponse<T>> {
+    if (this.shouldSendAsBeacon(params)) {
+      this.sendBeacon(params);
+      return;
+    }
+
+    return this.passthrough.call(params);
+  }
+
+  private get beaconApiIsUsable() {
+    return typeof navigator.sendBeacon === 'function';
+  }
+
+  private sendBeacon(params: IEndpointCallParameters) {
+    const url = UrlUtils.normalizeAsString({
+      paths: params.url,
+      queryAsString: params.queryString
+    });
+    const data = EndpointCaller.convertJsonToFormBody(params.requestData);
+
+    navigator.sendBeacon(url, new Blob([data], { type: 'application/x-www-form-urlencoded' }));
+  }
+
+  private shouldSendAsBeacon(params: IEndpointCallParameters): boolean {
+    return params.url.indexOf('/click') != -1 && this.beaconApiIsUsable;
+  }
+}

--- a/src/rest/EndpointCaller.ts
+++ b/src/rest/EndpointCaller.ts
@@ -211,24 +211,22 @@ export class EndpointCaller implements IEndpointCaller {
     this.logger = new Logger(this);
   }
 
-  public static convertJsonToQueryString(json: { [key: string]: any }): string[] {
+  public static convertJsonToQueryString(json: Record<string, any>): string[] {
     Assert.exists(json);
 
-    const result: string[] = [];
-    _.each(json, (value, key) => {
-      if (value != null) {
-        if (_.isObject(value)) {
-          result.push(key + '=' + Utils.safeEncodeURIComponent(JSON.stringify(value)));
-        } else {
-          result.push(key + '=' + Utils.safeEncodeURIComponent(value.toString()));
+    return _.chain(json)
+      .map((value, key) => {
+        if (value != null) {
+          const stringValue = _.isObject(value) ? JSON.stringify(value) : value.toString();
+          return `${key}=${Utils.safeEncodeURIComponent(stringValue)}`;
         }
-      }
-    });
-
-    return result;
+        return null;
+      })
+      .compact()
+      .value();
   }
 
-  public static convertJsonToFormBody(json: { [key: string]: any }): string {
+  public static convertJsonToFormBody(json: Record<string, any>): string {
     return this.convertJsonToQueryString(json).join('&');
   }
 

--- a/src/ui/Analytics/Analytics.ts
+++ b/src/ui/Analytics/Analytics.ts
@@ -424,7 +424,7 @@ export class Analytics extends Component {
     }
 
     if (!this.options.organization && this.defaultEndpoint) {
-      this.options.organization = this.defaultEndpoint.options.queryStringArguments['workgroup'];
+      this.options.organization = this.defaultEndpoint.options.queryStringArguments['organizationId'];
     }
   }
 

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -45,6 +45,9 @@ QueryStateModelTest();
 import { EndpointCallerTest } from './rest/EndpointCallerTest';
 EndpointCallerTest();
 
+import { AnalyticsEndpointCallerTest } from './rest/AnalyticsEndpointCallerTest';
+AnalyticsEndpointCallerTest();
+
 import { FacetQueryControllerTest } from './controllers/FacetQueryControllerTest';
 FacetQueryControllerTest();
 

--- a/unitTests/rest/AnalyticsEndpointCallerTest.ts
+++ b/unitTests/rest/AnalyticsEndpointCallerTest.ts
@@ -1,0 +1,107 @@
+import { AnalyticsEndpointCaller } from '../../src/rest/AnalyticsEndpointCaller';
+import { EndpointCaller } from '../../src/Core';
+
+export const AnalyticsEndpointCallerTest = () => {
+  describe('AnalyticsEndpointCaller', () => {
+    let analyticsCaller: AnalyticsEndpointCaller;
+
+    const buildRequest = (url: string) => {
+      return {
+        url,
+        method: 'POST',
+        requestData: {},
+        queryString: [],
+        responseType: 'text',
+        errorsAsSuccess: false
+      };
+    };
+
+    beforeEach(() => {
+      analyticsCaller = new AnalyticsEndpointCaller();
+      jasmine.Ajax.install();
+    });
+
+    afterEach(() => {
+      jasmine.Ajax.uninstall();
+    });
+
+    it('should not use sendBeacon for search event', () => {
+      analyticsCaller.call(buildRequest('https://blah.analytics.com/searches'));
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe('https://blah.analytics.com/searches');
+    });
+
+    it('should not use sendBeacon for custom event', () => {
+      analyticsCaller.call(buildRequest('https://blah.analytics.com/custom'));
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe('https://blah.analytics.com/custom');
+    });
+
+    it('should use sendBeacon for click event', () => {
+      analyticsCaller.call(buildRequest('https://blah.analytics.com/click'));
+      expect(jasmine.Ajax.requests.mostRecent()).toBeUndefined();
+    });
+
+    it('should not use sendBeacon for click event if the API is not usable', () => {
+      const origSendBeacon = navigator.sendBeacon;
+      navigator.sendBeacon = { oh: 'boy' } as any;
+      analyticsCaller.call(buildRequest('https://blah.analytics.com/click'));
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe('https://blah.analytics.com/click');
+      navigator.sendBeacon = origSendBeacon;
+    });
+
+    describe('when navigator.sendBeacon is mocked', () => {
+      let spyBeacon: jasmine.Spy;
+      let spyBlob: jasmine.Spy;
+
+      let origSendBeacon: any;
+      let origBlob: any;
+
+      beforeEach(() => {
+        origSendBeacon = navigator.sendBeacon;
+        origBlob = window.Blob;
+
+        spyBlob = jasmine.createSpy('blob', Blob);
+        spyBeacon = jasmine.createSpy('sendBeacon', navigator.sendBeacon);
+        navigator.sendBeacon = spyBeacon;
+        window.Blob = spyBlob as any;
+      });
+      afterEach(() => {
+        navigator.sendBeacon = origSendBeacon;
+        window.Blob = origBlob;
+      });
+
+      it('should properly esnd the request type as application/x-www-form-urlencoded', () => {
+        analyticsCaller.call(buildRequest('https://blah.analytics.com/click'));
+        expect(spyBlob).toHaveBeenCalledWith(jasmine.anything(), jasmine.objectContaining({ type: 'application/x-www-form-urlencoded' }));
+      });
+
+      it('should properly send the access token as a query string parameter', () => {
+        analyticsCaller.options.accessToken = 'foo';
+        analyticsCaller.call(buildRequest('https://blah.analytics.com/click'));
+        expect(spyBeacon).toHaveBeenCalledWith('https://blah.analytics.com/click?access_token=foo', jasmine.anything());
+      });
+
+      it('should properly encode the payload', () => {
+        const payload = {
+          actionCause: 'something',
+          customData: {
+            foo: 'bar'
+          }
+        };
+
+        analyticsCaller.call({
+          url: 'https://blah.analytics.com/click',
+          method: 'POST',
+          requestData: payload,
+          queryString: [],
+          responseType: 'text',
+          errorsAsSuccess: false
+        });
+
+        expect(spyBlob).toHaveBeenCalledWith(
+          jasmine.arrayContaining([EndpointCaller.convertJsonToFormBody({ clickEvent: payload })]),
+          jasmine.anything()
+        );
+      });
+    });
+  });
+};

--- a/unitTests/rest/AnalyticsEndpointCallerTest.ts
+++ b/unitTests/rest/AnalyticsEndpointCallerTest.ts
@@ -70,7 +70,7 @@ export const AnalyticsEndpointCallerTest = () => {
         window.Blob = origBlob;
       });
 
-      it('should properly esnd the request type as application/x-www-form-urlencoded', () => {
+      it('should properly send the request type as application/x-www-form-urlencoded', () => {
         analyticsCaller.call(buildRequest('https://blah.analytics.com/click'));
         expect(spyBlob).toHaveBeenCalledWith(jasmine.anything(), jasmine.objectContaining({ type: 'application/x-www-form-urlencoded' }));
       });

--- a/unitTests/rest/AnalyticsEndpointCallerTest.ts
+++ b/unitTests/rest/AnalyticsEndpointCallerTest.ts
@@ -64,6 +64,7 @@ export const AnalyticsEndpointCallerTest = () => {
         navigator.sendBeacon = spyBeacon;
         window.Blob = spyBlob as any;
       });
+
       afterEach(() => {
         navigator.sendBeacon = origSendBeacon;
         window.Blob = origBlob;

--- a/unitTests/ui/AnalyticsEndpointTest.ts
+++ b/unitTests/ui/AnalyticsEndpointTest.ts
@@ -1,6 +1,5 @@
 import { AccessToken } from '../../src/rest/AccessToken';
 import { AnalyticsEndpoint } from '../../src/rest/AnalyticsEndpoint';
-import { IAPIAnalyticsEventResponse } from '../../src/rest/APIAnalyticsEventResponse';
 import { IAPIAnalyticsSearchEventsResponse } from '../../src/rest/APIAnalyticsSearchEventsResponse';
 import { IErrorResponse } from '../../src/rest/EndpointCaller';
 import { Cookie } from '../../src/utils/CookieUtils';
@@ -77,42 +76,6 @@ export function AnalyticsEndpointTest() {
         status: 200,
         responseText: JSON.stringify({ searchEventResponses: [{ visitId: 'visitid' }] })
       });
-    });
-
-    it('allow to sendDocumentViewEvent', done => {
-      let fakeClickEvent = FakeResults.createFakeClickEvent();
-      endpoint
-        .sendDocumentViewEvent(fakeClickEvent)
-        .then((res: IAPIAnalyticsEventResponse) => {
-          expect(res.visitId).toBe('visitid');
-          // Here, the current visit id is already set, so it should return immediately.
-          expect(endpoint.getCurrentVisitId()).toBe('visitid');
-        })
-        .catch((e: IErrorResponse) => {
-          fail(e);
-          return e;
-        })
-        .then(() => done());
-
-      // Here, the current visit id should be undefined
-      expect(endpoint.getCurrentVisitId()).toBeUndefined();
-      expect(jasmine.Ajax.requests.mostRecent().method).toBe('POST');
-      expect(jasmine.Ajax.requests.mostRecent().requestHeaders['Authorization']).toBe('Bearer token');
-      expect(jasmine.Ajax.requests.mostRecent().requestHeaders['Content-Type']).toBe('application/json; charset="UTF-8"');
-      expect(JSON.parse(jasmine.Ajax.requests.mostRecent().params)['viewMethod']).toBe(fakeClickEvent.viewMethod);
-      expect(JSON.parse(jasmine.Ajax.requests.mostRecent().params)['documentUrl']).toBe(fakeClickEvent.documentUrl);
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 200,
-        responseText: JSON.stringify({ visitId: 'visitid' })
-      });
-    });
-
-    it('sends organization as parameter when sending a document view event', () => {
-      let fakeClickEvent = FakeResults.createFakeClickEvent();
-      endpoint.sendDocumentViewEvent(fakeClickEvent);
-
-      expect(jasmine.Ajax.requests.mostRecent().url.indexOf('org=organization') != -1).toBe(true);
     });
 
     it('sends organization as parameter when sending a search event', () => {

--- a/unitTests/ui/AnalyticsTest.ts
+++ b/unitTests/ui/AnalyticsTest.ts
@@ -15,7 +15,7 @@ export function AnalyticsTest() {
     beforeEach(() => {
       SearchEndpoint.endpoints['default'] = new SearchEndpoint({
         accessToken: 'some token',
-        queryStringArguments: { workgroup: 'organization' },
+        queryStringArguments: { organizationId: 'organization' },
         restUri: 'some/uri'
       });
     });
@@ -32,7 +32,7 @@ export function AnalyticsTest() {
           new Mock.AdvancedComponentSetupOptions(null, null, env => {
             env.searchInterface.options.endpoint = new SearchEndpoint({
               accessToken: 'another token',
-              queryStringArguments: { workgroup: 'another organization' },
+              queryStringArguments: { organizationId: 'another organization' },
               restUri: 'another/uri'
             });
             return env;
@@ -53,11 +53,12 @@ export function AnalyticsTest() {
       beforeEach(() => {
         SearchEndpoint.endpoints['default'] = new SearchEndpoint({
           accessToken: 'some token',
-          queryStringArguments: { workgroup: 'organization' },
+          queryStringArguments: { organizationId: 'organization' },
           restUri: 'some/uri'
         });
         test = Mock.basicComponentSetup<Analytics>(Analytics);
       });
+
       afterEach(() => {
         test = null;
       });


### PR DESCRIPTION
We'll need to wait for UA to modify the write service to accepts different Content-Type for this to work, but this is the changes that would be required. For now, I just did the modification without being able to test it for real from end to end, so this is not ready to be merged yet.

I'm not 100% happy with the changes though, as it uses beacon for *all* click events, as opposed to only those that will make the page unloads from the browser (ie: navigating to another page). That's because, on a beacon event, we cannot listen to the response for the request (which is okay when the user is leaving the page anyway), but would not be ideal for normal click event that do not make the browser load a new page.

I have to think a bit more about what I could do to achieve that.

I'll also add tests once I can confirm that it works properly form end to end.

https://coveord.atlassian.net/browse/JSUI-2460





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)