### PR TITLE
Trigger events from root if the element is not a descendant of the search interface

### DIFF
--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -710,9 +710,17 @@ export class Omnibox extends Component {
       }
     }
 
-    this.bind.trigger(this.root, OmniboxEvents.omniboxPreprocessResultForQuery, preprocessResultForQueryArgs);
+    this.triggerOmniboxPreprocessResultForQuery(preprocessResultForQueryArgs);
     const query = preprocessResultForQueryArgs.result.toString();
     new QueryboxQueryParameters(this.options).addParameters(data.queryBuilder, query);
+  }
+
+  private triggerOmniboxPreprocessResultForQuery(args: IOmniboxPreprocessResultForQueryEventArgs) {
+    this.bind.trigger(this.element, OmniboxEvents.omniboxPreprocessResultForQuery, args);
+
+    if (!$$(this.element).isDescendant(this.root)) {
+      this.bind.trigger(this.root, OmniboxEvents.omniboxPreprocessResultForQuery, args);
+    }
   }
 
   private handleNewQuery(data: INewQueryEventArgs) {

--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -5,27 +5,36 @@
 
 import 'styling/_Omnibox';
 import * as _ from 'underscore';
-import { exportGlobally } from '../../GlobalExports';
+import { findWhere } from 'underscore';
+import { BreadcrumbEvents } from '../../events/BreadcrumbEvents';
 import {
   IOmniboxPreprocessResultForQueryEventArgs,
   IPopulateOmniboxSuggestionsEventArgs,
-  OmniboxEvents,
-  IQuerySuggestSelection
+  IQuerySuggestSelection,
+  OmniboxEvents
 } from '../../events/OmniboxEvents';
-import { IBuildingQueryEventArgs, IDuringQueryEventArgs, QueryEvents, INewQueryEventArgs } from '../../events/QueryEvents';
+import { IBuildingQueryEventArgs, IDuringQueryEventArgs, INewQueryEventArgs, QueryEvents } from '../../events/QueryEvents';
 import { StandaloneSearchInterfaceEvents } from '../../events/StandaloneSearchInterfaceEvents';
+import { exportGlobally } from '../../GlobalExports';
+import { ExpressionDef } from '../../magicbox/Expression/Expression';
+import { Grammar } from '../../magicbox/Grammar';
+import { Complete } from '../../magicbox/Grammars/Complete';
+import { Expressions } from '../../magicbox/Grammars/Expressions';
+import { createMagicBox, MagicBoxInstance } from '../../magicbox/MagicBox';
+import { Result } from '../../magicbox/Result/Result';
+import { Suggestion } from '../../magicbox/SuggestionsManager';
 import { Assert } from '../../misc/Assert';
 import { COMPONENT_OPTIONS_ATTRIBUTES } from '../../models/ComponentOptionsModel';
 import { IAttributeChangedEventArg, MODEL_EVENTS } from '../../models/Model';
-import { QUERY_STATE_ATTRIBUTES, QueryStateModel } from '../../models/QueryStateModel';
+import { QueryStateModel, QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
 import { l } from '../../strings/Strings';
 import { $$, Dom } from '../../utils/Dom';
 import { Utils } from '../../utils/Utils';
 import {
+  analyticsActionCauseList,
   IAnalyticsActionCause,
   IAnalyticsNoMeta,
-  IAnalyticsOmniboxSuggestionMeta,
-  analyticsActionCauseList
+  IAnalyticsOmniboxSuggestionMeta
 } from '../Analytics/AnalyticsActionListMeta';
 import { PendingSearchAsYouTypeSearchEvent } from '../Analytics/PendingSearchAsYouTypeSearchEvent';
 import { logSearchBoxSubmitEvent } from '../Analytics/SharedAnalyticsCalls';
@@ -34,23 +43,14 @@ import { IComponentBindings } from '../Base/ComponentBindings';
 import { ComponentOptions, IFieldOption } from '../Base/ComponentOptions';
 import { Initialization } from '../Base/Initialization';
 import { IQueryboxOptions, Querybox } from '../Querybox/Querybox';
+import { QueryboxOptionsProcessing } from '../Querybox/QueryboxOptionsProcessing';
 import { QueryboxQueryParameters } from '../Querybox/QueryboxQueryParameters';
 import { StandaloneSearchInterface } from '../SearchInterface/SearchInterface';
 import { FieldAddon } from './FieldAddon';
 import { OldOmniboxAddon } from './OldOmniboxAddon';
+import { OmniboxAnalytics } from './OmniboxAnalytics';
 import { QueryExtensionAddon } from './QueryExtensionAddon';
 import { IQuerySuggestAddon, QuerySuggestAddon, VoidQuerySuggestAddon } from './QuerySuggestAddon';
-import { Grammar } from '../../magicbox/Grammar';
-import { Complete } from '../../magicbox/Grammars/Complete';
-import { Expressions } from '../../magicbox/Grammars/Expressions';
-import { Suggestion } from '../../magicbox/SuggestionsManager';
-import { ExpressionDef } from '../../magicbox/Expression/Expression';
-import { Result } from '../../magicbox/Result/Result';
-import { MagicBoxInstance, createMagicBox } from '../../magicbox/MagicBox';
-import { QueryboxOptionsProcessing } from '../Querybox/QueryboxOptionsProcessing';
-import { OmniboxAnalytics } from './OmniboxAnalytics';
-import { findWhere } from 'underscore';
-import { BreadcrumbEvents } from '../../events/BreadcrumbEvents';
 
 export interface IOmniboxSuggestion extends Suggestion {
   executableConfidence?: number;
@@ -655,13 +655,24 @@ export class Omnibox extends Component {
         suggestions: [],
         omnibox: this
       };
-      this.bind.trigger(this.element, OmniboxEvents.populateOmniboxSuggestions, suggestionsEventArgs);
+
+      this.triggerOmniboxSuggestions(suggestionsEventArgs);
+
       if (!Utils.isNullOrEmptyString(text)) {
         this.omniboxAnalytics.partialQueries.push(text);
       }
+
       return _.compact(suggestionsEventArgs.suggestions);
     } else {
       return [];
+    }
+  }
+
+  private triggerOmniboxSuggestions(args: IPopulateOmniboxSuggestionsEventArgs) {
+    this.bind.trigger(this.element, OmniboxEvents.populateOmniboxSuggestions, args);
+
+    if (!$$(this.element).isDescendant(this.root)) {
+      this.bind.trigger(this.root, OmniboxEvents.populateOmniboxSuggestions, args);
     }
   }
 
@@ -699,7 +710,7 @@ export class Omnibox extends Component {
       }
     }
 
