### PR TITLE
Fix an issue where scroll to top was not working in Lightning Locker JSUI-2516

### DIFF
--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -624,9 +624,9 @@ export class ResultList extends Component {
       return;
     }
 
-    if (this.options.infiniteScrollContainer instanceof Window) {
+    if (typeof this.options.infiniteScrollContainer.scrollTo === 'function') {
       const win = <Window>this.options.infiniteScrollContainer;
-      const searchInterfacePosition = win.pageYOffset + this.searchInterface.element.getBoundingClientRect().top;
+      const searchInterfacePosition = window.pageYOffset + this.searchInterface.element.getBoundingClientRect().top;
       win.scrollTo(0, searchInterfacePosition);
     } else {
       const el = <HTMLElement>this.options.infiniteScrollContainer;

--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -625,9 +625,8 @@ export class ResultList extends Component {
     }
 
     if (typeof this.options.infiniteScrollContainer.scrollTo === 'function') {
-      const win = <Window>this.options.infiniteScrollContainer;
       const searchInterfacePosition = window.pageYOffset + this.searchInterface.element.getBoundingClientRect().top;
-      win.scrollTo(0, searchInterfacePosition);
+      this.options.infiniteScrollContainer.scrollTo(0, searchInterfacePosition);
     } else {
       const el = <HTMLElement>this.options.infiniteScrollContainer;
       el.scrollTop = 0;

--- a/unitTests/ui/ResultListTest.ts
+++ b/unitTests/ui/ResultListTest.ts
@@ -801,9 +801,7 @@ export function ResultListTest() {
 
           beforeEach(() => {
             jasmine.clock().install();
-            document.createElement('div');
             infiniteScrollContainer = document.createElement('div');
-
             scrollToSpy = spyOn(infiniteScrollContainer, 'scrollTo');
 
             // Inner value of scrollTop.


### PR DESCRIPTION
The issue arose due to the fact that **Window** is not **Window** in **Lightning Locker** but is instead **Secured Window**.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)