### PR TITLE
JSUI-2682 Update QSM with searchbox query before executing query on SearchButton click

### DIFF
--- a/src/ui/SearchButton/SearchButton.ts
+++ b/src/ui/SearchButton/SearchButton.ts
@@ -9,8 +9,15 @@ import { IAnalyticsNoMeta, analyticsActionCauseList } from '../Analytics/Analyti
 import { Component } from '../Base/Component';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { Initialization } from '../Base/Initialization';
+import { QueryStateModel } from '../../models/QueryStateModel';
 
-export interface ISearchButtonOptions {}
+export interface ISearchButtonOptions {
+  searchBox?: ISearchButtonSearchBox;
+}
+
+export interface ISearchButtonSearchBox {
+  getText: () => string;
+}
 
 /**
  * The SearchButton component renders a search icon that the end user can click to trigger a new query.
@@ -67,8 +74,14 @@ export class SearchButton extends Component {
 
   private handleClick() {
     this.logger.debug('Performing query following button click');
+    this.updateQueryStateModelWithSearchBoxQuery();
     this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.searchboxSubmit, {});
     this.queryController.executeQuery({ origin: this });
+  }
+
+  private updateQueryStateModelWithSearchBoxQuery() {
+    const searchBox = this.options && this.options.searchBox;
+    searchBox && this.queryStateModel.set(QueryStateModel.attributesEnum.q, searchBox.getText());
   }
 }
 

--- a/src/ui/SearchButton/SearchButton.ts
+++ b/src/ui/SearchButton/SearchButton.ts
@@ -12,10 +12,10 @@ import { Initialization } from '../Base/Initialization';
 import { QueryStateModel } from '../../models/QueryStateModel';
 
 export interface ISearchButtonOptions {
-  searchBox?: ISearchButtonSearchBox;
+  searchbox?: ISearchButtonSearchbox;
 }
 
-export interface ISearchButtonSearchBox {
+export interface ISearchButtonSearchbox {
   getText: () => string;
 }
 
@@ -74,14 +74,14 @@ export class SearchButton extends Component {
 
   private handleClick() {
     this.logger.debug('Performing query following button click');
-    this.updateQueryStateModelWithSearchBoxQuery();
+    this.updateQueryStateModelWithSearchboxQuery();
     this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.searchboxSubmit, {});
     this.queryController.executeQuery({ origin: this });
   }
 
-  private updateQueryStateModelWithSearchBoxQuery() {
-    const searchBox = this.options && this.options.searchBox;
-    searchBox && this.queryStateModel.set(QueryStateModel.attributesEnum.q, searchBox.getText());
+  private updateQueryStateModelWithSearchboxQuery() {
+    const searchbox = this.options && this.options.searchbox;
+    searchbox && this.queryStateModel.set(QueryStateModel.attributesEnum.q, searchbox.getText());
   }
 }
 

--- a/src/ui/Searchbox/Searchbox.ts
+++ b/src/ui/Searchbox/Searchbox.ts
@@ -153,7 +153,7 @@ export class Searchbox extends Component {
 
     const anchor = $$('a');
     this.element.appendChild(anchor.el);
-    this.searchButton = new SearchButton(anchor.el, { searchBox: this.searchbox }, this.bindings);
+    this.searchButton = new SearchButton(anchor.el, { searchbox: this.searchbox }, this.bindings);
   }
 
   private applyMagicBoxIcon() {

--- a/src/ui/Searchbox/Searchbox.ts
+++ b/src/ui/Searchbox/Searchbox.ts
@@ -120,7 +120,7 @@ export class Searchbox extends Component {
    * @param bindings The bindings that the component requires to function normally. If not set, these will be
    * automatically resolved (with a slower execution time).
    */
