### PR TITLE
JSUI-2489 Fix the issue where the OmniboxResultlist didn't render in the docs

### DIFF
--- a/docs/playground/src/PlaygroundConfiguration.ts
+++ b/docs/playground/src/PlaygroundConfiguration.ts
@@ -304,18 +304,18 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
               className: 'result-template',
               type: 'text/underscore'
             },
-            new SectionBuilder()
-              .withComponent(
-                'CoveoIcon',
-                {
-                  'data-small': 'true',
-                  'data-with-label': 'false',
-                  style: 'display:inline-block; vertical-align:middle; margin-right:5px;'
-                },
-                'span'
-              )
-              .withComponent('CoveoResultLink', {}, 'a')
-              .build()
+            `<div class="coveo-result-frame">
+              <div class="coveo-result-cell" style="vertical-align:top;text-align:center;width:32px;">
+                <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
+              </div>
+              <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
+                <div class="coveo-result-row" style="margin-top:0;">
+                  <div class="coveo-result-cell" ">
+                    <a class="CoveoResultLink" ></a>
+                  </div>
+                </div>
+              </div>
+            </div>`
           )
         )
       )
@@ -325,7 +325,7 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
       headerTitle: ''
     },
     toExecute: () => {
-      setMinHeightOnSearchInterface('500px');
+      setMinHeightOnSearchInterface('350px');
       getSearchInterfaceInstance().options.resultsPerPage = 5;
     }
   },


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2489

What I think happened is if we used the `withComponent` method, the browser simply delete the script tag so the browser then tried to render the component but it failed since a lot of its values were not initialized yet.

Putting text directly fixed that problem.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)