-    this.bind.trigger(this.element, OmniboxEvents.omniboxPreprocessResultForQuery, preprocessResultForQueryArgs);
+    this.bind.trigger(this.root, OmniboxEvents.omniboxPreprocessResultForQuery, preprocessResultForQueryArgs);
     const query = preprocessResultForQueryArgs.result.toString();
     new QueryboxQueryParameters(this.options).addParameters(data.queryBuilder, query);
   }

--- a/unitTests/ui/OmniboxTest.ts
+++ b/unitTests/ui/OmniboxTest.ts
@@ -76,6 +76,32 @@ export function OmniboxTest() {
       });
     });
 
+    describe('when the omnibox launches omniboxPreprocessResultForQuery events', () => {
+      it('it triggers the event from the component element as well as root element if the omnibox is not a descendant of its root', () => {
+        const fakeRoot = document.createElement('div');
+        test.cmp.root = fakeRoot;
+        const spy = jasmine.createSpy('spy');
+
+        $$(fakeRoot).on(OmniboxEvents.omniboxPreprocessResultForQuery, spy);
+        $$(test.cmp.element).on(OmniboxEvents.omniboxPreprocessResultForQuery, spy);
+
+        Simulate.query(test.env);
+        expect(spy).toHaveBeenCalledTimes(2);
+      });
+
+      it('it triggers the event only once if the element is a descendant of its root', () => {
+        const fakeRoot = document.createElement('div');
+        test.cmp.root = fakeRoot;
+        fakeRoot.appendChild(test.cmp.element);
+
+        const spy = jasmine.createSpy('spy');
+        $$(fakeRoot).on(OmniboxEvents.omniboxPreprocessResultForQuery, spy);
+
+        Simulate.query(test.env);
+        expect(spy).toHaveBeenCalledTimes(1);
+      });
+    });
+
     describe('on submit', () => {
       beforeEach(() => test.cmp.submit());
 

--- a/unitTests/ui/OmniboxTest.ts
+++ b/unitTests/ui/OmniboxTest.ts
@@ -1,16 +1,15 @@
-import * as Mock from '../MockEnvironment';
-import { Omnibox } from '../../src/ui/Omnibox/Omnibox';
-import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
-import { IOmniboxOptions, IOmniboxSuggestion } from '../../src/ui/Omnibox/Omnibox';
-import { Simulate } from '../Simulate';
-import { $$ } from '../../src/utils/Dom';
-import { l } from '../../src/strings/Strings';
-import { InitializationEvents } from '../../src/events/InitializationEvents';
-import { IFieldDescription } from '../../src/rest/FieldDescription';
-import { Suggestion } from '../../src/magicbox/SuggestionsManager';
-import { KEYBOARD, OmniboxEvents, BreadcrumbEvents, QueryEvents } from '../../src/Core';
 import { IQueryOptions } from '../../src/controllers/QueryController';
+import { BreadcrumbEvents, KEYBOARD, OmniboxEvents, QueryEvents } from '../../src/Core';
+import { InitializationEvents } from '../../src/events/InitializationEvents';
+import { Suggestion } from '../../src/magicbox/SuggestionsManager';
+import { IFieldDescription } from '../../src/rest/FieldDescription';
+import { l } from '../../src/strings/Strings';
+import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
+import { IOmniboxOptions, IOmniboxSuggestion, Omnibox } from '../../src/ui/Omnibox/Omnibox';
 import { IOmniboxAnalytics } from '../../src/ui/Omnibox/OmniboxAnalytics';
+import { $$ } from '../../src/utils/Dom';
+import * as Mock from '../MockEnvironment';
+import { Simulate } from '../Simulate';
 import { initOmniboxAnalyticsMock } from './QuerySuggestPreviewTest';
 
 export function OmniboxTest() {
@@ -48,6 +47,34 @@ export function OmniboxTest() {
         })
       );
     }
