### PR TITLE
JSUI-2548 Fix missingTerms example in the docs

### DIFF
--- a/docs/playground/src/PlaygroundConfiguration.ts
+++ b/docs/playground/src/PlaygroundConfiguration.ts
@@ -261,6 +261,7 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
         Coveo.state(searchInterface, 'q', 'getting started klingon language');
       });
     },
+    element: new SectionBuilder().withComponent('CoveoMissingTerms').build(),
     isResultComponent: true,
     basicExpression: 'getting started klingon language'
   },


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2548

Since the `missingTerms` is a new component, it won't work until the reference of the file `CoveoJsSearch.min.js` in `default.hbs` has been updated to the new version

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)