### PR TITLE
JSUI-2679 Pass corrected word to localized string placeholder processing utility

### DIFF
--- a/src/ui/DidYouMean/DidYouMean.ts
+++ b/src/ui/DidYouMean/DidYouMean.ts
@@ -139,17 +139,15 @@ export class DidYouMean extends Component {
     this.logger.trace('Received query results from new query', results);
 
     if (Utils.isNonEmptyArray(results.queryCorrections)) {
-      let correctedSentence = this.buildCorrectedSentence(results.queryCorrections[0]);
+      const correctedSentence = this.buildCorrectedSentence(results.queryCorrections[0]);
       this.correctedTerm = results.queryCorrections[0].correctedQuery;
-      let didYouMean = $$('div', { className: 'coveo-did-you-mean-suggestion' }, l('didYouMean', '')).el;
-      this.element.appendChild(didYouMean);
 
-      let searchTerm = $$('a', {}, correctedSentence).el;
-      didYouMean.appendChild(searchTerm);
+      const correctedWordEl = $$('a', {}, correctedSentence).el;
+      const didYouMean = $$('div', { className: 'coveo-did-you-mean-suggestion' }, l('didYouMean', correctedWordEl.outerHTML));
+      this.element.appendChild(didYouMean.el);
 
-      $$(searchTerm).on('click', () => {
-        this.doQueryWithCorrectedTerm();
-      });
+      const appendedCorrectedWordEl = didYouMean.find(correctedWordEl.tagName);
+      $$(appendedCorrectedWordEl).on('click', () => this.doQueryWithCorrectedTerm());
 
       $$(this.element).show();
     }

--- a/unitTests/ui/DidYouMeanTest.ts
+++ b/unitTests/ui/DidYouMeanTest.ts
@@ -14,6 +14,11 @@ export function DidYouMeanTest() {
   describe('DidYouMean', () => {
     let test: Mock.IBasicComponentSetup<DidYouMean>;
     let fakeQueryCorrection: IQueryCorrection;
+
+    function correctedWord() {
+      return $$(test.cmp.element).find('.coveo-did-you-mean-suggestion a');
+    }
+
     beforeEach(() => {
       test = Mock.basicComponentSetup<DidYouMean>(DidYouMean);
       fakeQueryCorrection = {
@@ -63,6 +68,17 @@ export function DidYouMeanTest() {
       };
       test.cmp.doQueryWithCorrectedTerm();
       expect(analyticsSpy).toHaveBeenCalledWith(analyticsActionCauseList.didyoumeanClick, {});
+    });
+
+    it(`when there is a successful query returning results and query corrections,
+    when clicking the corrected word,
+    it calls doQueryWithCorrectedTerm`, () => {
+      Simulate.query(test.env, { results: FakeResults.createFakeResults(1), queryCorrections: [fakeQueryCorrection] });
+
+      spyOn(test.cmp, 'doQueryWithCorrectedTerm');
+      correctedWord().click();
+
+      expect(test.cmp.doQueryWithCorrectedTerm).toHaveBeenCalledTimes(1);
     });
 
     describe('exposes options', () => {
@@ -209,9 +225,8 @@ export function DidYouMeanTest() {
             }
           ]
         });
-        expect($$(test.cmp.element).find('.coveo-did-you-mean-suggestion a').innerHTML).toBe(
-          '&lt;script&gt;alert("hack the internet")&lt;/script&gt;'
-        );
+
+        expect(correctedWord().innerHTML).toBe('&lt;script&gt;alert("hack the internet")&lt;/script&gt;');
       });
 
       it('when query is autocorrected', () => {
@@ -223,9 +238,7 @@ export function DidYouMeanTest() {
             }
           ]
         });
-        expect($$(test.cmp.element).find('.coveo-did-you-mean-suggestion a').innerHTML).toBe(
-          '&lt;script&gt;alert("thou shalt surely die")&lt;/script&gt;'
-        );
+        expect(correctedWord().innerHTML).toBe('&lt;script&gt;alert("thou shalt surely die")&lt;/script&gt;');
       });
     });
   });

--- a/unitTests/ui/DidYouMeanTest.ts
+++ b/unitTests/ui/DidYouMeanTest.ts
@@ -15,7 +15,7 @@ export function DidYouMeanTest() {
     let test: Mock.IBasicComponentSetup<DidYouMean>;
     let fakeQueryCorrection: IQueryCorrection;
 
-    function correctedWord() {
+    function getCorrectedWord() {
       return $$(test.cmp.element).find('.coveo-did-you-mean-suggestion a');
     }
 
@@ -76,7 +76,7 @@ export function DidYouMeanTest() {
       Simulate.query(test.env, { results: FakeResults.createFakeResults(1), queryCorrections: [fakeQueryCorrection] });
 
       spyOn(test.cmp, 'doQueryWithCorrectedTerm');
-      correctedWord().click();
+      getCorrectedWord().click();
 
       expect(test.cmp.doQueryWithCorrectedTerm).toHaveBeenCalledTimes(1);
     });
@@ -226,7 +226,7 @@ export function DidYouMeanTest() {
           ]
         });
 
-        expect(correctedWord().innerHTML).toBe('&lt;script&gt;alert("hack the internet")&lt;/script&gt;');
+        expect(getCorrectedWord().innerHTML).toBe('&lt;script&gt;alert("hack the internet")&lt;/script&gt;');
       });
 
       it('when query is autocorrected', () => {
@@ -238,7 +238,7 @@ export function DidYouMeanTest() {
             }
           ]
         });
-        expect(correctedWord().innerHTML).toBe('&lt;script&gt;alert("thou shalt surely die")&lt;/script&gt;');
+        expect(getCorrectedWord().innerHTML).toBe('&lt;script&gt;alert("thou shalt surely die")&lt;/script&gt;');
       });
     });
   });


### PR DESCRIPTION
The corrected word in the DidYouMean message was always appended at the end up until now.

With this change, it will now be possible to change the location of the corrected word in the by specifying a custom localized string containing a placeholder in the desired position.  


![custom_did-you-mean_corrected_word_placement](https://user-images.githubusercontent.com/5565841/66612154-df8db400-eb8e-11e9-84ed-97065c0b9553.PNG)

https://coveord.atlassian.net/browse/JSUI-2679





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)