### PR TITLE
JSUI-2594 Prevent resetting the category facet state when there are no results

### DIFF
--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -409,18 +409,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   }
 
   private handleNoResults() {
-    if (this.isPristine()) {
-      this.hide();
-      return;
-    }
-
-    if (this.hasValues) {
-      this.show();
-      return;
-    }
-
-    this.activePath = this.options.basePath;
-    this.hide();
+    this.hasValues ? this.show() : this.hide();
   }
 
   public handleQuerySuccess(args: IQuerySuccessEventArgs) {

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -41,6 +41,7 @@ import { AccessibleButton } from '../../utils/AccessibleButton';
 import { IStringMap } from '../../rest/GenericParam';
 import { DependsOnManager, IDependentFacet } from '../../utils/DependsOnManager';
 import { ResultListUtils } from '../../utils/ResultListUtils';
+import { CategoryFacetValuesTree } from './CategoryFacetValuesTree';
 
 export interface ICategoryFacetOptions extends IResponsiveComponentOptions {
   field: IFieldOption;
@@ -300,6 +301,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   private numberOfChildValuesCurrentlyDisplayed = 0;
   private numberOfValues: number;
   private dependsOnManager: DependsOnManager;
+  private categoryFacetValuesTree: CategoryFacetValuesTree;
 
   public static WAIT_ELEMENT_CLASS = 'coveo-category-facet-header-wait-animation';
 
@@ -313,6 +315,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
     this.categoryValueRoot.path = this.activePath;
     this.currentPage = 0;
     this.numberOfValues = this.options.numberOfValues;
+    this.categoryFacetValuesTree = new CategoryFacetValuesTree();
 
     this.tryToInitFacetSearch();
 
@@ -666,6 +669,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   }
 
   private renderValues(categoryFacetResult: ICategoryFacetResult, numberOfRequestedValues: number) {
+    this.categoryFacetValuesTree.storeNewValues(categoryFacetResult);
     this.show();
     let sortedParentValues = this.sortParentValues(categoryFacetResult.parentValues);
     let currentParentValue: CategoryValueParent = this.categoryValueRoot;
@@ -885,22 +889,19 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
       return;
     }
 
-    let lastParentValue = this.getVisibleParentValues().pop();
-
-    if (!lastParentValue) {
-      // This means we're in a special corner case where the current base path is configured
-      // to one level before the last values in the tree.
-      // In that case, there's simply no parent, so we must tweak things a bit so it plays nicely with the breadcrumb.
-      // We can simulate the "last parent value" as being the current active path itself.
-      lastParentValue = this.activeCategoryValue.getDescriptor();
-    }
+    const lastParentValue = this.categoryFacetValuesTree.getValueForLastPartInPath(this.activePath);
+    const descriptor: CategoryValueDescriptor = {
+      path: this.activePath,
+      count: lastParentValue.numberOfResults,
+      value: lastParentValue.value
+    };
 
     const resetFacet = () => {
       this.logAnalyticsEvent(analyticsActionCauseList.breadcrumbFacet);
       this.reset();
     };
 
-    const categoryFacetBreadcrumbBuilder = new CategoryFacetBreadcrumb(this, resetFacet, lastParentValue);
+    const categoryFacetBreadcrumbBuilder = new CategoryFacetBreadcrumb(this, resetFacet, descriptor);
 
     args.breadcrumbs.push({ element: categoryFacetBreadcrumbBuilder.build() });
   }

--- a/src/ui/CategoryFacet/CategoryFacetValuesTree.ts
+++ b/src/ui/CategoryFacet/CategoryFacetValuesTree.ts
@@ -1,0 +1,50 @@
+import { ICategoryFacetValue } from '../../rest/CategoryFacetValue';
+import { ICategoryFacetResult } from '../../rest/CategoryFacetResult';
+import { find } from 'underscore';
+
+type ISeenValue = { result: ICategoryFacetValue; children: ISeenValue[] };
+
+export class CategoryFacetValuesTree {
+  public seenValues: ISeenValue[] = [];
+
+  public getValueForLastPartInPath(path: string[]) {
+    const nullCategoryFacetValue: ICategoryFacetValue = { value: '', numberOfResults: 0 };
+    let currentNode: ISeenValue;
+
+    for (const part of path) {
+      const nodesToSearch = currentNode ? currentNode.children : this.seenValues;
+      const node = this.findNodeWithValue(nodesToSearch, part);
+
+      if (!node) {
+        return nullCategoryFacetValue;
+      }
+
+      currentNode = node;
+    }
+
+    return currentNode ? currentNode.result : nullCategoryFacetValue;
+  }
+
+  public storeNewValues(categoryFacetResult: ICategoryFacetResult) {
+    let currentNodes = this.seenValues;
+
+    for (const parent of categoryFacetResult.parentValues) {
+      const node = this.findNodeWithValue(currentNodes, parent.value);
+
+      if (!node) {
+        const newNode: ISeenValue = { result: parent, children: [] };
+        currentNodes.push(newNode);
+      }
+
+      currentNodes = this.findNodeWithValue(currentNodes, parent.value).children;
+    }
+
+    categoryFacetResult.values
+      .filter(result => !this.findNodeWithValue(currentNodes, result.value))
+      .forEach(result => currentNodes.push({ result, children: [] }));
+  }
+
+  private findNodeWithValue(nodes: ISeenValue[], value: string) {
+    return find(nodes, node => node.result.value === value);
+  }
+}

