### PR TITLE
JSUI-2475 Use the DOM empty method instead of overwritting innerHTML

### DIFF
--- a/src/ui/ResultList/ResultContainer.ts
+++ b/src/ui/ResultList/ResultContainer.ts
@@ -19,7 +19,7 @@ export class ResultContainer {
 
   public empty() {
     this.searchInterface.detachComponentsInside(this.resultContainerElement.el);
-    this.resultContainerElement.el.innerHTML = '';
+    $$(this.resultContainerElement).empty();
   }
 
   public addClass(classToAdd: string) {


### PR DESCRIPTION
With this change popper's reference seems to be correctly destroyed and the message doesn't show up in IE11
https://coveord.atlassian.net/browse/JSUI-2475





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)