### PR TITLE
Add setter on query builder

### DIFF
--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -1,4 +1,5 @@
 import { history } from 'coveo.analytics';
+import { NullStorage } from 'coveo.analytics/dist/storage';
 import * as _ from 'underscore';
 import {
   IBuildingCallOptionsEventArgs,
@@ -30,7 +31,6 @@ import { LocalStorageUtils } from '../utils/LocalStorageUtils';
 import { QueryUtils } from '../utils/QueryUtils';
 import { UrlUtils } from '../utils/UrlUtils';
 import { Utils } from '../utils/Utils';
-import { NullStorage } from 'coveo.analytics/dist/storage';
 
 /**
  * Possible options when performing a query with the query controller

--- a/src/ui/Base/QueryBuilder.ts
+++ b/src/ui/Base/QueryBuilder.ts
@@ -1,13 +1,13 @@
-import { ExpressionBuilder } from './ExpressionBuilder';
-import { IRankingFunction } from '../../rest/RankingFunction';
-import { IQueryFunction } from '../../rest/QueryFunction';
-import { IGroupByRequest } from '../../rest/GroupByRequest';
-import { IQuery, IFacetOptions, IUserActionsRequest } from '../../rest/Query';
-import { QueryBuilderExpression } from './QueryBuilderExpression';
 import * as _ from 'underscore';
-import { Utils } from '../../utils/Utils';
 import { ICategoryFacetRequest } from '../../rest/CategoryFacetRequest';
 import { IFacetRequest } from '../../rest/Facet/FacetRequest';
+import { IGroupByRequest } from '../../rest/GroupByRequest';
+import { IFacetOptions, IQuery, IUserActionsRequest } from '../../rest/Query';
+import { IQueryFunction } from '../../rest/QueryFunction';
+import { IRankingFunction } from '../../rest/RankingFunction';
+import { Utils } from '../../utils/Utils';
+import { ExpressionBuilder } from './ExpressionBuilder';
+import { QueryBuilderExpression } from './QueryBuilderExpression';
 
 /**
  * The QueryBuilder is used to build a {@link IQuery} that will be able to be executed using the Search API.
@@ -528,11 +528,19 @@ export class QueryBuilder {
     return this.groupByRequests;
   }
 
+  private set groupBy(groupBy: IGroupByRequest[]) {
+    this.groupByRequests = groupBy;
+  }
+
   private get facets() {
     if (Utils.isEmptyArray(this.facetRequests)) {
       return undefined;
     }
 
     return this.facetRequests;
+  }
+
+  private set facets(facets: IFacetRequest[]) {
+    this.facetRequests = facets;
   }
 }


### PR DESCRIPTION
TLDR: 

Salesforce Locker service modifies underscore.js module to add `strict mode`;
This means the _.extend function starts throwing when extending object with getter but no setter...


https://coveord.atlassian.net/browse/JSUI-2640





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)