### PR TITLE
Fix an issue the SalesForce Sidepanel

### DIFF
--- a/src/ui/Facet/FacetSettings.ts
+++ b/src/ui/Facet/FacetSettings.ts
@@ -157,7 +157,7 @@ export class FacetSettings extends FacetSort {
     new Popper(this.settingsButton, this.settingsPopup, {
       modifiers: {
         preventOverflow: {
-          boundariesElement: this.facet.root
+          boundariesElement: this.facet.element.parentElement
         }
       }
     });


### PR DESCRIPTION
Use facet's parent element instead of root as boundaries element

When a facet is inside a scroll container the facet setting dropdown was behaving strangely and sometime was hidden.



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)