### PR TITLE
JSUI-2546 Update missingTerms to update when the query update

### DIFF
--- a/src/models/QueryStateModel.ts
+++ b/src/models/QueryStateModel.ts
@@ -76,7 +76,7 @@ export class QueryStateModel extends Model {
     quickview: '',
     debug: false,
     numberOfResults: 10,
-    missingTerm: []
+    missingTerms: []
   };
 
   static attributesEnum = {
@@ -92,7 +92,7 @@ export class QueryStateModel extends Model {
     quickview: 'quickview',
     debug: 'debug',
     numberOfResults: 'numberOfResults',
-    missingTerm: 'missingTerm'
+    missingTerms: 'missingTerms'
   };
 
   static getFacetId(id: string, include: boolean = true) {

--- a/src/ui/MissingTerm/MissingTermManager.ts
+++ b/src/ui/MissingTerm/MissingTermManager.ts
@@ -119,7 +119,12 @@ export class MissingTermManager {
       }
     });
     this.setUpdateTermsForcedToAppear(termForcedToAppearCopy);
-    const breadcrumb = get(document.querySelector('.CoveoBreadcrumb')) as Breadcrumb;
+    const breadcrumbSelector = document.querySelector('.CoveoBreadcrumb');
+    if (!breadcrumbSelector) {
+      return;
+    }
+
+    let breadcrumb = <Breadcrumb>get(<HTMLElement>breadcrumbSelector);
     if (breadcrumb) {
       breadcrumb.getBreadcrumbs();
       $$(this.root).trigger(BreadcrumbEvents.redrawBreadcrumb);

--- a/src/ui/MissingTerm/MissingTerms.ts
+++ b/src/ui/MissingTerm/MissingTerms.ts
@@ -8,6 +8,7 @@ import { Dom } from '../../utils/Dom';
 import { analyticsActionCauseList, IAnalyticsIncludeMissingTerm } from '../Analytics/AnalyticsActionListMeta';
 import { IQueryResult } from '../../rest/QueryResult';
 import XRegExp = require('xregexp');
+import { MissingTermManager } from './MissingTermManager';
 
 export interface IMissingTermsOptions {
   caption?: string;
@@ -56,10 +57,6 @@ export class MissingTerms extends Component {
     });
   };
 