--- a/src/ui/CategoryFacet/CategoryFacetValuesTree.ts
+++ b/src/ui/CategoryFacet/CategoryFacetValuesTree.ts
@@ -2,7 +2,7 @@ import { ICategoryFacetValue } from '../../rest/CategoryFacetValue';
 import { ICategoryFacetResult } from '../../rest/CategoryFacetResult';
 import { find } from 'underscore';
 
-type ISeenValue = { result: ICategoryFacetValue; children: ISeenValue[] };
+export type ISeenValue = { result: ICategoryFacetValue; children: ISeenValue[] };
 
 export class CategoryFacetValuesTree {
   public seenValues: ISeenValue[] = [];

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -519,6 +519,9 @@ AccessTokenTest();
 import { CategoryFacetTest } from './ui/CategoryFacet/CategoryFacetTest';
 CategoryFacetTest();
 
+import { CategoryFacetValuesTreeTest } from './ui/CategoryFacet/CategoryFacetValuesTreeTest';
+CategoryFacetValuesTreeTest();
+
 import { FacetValueSuggestionsTest } from './ui/FacetValueSuggestionsTest';
 FacetValueSuggestionsTest();
 

--- a/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
@@ -119,18 +119,26 @@ export function CategoryFacetTest() {
         expect(test.cmp.hide).toHaveBeenCalled();
       });
 
