### PR TITLE
JSUI-2605 CSS tweak for QuerySuggestPreview

### DIFF
--- a/sass/_QuerySuggestPreview.scss
+++ b/sass/_QuerySuggestPreview.scss
@@ -13,7 +13,7 @@
   }
   .coveo-preview-container {
     border: none;
-    background: $grey-100;
+    background: $white;
     flex: 1 1 100%;
   }
   .coveo-preview-results {
@@ -31,5 +31,10 @@
     padding: 10px;
     font-weight: normal;
     margin-top: 0;
+  }
+  .coveo-preview-selectable.coveo-omnibox-selected,
+  .coveo-preview-selectable:hover {
+    outline: $default-border;
+    outline-offset: -1px;
   }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2605

Remove Grey background because we could have white background on some image
and added a greyborder when a preview has the focus to see which ose is selected

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)