-  // Used to split terms and phrases. Match character that can separate words or caracter for Chinese, Japanese and Korean.
-  // Han: Unicode script for Chinesse character
-  // We only need to import 1 Asian, charcaters script because what is important here is the space between the caracter and any script will contain it
-  private wordBoundary = '(([\\p{Han}])?([^(\\p{Latin}-)])|^|$)';
   private termForcedToAppear: string[];
 
   /**
@@ -104,11 +101,11 @@ export class MissingTerms extends Component {
     }
     this.updateTermForcedToAppear();
     this.termForcedToAppear.push(term);
-    this.queryStateModel.set('missingTerm', [...this.termForcedToAppear]);
+    this.queryStateModel.set('missingTerms', [...this.termForcedToAppear]);
   }
 
   private updateTermForcedToAppear() {
-    this.termForcedToAppear = [...this.queryStateModel.get('missingTerm')];
+    this.termForcedToAppear = [...this.queryStateModel.get('missingTerms')];
   }
 
   private addMissingTerms() {
@@ -170,7 +167,7 @@ export class MissingTerms extends Component {
   }
 
   private createWordBoundaryDelimitedRegex(term: string): RegExp {
-    return XRegExp(`${this.wordBoundary}(${term})${this.wordBoundary}`, 'g');
+    return XRegExp(`${MissingTermManager.wordBoundary}(${term})${MissingTermManager.wordBoundary}`, 'g');
   }
 
   private containsFeaturedResults(term: string): boolean {

--- a/unitTests/ui/MissingTermManagerTest.ts
+++ b/unitTests/ui/MissingTermManagerTest.ts
@@ -6,29 +6,29 @@ import { $$, l } from '../Test';
 export function MissingTermsManagerTest() {
   describe('MissingTermManager', () => {
     let env: Mock.IMockEnvironment;
-    let missingTerms: string[];
 
-    const spyGet = () => {
-      return missingTerms;
+    const getMissingTerms = () => {
+      return [...env.queryStateModel.get('missingTerms')];
     };
-    const spySet = (key: any, values: any) => {
-      missingTerms = values;
+
+    const setMissingTerms = (term: string) => {
+      const missingterm = [...env.queryStateModel.get('missingTerms')];
+      missingterm.push(term);
+      env.queryStateModel.set('missingTerms', missingterm);
     };
+
     const populateBreadcrumb = () => {
       return Simulate.breadcrumb(env);
     };
 
     beforeEach(() => {
-      env = new Mock.MockEnvironmentBuilder().build();
+      env = new Mock.MockEnvironmentBuilder().withLiveQueryStateModel().build();
       new MissingTermManager(env.root, env.queryStateModel, env.queryController);
-      env.queryStateModel.get = jasmine.createSpy('missingTermSpy').and.callFake(spyGet);
-      env.queryStateModel.set = jasmine.createSpy('missingTermSpy').and.callFake(spySet);
-      missingTerms = [];
     });
 
     it('add missing term from the url in advance query', () => {
       const aMissingTerm = 'is';
-      missingTerms.push(aMissingTerm);
+      setMissingTerms(aMissingTerm);
       const simulation = Simulate.query(env, {
         query: {
           q: 'this is my query'
@@ -37,10 +37,28 @@ export function MissingTermsManagerTest() {
       expect(simulation.queryBuilder.advancedExpression.build()).toBe(aMissingTerm);
     });
 
+    it(`when the query change,
+    if the missing term is no longer in the query,
+    it is removed from the missing term`, () => {
+      const aMissingTerm = 'is';
+      setMissingTerms(aMissingTerm);
+      env.queryStateModel.set('q', 'this my query');
+      expect(getMissingTerms().length).toBe(0);
+    });
+
+    it(`when the query change,
+    if the missing term is still present in the query,
+    it stay in missing term`, () => {
+      const aMissingTerm = 'is';
+      setMissingTerms(aMissingTerm);
+      env.queryStateModel.set('q', 'this is my super query');
+      expect(getMissingTerms().length).toBe(1);
+    });
+
     describe('the breadcrumb', () => {
       it('should populate when the event is triggered', () => {
         const aMissingTerm = 'is';
-        missingTerms.push(aMissingTerm);
+        setMissingTerms(aMissingTerm);
         const breadcrumb = populateBreadcrumb();
         expect(breadcrumb.length).toBe(1);
         expect($$(breadcrumb[0].element).find('.coveo-missing-term-breadcrumb-title').innerHTML).toBe(l('MustContain'));
@@ -48,21 +66,24 @@ export function MissingTermsManagerTest() {
       });
 
       it('should empty when the event is triggered', () => {
-        missingTerms.push('is');
+        const aMissingTerm = 'is';
+        setMissingTerms(aMissingTerm);
         populateBreadcrumb();
-        expect(missingTerms).not.toEqual([]);
+        expect(getMissingTerms()).not.toEqual([]);
         Simulate.clearBreadcrumb(env);
-        expect(missingTerms).toEqual([]);
+        expect(getMissingTerms()).toEqual([]);
       });
 
       it('should remove an element when it is clicked', () => {
-        missingTerms.push('is');
-        missingTerms.push('this');
+        const missingTerm1 = 'is';
+        const missingTerm2 = 'this';
+        setMissingTerms(missingTerm1);
+        setMissingTerms(missingTerm2);
         const breadcrumb = populateBreadcrumb();
         const element = $$(breadcrumb[0].element).find('.coveo-missing-term-breadcrumb-clear');
-        expect(missingTerms.length).toBe(2);
+        expect(getMissingTerms().length).toBe(2);
         element.click();
-        expect(missingTerms.length).toBe(1);
+        expect(getMissingTerms().length).toBe(1);
       });
     });
   });

--- a/unitTests/ui/MissingTermsTest.ts
+++ b/unitTests/ui/MissingTermsTest.ts
@@ -96,6 +96,10 @@ export function MissingTermsTest() {
       });
     });
     describe('when the langage is', () => {
+      const getMissingTerms = () => {
+        return test.cmp.queryStateModel.get('missingTerms');
+      };
+
       describe('English', () => {
         describe('when fetching the missing terms from a query', () => {
           let expectedResult: string[];
@@ -129,7 +133,7 @@ export function MissingTermsTest() {
             test = mockComponent(query);
             test.cmp.queryController.executeQuery();
             test.cmp.addTermForcedToAppear(termPresent);
-            expect(test.cmp.queryStateModel.get('missingTerm')).toEqual([termPresent]);
+            expect(getMissingTerms()).toEqual([termPresent]);
           });
 
           it('and the term is the first word in the query, the term is added to the url', () => {
@@ -139,7 +143,7 @@ export function MissingTermsTest() {
             test = mockComponent(query);
             test.cmp.addTermForcedToAppear(firstWord);
             test.cmp.queryController.executeQuery();
-            expect(test.cmp.queryStateModel.get('missingTerm')).toEqual([firstWord]);
+            expect(getMissingTerms()).toEqual([firstWord]);
           });
 
           it('and the term is the last word in the query, the term is added to the url', () => {
@@ -148,7 +152,7 @@ export function MissingTermsTest() {
             fakeResult.absentTerms = [lastWord];
             test = mockComponent(query);
             test.cmp.addTermForcedToAppear(lastWord);
-            expect(test.cmp.queryStateModel.get('missingTerm')).toEqual([lastWord]);
+            expect(getMissingTerms()).toEqual([lastWord]);
           });
 
           it('and the term is not present, queryStateModel.set is never called', () => {
@@ -166,7 +170,7 @@ export function MissingTermsTest() {
             fakeResult.absentTerms = [hyphensWord];
             test = mockComponent(query);
             test.cmp.addTermForcedToAppear(hyphensWord);
-            expect(test.cmp.queryStateModel.get('missingTerm')).toEqual([hyphensWord]);
+            expect(getMissingTerms()).toEqual([hyphensWord]);
           });
 
           it('and the term present is surrounded by special character, the term is added to the url', () => {
@@ -175,7 +179,7 @@ export function MissingTermsTest() {
             fakeResult.absentTerms = [specialCharacter];
             test = mockComponent(query);
             test.cmp.addTermForcedToAppear(specialCharacter);
-            expect(test.cmp.queryStateModel.get('missingTerm')).toEqual([specialCharacter]);
+            expect(getMissingTerms()).toEqual([specialCharacter]);
           });
         });
       });
@@ -188,7 +192,7 @@ export function MissingTermsTest() {
             fakeResult.absentTerms = [koreanWordPresent];
             test = mockComponent(query);
             test.cmp.addTermForcedToAppear(koreanWordPresent);
-            expect(test.cmp.queryStateModel.get('missingTerm')).toEqual([koreanWordPresent]);
+            expect(getMissingTerms()).toEqual([koreanWordPresent]);
           });
 
           it('and the term is the first word in the query, the term is added to the url', () => {
@@ -197,7 +201,7 @@ export function MissingTermsTest() {
             fakeResult.absentTerms = [koreanFirstWord];
             test = mockComponent(query);
             test.cmp.addTermForcedToAppear(koreanFirstWord);
-            expect(test.cmp.queryStateModel.get('missingTerm')).toEqual([koreanFirstWord]);
+            expect(getMissingTerms()).toEqual([koreanFirstWord]);
           });
 
           it('and the term is the last word in the query, the term is added to the url', () => {
@@ -206,7 +210,7 @@ export function MissingTermsTest() {
             fakeResult.absentTerms = [KoreanlastWord];
             test = mockComponent(query);
             test.cmp.addTermForcedToAppear(KoreanlastWord);
-            expect(test.cmp.queryStateModel.get('missingTerm')).toEqual([KoreanlastWord]);
+            expect(getMissingTerms()).toEqual([KoreanlastWord]);
           });
 
           it('and the term is a single character surronded by other character, the term is added to the url', () => {
@@ -215,7 +219,7 @@ export function MissingTermsTest() {
             fakeResult.absentTerms = [KoreanWordPresentMultipleTimes];
             test = mockComponent(query);
             test.cmp.addTermForcedToAppear(KoreanWordPresentMultipleTimes);
-            expect(test.cmp.queryStateModel.get('missingTerm')).toEqual([KoreanWordPresentMultipleTimes]);
+            expect(getMissingTerms()).toEqual([KoreanWordPresentMultipleTimes]);
           });
         });
       });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2546

So now we update the missing term when the query change.
If the missingTerms are still present in the new query, they will persist.
If not, they are removed from the missing term.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)