### PR TITLE
Export AccessibleButton

### DIFF
--- a/src/UtilsModules.ts
+++ b/src/UtilsModules.ts
@@ -1,3 +1,4 @@
+export { AccessibleButton } from './utils/AccessibleButton';
 export { ColorUtils } from './utils/ColorUtils';
 export { Cookie } from './utils/CookieUtils';
 export { CurrencyUtils } from './utils/CurrencyUtils';


### PR DESCRIPTION
The component is exposed in the declaration file, but was not exported in the real project, ending in a "cannot read property of undefined" at runtime.

I think it makes sense to expose it for other custom components

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)