### PR TITLE
JSUI-2567 travis CI missing dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
 before_install:
   - npm install -g npm@5.5.1
   - if [ "x$TRAVIS_TAG" != "x" ]; then wget https://repo1.maven.org/maven2/com/veracode/vosp/api/wrappers/vosp-api-wrappers-java/$VERACODE_WRAPPER_VERSION/vosp-api-wrappers-java-$VERACODE_WRAPPER_VERSION.jar ; fi
+  - sudo apt-get install libgconf2-4
 script:
 - source read.version.sh
 - echo $PACKAGE_JSON_VERSION


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2567

Headless Chrome is missing a dependency to start

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)