### PR TITLE
JSUI-2488 Readding commas to long date format

### DIFF
--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -331,7 +331,7 @@ export class DateUtils {
     }
 
     if (options.useLongDateFormat) {
-      return `${dateOnly.format('dddd')} ${dateOnly.format('LL')} ${dateOnly.format('YYYY')}`;
+      return `${dateOnly.format('dddd')}, ${dateOnly.format('LL')}, ${dateOnly.format('YYYY')}`;
     }
 
     return dateOnly.format('L');

--- a/src/utils/DateUtils.ts
+++ b/src/utils/DateUtils.ts
@@ -183,6 +183,8 @@ class DefaultDateToStringOptions extends Options implements IDateToStringOptions
  * using the correct culture, language and format. It also offers methods to convert date objects to strings.
  */
 export class DateUtils {
+  private static momentjsLocaleDataMap: Record<string, moment.Locale> = {}
+
   // This function is used to call convertToStandardDate for legacy reasons. convertFromJsonDateIfNeeded was refactored to
   // convertToStandardDate, which would be a breaking change otherwise.
   static convertFromJsonDateIfNeeded(date: any): Date {
@@ -207,8 +209,20 @@ export class DateUtils {
   }
 
   public static setLocale(): void {
+    DateUtils.saveOriginalMomentLocaleData();
     moment.updateLocale(DateUtils.momentjsCompatibleLocale, DateUtils.transformGlobalizeCalendarToMomentCalendar());
     moment.locale(DateUtils.momentjsCompatibleLocale);
+  }
+
+  private static saveOriginalMomentLocaleData() {
+    const locale = DateUtils.momentjsCompatibleLocale;
+    const alreadySaved = DateUtils.momentjsLocaleDataMap[locale] != null;
+
+    if (alreadySaved) {
+      return;
+    }
+
+    DateUtils.momentjsLocaleDataMap[locale] = moment.localeData();
   }
 
   /**
@@ -331,10 +345,19 @@ export class DateUtils {
     }
 
     if (options.useLongDateFormat) {
-      return `${dateOnly.format('dddd')}, ${dateOnly.format('LL')}, ${dateOnly.format('YYYY')}`;
+      return dateOnly.format(this.longDateFormat);
     }
 
     return dateOnly.format('L');
+  }
+
+  private static get longDateFormat() {
+    const momentLocaleData = DateUtils.momentjsLocaleDataMap[DateUtils.momentjsCompatibleLocale];
+    
+    return momentLocaleData
+    .longDateFormat('LLLL')
+    .replace(/[h:mA]/g, '')
+    .trim();
   }
 
   /**

--- a/unitTests/ui/CoreHelpersTest.ts
+++ b/unitTests/ui/CoreHelpersTest.ts
@@ -218,7 +218,7 @@ export function CoreHelperTest() {
 
         it('should work correctly with useLongDateFormat', () => {
           options.useLongDateFormat = true;
-          expect(TemplateHelpers.getHelper('date')(new Date(1981, 3, 11), options)).toEqual('Saturday April 11 1981');
+          expect(TemplateHelpers.getHelper('date')(new Date(1981, 3, 11), options)).toEqual('Saturday, April 11, 1981');
         });
 
         it('should work correctly with correct default options ', () => {

--- a/unitTests/ui/DateUtilsTest.ts
+++ b/unitTests/ui/DateUtilsTest.ts
@@ -71,6 +71,18 @@ export function DateUtilsTest() {
       expect(DateUtils.dateToString(testDate(), options)).toEqual(l('02/11/1980'));
     });
 
+    it(`when the #useLongDateFormat option is true, when calling #dateToString,
+    it returns a date with the correct form`, () => {
+      options.useTodayYesterdayAndTomorrow = false;
+      options.useWeekdayIfThisWeek = false;
+      options.omitYearIfCurrentOne = false;
+
+      options.useLongDateFormat = true;
+
+      const date = DateUtils.dateToString(testDate(), options);
+      expect(date).toBe('Monday, February 11, 1980');
+    });
+
     it('should return `Invalid Date` if the date input is incorrect', () => {
       expect(DateUtils.dateToString(DateUtils.convertToStandardDate('foobar'), options)).toEqual(l('Invalid date'));
     });


### PR DESCRIPTION
We introduced a regression in the long date format in [this PR](https://github.com/coveo/search-ui/commit/747843360b05fe6f3da930a962cafa61dd88b01a), where the different parts of the date stopped being delimited by commas.

Here is the relevant snippet from the linked PR:
```
if (options.useLongDateFormat) {
-    return dateOnly.format('dddd, MMMM DD, YYYY');
+    return `${dateOnly.format('dddd')} ${dateOnly.format('LL')} ${dateOnly.format('YYYY')}`;
}
```

This PR readds the commas and a unit test.

https://coveord.atlassian.net/browse/JSUI-2488





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)