### PR TITLE
Add isUserActionView field to the IQueryResult interface

### DIFF
--- a/src/rest/QueryResult.ts
+++ b/src/rest/QueryResult.ts
@@ -105,6 +105,12 @@ export interface IQueryResult {
    * See also [Coveo Machine Learning](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=177).
    */
   isRecommendation: boolean;
+
+  /**
+   * Contains a value that specifies whether the result was seen by the user targeted in the query.
+   */
+  isUserActionView?: boolean;
+
   /**
    * Specifies whether the result is a Featured Result in the Coveo Query Pipeline (see [Managing Query Pipeline Featured Results](http://www.coveo.com/go?dest=cloudhelp&lcid=9&context=126)).
    */


### PR DESCRIPTION
Search API added a field that we want to use for the viewed by customer feature (in search-ui-extension). This PR simply add the field into the 'model' of the results.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)