### PR TITLE
JSUI-2652 Don't display facet values that are "idle" and without results

### DIFF
--- a/src/controllers/DynamicFacetRangeQueryController.ts
+++ b/src/controllers/DynamicFacetRangeQueryController.ts
@@ -5,10 +5,6 @@ import { DynamicFacetRange } from '../ui/DynamicFacet/DynamicFacetRange';
 export class DynamicFacetRangeQueryController extends DynamicFacetQueryController {
   protected facet: DynamicFacetRange;
 
-  private get hasValues() {
-    return !!this.facet.values.allFacetValues.length;
-  }
-
   public get facetRequest(): IFacetRequest {
     return {
       facetId: this.facet.options.id,
@@ -16,12 +12,12 @@ export class DynamicFacetRangeQueryController extends DynamicFacetQueryControlle
       type: this.facet.facetType,
       currentValues: this.currentValues,
       numberOfValues: this.numberOfValues,
-      freezeCurrentValues: this.hasValues
+      freezeCurrentValues: this.facet.values.hasValues
     };
   }
 
   protected get numberOfValues() {
-    return this.hasValues ? this.currentValues.length : this.facet.options.numberOfValues;
+    return this.facet.values.hasValues ? this.currentValues.length : this.facet.options.numberOfValues;
   }
 
   protected get currentValues(): IFacetRequestValue[] {

--- a/src/controllers/DynamicFacetRangeQueryController.ts
+++ b/src/controllers/DynamicFacetRangeQueryController.ts
@@ -6,7 +6,7 @@ export class DynamicFacetRangeQueryController extends DynamicFacetQueryControlle
   protected facet: DynamicFacetRange;
 
   private get hasValues() {
-    return !this.facet.values.isEmpty;
+    return !!this.facet.values.allFacetValues.length;
   }
 
   public get facetRequest(): IFacetRequest {

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -695,7 +695,7 @@ export class DynamicFacet extends Component implements IAutoLayoutAdjustableInsi
     this.toggleSearchDisplay();
     $$(this.element).toggleClass('coveo-dynamic-facet-collapsed', this.isCollapsed);
     $$(this.element).toggleClass('coveo-active', this.values.hasSelectedValues);
-    $$(this.element).toggleClass('coveo-hidden', this.values.isEmpty);
+    $$(this.element).toggleClass('coveo-hidden', !this.values.hasDisplayedValues);
   }
 
   private toggleSearchDisplay() {

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
@@ -57,7 +57,7 @@ export class DynamicFacetValues {
     return this.facetValues.filter(value => !value.isIdle);
   }
 
-  private get nonEmptyOrActiveFacetValues() {
+  private get displayedValues() {
     return this.facetValues.filter(value => !value.isIdle || value.numberOfResults > 0);
   }
 
@@ -77,8 +77,12 @@ export class DynamicFacetValues {
     this.facetValues.forEach(value => value.deselect());
   }
 
-  public get isEmpty() {
-    return !this.nonEmptyOrActiveFacetValues.length;
+  public get hasValues() {
+    return !!this.allFacetValues.length;
+  }
+
+  public get hasDisplayedValues() {
+    return !!this.displayedValues.length;
   }
 
   public hasSelectedValue(arg: string | DynamicFacetValue) {
@@ -162,7 +166,7 @@ export class DynamicFacetValues {
     const fragment = document.createDocumentFragment();
     $$(this.list).empty();
 
-    this.nonEmptyOrActiveFacetValues.forEach(facetValue => {
+    this.displayedValues.forEach(facetValue => {
       fragment.appendChild(facetValue.renderedElement);
     });
 

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
@@ -57,6 +57,10 @@ export class DynamicFacetValues {
     return this.facetValues.filter(value => !value.isIdle);
   }
 
+  private get nonEmptyOrActiveFacetValues() {
+    return this.facetValues.filter(value => !value.isIdle || value.numberOfResults > 0);
+  }
+
   public get hasSelectedValues() {
     return !!findWhere(this.facetValues, { state: FacetValueState.selected });
   }
@@ -74,7 +78,7 @@ export class DynamicFacetValues {
   }
 
   public get isEmpty() {
-    return !this.facetValues.length;
+    return !this.nonEmptyOrActiveFacetValues.length;
   }
 
   public hasSelectedValue(arg: string | DynamicFacetValue) {
@@ -158,7 +162,7 @@ export class DynamicFacetValues {
     const fragment = document.createDocumentFragment();
     $$(this.list).empty();
 
-    this.facetValues.forEach(facetValue => {
+    this.nonEmptyOrActiveFacetValues.forEach(facetValue => {
       fragment.appendChild(facetValue.renderedElement);
     });
 

--- a/src/ui/DynamicFacetManager/DynamicFacetManager.ts
+++ b/src/ui/DynamicFacetManager/DynamicFacetManager.ts
@@ -97,8 +97,8 @@ export class DynamicFacetManager extends Component {
     return this.childrenFacets.filter(facet => !facet.disabled);
   }
 
-  private get facetsWithValues() {
-    return this.childrenFacets.filter(facet => !facet.values.isEmpty);
+  private get facetsWithDisplayedValues() {
+    return this.childrenFacets.filter(facet => facet.values.hasDisplayedValues);
   }
 
   /**
@@ -213,7 +213,7 @@ export class DynamicFacetManager extends Component {
       return;
     }
 
-    const [collapsableFacets, uncollapsableFacets] = partition(this.facetsWithValues, facet => facet.options.enableCollapse);
+    const [collapsableFacets, uncollapsableFacets] = partition(this.facetsWithDisplayedValues, facet => facet.options.enableCollapse);
     const [facetsWithActiveValues, remainingFacets] = partition(collapsableFacets, facet => facet.values.hasActiveValues);
     const indexOfFirstFacetToCollapse =
       this.options.maximumNumberOfExpandedFacets - uncollapsableFacets.length - facetsWithActiveValues.length;

--- a/unitTests/ui/DynamicFacet/DynamicFacetRangeTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetRangeTest.ts
@@ -43,7 +43,7 @@ export function DynamicFacetRangeTest() {
 
     it(`when the ranges option is not defined
       should not have values`, () => {
-      expect(test.cmp.values.isEmpty).toBe(true);
+      expect(test.cmp.values.hasValues).toBe(false);
     });
 
     it(`when the ranges option is defined

--- a/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValuesTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValuesTest.ts
@@ -99,8 +99,18 @@ export function DynamicFacetValuesTest() {
       expect(dynamicFacetValues.hasIdleValues).toBe(false);
     });
 
-    it('when there are values, isEmpty should return false', () => {
+    it('when there are values (non empty or active), isEmpty should return false', () => {
       expect(dynamicFacetValues.isEmpty).toBe(false);
+    });
+
+    it('when there are only idle values with no results, isEmpty should return true', () => {
+      const idleValueWithoutResult = mockFacetValues[0];
+      idleValueWithoutResult.state = FacetValueState.idle;
+      idleValueWithoutResult.numberOfResults = 0;
+      mockFacetValues = [idleValueWithoutResult];
+      initializeComponent();
+
+      expect(dynamicFacetValues.isEmpty).toBe(true);
     });
 
     it('when there are no values, isEmpty should return true', () => {
@@ -130,6 +140,14 @@ export function DynamicFacetValuesTest() {
     it('renders the correct number of children', () => {
       const element = dynamicFacetValues.render();
       expect(element.childElementCount).toBe(mockFacetValues.length);
+    });
+
+    it('does not renders children that are idle and without result', () => {
+      mockFacetValues[0].numberOfResults = 0;
+      initializeComponent();
+
+      const element = dynamicFacetValues.render();
+      expect(element.childElementCount).toBe(mockFacetValues.length - 1);
     });
 
     it(`when moreValuesAvailable is false

--- a/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValuesTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValuesTest.ts
@@ -99,24 +99,24 @@ export function DynamicFacetValuesTest() {
       expect(dynamicFacetValues.hasIdleValues).toBe(false);
     });
 
-    it('when there are values (non empty or active), isEmpty should return false', () => {
-      expect(dynamicFacetValues.isEmpty).toBe(false);
+    it('when there are values (non empty or active), hasDisplayedValues should return true', () => {
+      expect(dynamicFacetValues.hasDisplayedValues).toBe(true);
     });
 
-    it('when there are only idle values with no results, isEmpty should return true', () => {
+    it('when there are only idle values with no results, hasDisplayedValues should return false', () => {
       const idleValueWithoutResult = mockFacetValues[0];
       idleValueWithoutResult.state = FacetValueState.idle;
       idleValueWithoutResult.numberOfResults = 0;
       mockFacetValues = [idleValueWithoutResult];
       initializeComponent();
 
-      expect(dynamicFacetValues.isEmpty).toBe(true);
+      expect(dynamicFacetValues.hasDisplayedValues).toBe(false);
     });
 
-    it('when there are no values, isEmpty should return true', () => {
+    it('when there are no values, hasDisplayedValues should return false', () => {
       mockFacetValues = [];
       initializeComponent();
-      expect(dynamicFacetValues.isEmpty).toBe(true);
+      expect(dynamicFacetValues.hasDisplayedValues).toBe(false);
     });
 
     it('clearAll should set all values to selected=false', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2652

Because we get send ranges and freezeCurrentValue = true, we sometimes get empty idle values back, which we should not display, but need to keep in our "current values". Added a filter for not rendering them.
 



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)