### PR TITLE
JSUI-2659 Convert.finally() calls to async/await

### DIFF
--- a/src/ui/Analytics/PendingSearchEvent.ts
+++ b/src/ui/Analytics/PendingSearchEvent.ts
@@ -106,7 +106,7 @@ export class PendingSearchEvent {
       Assert.exists(queryResults);
       Assert.check(!this.finished);
 
-      const isRecommendationPanelAction = this.templateSearchEvent.actionCause == analyticsActionCauseList.recommendation.name;
+      const isRecommendationPanelAction = this.templateSearchEvent.actionCause === analyticsActionCauseList.recommendation.name;
 
       if (queryResults._reusedSearchUid !== true || isRecommendationPanelAction) {
         const searchEvent: ISearchEvent = { ...this.templateSearchEvent };
@@ -121,7 +121,7 @@ export class PendingSearchEvent {
     const index = indexOf(this.searchPromises, args.promise);
     this.searchPromises.splice(index, 1);
 
-    if (this.searchPromises.length == 0) {
+    if (!this.searchPromises.length) {
       this.flush();
     }
   }
@@ -187,9 +187,7 @@ export class PendingSearchEvent {
     // This is what they use to recognize a custom data that will be used internally by other coveo's service.
     // In this case, Coveo Machine Learning will be the consumer of this information.
     if (query.context != undefined) {
-      each(query.context, (value: string, key: string) => {
-        searchEvent.customData[`context_${key}`] = value;
-      });
+      each(query.context, (value: string, key: string) => (searchEvent.customData[`context_${key}`] = value));
     }
 
     if (queryResults.refinedKeywords != undefined && queryResults.refinedKeywords.length != 0) {

--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -529,7 +529,7 @@ export class ResultList extends Component {
   private async renderNewResults(data: IQueryResults) {
     const elements = await this.buildResults(data);
     this.renderResults(elements, true);
-    each(data.results, result => this.currentlyDisplayedResults.push(result));
+    this.currentlyDisplayedResults.push(...data.results);
     this.triggerNewResultsDisplayed();
   }
 
@@ -542,10 +542,8 @@ export class ResultList extends Component {
         this.handleScrollOfResultList();
       } else {
         this.logger.info(
-          `Result list has triggered 5 consecutive queries to try and fill up the scrolling container, but it is still unable to do so`
-        );
-        this.logger.info(
-          `Try explicitly setting the 'data-infinite-scroll-container-selector' option on the result list. See : https://coveo.github.io/search-ui/components/resultlist.html#options.infinitescrollcontainer`
+          `Result list has triggered 5 consecutive queries to try and fill up the scrolling container, but it is still unable to do so.
+          Try explicitly setting the 'data-infinite-scroll-container-selector' option on the result list. See : https://coveo.github.io/search-ui/components/resultlist.html#options.infinitescrollcontainer`
         );
       }
     });

--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -440,40 +440,7 @@ export class ResultList extends Component {
       this.showWaitingAnimationForInfiniteScrolling();
     }
 
-    this.fetchingMoreResults = this.queryController.fetchMore(count);
-    this.fetchingMoreResults.then((data: IQueryResults) => {
-      Assert.exists(data);
-      this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.pagerScrolling, {}, this.element);
-      const results = data.results;
-      this.reachedTheEndOfResults = count > data.results.length;
-      this.buildResults(data).then(async (elements: HTMLElement[]) => {
-        this.renderResults(elements, true);
-        each(results, result => {
-          this.currentlyDisplayedResults.push(result);
-        });
-        this.triggerNewResultsDisplayed();
-      });
-    });
-
-    this.fetchingMoreResults.finally(() => {
-      this.hideWaitingAnimationForInfiniteScrolling();
-      this.fetchingMoreResults = undefined;
-      Defer.defer(() => {
-        this.successiveScrollCount++;
-        if (this.successiveScrollCount <= ResultList.MAX_AMOUNT_OF_SUCESSIVE_REQUESTS) {
-          this.handleScrollOfResultList();
-        } else {
-          this.logger.info(
-            `Result list has triggered 5 consecutive queries to try and fill up the scrolling container, but it is still unable to do so`
-          );
-          this.logger.info(
-            `Try explicitly setting the 'data-infinite-scroll-container-selector' option on the result list. See : https://coveo.github.io/search-ui/components/resultlist.html#options.infinitescrollcontainer`
-          );
-        }
-      });
-    });
-
-    return this.fetchingMoreResults;
+    return this.fetchAndRenderMoreResults(count);
   }
 
   public get templateToHtml() {
@@ -537,6 +504,51 @@ export class ResultList extends Component {
 
   protected triggerNewResultsDisplayed() {
     $$(this.element).trigger(ResultListEvents.newResultsDisplayed, {});
+  }
+
+  private async fetchAndRenderMoreResults(count: number): Promise<IQueryResults> {
+    this.fetchingMoreResults = this.queryController.fetchMore(count);
+
+    try {
+      const data = await this.fetchingMoreResults;
+      Assert.exists(data);
+      this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.pagerScrolling, {}, this.element);
+
+      this.reachedTheEndOfResults = count > data.results.length;
+      this.renderNewResults(data);
+
+      this.resetStateAfterFetchingMoreResults();
+
+      return data;
+    } catch (e) {
+      this.resetStateAfterFetchingMoreResults();
+      return Promise.reject(e);
+    }
+  }
+
+  private async renderNewResults(data: IQueryResults) {
+    const elements = await this.buildResults(data);
+    this.renderResults(elements, true);
+    each(data.results, result => this.currentlyDisplayedResults.push(result));
+    this.triggerNewResultsDisplayed();
+  }
+
+  private resetStateAfterFetchingMoreResults() {
+    this.hideWaitingAnimationForInfiniteScrolling();
+    this.fetchingMoreResults = undefined;
+    Defer.defer(() => {
+      this.successiveScrollCount++;
+      if (this.successiveScrollCount <= ResultList.MAX_AMOUNT_OF_SUCESSIVE_REQUESTS) {
+        this.handleScrollOfResultList();
+      } else {
+        this.logger.info(
+          `Result list has triggered 5 consecutive queries to try and fill up the scrolling container, but it is still unable to do so`
+        );
+        this.logger.info(
+          `Try explicitly setting the 'data-infinite-scroll-container-selector' option on the result list. See : https://coveo.github.io/search-ui/components/resultlist.html#options.infinitescrollcontainer`
+        );
+      }
+    });
   }
 
   private handleDuringQuery() {

--- a/src/utils/DomUtils.ts
+++ b/src/utils/DomUtils.ts
@@ -11,7 +11,7 @@ import { IComponentBindings } from '../ui/Base/ComponentBindings';
 import { Initialization } from '../Core';
 import { Assert } from '../misc/Assert';
 
-interface IQuickViewHeaderOptions {
+export interface IQuickViewHeaderOptions {
   showDate: boolean;
   title: string;
 }

--- a/unitTests/utils/DomUtilsTest.ts
+++ b/unitTests/utils/DomUtilsTest.ts
@@ -71,8 +71,11 @@ export function DomUtilsTest() {
         it('should try to load a salesforce result link', async done => {
           DomUtils.getQuickviewHeader(fakeResult, { title: 'foo', showDate: true }, env.build());
           await load('SalesforceResultLink');
-          expect(spy).toHaveBeenCalled();
-          done();
+
+          setTimeout(() => {
+            expect(spy).toHaveBeenCalled();
+            done();
+          }, 0);
         });
       });
     });


### PR DESCRIPTION
This goal of this change is to make the search-ui compatible with client promise polyfills that do not support the `.finally` method.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)