+
+    describe('when the omnibox launches populateOmniboxSuggestions events', () => {
+      it('it triggers the event from the component element as well as root element if the omnibox is not a descendant of its root', async done => {
+        const fakeRoot = document.createElement('div');
+        test.cmp.root = fakeRoot;
+        const spy = jasmine.createSpy('spy');
+
+        $$(fakeRoot).on(OmniboxEvents.populateOmniboxSuggestions, spy);
+        $$(test.cmp.element).on(OmniboxEvents.populateOmniboxSuggestions, spy);
+
+        await test.cmp.magicBox.getSuggestions();
+        expect(spy).toHaveBeenCalledTimes(2);
+        done();
+      });
+
+      it('it triggers the event only once if the element is a descendant of its root', async done => {
+        const fakeRoot = document.createElement('div');
+        test.cmp.root = fakeRoot;
+        fakeRoot.appendChild(test.cmp.element);
+
+        const spy = jasmine.createSpy('spy');
+        $$(fakeRoot).on(OmniboxEvents.populateOmniboxSuggestions, spy);
+
+        await test.cmp.magicBox.getSuggestions();
+        expect(spy).toHaveBeenCalledTimes(1);
+        done();
+      });
+    });
 
     describe('on submit', () => {
       beforeEach(() => test.cmp.submit());


### PR DESCRIPTION
There's the possibility to configure components as "external" from the root of the search interface.

In those case, triggering the event from the Omnibox element only would mean it does not get picked up by other components inside the search interface, since they do not have a common ancestor.

https://coveord.atlassian.net/browse/JSUI-2639





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)