### PR TITLE
JSUI-2589 Include token query string param only if defined

### DIFF
--- a/src/rest/AnalyticsEndpointCaller.ts
+++ b/src/rest/AnalyticsEndpointCaller.ts
@@ -22,12 +22,20 @@ export class AnalyticsEndpointCaller implements IEndpointCaller {
   }
 
   private sendBeacon(params: IEndpointCallParameters) {
-    const url = UrlUtils.normalizeAsString({
-      paths: params.url,
-      queryAsString: params.queryString.concat(`access_token=${this.options.accessToken}`)
-    });
+    const queryAsString = params.queryString.concat(this.additionalQueryStringParams);
+    const url = UrlUtils.normalizeAsString({ paths: params.url, queryAsString });
     const data = EndpointCaller.convertJsonToFormBody({ clickEvent: params.requestData });
     navigator.sendBeacon(url, new Blob([data], { type: 'application/x-www-form-urlencoded' }));
+  }
+
+  private get additionalQueryStringParams() {
+    const tokenParam = this.accessTokenAsQueryString;
+    return tokenParam ? [tokenParam] : [];
+  }
+
+  private get accessTokenAsQueryString() {
+    const token = this.options.accessToken;
+    return token ? `access_token=${token}` : '';
   }
 
   private shouldSendAsBeacon(params: IEndpointCallParameters): boolean {

--- a/unitTests/rest/AnalyticsEndpointCallerTest.ts
+++ b/unitTests/rest/AnalyticsEndpointCallerTest.ts
@@ -81,6 +81,12 @@ export const AnalyticsEndpointCallerTest = () => {
         expect(spyBeacon).toHaveBeenCalledWith('https://blah.analytics.com/click?access_token=foo', jasmine.anything());
       });
 
+      it('when the access token is undefined, it should not send it as a query string parameter', () => {
+        analyticsCaller.options.accessToken = undefined;
+        analyticsCaller.call(buildRequest('https://blah.analytics.com/click'));
+        expect(spyBeacon).toHaveBeenCalledWith('https://blah.analytics.com/click', jasmine.anything());
+      });
+
       it('should properly encode the payload', () => {
         const payload = {
           actionCause: 'something',


### PR DESCRIPTION
The access token is not present in the Sitecore UI. Rather it is added by the sitecore server before forwarding the request to the platform. This PR checks if the access token is defined before adding it as a query string param.

https://coveord.atlassian.net/browse/JSUI-2589





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)