### PR TITLE
initialChoice is use in resultPerPages

### DIFF
--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -180,7 +180,7 @@ export class ResultsPerPage extends Component {
     const firstDisplayedChoice = this.options.choicesDisplayed[0];
     const configuredChoice = this.options.initialChoice;
     const queryStateModelChoice = this.queryStateModel.get(QueryStateModel.attributesEnum.numberOfResults);
-    const queryStateModelChoiceIsNotDefault = queryStateModelChoice !== firstDisplayedChoice;
+    const queryStateModelChoiceIsNotDefault = queryStateModelChoice !== QueryStateModel.defaultAttributes.numberOfResults;
 
     if (queryStateModelChoiceIsNotDefault && this.isValidChoice(queryStateModelChoice)) {
       return queryStateModelChoice;

--- a/unitTests/ui/ResultsPerPageTest.ts
+++ b/unitTests/ui/ResultsPerPageTest.ts
@@ -213,6 +213,19 @@ export function ResultsPerPageTest() {
         });
         expect(test.env.queryController.options.resultsPerPage).toBe(firstChoice);
       });
+
+      it('initialChoice set to non default value is use when default value is in choicesDisplayed', () => {
+        let initialChoice = 5;
+        test = Mock.optionsComponentSetup<ResultsPerPage, IResultsPerPageOptions>(ResultsPerPage, {
+          initialChoice: initialChoice,
+          choicesDisplayed: [initialChoice, 10, 15, 20]
+        });
+        Simulate.initialization(test.env);
+        Simulate.query(test.env, {
+          results: FakeResults.createFakeResults(100)
+        });
+        expect(test.env.queryController.options.resultsPerPage).toBe(initialChoice);
+      });
     });
   });
 }

--- a/unitTests/ui/ResultsPerPageTest.ts
+++ b/unitTests/ui/ResultsPerPageTest.ts
@@ -214,8 +214,10 @@ export function ResultsPerPageTest() {
         expect(test.env.queryController.options.resultsPerPage).toBe(firstChoice);
       });
 
-      it('initialChoice set to non default value is use when default value is in choicesDisplayed', () => {
-        let initialChoice = 5;
+      it(`when the QSM numberOfResults is equal to the default QSM number of results,
+      when the initialChoice option is not equal to the default QSM numberOfResults,
+      it sets the resultsPerPage to the initialChoice`, () => {
+        const initialChoice = 5;
         test = Mock.optionsComponentSetup<ResultsPerPage, IResultsPerPageOptions>(ResultsPerPage, {
           initialChoice: initialChoice,
           choicesDisplayed: [initialChoice, 10, 15, 20]


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2390

When the default value of ResultsPerPage was in ChoiceDisplayed, it didn't use the initial choice option

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)