-      it('does not hide the component when the facet is in an "active" state and has available values', () => {
+      it('does not hide the component when the facet has available values', () => {
         test.cmp.activePath = ['value1'];
         spyOn(test.cmp, 'getAvailableValues').and.returnValue(['value1', 'value2']);
         simulateNoResults();
         expect(test.cmp.hide).not.toHaveBeenCalled();
       });
 
-      it('hides the component when the facet is in an "active" state but has no available values', () => {
-        test.cmp.activePath = ['value1'];
-        spyOn(test.cmp, 'getAvailableValues').and.returnValue([]);
-        simulateNoResults();
-        expect(test.cmp.hide).toHaveBeenCalled();
+      describe(`when the facet does not have available values,
+      when simulating no results`, () => {
+        it(`does not call the query state model (doing so would prevent going back in history using the back button)`, () => {
+          spyOn(test.cmp.queryStateModel, 'set');
+          simulateNoResults();
+          expect(test.cmp.queryStateModel.set).not.toHaveBeenCalled();
+        });
+
+        it('hides the component', () => {
+          spyOn(test.cmp, 'getAvailableValues').and.returnValue([]);
+          simulateNoResults();
+          expect(test.cmp.hide).toHaveBeenCalled();
+        });
       });
     });
 

--- a/unitTests/ui/CategoryFacet/CategoryFacetValuesTreeTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetValuesTreeTest.ts
@@ -1,0 +1,130 @@
+import { CategoryFacetValuesTree } from '../../../src/ui/CategoryFacet/CategoryFacetValuesTree';
+import { ICategoryFacetValue } from '../../../src/rest/CategoryFacetValue';
+import { ICategoryFacetResult } from '../../../src/rest/CategoryFacetResult';
+
+function buildCategoryFacetValue(config: Partial<ICategoryFacetValue> = {}): ICategoryFacetValue {
+  return {
+    numberOfResults: 0,
+    value: '',
+    ...config
+  };
+}
+
+function buildCategoryFacetResult(config: Partial<ICategoryFacetResult> = {}): ICategoryFacetResult {
+  return {
+    field: '',
+    notImplemented: false,
+    parentValues: [],
+    values: [],
+    ...config
+  };
+}
+
+export function CategoryFacetValuesTreeTest() {
+  describe('CategoryFacetValuesTree', () => {
+    let klass: CategoryFacetValuesTree;
+
+    beforeEach(() => (klass = new CategoryFacetValuesTree()));
+
+    describe(`when the category facet result has no parents but has values, calling #storeNewValues`, () => {
+      const value1 = buildCategoryFacetValue({ value: 'hello' });
+      const value2 = buildCategoryFacetValue({ value: 'world' });
+      const result = buildCategoryFacetResult({ parentValues: [], values: [value1, value2] });
+
+      beforeEach(() => klass.storeNewValues(result));
+
+      it(`adds the values to base level of #seenValues`, () => {
+        const [firstSeenValue, secondSeenValue] = klass.seenValues;
+        expect(firstSeenValue.result).toEqual(value1);
+        expect(secondSeenValue.result).toEqual(value2);
+      });
+
+      it(`calling #storeNewValues a second time with the same values does not add the values again`, () => {
+        klass.storeNewValues(result);
+        expect(klass.seenValues.length).toBe(result.values.length);
+      });
+    });
+
+    describe(`when the category facet result has a parent value and no values, calling #storeNewValues`, () => {
+      const parentValue = buildCategoryFacetValue({ value: 'parent' });
+      const result = buildCategoryFacetResult({ parentValues: [parentValue], values: [] });
+
+      beforeEach(() => klass.storeNewValues(result));
+
+      it(`adds the parent value to base level of #seenValues`, () => {
+        const [firstSeenValue] = klass.seenValues;
+        expect(firstSeenValue.result).toEqual(parentValue);
+      });
+
+      it(`calling #storeNewValues a second time with the same parent value does not add the parent value again`, () => {
+        klass.storeNewValues(result);
+        expect(klass.seenValues.length).toBe(result.parentValues.length);
+      });
+    });
+
+    it(`when the category facet result has two parent values and no values,
+    calling #storeNewValues adds the first parent value to base level of #seenValues,
+    and the second parent value as a child of the first parent value`, () => {
+      const parentValue1 = buildCategoryFacetValue({ value: 'parent1' });
+      const parentValue2 = buildCategoryFacetValue({ value: 'parent2' });
+      const result = buildCategoryFacetResult({ parentValues: [parentValue1, parentValue2], values: [] });
+
+      klass.storeNewValues(result);
+
+      const [firstSeenValue] = klass.seenValues;
+      expect(firstSeenValue.result).toEqual(parentValue1);
+      expect(firstSeenValue.children[0].result).toEqual(parentValue2);
+    });
+
+    it(`when the category facet result has one parent value and one value,
+    calling #storeNewValues adds the value as a child of the parent value`, () => {
+      const parentValue = buildCategoryFacetValue({ value: 'parent' });
+      const childValue = buildCategoryFacetValue({ value: 'child' });
+      const result = buildCategoryFacetResult({ parentValues: [parentValue], values: [childValue] });
+
+      klass.storeNewValues(result);
+
+      const [firstSeenValue] = klass.seenValues;
+      expect(firstSeenValue.result).toEqual(parentValue);
+      expect(firstSeenValue.children[0].result).toEqual(childValue);
+    });
+
+    it(`when calling #getValueForLastPartInPath with an empty array,
+    it returns a an object with #value that is an empty string`, () => {
+      const result = klass.getValueForLastPartInPath([]);
+      expect(result.value).toBe('');
+    });
+
+    it(`when calling #getValueForLastPartInPath with an array with a value that has not been seen,
+    it returns an object with #value that is an empty string`, () => {
+      const result = klass.getValueForLastPartInPath(['newValue']);
+      expect(result.value).toBe('');
+    });
+
+    describe(`when calling #storeNewValues with two parent values`, () => {
+      const parent1 = buildCategoryFacetValue({ value: 'parent1' });
+      const parent2 = buildCategoryFacetValue({ value: 'parent2' });
+
+      beforeEach(() => {
+        const result = buildCategoryFacetResult({ parentValues: [parent1, parent2] });
+        klass.storeNewValues(result);
+      });
+
+      it(`when calling #getValueForLastPartInPath with the names of the parent values in the correct order,
+      it returns the second parent`, () => {
+        const path = [parent1.value, parent2.value];
+        const lastParent = klass.getValueForLastPartInPath(path);
+
+        expect(lastParent.value).toBe(parent2.value);
+      });
+
+      it(`when calling #getValueForLastPartInPath with the names of the parent values in reverse order,
+      it returns an object with #value that is an empty string`, () => {
+        const path = [parent2.value, parent1.value];
+        const lastParent = klass.getValueForLastPartInPath(path);
+
+        expect(lastParent.value).toBe('');
+      });
+    });
+  });
+}


### PR DESCRIPTION
**The problem:**

When a category facet is selected, performing a search query giving no results causes two query state model (QSM) updates (one for the query, the other for clearing the active category facet). This creates a loop of search queries with no results that prevents us from going back in history.

**The solution:**

There were at least two ideas to solve the issue.

The one I chose was to not update the QSM when there are no values for an active category facet. This means that when another search is done that does give results, the category facet state will be preserved to what it was before. This behaviour matches that of the standard facet.

Another approach might have been to update the QSM with the `silent` option set to `true`. I did not experiment to see if it would work, but assuming it does, this would mean the category facet would be in it's default state when reappearing.

I did not choose the second behaviour because it would diverge from the regular facet.

https://coveord.atlassian.net/browse/JSUI-2594





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)