### PR TITLE
Fixed regex used to automatically detect fields to include

### DIFF
--- a/src/ui/Templates/TemplateConditionEvaluator.ts
+++ b/src/ui/Templates/TemplateConditionEvaluator.ts
@@ -8,14 +8,14 @@ export class TemplateConditionEvaluator {
     const regexAcceptableCharacters = '[a-z0-9_]';
     // Matches a field preceded by a `@` symbol.
     // getFieldFromString('@hello_world') === ['hello_world']
-    const regexAtMatcher = `(?:(?!\\b@)@(${regexAcceptableCharacters}+(?:\.${regexAcceptableCharacters}+)*\\b))`;
-    // Matches a field preceded by an name and a period.
+    const regexAtMatcher = `(?:(?!\\b@)@(${regexAcceptableCharacters}+(?:\\.${regexAcceptableCharacters}+)*\\b))`;
+    // Matches a field preceded by the word raw and a period.
     // getFieldFromString('john.doe') === ['doe']
     const regexObjectFieldMatcher = `\\braw\\.(${regexAcceptableCharacters}+)`;
-    // Matches a key between single or double quotes.
-    // getFieldFromString('hello["world"]') === ['world']
+    // Matches a key following the word raw between single or double quotes.
+    // getFieldFromString('raw["world"]') === ['world']
     const regexKeyMatcher = `\\braw\\[(?:'([^']+)'|"([^"]+)")\\]`;
-    const fieldRegex = new RegExp(`/${regexAtMatcher}|${regexObjectFieldMatcher}|${regexKeyMatcher}/gi`);
+    const fieldRegex = new RegExp(`${regexAtMatcher}|${regexObjectFieldMatcher}|${regexKeyMatcher}`, 'gi');
     const matches = StringUtils.match(text, fieldRegex);
     var fields: string[] = _.map(matches, field => {
       return field[1] || field[2] || field[3] || field[4] || null;

--- a/src/ui/Templates/TemplateConditionEvaluator.ts
+++ b/src/ui/Templates/TemplateConditionEvaluator.ts
@@ -5,16 +5,18 @@ import * as _ from 'underscore';
 
 export class TemplateConditionEvaluator {
   static getFieldFromString(text: string): string[] {
-    const regexAcceptableCharacters = '[a-z0-9_]';
+    const regexAcceptableCharacter = '[a-z0-9_]';
+    const regexStartOfWord = '(?:^|\\s)';
+    const regexEndOfWord = '(?:$|\\s)';
     // Matches a field preceded by a `@` symbol.
     // getFieldFromString('@hello_world') === ['hello_world']
-    const regexAtMatcher = `(?:(?!\\b@)@(${regexAcceptableCharacters}+(?:\\.${regexAcceptableCharacters}+)*\\b))`;
+    const regexAtMatcher = `${regexStartOfWord}@(${regexAcceptableCharacter}+)${regexEndOfWord}`;
     // Matches a field preceded by the word raw and a period.
     // getFieldFromString('john.doe') === ['doe']
-    const regexObjectFieldMatcher = `\\braw\\.(${regexAcceptableCharacters}+)`;
+    const regexObjectFieldMatcher = `${regexStartOfWord}raw\\.(${regexAcceptableCharacter}+)${regexEndOfWord}`;
     // Matches a key following the word raw between single or double quotes.
     // getFieldFromString('raw["world"]') === ['world']
-    const regexKeyMatcher = `\\braw\\[(?:'([^']+)'|"([^"]+)")\\]`;
+    const regexKeyMatcher = `${regexStartOfWord}raw\\[(?:'([^']+)'|"([^"]+)")\\]${regexEndOfWord}`;
     const fieldRegex = new RegExp(`${regexAtMatcher}|${regexObjectFieldMatcher}|${regexKeyMatcher}`, 'gi');
     const matches = StringUtils.match(text, fieldRegex);
     var fields: string[] = _.map(matches, field => {

--- a/src/ui/Templates/TemplateConditionEvaluator.ts
+++ b/src/ui/Templates/TemplateConditionEvaluator.ts
@@ -17,7 +17,7 @@ export class TemplateConditionEvaluator {
     const regexKeyMatcher = `\\braw\\[(?:'([^']+)'|"([^"]+)")\\]`;
     const fieldRegex = new RegExp(`${regexAtMatcher}|${regexObjectFieldMatcher}|${regexKeyMatcher}`, 'gi');
     const matches = StringUtils.match(text, fieldRegex);
-    var fields: string[] = _.map(matches, field => {
+    const fields: string[] = _.map(matches, field => {
       return field[1] || field[2] || field[3] || field[4] || null;
     });
 

--- a/src/ui/Templates/TemplateConditionEvaluator.ts
+++ b/src/ui/Templates/TemplateConditionEvaluator.ts
@@ -5,12 +5,21 @@ import * as _ from 'underscore';
 
 export class TemplateConditionEvaluator {
   static getFieldFromString(text: string): string[] {
-    var fields: string[] = _.map(
-      StringUtils.match(text, /(?:(?!\b@)@([a-z0-9]+(?:\.[a-z0-9]+)*\b))|\braw.([a-z0-9]+)|\braw\['([^']+)'\]|\braw\["([^"]+)"\]/gi),
-      field => {
-        return field[1] || field[2] || field[3] || field[4] || null;
-      }
-    );
+    const regexAcceptableCharacters = '[a-z0-9_]';
+    // Matches a field preceded by a `@` symbol.
+    // getFieldFromString('@hello_world') === ['hello_world']
+    const regexAtMatcher = `(?:(?!\\b@)@(${regexAcceptableCharacters}+(?:\.${regexAcceptableCharacters}+)*\\b))`;
+    // Matches a field preceded by an name and a period.
+    // getFieldFromString('john.doe') === ['doe']
+    const regexObjectFieldMatcher = `\\braw\\.(${regexAcceptableCharacters}+)`;
+    // Matches a key between single or double quotes.
+    // getFieldFromString('hello["world"]') === ['world']
+    const regexKeyMatcher = `\\braw\\[(?:'([^']+)'|"([^"]+)")\\]`;
+    const fieldRegex = new RegExp(`/${regexAtMatcher}|${regexObjectFieldMatcher}|${regexKeyMatcher}/gi`);
+    const matches = StringUtils.match(text, fieldRegex);
+    var fields: string[] = _.map(matches, field => {
+      return field[1] || field[2] || field[3] || field[4] || null;
+    });
 
     return fields;
   }

--- a/src/ui/Templates/TemplateConditionEvaluator.ts
+++ b/src/ui/Templates/TemplateConditionEvaluator.ts
@@ -4,24 +4,17 @@ import { ResponsiveComponents } from '../ResponsiveComponents/ResponsiveComponen
 import * as _ from 'underscore';
 
 export class TemplateConditionEvaluator {
-  static getFieldFromString(text: string): string[] {
-    const regexAcceptableCharacter = '[a-z0-9_]';
-    // Matches a field preceded by a `@` symbol.
-    // getFieldFromString('@hello_world') === ['hello_world']
-    const regexAtMatcher = `@(${regexAcceptableCharacter}+)\\b`;
-    // Matches a field preceded by the word raw and a period.
-    // getFieldFromString('john.doe') === ['doe']
-    const regexObjectFieldMatcher = `\\braw\\.(${regexAcceptableCharacter}+)\\b`;
-    // Matches a key following the word raw between single or double quotes.
-    // getFieldFromString('raw["world"]') === ['world']
-    const regexKeyMatcher = `\\braw\\[(?:'([^']+)'|"([^"]+)")\\]`;
-    const fieldRegex = new RegExp(`${regexAtMatcher}|${regexObjectFieldMatcher}|${regexKeyMatcher}`, 'gi');
-    const matches = StringUtils.match(text, fieldRegex);
-    const fields: string[] = _.map(matches, field => {
-      return field[1] || field[2] || field[3] || field[4] || null;
-    });
+  static getFieldFromString(text: string) {
+    const acceptableCharacterInFieldName = '[a-z0-9_]';
+    const fieldWithAtSymbolPrefix = `@(${acceptableCharacterInFieldName}+)\\b`;
+    const rawFieldAccessedUsingDotOperator = `\\braw\\.(${acceptableCharacterInFieldName}+)\\b`;
+    const fieldBetweenDoubleQuotes = `"[^"]*?(${acceptableCharacterInFieldName}+)[^"]*?"`;
+    const fieldBetweenSingleQuotes = `'[^']*?(${acceptableCharacterInFieldName}+)[^']*?'`;
+    const rawFieldAccessedUsingString = `\\braw\\[(?:${fieldBetweenDoubleQuotes}|${fieldBetweenSingleQuotes})\\]`;
+    const fieldMatcher = new RegExp(`${fieldWithAtSymbolPrefix}|${rawFieldAccessedUsingDotOperator}|${rawFieldAccessedUsingString}`, 'gi');
+    const matchedFields = StringUtils.match(text, fieldMatcher);
 
-    return fields;
+    return _.map(matchedFields, match => _.find(match.splice(1), field => field));
   }
 
   static evaluateCondition(condition: string, result: IQueryResult, responsiveComponents = new ResponsiveComponents()): Boolean {

--- a/src/ui/Templates/TemplateConditionEvaluator.ts
+++ b/src/ui/Templates/TemplateConditionEvaluator.ts
@@ -6,17 +6,15 @@ import * as _ from 'underscore';
 export class TemplateConditionEvaluator {
   static getFieldFromString(text: string): string[] {
     const regexAcceptableCharacter = '[a-z0-9_]';
-    const regexStartOfWord = '(?:^|\\s)';
-    const regexEndOfWord = '(?:$|\\s)';
     // Matches a field preceded by a `@` symbol.
     // getFieldFromString('@hello_world') === ['hello_world']
-    const regexAtMatcher = `${regexStartOfWord}@(${regexAcceptableCharacter}+)${regexEndOfWord}`;
+    const regexAtMatcher = `@(${regexAcceptableCharacter}+)\\b`;
     // Matches a field preceded by the word raw and a period.
     // getFieldFromString('john.doe') === ['doe']
-    const regexObjectFieldMatcher = `${regexStartOfWord}raw\\.(${regexAcceptableCharacter}+)${regexEndOfWord}`;
+    const regexObjectFieldMatcher = `\\braw\\.(${regexAcceptableCharacter}+)\\b`;
     // Matches a key following the word raw between single or double quotes.
     // getFieldFromString('raw["world"]') === ['world']
-    const regexKeyMatcher = `${regexStartOfWord}raw\\[(?:'([^']+)'|"([^"]+)")\\]${regexEndOfWord}`;
+    const regexKeyMatcher = `\\braw\\[(?:'([^']+)'|"([^"]+)")\\]`;
     const fieldRegex = new RegExp(`${regexAtMatcher}|${regexObjectFieldMatcher}|${regexKeyMatcher}`, 'gi');
     const matches = StringUtils.match(text, fieldRegex);
     var fields: string[] = _.map(matches, field => {

--- a/unitTests/ui/TemplateConditionEvaluatorTest.ts
+++ b/unitTests/ui/TemplateConditionEvaluatorTest.ts
@@ -16,7 +16,7 @@ export function TemplateConditionEvaluatorTest() {
       ).toBeTruthy();
     });
 
-    it('should be able to find a field in the format word.FIELDNAME', () => {
+    it('should be able to find a field in the format raw.FIELDNAME', () => {
       expect(
         Utils.arrayEqual(
           TemplateConditionEvaluator.getFieldFromString('raw.first_field raw.second raw.third'),
@@ -26,7 +26,7 @@ export function TemplateConditionEvaluatorTest() {
       ).toBeTruthy();
     });
 
-    it("should be able to find a field in the format word['FIELDNAME']", () => {
+    it("should be able to find a field in the format raw['FIELDNAME']", () => {
       expect(
         Utils.arrayEqual(
           TemplateConditionEvaluator.getFieldFromString(`raw['first_field'] raw['second'] raw['third']`),
@@ -36,7 +36,7 @@ export function TemplateConditionEvaluatorTest() {
       ).toBeTruthy();
     });
 
-    it('should be able to find a field in the format word["FIELDNAME"]', () => {
+    it('should be able to find a field in the format raw["FIELDNAME"]', () => {
       expect(
         Utils.arrayEqual(
           TemplateConditionEvaluator.getFieldFromString(`raw["first_field"] raw["second"] raw["third"]`),
@@ -50,6 +50,13 @@ export function TemplateConditionEvaluatorTest() {
       expect(TemplateConditionEvaluator.getFieldFromString(`My name is John Doe`).length).toBe(0);
     });
 
+    it('should not match an empty field name', () => {
+      expect(TemplateConditionEvaluator.getFieldFromString(`@`).length).toBe(0);
+      expect(TemplateConditionEvaluator.getFieldFromString(`raw.`).length).toBe(0);
+      expect(TemplateConditionEvaluator.getFieldFromString(`raw['']`).length).toBe(0);
+      expect(TemplateConditionEvaluator.getFieldFromString(`raw[""]`).length).toBe(0);
+    });
+
     it('should not accept anything other than the @ symbol, "raw" and a period, or brackets before a field name', () => {
       expect(TemplateConditionEvaluator.getFieldFromString(`aw.foo`).length).toBe(0);
       expect(TemplateConditionEvaluator.getFieldFromString(`aw["foo"]`).length).toBe(0);
@@ -58,11 +65,11 @@ export function TemplateConditionEvaluatorTest() {
       expect(TemplateConditionEvaluator.getFieldFromString(`<foo`).length).toBe(0);
     });
 
-    it("should not allow symbols within a field's name unless it is in between quotes", () => {
+    it("should not allow symbols within a field's name", () => {
       expect(
         Utils.arrayEqual(
           TemplateConditionEvaluator.getFieldFromString(`@foo#bar raw.hello#world raw['brown#fox']`),
-          ['foo', 'hello', 'brown#fox'],
+          ['foo', 'hello', 'brown'],
           false
         )
       ).toBeTruthy();

--- a/unitTests/ui/TemplateConditionEvaluatorTest.ts
+++ b/unitTests/ui/TemplateConditionEvaluatorTest.ts
@@ -2,13 +2,56 @@ import { TemplateConditionEvaluator } from '../../src/ui/Templates/TemplateCondi
 import { FakeResults } from '../Fake';
 import { IQueryResult } from '../../src/rest/QueryResult';
 import { ResponsiveComponents } from '../../src/ui/ResponsiveComponents/ResponsiveComponents';
+import { Utils } from '../../src/utils/Utils';
 
 export function TemplateConditionEvaluatorTest() {
   describe('TemplateConditionEvaluator', () => {
-    it('should be able to extract the coveo fields from a given arbitrary string', () => {
-      expect(TemplateConditionEvaluator.getFieldFromString('raw.foo @foobar test test raw["baz"] not a field')).toEqual(
-        jasmine.arrayContaining(['foo', 'foobar', 'baz'])
-      );
+    it('should be able to find a field in the format @FIELDNAME', () => {
+      expect(
+        Utils.arrayEqual(
+          TemplateConditionEvaluator.getFieldFromString('@first_field second third@fourth @fifth'),
+          ['first_field', 'fifth'],
+          false
+        )
+      ).toBeTruthy();
+    });
+
+    it('should be able to find a field in the format word.FIELDNAME', () => {
+      expect(
+        Utils.arrayEqual(
+          TemplateConditionEvaluator.getFieldFromString('first.second raw.third .fifth aw.sixth raw.seventh_field'),
+          ['third', 'seventh_field'],
+          false
+        )
+      ).toBeTruthy();
+    });
+
+    it('should be able to find a field in the format word["FIELDNAME"]', () => {
+      expect(
+        Utils.arrayEqual(
+          TemplateConditionEvaluator.getFieldFromString(
+            `first['second'] raw[fourth] aw['fifth'] raw['sixth_field'] raw[\`seventh\`] raw["eight"]`
+          ),
+          ['sixth_field', 'eight'],
+          false
+        )
+      ).toBeTruthy();
+    });
+
+    it('should not be able to find a field in the format raw.@FIELDNAME', () => {
+      expect(TemplateConditionEvaluator.getFieldFromString(`raw.@field`).length).toBe(0);
+    });
+
+    it('should not be able to find a field in the format raw[@FIELDNAME]', () => {
+      expect(TemplateConditionEvaluator.getFieldFromString(`raw[@field]`).length).toBe(0);
+    });
+
+    it('should not be able to find a field in the format @raw.FIELDNAME', () => {
+      expect(TemplateConditionEvaluator.getFieldFromString(`@raw.field`).length).toBe(0);
+    });
+
+    it('should not be able to find a field in the format @raw["field"]', () => {
+      expect(TemplateConditionEvaluator.getFieldFromString(`@raw["field"]`).length).toBe(0);
     });
 
     describe('should be able to evaluate a basic boolean condition', () => {


### PR DESCRIPTION
Fixed an error where the regex `TemplateConditionEvaluator.getFieldFromString` would not detect fields with an underscore in their names.
Added more unit tests for the function.

https://coveord.atlassian.net/browse/JSUI-2572

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)