### PR TITLE
JSUI-2491 Triggering openQuickView event on SearchInterface instead of element

### DIFF
--- a/src/ui/Quickview/QuickviewDocument.ts
+++ b/src/ui/Quickview/QuickviewDocument.ts
@@ -1,4 +1,3 @@
-import * as _ from 'underscore';
 import { IQuickviewLoadedEventArgs, QuickviewEvents } from '../../events/QuickviewEvents';
 import { IOpenQuickviewEventArgs } from '../../events/ResultListEvents';
 import { Assert } from '../../misc/Assert';
@@ -14,7 +13,7 @@ import { Initialization } from '../Base/Initialization';
 import { QuickviewDocumentIframe } from './QuickviewDocumentIframe';
 import { QuickviewDocumentHeader } from './QuickviewDocumentHeader';
 import { QuickviewDocumentWords } from './QuickviewDocumentWords';
-import { each } from 'underscore';
+import { each, keys } from 'underscore';
 import { QuickviewDocumentWordButton } from './QuickviewDocumentWordButton';
 import { QuickviewDocumentPreviewBar } from './QuickviewDocumentPreviewBar';
 
@@ -92,11 +91,9 @@ export class QuickviewDocument extends Component {
     this.ensureDom();
 
     const beforeLoad = new Date().getTime();
-    const termsToHighlight = _.keys(this.result.termsToHighlight);
+    const termsToHighlight = this.initialTermsToHighlight;
 
-    $$(this.element).trigger(QuickviewEvents.openQuickview, {
-      termsToHighlight
-    } as IOpenQuickviewEventArgs);
+    this.triggerOpenQuickViewEvent({ termsToHighlight });
 
     this.checkIfTermsToHighlightWereModified(termsToHighlight);
 
@@ -131,6 +128,14 @@ export class QuickviewDocument extends Component {
     }
   }
 
+  private get initialTermsToHighlight() {
+    return keys(this.result.termsToHighlight);
+  }
+
+  private triggerOpenQuickViewEvent(args: IOpenQuickviewEventArgs) {
+    $$(this.root).trigger(QuickviewEvents.openQuickview, args)
+  }
+
   private get query() {
     return { ...this.queryController.getLastQuery() };
   }
@@ -141,21 +146,21 @@ export class QuickviewDocument extends Component {
     } as IQuickviewLoadedEventArgs);
   }
 
-  private handleTermsToHighlight(termsToHighlight: Array<string>, queryObject: IQuery) {
+  private handleTermsToHighlight(termsToHighlight: string[], queryObject: IQuery) {
     for (const term in this.result.termsToHighlight) {
       delete this.result.termsToHighlight[term];
     }
     let query = '';
-    _.each(termsToHighlight, term => {
+    each(termsToHighlight, term => {
       query += term + ' ';
-      this.result.termsToHighlight[term] = new Array<string>(term);
+      this.result.termsToHighlight[term] = [term];
     });
     query = query.substring(0, query.length - 1);
     queryObject.q = query;
   }
 
-  private checkIfTermsToHighlightWereModified(termsToHighlight: Array<string>) {
-    if (!Utils.arrayEqual(termsToHighlight, _.keys(this.result.termsToHighlight))) {
+  private checkIfTermsToHighlightWereModified(termsToHighlight: string[]) {
+    if (!Utils.arrayEqual(termsToHighlight, this.initialTermsToHighlight)) {
       this.termsToHighlightWereModified = true;
     }
   }

--- a/src/ui/Quickview/QuickviewDocument.ts
+++ b/src/ui/Quickview/QuickviewDocument.ts
@@ -50,7 +50,6 @@ export class QuickviewDocument extends Component {
 
   private iframe: QuickviewDocumentIframe;
   private header: QuickviewDocumentHeader;
-  private termsToHighlightWereModified: boolean;
 
   /**
    * Creates a new `QuickviewDocument` component.
@@ -70,7 +69,6 @@ export class QuickviewDocument extends Component {
 
     this.options = ComponentOptions.initComponentOptions(element, QuickviewDocument, options);
     this.result = result || this.resolveResult();
-    this.termsToHighlightWereModified = false;
     Assert.exists(this.result);
   }
 
@@ -95,9 +93,9 @@ export class QuickviewDocument extends Component {
 
     this.triggerOpenQuickViewEvent({ termsToHighlight });
 
-    this.checkIfTermsToHighlightWereModified(termsToHighlight);
-
-    if (this.termsToHighlightWereModified) {
+    const termsWereModified = this.wereTermsToHighlightModified(termsToHighlight);
+    
+    if (termsWereModified) {
       this.handleTermsToHighlight(termsToHighlight, this.query);
     }
 
@@ -159,10 +157,8 @@ export class QuickviewDocument extends Component {
     queryObject.q = query;
   }
 
-  private checkIfTermsToHighlightWereModified(termsToHighlight: string[]) {
-    if (!Utils.arrayEqual(termsToHighlight, this.initialTermsToHighlight)) {
-      this.termsToHighlightWereModified = true;
-    }
+  private wereTermsToHighlightModified(termsToHighlight: string[]) {
+    return !Utils.arrayEqual(termsToHighlight, this.initialTermsToHighlight);
   }
 }
 

--- a/unitTests/ui/QuickviewDocumentTest.ts
+++ b/unitTests/ui/QuickviewDocumentTest.ts
@@ -18,13 +18,13 @@ export function QuickviewDocumentTest() {
 
     it('should trigger an openQuickview event when opening', () => {
       const openSpy = jasmine.createSpy('open');
-      $$(test.cmp.element).on(QuickviewEvents.openQuickview, openSpy);
+      $$(test.cmp.root).on(QuickviewEvents.openQuickview, openSpy);
       test.cmp.open();
       expect(openSpy).toHaveBeenCalled();
     });
 
     it('should properly modify the terms to highlight on the result', () => {
-      $$(test.cmp.element).on(QuickviewEvents.openQuickview, (e, args) => {
+      $$(test.cmp.root).on(QuickviewEvents.openQuickview, (e, args) => {
         args.termsToHighlight.push('bar');
         args.termsToHighlight.push('baz');
       });


### PR DESCRIPTION
By triggering the event of the search interface rather than the CoveoQuickViewDocument, listeners on the SearchInterface or the body tag containing the interface will receive the event only once, which is what we want.

This solution is still breaking if a listener is attached on the `CoveoQuickviewDocument` or any parent up to but not including the body tag. This breaking change is reflected in the updates to the unit tests.

Another more complex option would be to:

1. Detect if the root and the body tag are the same element.
2. a. If they are, trigger the event on the element only.
 b. If they are not, trigger the event on the element and on the Search Interface.

The down-side of this solution is if the listener is on the body tag rather than the SearchInterface (which Jerome mentions is what he adapted his code to), then the listener will be triggered twice.

Let me know what you prefer,


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)