### PR TITLE
Fixed highlight for facets appearing in searchbox with includeInOmnibox.

### DIFF
--- a/sass/_Omnibox.scss
+++ b/sass/_Omnibox.scss
@@ -108,4 +108,10 @@
       text-overflow: ellipsis;
     }
   }
+  .coveo-facet-value-caption {
+    font-weight: bold;
+    .coveo-highlight {
+      font-weight: normal;
+    }
+  }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2653

Fixed an issue where highlights in `Facet` suggestions in the search box (from `Facet` with `includeInOmnibox: true`) wouldn't respect the new CSS highlight.

They now look like the following:
![image](https://user-images.githubusercontent.com/54454747/65451523-57c54d00-de0d-11e9-9e07-138e8c544ac3.png)


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)