### PR TITLE
JSUI-2462  Remove isInternalQuery flag as backend will manage it on their side

### DIFF
--- a/src/controllers/DynamicFacetQueryController.ts
+++ b/src/controllers/DynamicFacetQueryController.ts
@@ -67,6 +67,8 @@ export class DynamicFacetQueryController {
 
   public executeIsolatedQuery(): Promise<IQueryResults> {
     const query = this.facet.queryController.getLastQuery();
+    // Specifying a numberOfResults of 0 will not log the query as a full fledged query in the API
+    // it will also alleviate the load on the index
     query.numberOfResults = 0;
 
     const previousFacetRequestIndex = findIndex(query.facets, { facetId: this.facet.options.id });

--- a/src/controllers/DynamicFacetQueryController.ts
+++ b/src/controllers/DynamicFacetQueryController.ts
@@ -67,8 +67,6 @@ export class DynamicFacetQueryController {
 
   public executeIsolatedQuery(): Promise<IQueryResults> {
     const query = this.facet.queryController.getLastQuery();
-    // @ts-ignore
-    query.isInternalQuery = true;
     query.numberOfResults = 0;
 
     const previousFacetRequestIndex = findIndex(query.facets, { facetId: this.facet.options.id });

--- a/unitTests/controllers/DynamicFacetQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicFacetQueryControllerTest.ts
@@ -166,7 +166,6 @@ export function DynamicFacetQueryControllerTest() {
         dynamicFacetQueryController.executeIsolatedQuery();
         expect(mockEndpoint.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            isInternalQuery: true,
             numberOfResults: 0
           })
         );

--- a/unitTests/controllers/DynamicFacetQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicFacetQueryControllerTest.ts
@@ -162,7 +162,8 @@ export function DynamicFacetQueryControllerTest() {
         facet.queryController.getLastQuery = () => queryBuilder.build();
       });
 
-      it(`should update query parameters`, () => {
+      it(`should send a numberOfResults of 0 in order not to log the query as a full fleged query
+        and alleviate the load on the index`, () => {
         dynamicFacetQueryController.executeIsolatedQuery();
         expect(mockEndpoint.search).toHaveBeenCalledWith(
           jasmine.objectContaining({


### PR DESCRIPTION



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)