-  constructor(public element: HTMLElement, public options?: ISearchboxOptions, bindings?: IComponentBindings) {
+  constructor(public element: HTMLElement, public options?: ISearchboxOptions, public bindings?: IComponentBindings) {
     super(element, Searchbox.ID, bindings);
 
     this.options = ComponentOptions.initComponentOptions(element, Searchbox, options);
@@ -129,29 +129,46 @@ export class Searchbox extends Component {
       $$(element).addClass('coveo-inline');
     }
 
+    this.initSearchBox();
+    this.initSearchButton();
+    this.applyMagicBoxIcon();
+    this.applyCustomHeight();
+  }
+
+  private initSearchBox() {
     const div = document.createElement('div');
     this.element.appendChild(div);
 
-    if (this.options.addSearchButton) {
-      const anchor = $$('a');
-      this.element.appendChild(anchor.el);
-      this.searchButton = new SearchButton(anchor.el, undefined, bindings);
-    }
-
     if (this.options.enableOmnibox) {
-      this.searchbox = new Omnibox(div, this.options, bindings);
+      this.searchbox = new Omnibox(div, this.options, this.bindings);
     } else {
-      this.searchbox = new Querybox(div, this.options, bindings);
+      this.searchbox = new Querybox(div, this.options, this.bindings);
+    }
+  }
+
+  private initSearchButton() {
+    if (!this.options.addSearchButton) {
+      return;
     }
 
+    const anchor = $$('a');
+    this.element.appendChild(anchor.el);
+    this.searchButton = new SearchButton(anchor.el, { searchBox: this.searchbox }, this.bindings);
+  }
+
+  private applyMagicBoxIcon() {
     const magicBoxIcon = $$(this.element).find('.magic-box-icon');
     magicBoxIcon.innerHTML = SVGIcons.icons.mainClear;
     SVGDom.addClassToSVGInContainer(magicBoxIcon, 'magic-box-clear-svg');
+  }
 
-    if (this.options.height) {
-      $$(element).addClass('coveo-custom-height');
-      SearchBoxResize.resize(this.element, options.height);
+  private applyCustomHeight() {
+    if (!this.options.height) {
+      return;
     }
+
+    $$(this.element).addClass('coveo-custom-height');
+    SearchBoxResize.resize(this.element, this.options.height);
   }
 }
 

--- a/unitTests/ui/SearchButtonTest.ts
+++ b/unitTests/ui/SearchButtonTest.ts
@@ -1,6 +1,7 @@
 import * as Mock from '../MockEnvironment';
-import { SearchButton } from '../../src/ui/SearchButton/SearchButton';
+import { SearchButton, ISearchButtonOptions } from '../../src/ui/SearchButton/SearchButton';
 import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
+import { QueryStateModel } from '../../src/Core';
 
 export function SearchButtonTest() {
   describe('SearchButton', () => {
@@ -26,6 +27,23 @@ export function SearchButtonTest() {
     it('will log an analytics event', function() {
       test.cmp.click();
       expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.searchboxSubmit, {});
+    });
+
+    it(`when the #options.searchBox is defined, when clicking the button,
+    it calls QueryStateModel #set to update the query`, () => {
+      const options: ISearchButtonOptions = {
+        searchBox: { getText: () => 'some query' }
+      };
+
+      test = Mock.basicComponentSetup<SearchButton>(SearchButton, options);
+      test.cmp.click();
+
+      expect(test.env.queryStateModel.set).toHaveBeenCalledWith(QueryStateModel.attributesEnum.q, options.searchBox.getText());
+    });
+
+    it(`when the #options is null, when clicking the button, it does not throw an error`, () => {
+      test = Mock.basicComponentSetup<SearchButton>(SearchButton, null);
+      expect(() => test.cmp.click()).not.toThrow();
     });
   });
 }

--- a/unitTests/ui/SearchButtonTest.ts
+++ b/unitTests/ui/SearchButtonTest.ts
@@ -29,16 +29,16 @@ export function SearchButtonTest() {
       expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.searchboxSubmit, {});
     });
 
-    it(`when the #options.searchBox is defined, when clicking the button,
+    it(`when the #options.searchbox is defined, when clicking the button,
     it calls QueryStateModel #set to update the query`, () => {
       const options: ISearchButtonOptions = {
-        searchBox: { getText: () => 'some query' }
+        searchbox: { getText: () => 'some query' }
       };
 
       test = Mock.basicComponentSetup<SearchButton>(SearchButton, options);
       test.cmp.click();
 
-      expect(test.env.queryStateModel.set).toHaveBeenCalledWith(QueryStateModel.attributesEnum.q, options.searchBox.getText());
+      expect(test.env.queryStateModel.set).toHaveBeenCalledWith(QueryStateModel.attributesEnum.q, options.searchbox.getText());
     });
 
     it(`when the #options is null, when clicking the button, it does not throw an error`, () => {


### PR DESCRIPTION
**Problem**
When there are two or more searchboxes in the page, if a user clicks the search button of any other than the first searchbox, they will need to press twice to send the query.

**Cause**
The reason is the BuildingQuery event is handled first by the first searchbox in the page. It adds it's old query and blocks further additions (see file `QueryBoxQueryParameters.ts`).

When the second searchbox processes the event, it is not able to add it's query. It does update the QSM though, synchronizing it's query with the first searchbox. Since the query is now synchronized across both searchboxes, on the second click, the intended keywords are sent.

**Solution**
When the search button is clicked, we sync all searchboxes with the new query using the QSM, before executing the query.

https://coveord.atlassian.net/browse/JSUI-2682





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)