### PR TITLE
JSUI-2495  scss variables not converted in css

### DIFF
--- a/sass/_Quickview.scss
+++ b/sass/_Quickview.scss
@@ -32,7 +32,6 @@
     // Tooltip under element, arrow on top
     &[x-placement^='bottom'] > div {
       top: -$arrow-width;
-      left: calc(50% - $arrow-width);
       border-width: 0 $arrow-width $arrow-height;
       border-color: $arrow-color transparent;
     }
@@ -40,14 +39,12 @@
     // Tooltip over element, arrow on bottom
     &[x-placement^='top'] > div {
       bottom: -$arrow-width;
-      left: calc(50% - $arrow-width);
       border-width: $arrow-height $arrow-width 0;
       border-color: $arrow-color transparent;
     }
 
     // Tooltip on the right of element, arrow on the left
     &[x-placement^='right'] > div {
-      top: calc(50% - $arrow-width);
       left: -$arrow-width;
       border-width: $arrow-width $arrow-height $arrow-width 0;
       border-color: transparent $arrow-color;
@@ -55,7 +52,6 @@
 
     // Tooltip on the left of element, arrow on the right
     &[x-placement^='left'] > div {
-      top: calc(50% - $arrow-width);
       right: -$arrow-width;
       left: auto;
       border-width: $arrow-width 0 $arrow-width $arrow-height;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2495

So this was the problem: https://github.com/sass/sass/issues/818

After more testing, the rule for left and top when using calc() was always overwritten because the element had the value set so I decided to delete it

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)