### PR TITLE
JSUI-2685 Move generation of search result previews to SuggestionsManager

### DIFF
--- a/gulpTasks/definition.js
+++ b/gulpTasks/definition.js
@@ -40,6 +40,7 @@ gulp.task('cleanDefs', function() {
       .pipe(replace(/\(this: [A-Za-z_-]+, /gm, '('))
       .pipe(replace(/\| null/gm, '| void'))
       .pipe(replace(/moment\.[a-zA-Z]+/g, 'any'))
+      .pipe(replace(/<\s?([a-z]+)\s?=\s?[a-z]+\s?>/gi, '<$1>'))
       .pipe(gulp.dest('bin/ts/')) );
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coveo-search-ui",
-  "version": "2.0.403",
+  "version": "2.0.404",
   "description": "Coveo JavaScript Search Framework",
   "main": "./bin/js/CoveoJsSearch.js",
   "types": "./bin/ts/CoveoJsSearch.d.ts",

--- a/src/magicbox/MagicBox.ts
+++ b/src/magicbox/MagicBox.ts
@@ -142,14 +142,7 @@ export class MagicBoxInstance {
     };
 
     this.inputManager.onkeydown = (key: number) => {
-      if (key === KEYBOARD.UP_ARROW || key === KEYBOARD.DOWN_ARROW) {
-        return false;
-      }
-      if (
-        this.suggestionsManager.hasFocus &&
-        this.suggestionsManager.hasPreviews &&
-        (key === KEYBOARD.LEFT_ARROW || key === KEYBOARD.RIGHT_ARROW)
-      ) {
+      if (this.shouldMoveInSuggestions(key)) {
         return false;
       }
       if (key === KEYBOARD.ENTER) {
@@ -173,7 +166,9 @@ export class MagicBoxInstance {
 
     this.inputManager.onkeyup = (key: number) => {
       this.onmove && this.onmove();
-      const allowHorizontalMovement = this.suggestionsManager.hasFocus && this.suggestionsManager.hasPreviews;
+      if (!this.shouldMoveInSuggestions(key)) {
+        return true;
+      }
       switch (key) {
         case KEYBOARD.UP_ARROW:
           this.suggestionsManager.moveUp();
@@ -182,19 +177,11 @@ export class MagicBoxInstance {
           this.suggestionsManager.moveDown();
           break;
         case KEYBOARD.LEFT_ARROW:
-          if (!allowHorizontalMovement) {
-            return true;
-          }
           this.suggestionsManager.moveLeft();
           break;
         case KEYBOARD.RIGHT_ARROW:
-          if (!allowHorizontalMovement) {
-            return true;
-          }
           this.suggestionsManager.moveRight();
           break;
-        default:
-          return true;
       }
       if (this.suggestionsManager.selectedSuggestion) {
         this.focusOnSuggestion(this.suggestionsManager.selectedSuggestion);
@@ -208,6 +195,20 @@ export class MagicBoxInstance {
     this.suggestionsManager.mergeSuggestions(this.getSuggestions != null ? this.getSuggestions() : [], suggestions => {
       this.updateSuggestion(suggestions);
     });
+  }
+
+  private shouldMoveInSuggestions(key: KEYBOARD) {
+    switch (key) {
+      case KEYBOARD.UP_ARROW:
+      case KEYBOARD.DOWN_ARROW:
+        return true;
+      case KEYBOARD.LEFT_ARROW:
+      case KEYBOARD.RIGHT_ARROW:
+        if (this.suggestionsManager.hasFocus && this.suggestionsManager.hasPreviews) {
+          return true;
+        }
+    }
+    return false;
   }
 
   private updateSuggestion(suggestions: Suggestion[]) {

--- a/src/magicbox/MagicBox.ts
+++ b/src/magicbox/MagicBox.ts
@@ -87,7 +87,7 @@ export class MagicBoxInstance {
     this.element.appendChild(suggestionsContainer);
 
     this.suggestionsManager = new SuggestionsManager(suggestionsContainer, this.element, this.inputManager, {
-      selectableClass: this.options.selectableSuggestionClass,
+      suggestionClass: this.options.selectableSuggestionClass,
       selectedClass: this.options.selectedSuggestionClass,
       timeout: this.options.suggestionTimeout
     });
@@ -145,6 +145,13 @@ export class MagicBoxInstance {
       if (key === KEYBOARD.UP_ARROW || key === KEYBOARD.DOWN_ARROW) {
         return false;
       }
+      if (
+        this.suggestionsManager.hasFocus &&
+        this.suggestionsManager.hasPreviews &&
+        (key === KEYBOARD.LEFT_ARROW || key === KEYBOARD.RIGHT_ARROW)
+      ) {
+        return false;
+      }
       if (key === KEYBOARD.ENTER) {
         const suggestion = this.suggestionsManager.selectAndReturnKeyboardFocusedElement();
         if (suggestion == null) {
@@ -166,12 +173,25 @@ export class MagicBoxInstance {
 
     this.inputManager.onkeyup = (key: number) => {
       this.onmove && this.onmove();
+      const allowHorizontalMovement = this.suggestionsManager.hasFocus && this.suggestionsManager.hasPreviews;
       switch (key) {
         case KEYBOARD.UP_ARROW:
           this.suggestionsManager.moveUp();
           break;
         case KEYBOARD.DOWN_ARROW:
           this.suggestionsManager.moveDown();
+          break;
+        case KEYBOARD.LEFT_ARROW:
+          if (!allowHorizontalMovement) {
+            return true;
+          }
+          this.suggestionsManager.moveLeft();
+          break;
+        case KEYBOARD.RIGHT_ARROW:
+          if (!allowHorizontalMovement) {
+            return true;
+          }
+          this.suggestionsManager.moveRight();
           break;
         default:
           return true;

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -110,8 +110,8 @@ export class SuggestionsManager {
   }
 
   public handleMouseOver(e) {
-    let target = $$(<HTMLElement>e.target);
-    let parents = target.parents(this.options.suggestionClass);
+    const target = $$(<HTMLElement>e.target);
+    const parents = target.parents(this.options.suggestionClass);
     if (target.hasClass(this.options.suggestionClass)) {
       this.processMouseSelection(target.el);
     } else if (parents.length > 0 && this.element.contains(parents[0])) {
@@ -120,12 +120,12 @@ export class SuggestionsManager {
   }
 
   public handleMouseOut(e) {
-    let target = $$(<HTMLElement>e.target);
-    let targetParents = target.parents(this.options.suggestionClass);
+    const target = $$(<HTMLElement>e.target);
+    const targetParents = target.parents(this.options.suggestionClass);
 
     //e.relatedTarget is not available if moving off the browser window or is an empty object `{}` when moving out of namespace in LockerService.
     if (e.relatedTarget && $$(e.relatedTarget).isValid()) {
-      let relatedTargetParents = $$(<HTMLElement>e.relatedTarget).parents(this.options.suggestionClass);
+      const relatedTargetParents = $$(<HTMLElement>e.relatedTarget).parents(this.options.suggestionClass);
       if (target.hasClass(this.options.selectedClass) && !$$(<HTMLElement>e.relatedTarget).hasClass(this.options.suggestionClass)) {
         this.removeSelectedStatus(target.el);
       } else if (relatedTargetParents.length == 0 && targetParents.length > 0) {
@@ -561,12 +561,12 @@ export class SuggestionsManager {
     return populateEventArgs.previewsQuery;
   }
 
-  // TODO: Move this to a seperate class
+  // TODO: Move this to a separate class
   private updateSearchResultPreviewsHeader(text: string) {
     this.previewContainer.findClass('coveo-preview-header')[0].innerText = text;
   }
 
-  // TODO: Move this to a seperate class
+  // TODO: Move this to a separate class
   private updateSearchResultPreviews(previews: ISearchResultPreview[]) {
     const previewWidth = previews.length % 3 === 0 ? 33 : 50;
     const resultsContainer = $$(this.previewContainer.findClass('coveo-preview-results')[0]);

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -1,10 +1,10 @@
 import { compact, defaults, each, indexOf } from 'underscore';
 import { IQuerySuggestSelection, OmniboxEvents } from '../events/OmniboxEvents';
 import { Component } from '../ui/Base/Component';
-import { resultPerRow } from '../ui/QuerySuggestPreview/QuerySuggestPreview';
 import { $$, Dom } from '../utils/Dom';
 import { Utils } from '../utils/Utils';
 import { InputManager } from './InputManager';
+import { findIndex } from 'lodash';
 
 export interface Suggestion {
   text?: string;
@@ -15,10 +15,16 @@ export interface Suggestion {
   onSelect?: () => void;
 }
 
+export interface ISearchResultPreview {
+  element: HTMLElement;
+  onSelect: () => void;
+}
+
 export interface SuggestionsManagerOptions {
-  selectableClass?: string;
+  suggestionClass?: string;
   selectedClass?: string;
   timeout?: number;
+  previewHeaderText?: string;
 }
 
 enum Direction {
@@ -28,15 +34,46 @@ enum Direction {
   Right = 'Right'
 }
 
+export interface IPopulateSearchResultPreviewsEventArgs {
+  suggestionText: string;
+  previewsQuery: Promise<ISearchResultPreview[]>;
+}
+
+export enum SuggestionsManagerEvents {
+  PopulateSearchResultPreviews = 'populateSearchResultPreviews'
+}
+
 export class SuggestionsManager {
   public hasSuggestions: boolean;
   private pendingSuggestion: Promise<Suggestion[]>;
   private options: SuggestionsManagerOptions;
-  private keyboardFocusedSuggestion: HTMLElement;
+  private keyboardFocusedElement: HTMLElement;
   private suggestionsListbox: Dom;
   private suggestionsPreviewContainer: Dom;
   private lastSelectedSuggestion: HTMLElement;
   private root: HTMLElement;
+  private containsPreviews: boolean;
+  private previewContainer: Dom;
+  private lastPreviewsQuery: Promise<ISearchResultPreview[]>;
+
+  public get hasFocus() {
+    return $$(this.element).findClass(this.options.selectedClass).length > 0;
+  }
+
+  public get hasPreviews() {
+    return !!this.suggestionsPreviewContainer;
+  }
+
+  private get resultPerRow() {
+    // To account for every CSS that may span previews over multiple rows, this solution was found: https://stackoverflow.com/a/49090306
+    const previewSelectables = $$(this.element).findAll(`.coveo-preview-selectable`);
+    if (previewSelectables.length === 0) {
+      return 0;
+    }
+    const firstVerticalOffset = previewSelectables[0].offsetTop;
+    const firstIndexOnNextRow = findIndex(previewSelectables, previewSelectable => previewSelectable.offsetTop !== firstVerticalOffset);
+    return firstIndexOnNextRow !== -1 ? firstIndexOnNextRow : previewSelectables.length;
+  }
 
   constructor(
     private element: HTMLElement,
@@ -46,8 +83,9 @@ export class SuggestionsManager {
   ) {
     this.root = Component.resolveRoot(element);
     this.options = defaults(options, <SuggestionsManagerOptions>{
-      selectableClass: 'magic-box-suggestion',
-      selectedClass: 'magic-box-selected'
+      suggestionClass: 'magic-box-suggestion',
+      selectedClass: 'magic-box-selected',
+      previewHeaderText: 'Query result items for'
     });
     // Put in a sane default, so as to not reject every suggestions if not set on initialization
     if (this.options.timeout == undefined) {
@@ -65,16 +103,15 @@ export class SuggestionsManager {
     });
 
     this.suggestionsListbox = this.buildSuggestionsContainer();
-    this.suggestionsPreviewContainer = this.initPreviewForSuggestions(this.suggestionsListbox);
-    $$(this.element).append(this.suggestionsPreviewContainer.el);
+    $$(this.element).append(this.suggestionsListbox.el);
     this.addAccessibilityPropertiesForCombobox();
     this.appendEmptySuggestionOption();
   }
 
   public handleMouseOver(e) {
     let target = $$(<HTMLElement>e.target);
-    let parents = target.parents(this.options.selectableClass);
-    if (target.hasClass(this.options.selectableClass)) {
+    let parents = target.parents(this.options.suggestionClass);
+    if (target.hasClass(this.options.suggestionClass)) {
       this.processMouseSelection(target.el);
     } else if (parents.length > 0 && this.element.contains(parents[0])) {
       this.processMouseSelection(parents[0]);
@@ -83,12 +120,12 @@ export class SuggestionsManager {
 
   public handleMouseOut(e) {
     let target = $$(<HTMLElement>e.target);
-    let targetParents = target.parents(this.options.selectableClass);
+    let targetParents = target.parents(this.options.suggestionClass);
 
     //e.relatedTarget is not available if moving off the browser window or is an empty object `{}` when moving out of namespace in LockerService.
     if (e.relatedTarget && $$(e.relatedTarget).isValid()) {
-      let relatedTargetParents = $$(<HTMLElement>e.relatedTarget).parents(this.options.selectableClass);
-      if (target.hasClass(this.options.selectedClass) && !$$(<HTMLElement>e.relatedTarget).hasClass(this.options.selectableClass)) {
+      let relatedTargetParents = $$(<HTMLElement>e.relatedTarget).parents(this.options.suggestionClass);
+      if (target.hasClass(this.options.selectedClass) && !$$(<HTMLElement>e.relatedTarget).hasClass(this.options.suggestionClass)) {
         this.removeSelectedStatus(target.el);
       } else if (relatedTargetParents.length == 0 && targetParents.length > 0) {
         this.removeSelectedStatus(targetParents[0]);
@@ -120,20 +157,21 @@ export class SuggestionsManager {
   }
 
   public selectAndReturnKeyboardFocusedElement(): HTMLElement {
-    const selected = this.keyboardFocusedSuggestion;
+    const selected = this.keyboardFocusedElement;
     if (selected != null) {
       $$(selected).trigger('keyboardSelect');
       // By definition, once an element has been "selected" with the keyboard,
       // it is not longer "active" since the event has been processed.
-      this.keyboardFocusedSuggestion = null;
+      this.keyboardFocusedElement = null;
     }
     return selected;
   }
 
   public clearKeyboardFocusedElement() {
-    this.keyboardFocusedSuggestion = null;
+    this.keyboardFocusedElement = null;
   }
 
+  // TODO: Replace this with a class that can accumulate results more cleanly (e.g., QueriesProcessor)
   public mergeSuggestions(suggestions: Array<Promise<Suggestion[]> | Suggestion[]>, callback?: (suggestions: Suggestion[]) => void) {
     let results: Suggestion[] = [];
     let timeout;
@@ -234,28 +272,28 @@ export class SuggestionsManager {
   }
 
   public get selectedSuggestion(): Suggestion {
-    if (this.htmlElementIsSuggestion(this.keyboardFocusedSuggestion)) {
-      return this.returnMoved(this.keyboardFocusedSuggestion) as Suggestion;
+    if (this.htmlElementIsSuggestion(this.keyboardFocusedElement)) {
+      return this.returnMoved(this.keyboardFocusedElement) as Suggestion;
     }
     return null;
   }
 
   private processKeyboardSelection(suggestion: HTMLElement) {
     this.addSelectedStatus(suggestion);
-    this.updateSelectedSuggestion(suggestion.innerText);
-    this.keyboardFocusedSuggestion = suggestion;
+    this.updateSelectedSuggestion(suggestion);
+    this.keyboardFocusedElement = suggestion;
     $$(this.inputManager.input).setAttribute('aria-activedescendant', $$(suggestion).getAttribute('id'));
   }
 
-  private processKeyboardPreviewSelection(suggestion: HTMLElement) {
-    this.addSelectedStatus(suggestion);
-    this.keyboardFocusedSuggestion = suggestion;
+  private processKeyboardPreviewSelection(preview: HTMLElement) {
+    this.addSelectedStatus(preview);
+    this.keyboardFocusedElement = preview;
   }
 
   private processMouseSelection(suggestion: HTMLElement) {
     this.addSelectedStatus(suggestion);
-    this.updateSelectedSuggestion(suggestion.innerText);
-    this.keyboardFocusedSuggestion = null;
+    this.updateSelectedSuggestion(suggestion);
+    this.keyboardFocusedElement = null;
   }
 
   private buildSuggestionsContainer() {
@@ -267,38 +305,35 @@ export class SuggestionsManager {
   }
 
   private buildPreviewContainer() {
-    return $$('div', {
-      className: 'coveo-preview-container'
-    }).el;
+    return (this.previewContainer = $$(
+      'div',
+      {
+        className: 'coveo-preview-container'
+      },
+      $$('h4', {
+        className: 'coveo-preview-header'
+      }),
+      $$('div', {
+        className: 'coveo-preview-results'
+      })
+    )).el;
   }
 
-  private get querySuggestPreviewComponent() {
-    const querySuggestPreviewElement: HTMLElement = $$(this.root).find(`.${Component.computeCssClassNameForType('QuerySuggestPreview')}`);
-    if (!querySuggestPreviewElement) {
-      return;
-    }
-    return Component.get(querySuggestPreviewElement);
-  }
-
-  private initPreviewForSuggestions(suggestions: Dom) {
-    const querySuggestPreview = this.querySuggestPreviewComponent;
-    if (!querySuggestPreview) {
-      return suggestions;
-    }
-
-    const suggestionContainerParent = $$('div', {
-      className: 'coveo-suggestion-container'
-    });
-
-    const previewContainer = this.buildPreviewContainer();
-    suggestionContainerParent.append(suggestions.el);
-    suggestionContainerParent.append(previewContainer);
-    return suggestionContainerParent;
+  private initPreviewForSuggestions() {
+    this.suggestionsPreviewContainer = $$(
+      'div',
+      {
+        className: 'coveo-suggestion-container'
+      },
+      this.suggestionsListbox.el,
+      this.buildPreviewContainer()
+    );
+    this.element.appendChild(this.suggestionsPreviewContainer.el);
   }
 
   private createDomFromSuggestion(suggestion: Suggestion) {
     const dom = $$('div', {
-      className: `magic-box-suggestion ${this.options.selectableClass}`
+      className: `magic-box-suggestion ${this.options.suggestionClass}`
     });
 
     dom.on('click', () => {
@@ -350,7 +385,7 @@ export class SuggestionsManager {
   private modifyDomFromExistingSuggestion(dom: HTMLElement) {
     // this need to be done if the selection is in cache and the dom is set in the suggestion
     this.removeSelectedStatus(dom);
-    const found = $$(dom).find('.' + this.options.selectableClass);
+    const found = $$(dom).find('.' + this.options.suggestionClass);
     this.removeSelectedStatus(found);
     return $$(dom);
   }
@@ -366,22 +401,20 @@ export class SuggestionsManager {
 
   private moveWithinSuggestion(direction: Direction) {
     const currentlySelected = $$(this.element).find(`.${this.options.selectedClass}`);
-    const selectables = $$(this.element).findAll(`.${this.options.selectableClass}`);
+    const selectables = $$(this.element).findAll(`.${this.options.suggestionClass}`);
     const currentIndex = indexOf(selectables, currentlySelected);
 
     let index = direction === Direction.Up ? currentIndex - 1 : currentIndex + 1;
     index = (index + selectables.length) % selectables.length;
 
-    this.lastSelectedSuggestion = selectables[index];
-
-    this.selectQuerySuggest(this.lastSelectedSuggestion);
+    this.selectQuerySuggest(selectables[index]);
   }
 
   private selectQuerySuggest(suggestion: HTMLElement) {
     if (suggestion) {
       this.processKeyboardSelection(suggestion);
     } else {
-      this.keyboardFocusedSuggestion = null;
+      this.keyboardFocusedElement = null;
       this.inputManager.input.removeAttribute('aria-activedescendant');
     }
 
@@ -390,7 +423,7 @@ export class SuggestionsManager {
 
   private moveWithQuerySuggestPreview(direction: Direction) {
     const currentlySelected = $$(this.element).find(`.${this.options.selectedClass}`);
-    const omniboxSelectables = $$(this.element).findAll(`.${this.options.selectableClass}`);
+    const omniboxSelectables = $$(this.element).findAll(`.${this.options.suggestionClass}`);
     const previewSelectables = $$(this.element).findAll(`.coveo-preview-selectable`);
     const omniboxIndex = indexOf(omniboxSelectables, currentlySelected);
     const previewIndex = indexOf(previewSelectables, currentlySelected);
@@ -435,7 +468,7 @@ export class SuggestionsManager {
     const previewSelectables = $$(this.element).findAll(`.coveo-preview-selectable`);
     const previewIndex = indexOf(previewSelectables, currentlySelected);
 
-    if (previewSelectables.length <= resultPerRow) {
+    if (previewSelectables.length <= this.resultPerRow) {
       return null;
     }
     const offset = Math.ceil(previewSelectables.length / 2);
@@ -471,21 +504,21 @@ export class SuggestionsManager {
     return null;
   }
 
-  private addSelectedStatus(suggestion: HTMLElement): void {
+  private addSelectedStatus(element: HTMLElement): void {
     const selected = this.element.getElementsByClassName(this.options.selectedClass);
     for (let i = 0; i < selected.length; i++) {
       const elem = <HTMLElement>selected.item(i);
       this.removeSelectedStatus(elem);
     }
-    $$(suggestion).addClass(this.options.selectedClass);
-    this.updateSelectedSuggestion(suggestion.innerText);
-    this.updateAreaSelectedIfDefined(suggestion, 'true');
+    $$(element).addClass(this.options.selectedClass);
+    this.updateAreaSelectedIfDefined(element, 'true');
   }
 
-  private updateSelectedSuggestion(suggestion: string) {
+  private updateSelectedSuggestion(suggestion: HTMLElement) {
     $$(this.root).trigger(OmniboxEvents.querySuggestGetFocus, <IQuerySuggestSelection>{
-      suggestion
+      suggestion: suggestion.innerText
     });
+    this.displaySearchResultPreviewsForSuggestion(suggestion);
   }
 
   private removeSelectedStatus(suggestion: HTMLElement): void {
@@ -514,7 +547,66 @@ export class SuggestionsManager {
   }
 
   private htmlElementIsSuggestion(selected: HTMLElement) {
-    const omniboxSelectables = $$(this.element).findAll(`.${this.options.selectableClass}`);
+    const omniboxSelectables = $$(this.element).findAll(`.${this.options.suggestionClass}`);
     return indexOf(omniboxSelectables, selected) > -1;
+  }
+
+  private getSearchResultPreviewsQuery(suggestion: HTMLElement) {
+    const populateEventArgs: IPopulateSearchResultPreviewsEventArgs = {
+      suggestionText: suggestion.innerText,
+      previewsQuery: null
+    };
+    $$(this.root).trigger(SuggestionsManagerEvents.PopulateSearchResultPreviews, populateEventArgs);
+    return populateEventArgs.previewsQuery;
+  }
+
+  // TODO: Move this to a seperate class
+  private updateSearchResultPreviewsHeader(text: string) {
+    this.previewContainer.findClass('coveo-preview-header')[0].innerText = text;
+  }
+
+  // TODO: Move this to a seperate class
+  private updateSearchResultPreviews(previews: ISearchResultPreview[]) {
+    const previewWidth = previews.length % 3 === 0 ? 33 : 50;
+    const resultsContainer = $$(this.previewContainer.findClass('coveo-preview-results')[0]);
+    resultsContainer.empty();
+    const previewStyle = `0 0 ${previewWidth}%`;
+    previews.forEach(preview => {
+      preview.element.style.flex = previewStyle;
+      resultsContainer.append(preview.element);
+      const elementDom = $$(preview.element);
+      elementDom.on('click', () => preview.onSelect());
+      elementDom.on('keyboardSelect', () => preview.onSelect());
+    });
+  }
+
+  private displaySuggestionPreviews(suggestion: HTMLElement, previews: ISearchResultPreview[]) {
+    if (!this.suggestionsPreviewContainer) {
+      this.initPreviewForSuggestions();
+    }
+    this.lastPreviewsQuery = null;
+    this.lastSelectedSuggestion = suggestion;
+    this.updateSearchResultPreviews(previews);
+    this.containsPreviews = previews.length > 0;
+    this.element.classList.toggle('magic-box-hasPreviews', this.containsPreviews);
+    this.updateSearchResultPreviewsHeader(this.containsPreviews ? `${this.options.previewHeaderText} "${suggestion.innerText}"` : '');
+  }
+
+  private async loadSearchResultPreviews(suggestion: HTMLElement, query: Promise<ISearchResultPreview[]>) {
+    this.lastPreviewsQuery = query;
+    const previews = await this.lastPreviewsQuery;
+    if (this.lastPreviewsQuery !== query) {
+      return;
+    }
+    if (!previews) {
+      return;
+    }
+    this.displaySuggestionPreviews(suggestion, previews);
+  }
+
+  private async displaySearchResultPreviewsForSuggestion(suggestion: HTMLElement) {
+    if (this.lastSelectedSuggestion !== suggestion) {
+      await this.loadSearchResultPreviews(suggestion, this.getSearchResultPreviewsQuery(suggestion));
+    }
   }
 }

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -5,6 +5,7 @@ import { $$, Dom } from '../utils/Dom';
 import { Utils } from '../utils/Utils';
 import { InputManager } from './InputManager';
 import { findIndex } from 'lodash';
+import { l } from '../strings/Strings';
 
 export interface Suggestion {
   text?: string;
@@ -64,7 +65,7 @@ export class SuggestionsManager {
     return !!this.suggestionsPreviewContainer;
   }
 
-  private get resultPerRow() {
+  private get numberOfResultsPerRow() {
     // To account for every CSS that may span previews over multiple rows, this solution was found: https://stackoverflow.com/a/49090306
     const previewSelectables = $$(this.element).findAll(`.coveo-preview-selectable`);
     if (previewSelectables.length === 0) {
@@ -85,7 +86,7 @@ export class SuggestionsManager {
     this.options = defaults(options, <SuggestionsManagerOptions>{
       suggestionClass: 'magic-box-suggestion',
       selectedClass: 'magic-box-selected',
-      previewHeaderText: 'Query result items for'
+      previewHeaderText: l('QuerySuggestPreview')
     });
     // Put in a sane default, so as to not reject every suggestions if not set on initialization
     if (this.options.timeout == undefined) {
@@ -310,7 +311,7 @@ export class SuggestionsManager {
       {
         className: 'coveo-preview-container'
       },
-      $$('h4', {
+      $$('div', {
         className: 'coveo-preview-header'
       }),
       $$('div', {
@@ -468,7 +469,7 @@ export class SuggestionsManager {
     const previewSelectables = $$(this.element).findAll(`.coveo-preview-selectable`);
     const previewIndex = indexOf(previewSelectables, currentlySelected);
 
-    if (previewSelectables.length <= this.resultPerRow) {
+    if (previewSelectables.length <= this.numberOfResultsPerRow) {
       return null;
     }
     const offset = Math.ceil(previewSelectables.length / 2);

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -1,17 +1,11 @@
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { exportGlobally } from '../../GlobalExports';
-import { ComponentOptions, OmniboxEvents, Initialization, $$, Component } from '../../Core';
-import { IQuerySuggestSelection } from '../../events/OmniboxEvents';
+import { ComponentOptions, Initialization, $$, Component, Utils } from '../../Core';
 import { IQueryResults } from '../../rest/QueryResults';
 import 'styling/_QuerySuggestPreview';
-import { ResultListRenderer } from '../ResultList/ResultListRenderer';
-import { IInitializationParameters } from '../Base/Initialization';
-import { IResultListOptions } from '../ResultList/ResultListOptions';
 import { Template } from '../Templates/Template';
 import { TemplateComponentOptions } from '../Base/TemplateComponentOptions';
-import { ResultListTableRenderer } from '../ResultList/ResultListTableRenderer';
 import { ITemplateToHtml, TemplateToHtml } from '../Templates/TemplateToHtml';
-import { IQueryResult } from '../../rest/QueryResult';
 import { ResultLink } from '../ResultLink/ResultLink';
 import { OmniboxAnalytics } from '../Omnibox/OmniboxAnalytics';
 import {
@@ -19,6 +13,7 @@ import {
   analyticsActionCauseList,
   IAnalyticsClickQuerySuggestPreviewMeta
 } from '../Analytics/AnalyticsActionListMeta';
+import { SuggestionsManagerEvents, IPopulateSearchResultPreviewsEventArgs, ISearchResultPreview } from '../../magicbox/SuggestionsManager';
 
 export interface IQuerySuggestPreview {
   numberOfPreviewResults?: number;
@@ -28,8 +23,6 @@ export interface IQuerySuggestPreview {
   headerText?: string;
   executeQueryDelay?: number;
 }
-
-export const resultPerRow = 3;
 
 export class QuerySuggestPreview extends Component implements IComponentBindings {
   static ID = 'QuerySuggestPreview';
@@ -53,44 +46,11 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
       defaultValue: 3,
       min: 1,
       max: 6
-    }),
-    /**
-     * The width of the preview container (in pixels).
-     *
-     * If this option is `undefined` or lower than the remaning space left by the suggestion,
-     * the component takes all the space left by the query suggestions.
-     */
-    previewWidth: ComponentOptions.buildNumberOption(),
-    /**
-     *  The width of the suggestion container (in pixels).
-     *
-     *  If the value is set to `0`, the width will adjust to the longest displayed query suggestion.
-     *
-     * **Default:** `250`
-     * **Minimum:** `0`
-     */
-    suggestionWidth: ComponentOptions.buildNumberOption({ defaultValue: 250, min: 0 }),
-    /**
-     *  The text to display at the top of the preview, which is followed by "`<SUGGESTION>`", where `<SUGGESTION>` is the hovered query suggestion.
-     *
-     * **Default:** The localized string `Query result items for`
-     */
-    headerText: ComponentOptions.buildLocalizedStringOption({ defaultValue: 'QuerySuggestPreview' }),
-    /**
-     *  The amount of focus time (in milliseconds) required on a query suggestion before requesting a preview of its top results.
-     *
-     * **Default:** `200`
-     */
-    executeQueryDelay: ComponentOptions.buildNumberOption({ defaultValue: 200 })
+    })
   };
 
-  private previousSuggestionHovered: string;
-  private currentlyRenderedSuggestion: string;
-  private renderer: ResultListRenderer;
-  private timer;
+  private timer: Promise<void>;
   private omniboxAnalytics: OmniboxAnalytics;
-
-  public currentlyDisplayedResults: IQueryResult[] = [];
 
   /**
    * Creates a new QuerySuggestPreview component.
@@ -105,29 +65,18 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
     this.options = ComponentOptions.initComponentOptions(element, QuerySuggestPreview, options);
 
     if (!this.options.resultTemplate) {
+      // TODO: Add a default template
       this.logger.warn(
         `Specifying a result template is required for the 'QuerySuggestPreview' component to work properly. See `,
         `https://docs.coveo.com/340/#providing-query-suggestion-result-previews`
       );
     }
 
-    this.bind.onRootElement(OmniboxEvents.querySuggestGetFocus, (args: IQuerySuggestSelection) => this.querySuggestGetFocus(args));
-    this.bind.onRootElement(OmniboxEvents.querySuggestRendered, () => {
-      this.handleAfterComponentInit();
-    });
-    this.bind.onRootElement(OmniboxEvents.querySuggestLoseFocus, () => {
-      this.handleFocusOut();
-    });
+    this.bind.onRootElement(SuggestionsManagerEvents.PopulateSearchResultPreviews, (args: IPopulateSearchResultPreviewsEventArgs) =>
+      this.populateSearchResultPreviews(args)
+    );
 
     this.omniboxAnalytics = this.searchInterface.getOmniboxAnalytics();
-  }
-
-  /**
-   * Gets the list of currently displayed result.
-   * @returns {IQueryResult[]}
-   */
-  public get displayedResults(): IQueryResult[] {
-    return this.currentlyDisplayedResults;
   }
 
   private get templateToHtml() {
@@ -139,152 +88,52 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
     return new TemplateToHtml(templateToHtmlArgs);
   }
 
-  private handleFocusOut() {
-    clearTimeout(this.timer);
-    this.timer = null;
-    this.previousSuggestionHovered = null;
-    this.currentlyDisplayedResults = [];
+  private populateSearchResultPreviews(args: IPopulateSearchResultPreviewsEventArgs) {
+    args.previewsQuery = this.fetchSearchResultPreviews(args.suggestionText);
   }
 
-  private updatePreviewContainer(container: HTMLElement) {
-    if (!this.options.previewWidth) {
-      return;
+  private async fetchSearchResultPreviews(suggestionText: string) {
+    const timer = (this.timer = Utils.waitUntil(this.options.executeQueryDelay));
+    await timer;
+    if (this.timer !== timer) {
+      return [];
     }
-    container.style.width = `${this.options.previewWidth}px`;
-  }
-
-  private updateWidthOfSuggestionContainer(container: HTMLElement) {
-    if (!this.options.suggestionWidth) {
-      return;
-    }
-    container.style.width = `${this.options.suggestionWidth}px`;
-  }
-
-  private handleAfterComponentInit() {
-    const suggestionContainer = $$(this.root).find('.coveo-magicbox-suggestions');
-    if (suggestionContainer) {
-      this.updateWidthOfSuggestionContainer(suggestionContainer);
-    }
-    const previewContainer = $$(this.root).find('.coveo-preview-container');
-    if (previewContainer) {
-      this.updatePreviewContainer(previewContainer);
-    }
-  }
-
-  private buildPreviewHeader(suggestion: string) {
-    const text = `${this.options.headerText} "${suggestion}"`;
-    const header = $$('h4', { className: 'coveo-preview-header' }, text).el;
-    this.previewContainer.appendChild(header);
-  }
-
-  private buildResultsContainer() {
-    return $$('div', { className: 'coveo-preview-results' }).el;
-  }
-
-  private get previewContainer() {
-    return $$(this.root).find('.coveo-preview-container');
-  }
-
-  private querySuggestGetFocus(args: IQuerySuggestSelection) {
-    if (!this.previewContainer) {
-      return;
-    }
-
-    if (this.previousSuggestionHovered === args.suggestion) {
-      return;
-    }
-
-    if (args.suggestion === '') {
-      return;
-    }
-
-    this.previousSuggestionHovered = args.suggestion;
-    this.timer && clearTimeout(this.timer);
-    this.timer = setTimeout(() => {
-      this.currentlyRenderedSuggestion = args.suggestion;
-      this.logShowQuerySuggestPreview();
-      this.executeQueryHover();
-    }, this.options.executeQueryDelay);
-  }
-
-  private async executeQueryHover() {
     const previousQueryOptions = this.queryController.getLastQuery();
-    previousQueryOptions.q = this.currentlyRenderedSuggestion;
+    previousQueryOptions.q = suggestionText;
     previousQueryOptions.numberOfResults = this.options.numberOfPreviewResults;
+    this.logShowQuerySuggestPreview();
     const results = await this.queryController.getEndpoint().search(previousQueryOptions);
-    $$(this.previewContainer).empty();
-    this.currentlyDisplayedResults = [];
     if (!results) {
-      return;
+      return [];
     }
-    this.buildPreviewHeader(this.currentlyRenderedSuggestion);
-    this.buildResultsPreview(results);
+    return this.buildResultsPreview(suggestionText, results);
   }
 
-  private async buildResultsPreview(results: IQueryResults) {
-    const resultsContainer = this.buildResultsContainer();
-    this.previewContainer.appendChild(resultsContainer);
-    this.setupRenderer(resultsContainer);
-    const buildResults = await this.templateToHtml.buildResults(results, 'preview', this.currentlyDisplayedResults);
+  private async buildResultsPreview(suggestionText: string, results: IQueryResults) {
+    const buildResults = await this.templateToHtml.buildResults(results, 'preview', []);
     if (!(buildResults.length > 0)) {
-      return;
+      return [];
     }
-    this.updateResultElement(buildResults);
-    this.addOnClickListener(buildResults);
-    this.renderer.renderResults(buildResults, true, result => {});
+    return buildResults.map((element, index) => this.buildResultPreview(suggestionText, element, index));
   }
 
-  private updateResultElement(elements: HTMLElement[]) {
-    const resultAvailableSpace = elements.length === 4 ? '50%' : '33%';
-    elements.forEach(element => {
-      $$(element).addClass('coveo-preview-selectable');
-
-      $$(element).on('keyboardSelect', () => {
-        this.handleSelect(element);
-      });
-
-      this.updateResultPerRow(element, resultAvailableSpace);
-    });
+  private buildResultPreview(suggestionText: string, element: HTMLElement, rank: number): ISearchResultPreview {
+    $$(element).addClass('coveo-preview-selectable');
+    return {
+      element,
+      onSelect: () => this.handleSelect(suggestionText, element, rank)
+    };
   }
 
-  private handleSelect(element: HTMLElement) {
+  private handleSelect(suggestionText: string, element: HTMLElement, rank: number) {
+    this.logClickQuerySuggestPreview(suggestionText, rank, element);
     element.click();
     const link = $$(element).find(`.${Component.computeCssClassNameForType('ResultLink')}`);
     if (link) {
       const resultLink = <ResultLink>Component.get(link);
-      resultLink.openLinkAsConfigured() || resultLink.openLink();
+      resultLink.openLinkAsConfigured();
+      resultLink.openLink();
     }
-  }
-
-  private addOnClickListener(results: HTMLElement[]) {
-    results.forEach(result => {
-      const rank = results.indexOf(result);
-      this.bind.on(result, 'click', (e: MouseEvent) => {
-        this.handleOnClick(e, result, rank);
-      });
-    });
-  }
-
-  private handleOnClick(e: MouseEvent, element: HTMLElement, rank: number) {
-    this.logClickQuerySuggestPreview(rank, element);
-  }
-
-  private updateResultPerRow(element: HTMLElement, value: string) {
-    element.style.flex = `0 0 ${value}`;
-  }
-
-  private setupRenderer(resultsContainer: HTMLElement) {
-    const rendererOption: IResultListOptions = {
-      resultsContainer
-    };
-    const initParameters: IInitializationParameters = {
-      options: this.searchInterface.options.originalOptionsObject,
-      bindings: this.bindings
-    };
-
-    const autoCreateComponentsFn = (elem: HTMLElement) => Initialization.automaticallyCreateComponentsInside(elem, initParameters);
-
-    this.renderer = new ResultListTableRenderer(rendererOption, autoCreateComponentsFn);
   }
 
   private logShowQuerySuggestPreview() {
@@ -294,11 +143,11 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
     );
   }
 
-  private logClickQuerySuggestPreview(displayedRank: number, element: HTMLElement) {
+  private logClickQuerySuggestPreview(suggestionText: string, displayedRank: number, element: HTMLElement) {
     this.usageAnalytics.logCustomEvent<IAnalyticsClickQuerySuggestPreviewMeta>(
       analyticsActionCauseList.clickQuerySuggestPreview,
       {
-        suggestion: this.currentlyRenderedSuggestion,
+        suggestion: suggestionText,
         displayedRank
       },
       element

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -96,7 +96,7 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
   }
 
   private async fetchSearchResultPreviews(suggestionText: string) {
-    const timer = (this.timer = Utils.waitUntil(this.options.executeQueryDelay));
+    const timer = (this.timer = Utils.resolveAfter(this.options.executeQueryDelay));
     await timer;
     if (this.timer !== timer) {
       return [];

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -17,10 +17,7 @@ import { SuggestionsManagerEvents, IPopulateSearchResultPreviewsEventArgs, ISear
 
 export interface IQuerySuggestPreview {
   numberOfPreviewResults?: number;
-  previewWidth?: number;
-  suggestionWidth?: number;
   resultTemplate?: Template;
-  headerText?: string;
   executeQueryDelay?: number;
 }
 
@@ -46,7 +43,13 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
       defaultValue: 3,
       min: 1,
       max: 6
-    })
+    }),
+    /**
+     *  The amount of focus time (in milliseconds) required on a query suggestion before requesting a preview of its top results.
+     *
+     * **Default:** `200`
+     */
+    executeQueryDelay: ComponentOptions.buildNumberOption({ defaultValue: 200 })
   };
 
   private timer: Promise<void>;

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -435,7 +435,7 @@ export class Utils {
     return difference;
   }
 
-  static waitUntil<T = void>(ms: number, returns?: T): Promise<T> {
+  static resolveAfter<T = void>(ms: number, returns?: T): Promise<T> {
     return new Promise(resolve => setTimeout(() => (returns ? resolve(returns) : resolve()), ms));
   }
 }

--- a/src/utils/Utils.ts
+++ b/src/utils/Utils.ts
@@ -434,4 +434,8 @@ export class Utils {
     addDiff(secondObject, firstObject);
     return difference;
   }
+
+  static waitUntil<T = void>(ms: number, returns?: T): Promise<T> {
+    return new Promise(resolve => setTimeout(() => (returns ? resolve(returns) : resolve()), ms));
+  }
 }

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -1,253 +1,555 @@
 import { InputManager } from '../../src/magicbox/InputManager';
 import { MagicBoxInstance } from '../../src/magicbox/MagicBox';
-import { SuggestionsManager } from '../../src/magicbox/SuggestionsManager';
+import {
+  SuggestionsManager,
+  SuggestionsManagerEvents,
+  IPopulateSearchResultPreviewsEventArgs,
+  ISearchResultPreview,
+  Suggestion
+} from '../../src/magicbox/SuggestionsManager';
 import { $$, Dom } from '../../src/utils/Dom';
+import { Utils } from '../../src/utils/Utils';
+import { IMockEnvironment, MockEnvironmentBuilder } from '../MockEnvironment';
+import { OmniboxEvents } from '../../src/Core';
+import { last, first, reverse } from 'lodash';
+
+// function tickAndResolvePromise<T>(promise: Promise<T>, ms = 0): Promise<T> {
+//   jasmine.clock().tick(ms);
+//   return promise;
+// }
+
+function deferAsync() {
+  return Promise.resolve();
+}
+
+async function forEachAsync<T, U>(values: T[], callbackfn: (value: T, index: number, array: T[]) => Promise<U>): Promise<U[]> {
+  const accumulatedValues: U[] = [];
+  for (let i = 0; i < values.length; i++) {
+    accumulatedValues.push(await callbackfn(values[i], i, values));
+  }
+  return accumulatedValues;
+}
 
 export function SuggestionsManagerTest() {
   describe('SuggestionsManager', () => {
     const LOCKED_LOCKER_SERVICE_ELEMENT = {};
-    let container: Dom;
-    let suggestionContainer: Dom;
-    let suggestionManager: SuggestionsManager;
-    let suggestion: Dom;
-    let elementInsideSuggestion: Dom;
-    let suggestionClass = 'selectable';
-    let selectedClass = 'selected';
+    const suggestionClass = 'selectable';
+    const selectedClass = 'selected';
 
-    beforeEach(() => {
-      buildContainer();
-      const inputManager = new InputManager(document.createElement('div'), () => {}, {} as MagicBoxInstance);
+    describe('with preappended suggestions', () => {
+      let container: Dom;
+      let suggestionContainer: Dom;
+      let suggestionManager: SuggestionsManager;
+      let suggestion: Dom;
+      let elementInsideSuggestion: Dom;
 
-      suggestionManager = new SuggestionsManager(suggestionContainer.el, document.createElement('div'), inputManager, {
-        selectedClass,
-        suggestionClass
-      });
-    });
+      beforeEach(() => {
+        buildContainer();
+        const inputManager = new InputManager(document.createElement('div'), () => {}, {} as MagicBoxInstance);
 
-    it('builds suggestions parent correctly when adding a suggestion', () => {
-      suggestionManager.updateSuggestions([{}]);
-
-      expect(suggestionManager.hasSuggestions).toBe(true);
-      expect($$(suggestionContainer).hasClass('magic-box-hasSuggestion')).toBe(true);
-
-      const suggestionsElement = $$(suggestionContainer).find('.coveo-magicbox-suggestions');
-      expect(suggestionsElement).toBeTruthy();
-      expect(suggestionsElement.children.length).toBe(1);
-      expect(suggestionsElement.getAttribute('role')).toBe('listbox');
-    });
-
-    it('adds an empty option child to the suggestions parent when emptying sugggestions', () => {
-      // Start by adding a suggestion so that elements are correctly created first
-      suggestionManager.updateSuggestions([{}]);
-      suggestionManager.updateSuggestions([]);
-
-      expect(suggestionManager.hasSuggestions).toBe(false);
-      expect($$(suggestionContainer).hasClass('magic-box-hasSuggestion')).toBe(false);
-
-      const suggestionsElement = $$(suggestionContainer).find('.coveo-magicbox-suggestions');
-      expect(suggestionsElement.childElementCount).toBe(1);
-      expect(suggestionsElement.firstChild.textContent).toBe('');
-    });
-
-    it('builds suggestion children correctly when adding a suggestion', () => {
-      suggestionManager.updateSuggestions([{}]);
-
-      const suggestionElement = $$(suggestionContainer).find('#magic-box-suggestion-0');
-      expect(suggestionElement).toBeTruthy();
-      expect(suggestionElement.getAttribute('role')).toBe('option');
-    });
-
-    it('returns the correct selected element with keyboard on move down', () => {
-      suggestionManager.moveDown();
-      const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
-      expect($$(selectedWithKeyboard).hasClass(selectedClass)).toBe(true);
-      expect($$(selectedWithKeyboard).getAttribute('aria-selected')).toBe('true');
-      expect(selectedWithKeyboard).toBe(suggestion.el);
-    });
-
-    it('clearKeyboardFocusedElement sets the keyboard focused element to null', () => {
-      suggestionManager.moveDown();
-      suggestionManager.clearKeyboardFocusedElement();
-      expect(suggestionManager.selectAndReturnKeyboardFocusedElement()).toBeNull();
-    });
-
-    it('returns the correct selected element with keyboard on move up', () => {
-      suggestionManager.moveUp();
-      const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
-      expect($$(selectedWithKeyboard).hasClass(selectedClass)).toBe(true);
-      expect($$(selectedWithKeyboard).getAttribute('aria-selected')).toBe('true');
-      expect(selectedWithKeyboard).toBe(suggestion.el);
-    });
-
-    it('returns the correct selected element with keyboard on move left', () => {
-      suggestionManager.moveLeft();
-      const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
-      expect($$(selectedWithKeyboard).hasClass(selectedClass)).toBe(true);
-      expect($$(selectedWithKeyboard).getAttribute('aria-selected')).toBe('true');
-      expect(selectedWithKeyboard).toBe(suggestion.el);
-    });
-
-    it('returns the correct selected element with keyboard on move right', () => {
-      suggestionManager.moveRight();
-      const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
-      expect($$(selectedWithKeyboard).hasClass(selectedClass)).toBe(true);
-      expect($$(selectedWithKeyboard).getAttribute('aria-selected')).toBe('true');
-      expect(selectedWithKeyboard).toBe(suggestion.el);
-    });
-
-    it('return no selected element with successive call to selectAndReturnKeyboardFocusedElement()', () => {
-      suggestionManager.moveDown();
-      const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
-      expect(selectedWithKeyboard).toBeDefined();
-
-      const repeatCallToSelectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
-      expect(repeatCallToSelectedWithKeyboard).toBeNull();
-    });
-
-    it('return no selected element with keyboard on mouse over', () => {
-      suggestionManager.handleMouseOver({
-        target: suggestion.el
-      });
-      const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
-      expect(selectedWithKeyboard).toBeNull();
-    });
-
-    it('return no selected element with keyboard on mouse over following a move down', () => {
-      suggestionManager.moveDown();
-      suggestionManager.handleMouseOver({
-        target: suggestion.el
-      });
-      const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
-      expect(selectedWithKeyboard).toBeNull();
-    });
-
-    it('return no selected element with keyboard on mouse over following a move up', () => {
-      suggestionManager.moveUp();
-      suggestionManager.handleMouseOver({
-        target: suggestion.el
-      });
-      const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
-      expect(selectedWithKeyboard).toBeNull();
-    });
-
-    it('adds selected class and sets aria-selected to true when moving on element that is selectable', () => {
-      suggestionManager.handleMouseOver({
-        target: suggestion.el
-      });
-      expect(suggestion.hasClass(selectedClass)).toBe(true);
-      expect(suggestion.getAttribute('aria-selected')).toBe('true');
-    });
-
-    it('adds selected class and sets aria-selected to true when moving on element that is inside a selectable element', () => {
-      suggestionManager.handleMouseOver({
-        target: elementInsideSuggestion.el
-      });
-      expect(suggestion.hasClass(selectedClass)).toBe(true);
-      expect(suggestion.getAttribute('aria-selected')).toBe('true');
-    });
-
-    it('removes selected class and sets aria-selected to false when moving off a selected element', () => {
-      suggestion.addClass(selectedClass);
-      suggestion.setAttribute('aria-selected', 'true');
-
-      suggestionManager.handleMouseOut({
-        target: suggestion.el,
-        relatedTarget: container.el
+        suggestionManager = new SuggestionsManager(suggestionContainer.el, document.createElement('div'), inputManager, {
+          selectedClass,
+          suggestionClass
+        });
       });
 
-      expect(suggestion.hasClass(selectedClass)).toBe(false);
-      expect(suggestion.getAttribute('aria-selected')).toBe('false');
-    });
+      it('builds suggestions parent correctly when adding a suggestion', () => {
+        suggestionManager.updateSuggestions([{}]);
 
-    it('removes selected class and sets aria-selected to false when moving off a selected element in LockerService', () => {
-      suggestion.addClass(selectedClass);
-      suggestion.setAttribute('aria-selected', 'true');
+        expect(suggestionManager.hasSuggestions).toBe(true);
+        expect($$(suggestionContainer).hasClass('magic-box-hasSuggestion')).toBe(true);
 
-      suggestionManager.handleMouseOut({
-        target: suggestion.el,
-        relatedTarget: LOCKED_LOCKER_SERVICE_ELEMENT
+        const suggestionsElement = $$(suggestionContainer).find('.coveo-magicbox-suggestions');
+        expect(suggestionsElement).toBeTruthy();
+        expect(suggestionsElement.children.length).toBe(1);
+        expect(suggestionsElement.getAttribute('role')).toBe('listbox');
       });
 
-      expect(suggestion.hasClass(selectedClass)).toBe(false);
-      expect(suggestion.getAttribute('aria-selected')).toBe('false');
-    });
+      it('adds an empty option child to the suggestions parent when emptying sugggestions', () => {
+        // Start by adding a suggestion so that elements are correctly created first
+        suggestionManager.updateSuggestions([{}]);
+        suggestionManager.updateSuggestions([]);
 
-    it('removes selected class and sets aria-selected to false when moving off an element that is inside a selected element', () => {
-      suggestion.addClass(selectedClass);
-      suggestion.setAttribute('aria-selected', 'true');
+        expect(suggestionManager.hasSuggestions).toBe(false);
+        expect($$(suggestionContainer).hasClass('magic-box-hasSuggestion')).toBe(false);
 
-      suggestionManager.handleMouseOut({
-        target: elementInsideSuggestion.el,
-        relatedTarget: container.el
+        const suggestionsElement = $$(suggestionContainer).find('.coveo-magicbox-suggestions');
+        expect(suggestionsElement.childElementCount).toBe(1);
+        expect(suggestionsElement.firstChild.textContent).toBe('');
       });
 
-      expect(suggestion.hasClass(selectedClass)).toBe(false);
-      expect(suggestion.getAttribute('aria-selected')).toBe('false');
-    });
+      it('builds suggestion children correctly when adding a suggestion', () => {
+        suggestionManager.updateSuggestions([{}]);
 
-    it('removes selected class and sets aria-selected to false when moving off an element that is inside a selected element in LockerService', () => {
-      suggestion.addClass(selectedClass);
-      suggestion.setAttribute('aria-selected', 'true');
-
-      suggestionManager.handleMouseOut({
-        target: elementInsideSuggestion.el,
-        relatedTarget: LOCKED_LOCKER_SERVICE_ELEMENT
+        const suggestionElement = $$(suggestionContainer).find('#magic-box-suggestion-0');
+        expect(suggestionElement).toBeTruthy();
+        expect(suggestionElement.getAttribute('role')).toBe('option');
       });
 
-      expect(suggestion.hasClass(selectedClass)).toBe(false);
-      expect(suggestion.getAttribute('aria-selected')).toBe('false');
-    });
-
-    it('removes selected class and sets aria-selected to false when moving from a selected element to off the browser window', () => {
-      suggestion.addClass(selectedClass);
-      suggestion.setAttribute('aria-selected', 'true');
-
-      suggestionManager.handleMouseOut({
-        target: suggestion.el
+      it('returns the correct selected element with keyboard on move down', () => {
+        suggestionManager.moveDown();
+        const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
+        expect($$(selectedWithKeyboard).hasClass(selectedClass)).toBe(true);
+        expect($$(selectedWithKeyboard).getAttribute('aria-selected')).toBe('true');
+        expect(selectedWithKeyboard).toBe(suggestion.el);
       });
 
-      expect(suggestion.hasClass(selectedClass)).toBe(false);
-      expect(suggestion.getAttribute('aria-selected')).toBe('false');
-    });
-
-    it('removes selected class and sets aria-selected to false when moving from an element inside a selected element to off the browser window', () => {
-      suggestion.addClass(selectedClass);
-      suggestion.setAttribute('aria-selected', 'true');
-
-      suggestionManager.handleMouseOut({
-        target: elementInsideSuggestion.el
+      it('clearKeyboardFocusedElement sets the keyboard focused element to null', () => {
+        suggestionManager.moveDown();
+        suggestionManager.clearKeyboardFocusedElement();
+        expect(suggestionManager.selectAndReturnKeyboardFocusedElement()).toBeNull();
       });
 
-      expect(suggestion.hasClass(selectedClass)).toBe(false);
-      expect(suggestion.getAttribute('aria-selected')).toBe('false');
-    });
-
-    it('does not remove selected class or set aria-selected to false when moving element between two element inside the suggestion', () => {
-      let someDeepElement = document.createElement('div');
-      elementInsideSuggestion.el.appendChild(someDeepElement);
-      suggestion.addClass(selectedClass);
-      suggestion.setAttribute('aria-selected', 'true');
-
-      suggestionManager.handleMouseOut({
-        target: elementInsideSuggestion.el,
-        relatedTarget: someDeepElement
+      it('returns the correct selected element with keyboard on move up', () => {
+        suggestionManager.moveUp();
+        const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
+        expect($$(selectedWithKeyboard).hasClass(selectedClass)).toBe(true);
+        expect($$(selectedWithKeyboard).getAttribute('aria-selected')).toBe('true');
+        expect(selectedWithKeyboard).toBe(suggestion.el);
       });
 
-      expect(suggestion.hasClass(selectedClass)).toBe(true);
-      expect(suggestion.getAttribute('aria-selected')).toBe('true');
+      it('returns the correct selected element with keyboard on move left', () => {
+        suggestionManager.moveLeft();
+        const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
+        expect($$(selectedWithKeyboard).hasClass(selectedClass)).toBe(true);
+        expect($$(selectedWithKeyboard).getAttribute('aria-selected')).toBe('true');
+        expect(selectedWithKeyboard).toBe(suggestion.el);
+      });
+
+      it('returns the correct selected element with keyboard on move right', () => {
+        suggestionManager.moveRight();
+        const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
+        expect($$(selectedWithKeyboard).hasClass(selectedClass)).toBe(true);
+        expect($$(selectedWithKeyboard).getAttribute('aria-selected')).toBe('true');
+        expect(selectedWithKeyboard).toBe(suggestion.el);
+      });
+
+      it('return no selected element with successive call to selectAndReturnKeyboardFocusedElement()', () => {
+        suggestionManager.moveDown();
+        const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
+        expect(selectedWithKeyboard).toBeDefined();
+
+        const repeatCallToSelectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
+        expect(repeatCallToSelectedWithKeyboard).toBeNull();
+      });
+
+      it('return no selected element with keyboard on mouse over', () => {
+        suggestionManager.handleMouseOver({
+          target: suggestion.el
+        });
+        const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
+        expect(selectedWithKeyboard).toBeNull();
+      });
+
+      it('return no selected element with keyboard on mouse over following a move down', () => {
+        suggestionManager.moveDown();
+        suggestionManager.handleMouseOver({
+          target: suggestion.el
+        });
+        const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
+        expect(selectedWithKeyboard).toBeNull();
+      });
+
+      it('return no selected element with keyboard on mouse over following a move up', () => {
+        suggestionManager.moveUp();
+        suggestionManager.handleMouseOver({
+          target: suggestion.el
+        });
+        const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
+        expect(selectedWithKeyboard).toBeNull();
+      });
+
+      it('adds selected class and sets aria-selected to true when moving on element that is selectable', () => {
+        suggestionManager.handleMouseOver({
+          target: suggestion.el
+        });
+        expect(suggestion.hasClass(selectedClass)).toBe(true);
+        expect(suggestion.getAttribute('aria-selected')).toBe('true');
+      });
+
+      it('adds selected class and sets aria-selected to true when moving on element that is inside a selectable element', () => {
+        suggestionManager.handleMouseOver({
+          target: elementInsideSuggestion.el
+        });
+        expect(suggestion.hasClass(selectedClass)).toBe(true);
+        expect(suggestion.getAttribute('aria-selected')).toBe('true');
+      });
+
+      it('removes selected class and sets aria-selected to false when moving off a selected element', () => {
+        suggestion.addClass(selectedClass);
+        suggestion.setAttribute('aria-selected', 'true');
+
+        suggestionManager.handleMouseOut({
+          target: suggestion.el,
+          relatedTarget: container.el
+        });
+
+        expect(suggestion.hasClass(selectedClass)).toBe(false);
+        expect(suggestion.getAttribute('aria-selected')).toBe('false');
+      });
+
+      it('removes selected class and sets aria-selected to false when moving off a selected element in LockerService', () => {
+        suggestion.addClass(selectedClass);
+        suggestion.setAttribute('aria-selected', 'true');
+
+        suggestionManager.handleMouseOut({
+          target: suggestion.el,
+          relatedTarget: LOCKED_LOCKER_SERVICE_ELEMENT
+        });
+
+        expect(suggestion.hasClass(selectedClass)).toBe(false);
+        expect(suggestion.getAttribute('aria-selected')).toBe('false');
+      });
+
+      it('removes selected class and sets aria-selected to false when moving off an element that is inside a selected element', () => {
+        suggestion.addClass(selectedClass);
+        suggestion.setAttribute('aria-selected', 'true');
+
+        suggestionManager.handleMouseOut({
+          target: elementInsideSuggestion.el,
+          relatedTarget: container.el
+        });
+
+        expect(suggestion.hasClass(selectedClass)).toBe(false);
+        expect(suggestion.getAttribute('aria-selected')).toBe('false');
+      });
+
+      it('removes selected class and sets aria-selected to false when moving off an element that is inside a selected element in LockerService', () => {
+        suggestion.addClass(selectedClass);
+        suggestion.setAttribute('aria-selected', 'true');
+
+        suggestionManager.handleMouseOut({
+          target: elementInsideSuggestion.el,
+          relatedTarget: LOCKED_LOCKER_SERVICE_ELEMENT
+        });
+
+        expect(suggestion.hasClass(selectedClass)).toBe(false);
+        expect(suggestion.getAttribute('aria-selected')).toBe('false');
+      });
+
+      it('removes selected class and sets aria-selected to false when moving from a selected element to off the browser window', () => {
+        suggestion.addClass(selectedClass);
+        suggestion.setAttribute('aria-selected', 'true');
+
+        suggestionManager.handleMouseOut({
+          target: suggestion.el
+        });
+
+        expect(suggestion.hasClass(selectedClass)).toBe(false);
+        expect(suggestion.getAttribute('aria-selected')).toBe('false');
+      });
+
+      it('removes selected class and sets aria-selected to false when moving from an element inside a selected element to off the browser window', () => {
+        suggestion.addClass(selectedClass);
+        suggestion.setAttribute('aria-selected', 'true');
+
+        suggestionManager.handleMouseOut({
+          target: elementInsideSuggestion.el
+        });
+
+        expect(suggestion.hasClass(selectedClass)).toBe(false);
+        expect(suggestion.getAttribute('aria-selected')).toBe('false');
+      });
+
+      it('does not remove selected class or set aria-selected to false when moving element between two element inside the suggestion', () => {
+        const someDeepElement = document.createElement('div');
+        elementInsideSuggestion.el.appendChild(someDeepElement);
+        suggestion.addClass(selectedClass);
+        suggestion.setAttribute('aria-selected', 'true');
+
+        suggestionManager.handleMouseOut({
+          target: elementInsideSuggestion.el,
+          relatedTarget: someDeepElement
+        });
+
+        expect(suggestion.hasClass(selectedClass)).toBe(true);
+        expect(suggestion.getAttribute('aria-selected')).toBe('true');
+      });
+
+      function buildContainer() {
+        container = $$(document.createElement('div'));
+        suggestionContainer = $$(document.createElement('div'));
+        suggestion = $$(document.createElement('div'));
+        elementInsideSuggestion = $$(document.createElement('div'));
+
+        suggestion.addClass(suggestionClass);
+        suggestion.setAttribute('aria-selected', 'false');
+        suggestion.el.appendChild(elementInsideSuggestion.el);
+        suggestionContainer.el.appendChild(suggestion.el);
+        container.el.appendChild(suggestionContainer.el);
+      }
     });
 
-    function buildContainer() {
-      container = $$(document.createElement('div'));
-      suggestionContainer = $$(document.createElement('div'));
-      suggestion = $$(document.createElement('div'));
-      elementInsideSuggestion = $$(document.createElement('div'));
+    describe('with mock environment', () => {
+      let env: IMockEnvironment;
+      function buildEnvironment() {
+        return (env = new MockEnvironmentBuilder().build());
+      }
 
-      suggestion.addClass(suggestionClass);
-      suggestion.setAttribute('aria-selected', 'false');
-      suggestion.el.appendChild(elementInsideSuggestion.el);
-      suggestionContainer.el.appendChild(suggestion.el);
-      container.el.appendChild(suggestionContainer.el);
-    }
+      let magicBoxContainer: Dom;
+      function buildMagicBoxContainer() {
+        return (magicBoxContainer = $$('div'));
+      }
+
+      function mockInputManager() {
+        return {
+          input: $$('input').el as HTMLInputElement
+        } as InputManager;
+      }
+
+      let suggestionsManager: SuggestionsManager;
+      beforeEach(() => {
+        suggestionsManager = new SuggestionsManager(buildEnvironment().root, buildMagicBoxContainer().el, mockInputManager(), {
+          selectedClass,
+          suggestionClass
+        });
+      });
+
+      describe('calling mergeSuggestions', () => {
+        const textSuggestions = ['4', 'right'];
+        let suggestionOnSelects: { [text: string]: jasmine.Spy };
+        let suggestions: Suggestion[];
+        function createSuggestions() {
+          suggestionOnSelects = textSuggestions.reduce((obj, text) => ({ ...obj, [text]: jasmine.createSpy(text) }), {});
+          return (suggestions = textSuggestions.map(text => <Suggestion>{ text, onSelect: suggestionOnSelects[text] }));
+        }
+
+        let mergedSuggestions: Promise<Suggestion[]>;
+        function mergeSuggestions() {
+          mergedSuggestions = new Promise<Suggestion[]>(resolve => {
+            suggestionsManager.mergeSuggestions([Promise.resolve(createSuggestions())], mergedResult => resolve(mergedResult));
+          });
+        }
+
+        function waitForQuerySuggestRendered() {
+          return new Promise(resolve => {
+            $$(env.root).on(OmniboxEvents.querySuggestRendered, () => resolve());
+          });
+        }
+
+        function mouseFocusSuggestion(suggestionId: number) {
+          $$(suggestionElements[suggestionId]).trigger('mouseenter');
+        }
+
+        let suggestionElements: HTMLElement[];
+        beforeEach(async done => {
+          mergeSuggestions();
+          await waitForQuerySuggestRendered();
+          suggestionElements = $$(env.root).findClass(suggestionClass);
+          done();
+        });
+
+        it('calls the callback with the merged suggestions', async done => {
+          expect(await mergedSuggestions).toEqual(suggestions);
+          done();
+        });
+
+        it('renders suggestions', () => {
+          expect(suggestionElements.map(element => element.innerText)).toEqual(textSuggestions);
+        });
+
+        it("doesn't have a previews container after focusing a suggestion", () => {
+          mouseFocusSuggestion(0);
+          expect($$(env.root).findClass('coveo-preview-container').length).toEqual(0);
+        });
+
+        it("doesn't select mouse focused suggestions", () => {
+          suggestionElements.forEach((_, i) => {
+            mouseFocusSuggestion(i);
+            expect(suggestionsManager.selectAndReturnKeyboardFocusedElement()).toBeNull();
+          });
+        });
+
+        it("doesn't have a selected suggestion by default", () => {
+          expect(suggestionsManager.selectedSuggestion).toBeNull();
+        });
+
+        it('moving the focus down focuses the first suggestion', () => {
+          suggestionsManager.moveDown();
+          expect(suggestionsManager.selectedSuggestion.text).toEqual(first(suggestions).text);
+        });
+
+        it('moving the focus up focuses the first suggestion', () => {
+          suggestionsManager.moveUp();
+          expect(suggestionsManager.selectedSuggestion.text).toEqual(first(suggestions).text);
+        });
+
+        it('moving the focus up from the first suggestion focuses the last suggestion', () => {
+          suggestionsManager.moveDown();
+          suggestionsManager.moveUp();
+          expect(suggestionsManager.selectedSuggestion.text).toEqual(last(suggestions).text);
+        });
+
+        it('moving the focus down from the last suggestion focuses the first suggestion', () => {
+          suggestionsManager.moveDown();
+          suggestionsManager.moveUp();
+          suggestionsManager.moveDown();
+          expect(suggestionsManager.selectedSuggestion.text).toEqual(first(suggestions).text);
+        });
+
+        it('moving the focus down multiple times can reach every suggestion', () => {
+          suggestions.forEach(suggestion => {
+            suggestionsManager.moveDown();
+            expect(suggestionsManager.selectedSuggestion.text).toEqual(suggestion.text);
+          });
+        });
+
+        it('moving the focus up multiple times can reach every suggestion', () => {
+          suggestionsManager.moveDown();
+          reverse(suggestions).forEach(suggestion => {
+            suggestionsManager.moveUp();
+            expect(suggestionsManager.selectedSuggestion.text).toEqual(suggestion.text);
+          });
+        });
+
+        describe('with previews', () => {
+          const previewClassName = 'coveo-preview-selectable';
+          function buildPreview(text: string) {
+            return <ISearchResultPreview>{
+              element: $$(
+                'div',
+                {
+                  className: previewClassName
+                },
+                text
+              ).el,
+              onSelect: jasmine.createSpy(`onSelect${text}`)
+            };
+          }
+
+          let previewsBySuggestion: ISearchResultPreview[][];
+          const textPreviews = [['4K TV', 'Set of 4 pairs of socks'], ['The right spoon', '🔶', 'Right angle SATA cable']];
+          function buildPreviews() {
+            previewsBySuggestion = textPreviews.map(previewTextsForSuggestion => previewTextsForSuggestion.map(buildPreview));
+          }
+
+          const previewsPromisesWaitTimes = [1, 2];
+          function createPreviewsPromise(suggestionId: number) {
+            return Utils.waitUntil(previewsPromisesWaitTimes[suggestionId], previewsBySuggestion[suggestionId]);
+          }
+
+          let populateSpy: jasmine.Spy;
+          function bindPopulateEvent() {
+            populateSpy = jasmine.createSpy('PopulateSearchResultPreviews');
+            $$(env.root).on(SuggestionsManagerEvents.PopulateSearchResultPreviews, (_, args: IPopulateSearchResultPreviewsEventArgs) => {
+              populateSpy(args.suggestionText);
+              args.previewsQuery = createPreviewsPromise(textSuggestions.indexOf(args.suggestionText));
+            });
+          }
+
+          beforeEach(() => {
+            buildPreviews();
+            bindPopulateEvent();
+            jasmine.clock().install();
+          });
+
+          afterEach(() => {
+            jasmine.clock().uninstall();
+          });
+
+          it("doesn't populate previews on initialization", () => {
+            expect(populateSpy).not.toHaveBeenCalled();
+          });
+
+          it("doesn't append any previews when they aren't resolved yet", async done => {
+            mouseFocusSuggestion(0);
+            await deferAsync();
+            expect($$(env.root).findClass(previewClassName).length).toEqual(0);
+            done();
+          });
+
+          describe('after focusing a suggestion', () => {
+            let expectedSuggestionId: number;
+
+            async function moveDownToSuggestion(suggestionId: number) {
+              if (expectedSuggestionId === suggestionId) {
+                return;
+              }
+              for (expectedSuggestionId; expectedSuggestionId < suggestionId; expectedSuggestionId++) {
+                suggestionsManager.moveDown();
+              }
+              jasmine.clock().tick(previewsPromisesWaitTimes[suggestionId]);
+              await deferAsync();
+            }
+
+            beforeEach(() => {
+              expectedSuggestionId = -1;
+            });
+
+            it('has a previews container after focusing a suggestion', async done => {
+              await moveDownToSuggestion(0);
+              expect($$(env.root).findClass('coveo-preview-container').length).toEqual(1);
+              done();
+            });
+
+            it('populates the previews container', async done => {
+              await forEachAsync(textPreviews, async (previewTextsForSuggestion, id) => {
+                await moveDownToSuggestion(id);
+                expect(
+                  $$(env.root)
+                    .findClass(previewClassName)
+                    .map(element => element.innerText)
+                ).toEqual(previewTextsForSuggestion);
+              });
+              done();
+            });
+
+            it('moving the focus down multiple times can reach every suggestion', () => {
+              suggestions.forEach(suggestion => {
+                suggestionsManager.moveDown();
+                expect(suggestionsManager.selectedSuggestion.text).toEqual(suggestion.text);
+              });
+            });
+
+            it('moving the focus up multiple times can reach every suggestion', () => {
+              suggestionsManager.moveDown();
+              reverse(suggestions).forEach(suggestion => {
+                suggestionsManager.moveUp();
+                expect(suggestionsManager.selectedSuggestion.text).toEqual(suggestion.text);
+              });
+            });
+
+            it("moving the focus right when there's previews blurs the suggestion", async done => {
+              await moveDownToSuggestion(0);
+              suggestionsManager.moveRight();
+              expect(suggestionsManager.selectedSuggestion).toBeNull();
+              done();
+            });
+
+            it('can select and return the first preview by moving the focus right from the first suggestion', async done => {
+              await moveDownToSuggestion(0);
+              suggestionsManager.moveRight();
+              expect(suggestionsManager.selectAndReturnKeyboardFocusedElement().innerText).toEqual(first(first(textPreviews)));
+              done();
+            });
+
+            it('moving the focus left from the first preview focuses on the first suggestion', async done => {
+              await moveDownToSuggestion(0);
+              suggestionsManager.moveRight();
+              suggestionsManager.moveLeft();
+              expect(suggestionsManager.selectedSuggestion.text).toEqual(first(suggestions).text);
+              done();
+            });
+
+            it('can select every preview of every suggestion', async done => {
+              await forEachAsync(previewsBySuggestion, async (previews, suggestionId) => {
+                await moveDownToSuggestion(suggestionId);
+                previews.forEach((preview, previewId) => {
+                  suggestionsManager.moveRight();
+                  expect(suggestionsManager.selectAndReturnKeyboardFocusedElement().innerText).toEqual(
+                    textPreviews[suggestionId][previewId],
+                    `Unexpected preview at suggestion #${suggestionId} preview #${previewId}.`
+                  );
+                  expect(preview.onSelect).toHaveBeenCalled();
+                  (preview.onSelect as jasmine.Spy).calls.reset();
+                });
+                previews.forEach(() => suggestionsManager.moveLeft());
+              });
+              done();
+            });
+          });
+        });
+      });
+    });
   });
 }

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -351,7 +351,7 @@ export function SuggestionsManagerTest() {
         it("doesn't select mouse focused suggestions", () => {
           suggestionElements.forEach((_, i) => {
             mouseFocusSuggestion(i);
-            expect(suggestionsManager.selectAndReturnKeyboardFocusedElement()).toBeNull();
+            expect(suggestionsManager.selectAndReturnKeyboardFocusedElement()).toBeFalsy();
           });
         });
 

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -11,7 +11,7 @@ export function SuggestionsManagerTest() {
     let suggestionManager: SuggestionsManager;
     let suggestion: Dom;
     let elementInsideSuggestion: Dom;
-    let selectableClass = 'selectable';
+    let suggestionClass = 'selectable';
     let selectedClass = 'selected';
 
     beforeEach(() => {
@@ -20,7 +20,7 @@ export function SuggestionsManagerTest() {
 
       suggestionManager = new SuggestionsManager(suggestionContainer.el, document.createElement('div'), inputManager, {
         selectedClass,
-        selectableClass
+        suggestionClass
       });
     });
 
@@ -243,7 +243,7 @@ export function SuggestionsManagerTest() {
       suggestion = $$(document.createElement('div'));
       elementInsideSuggestion = $$(document.createElement('div'));
 
-      suggestion.addClass(selectableClass);
+      suggestion.addClass(suggestionClass);
       suggestion.setAttribute('aria-selected', 'false');
       suggestion.el.appendChild(elementInsideSuggestion.el);
       suggestionContainer.el.appendChild(suggestion.el);

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -13,11 +13,6 @@ import { IMockEnvironment, MockEnvironmentBuilder } from '../MockEnvironment';
 import { OmniboxEvents } from '../../src/Core';
 import { last, first, reverse } from 'lodash';
 
-// function tickAndResolvePromise<T>(promise: Promise<T>, ms = 0): Promise<T> {
-//   jasmine.clock().tick(ms);
-//   return promise;
-// }
-
 function deferAsync() {
   return Promise.resolve();
 }

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -420,7 +420,7 @@ export function SuggestionsManagerTest() {
 
           const previewsPromisesWaitTimes = [1, 2];
           function createPreviewsPromise(suggestionId: number) {
-            return Utils.waitUntil(previewsPromisesWaitTimes[suggestionId], previewsBySuggestion[suggestionId]);
+            return Utils.resolveAfter(previewsPromisesWaitTimes[suggestionId], previewsBySuggestion[suggestionId]);
           }
 
           let populateSpy: jasmine.Spy;

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -2,12 +2,10 @@ import * as Mock from '../MockEnvironment';
 import { IBasicComponentSetup } from '../MockEnvironment';
 import { QuerySuggestPreview, IQuerySuggestPreview } from '../../src/ui/QuerySuggestPreview/QuerySuggestPreview';
 import { IOmniboxAnalytics } from '../../src/ui/Omnibox/OmniboxAnalytics';
-import { $$, OmniboxEvents, HtmlTemplate, Dom, Component } from '../../src/Core';
+import { $$, HtmlTemplate, Component } from '../../src/Core';
 import { FakeResults } from '../Fake';
 import { IAnalyticsOmniboxSuggestionMeta, analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
-import { Suggestion, SuggestionsManager } from '../../src/magicbox/SuggestionsManager';
-import { InputManager } from '../../src/magicbox/InputManager';
-import { MagicBoxInstance } from '../../src/magicbox/MagicBox';
+import { SuggestionsManagerEvents, IPopulateSearchResultPreviewsEventArgs } from '../../src/magicbox/SuggestionsManager';
 import { IQueryResults } from '../../src/rest/QueryResults';
 import { last } from 'underscore';
 
@@ -41,15 +39,11 @@ export function QuerySuggestPreviewTest() {
   describe('QuerySuggestPreview', () => {
     let test: IBasicComponentSetup<QuerySuggestPreview>;
     let testEnv: Mock.MockEnvironmentBuilder;
-    let container: Dom;
-    let suggestionContainer: Dom;
-    let suggestionManager: SuggestionsManager;
-    let suggestion: Dom;
-    let elementInsideSuggestion: Dom;
     let omniboxAnalytics: IOmniboxAnalytics;
 
     function setupQuerySuggestPreview(options: IQuerySuggestPreview = {}) {
       const tmpl: HtmlTemplate = Mock.mock<HtmlTemplate>(HtmlTemplate);
+      (tmpl.instantiateToElement as jasmine.Spy).and.returnValue(Promise.resolve($$('div').el));
       options['resultTemplate'] = tmpl;
 
       test = Mock.advancedComponentSetup<QuerySuggestPreview>(
@@ -59,257 +53,89 @@ export function QuerySuggestPreviewTest() {
       spyOn(Component, 'resolveRoot').and.returnValue(testEnv.root);
     }
 
-    function triggerQuerySuggestHover(suggestion: string = 'test', fakeResults?: IQueryResults) {
+    function triggerPopulateSearchResultPreviews(suggestionText: string = 'test', fakeResults?: IQueryResults) {
       fakeResults = fakeResults || FakeResults.createFakeResults(test.cmp.options.numberOfPreviewResults);
       (test.env.searchEndpoint.search as jasmine.Spy).and.returnValue(Promise.resolve(fakeResults));
-      $$(testEnv.root).trigger(OmniboxEvents.querySuggestGetFocus, { suggestion });
+      const event: IPopulateSearchResultPreviewsEventArgs = { suggestionText, previewsQuery: null };
+      $$(testEnv.root).trigger(SuggestionsManagerEvents.PopulateSearchResultPreviews, event);
+      return event.previewsQuery;
     }
 
-    function triggerQuerySuggestHoverAndPassTime(suggestion: string = 'test', fakeResults?: IQueryResults) {
-      triggerQuerySuggestHover(suggestion);
+    function triggerPopulateSearchResultPreviewsAndPassTime(suggestion: string = 'test', fakeResults?: IQueryResults) {
+      const query = triggerPopulateSearchResultPreviews(suggestion);
       jasmine.clock().tick(test.cmp.options.executeQueryDelay);
-    }
-
-    function buildSuggestion() {
-      container = $$(document.createElement('div'));
-      suggestionContainer = $$(document.createElement('div'));
-      suggestion = $$(document.createElement('div'));
-      elementInsideSuggestion = $$(document.createElement('div'));
-
-      suggestion.el.appendChild(elementInsideSuggestion.el);
-      suggestionContainer.el.appendChild(suggestion.el);
-      container.el.appendChild(suggestionContainer.el);
-    }
-
-    function setupSuggestionsManager() {
-      buildSuggestion();
-      const inputManager = new InputManager(document.createElement('div'), () => {}, {} as MagicBoxInstance);
-
-      const container = document.createElement('div');
-      suggestionManager = new SuggestionsManager(suggestionContainer.el, container, inputManager, {});
-    }
-
-    function setupRenderPreview() {
-      test.env.root.appendChild(suggestionContainer.el);
-      (test.cmp.options.resultTemplate.instantiateToElement as jasmine.Spy).and.returnValue(Promise.resolve($$('div').el));
-    }
-
-    function setupSuggestion(suggestions: Suggestion[] = [{ text: 'test' }]) {
-      setupSuggestionsManager();
-      setupRenderPreview();
-      suggestionManager.updateSuggestions(suggestions);
-    }
-
-    function waitXms(ms: number) {
-      return Promise.resolve(
-        setTimeout(() => {
-          return;
-        }, ms)
-      );
+      return query;
     }
 
     beforeEach(() => {
       testEnv = new Mock.MockEnvironmentBuilder();
       omniboxAnalytics = this.initOmniboxAnalyticsMock(omniboxAnalytics);
       testEnv.searchInterface.getOmniboxAnalytics = jasmine.createSpy('omniboxAnalytics').and.returnValue(omniboxAnalytics) as any;
+      jasmine.clock().install();
+    });
+
+    afterEach(() => {
+      jasmine.clock().uninstall();
     });
 
     describe('expose options', () => {
-      beforeEach(() => {
-        jasmine.clock().install();
-      });
-
-      afterEach(() => {
-        jasmine.clock().uninstall();
-      });
-
-      it('numberOfPreviewResults set the number of results to query', () => {
+      it('numberOfPreviewResults set the number of results to query', async done => {
         const numberOfPreviewResults = 5;
         setupQuerySuggestPreview({ numberOfPreviewResults });
-        setupSuggestion();
-        triggerQuerySuggestHoverAndPassTime();
+        await triggerPopulateSearchResultPreviewsAndPassTime();
         expect(test.cmp.queryController.getLastQuery().numberOfResults).toBe(numberOfPreviewResults);
+        done();
       });
 
-      it('hoverTime set the time before the query is executed', () => {
+      it('hoverTime set the time before the query is executed', async done => {
         const executeQueryDelay = 200;
         setupQuerySuggestPreview({ executeQueryDelay });
-        setupSuggestion();
         expect(test.cmp.queryController.getLastQuery).not.toHaveBeenCalled();
-        triggerQuerySuggestHoverAndPassTime();
+        await triggerPopulateSearchResultPreviewsAndPassTime();
         expect(test.cmp.queryController.getLastQuery).toHaveBeenCalledTimes(1);
-      });
-
-      it('previewWidth change the witdh of the preview container', () => {
-        const width = 500;
-        setupQuerySuggestPreview({ previewWidth: width });
-        setupSuggestion();
-        triggerQuerySuggestHoverAndPassTime();
-        const previewContainer = $$(suggestionContainer.el).find('.coveo-preview-container');
-        expect(previewContainer.style.width).toEqual(`${width}px`);
-      });
-
-      it('suggestionWidth change the width of the suggestion container', () => {
-        const suggestionWidth = 250;
-        setupQuerySuggestPreview({ suggestionWidth });
-        setupSuggestion();
-        triggerQuerySuggestHoverAndPassTime();
-        const suggestionContainerById = $$(suggestionContainer.el).find('.coveo-magicbox-suggestions');
-        expect(suggestionContainerById.style.width).toBe(`${suggestionWidth}px`);
-      });
-
-      it('headerText change the text in the header of the preview', done => {
-        const headerText = 'Super Header';
-        const suggestion = 'test';
-        //We can't use the clock here because we are validating a DOM element
-        //Since we need to wait for some promise to finish and I can't wait for them
-        //since they were triggered by an event. Meanwhile, Jasmine will continue to
-        //evaluate and would fail the test
-        jasmine.clock().uninstall();
-        setupQuerySuggestPreview({ headerText });
-        setupSuggestion();
-        triggerQuerySuggestHover(suggestion);
-        setTimeout(() => {
-          const previewContainer = $$(suggestionContainer.el).find('.coveo-preview-header');
-          expect(previewContainer.innerText).toBe(`${headerText} "${suggestion}"`);
-          done();
-        }, test.cmp.options.executeQueryDelay);
-      });
-    });
-
-    describe('when the previews are rendered,', () => {
-      it(`if we have four element,
-      each take 50% of the remaining available space`, done => {
-        setupQuerySuggestPreview({ numberOfPreviewResults: 4 });
-        setupSuggestion();
-        triggerQuerySuggestHover();
-        setTimeout(() => {
-          const previewContainer = $$(suggestionContainer.el).find('.CoveoResult');
-          expect(previewContainer.style.flex).toBe('0 0 50%');
-          done();
-        }, test.cmp.options.executeQueryDelay);
-      });
-
-      it(`if we DON'T have 4 htmlElement,
-      each take 33% of the remaining available space`, done => {
-        setupQuerySuggestPreview({ numberOfPreviewResults: 6 });
-        setupSuggestion();
-        triggerQuerySuggestHover();
-        setTimeout(() => {
-          const previewContainer = $$(suggestionContainer.el).find('.CoveoResult');
-          expect(previewContainer.style.flex).toBe('0 0 33%');
-          done();
-        }, test.cmp.options.executeQueryDelay);
+        done();
       });
     });
 
     describe('When we hover', () => {
-      beforeEach(() => {
-        jasmine.clock().install();
-      });
-
-      afterEach(() => {
-        jasmine.clock().uninstall();
-      });
-
       it(`on the same Suggestion multiple times before the time in the option hoverTime has passed,
-      the query is is executed only once`, done => {
+      the query is is executed only once`, async done => {
         setupQuerySuggestPreview();
         test.cmp.queryController.getEndpoint().search = jasmine.createSpy('execQuery');
-        setupSuggestion();
-        triggerQuerySuggestHover();
-        triggerQuerySuggestHover();
-        triggerQuerySuggestHoverAndPassTime();
+        triggerPopulateSearchResultPreviews();
+        triggerPopulateSearchResultPreviews();
+        await triggerPopulateSearchResultPreviewsAndPassTime();
         expect(test.cmp.queryController.getEndpoint().search).toHaveBeenCalledTimes(1);
         done();
       });
 
       it(`on multiple suggestion before the time in the option hoverTime has passed,
-      the query is is executed only once with the last Suggestion we hovered on`, done => {
+      the query is is executed only once with the last Suggestion we hovered on`, async done => {
         const realQuery = 'testing3';
         setupQuerySuggestPreview();
         test.cmp.queryController.getEndpoint().search = jasmine.createSpy('execQuery');
-        setupSuggestion();
-        triggerQuerySuggestHover('testing');
-        triggerQuerySuggestHover('testing2');
-        triggerQuerySuggestHoverAndPassTime(realQuery);
+        triggerPopulateSearchResultPreviews('testing');
+        triggerPopulateSearchResultPreviews('testing2');
+        await triggerPopulateSearchResultPreviewsAndPassTime(realQuery);
         expect(test.cmp.queryController.getEndpoint().search).toHaveBeenCalledTimes(1);
         expect(test.cmp.queryController.getLastQuery().q).toBe(realQuery);
         done();
       });
 
       it(`and the query get executed, 
-      it logs an analytics search event`, () => {
+      it logs an analytics search event`, async done => {
         setupQuerySuggestPreview();
-        setupSuggestion();
-        triggerQuerySuggestHoverAndPassTime();
+        await triggerPopulateSearchResultPreviewsAndPassTime();
 
         expect(test.cmp.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(
           analyticsActionCauseList.showQuerySuggestPreview,
           jasmine.objectContaining(getMetadata(omniboxAnalytics))
         );
-      });
-    });
-
-    describe('currentlyDisplayedResults', () => {
-      it('get populated by rendered results', done => {
-        setupQuerySuggestPreview();
-        const fakeResults = FakeResults.createFakeResults(test.cmp.options.numberOfPreviewResults);
-        setupSuggestion();
-        triggerQuerySuggestHover('test', fakeResults);
-        setTimeout(() => {
-          expect(test.cmp.displayedResults).toEqual(fakeResults.results);
-          done();
-        }, test.cmp.options.executeQueryDelay);
-      });
-
-      it('get emptied when they aare no result to be rendered', done => {
-        setupQuerySuggestPreview();
-        const fakeResults = FakeResults.createFakeResults(0);
-        setupSuggestion();
-        triggerQuerySuggestHover('test', fakeResults);
-        setTimeout(() => {
-          expect(test.cmp.displayedResults).toEqual([]);
-          done();
-        }, test.cmp.options.executeQueryDelay);
-      });
-
-      it('get emptied when a querySuggest loose focus', done => {
-        setupQuerySuggestPreview();
-        setupSuggestion();
-        triggerQuerySuggestHover('test');
-        setTimeout(() => {
-          expect(test.cmp.displayedResults.length).toEqual(test.cmp.options.numberOfPreviewResults);
-          $$(test.cmp.root).trigger(OmniboxEvents.querySuggestLoseFocus);
-          expect(test.cmp.displayedResults).toEqual([]);
-          done();
-        }, test.cmp.options.executeQueryDelay);
-      });
-    });
-
-    describe('SuggestionsManager', () => {
-      it(`when moving right,
-      it returns a QuerySuggestPreview`, done => {
-        setupQuerySuggestPreview();
-        const fakeResults = FakeResults.createFakeResults(test.cmp.options.numberOfPreviewResults);
-        setupSuggestion();
-        triggerQuerySuggestHover('test', fakeResults);
-        setTimeout(() => {
-          suggestionManager.moveRight();
-          const selectedWithKeyboard = suggestionManager.selectAndReturnKeyboardFocusedElement();
-          expect(selectedWithKeyboard.classList).toContain('coveo-preview-selectable');
-          expect(selectedWithKeyboard.classList).toContain('magic-box-selected');
-          done();
-        }, test.cmp.options.executeQueryDelay);
+        done();
       });
     });
 
     describe('Analytics', () => {
-      function getAResult() {
-        const previewContainer = $$(suggestionContainer.el).find('.coveo-preview-results > .CoveoResult');
-        return previewContainer;
-      }
-
       function getAnalyticsMetadata(suggestion: string) {
         return jasmine.objectContaining({
           suggestion,
@@ -319,14 +145,13 @@ export function QuerySuggestPreviewTest() {
 
       it('it log an analytics with the appropriate event', async done => {
         const suggestion = 'test';
-        triggerQuerySuggestHover(suggestion);
-        await waitXms(test.cmp.options.executeQueryDelay);
-        const previewContainer = getAResult();
-        previewContainer.click();
+        setupQuerySuggestPreview();
+        const result = (await triggerPopulateSearchResultPreviewsAndPassTime(suggestion))[0];
+        result.onSelect();
         expect(test.cmp.usageAnalytics.logCustomEvent).toHaveBeenCalledWith(
           analyticsActionCauseList.clickQuerySuggestPreview,
           getAnalyticsMetadata(suggestion),
-          previewContainer
+          result.element
         );
         done();
       });
@@ -334,16 +159,14 @@ export function QuerySuggestPreviewTest() {
       it(`it log an analytics with the appropriate event,
       even if we hover on another suggestion before clicking`, async done => {
         const suggestion = 'test';
-        triggerQuerySuggestHover(suggestion);
-        await waitXms(test.cmp.options.executeQueryDelay);
-        triggerQuerySuggestHover(`bad ${suggestion}`);
-        await waitXms(test.cmp.options.executeQueryDelay - 100);
-        const previewContainer = getAResult();
-        previewContainer.click();
+        setupQuerySuggestPreview();
+        const result = (await triggerPopulateSearchResultPreviewsAndPassTime(suggestion))[0];
+        await triggerPopulateSearchResultPreviewsAndPassTime(`bad ${suggestion}`);
+        result.onSelect();
         expect(test.cmp.usageAnalytics.logCustomEvent).toHaveBeenCalledWith(
           analyticsActionCauseList.clickQuerySuggestPreview,
           getAnalyticsMetadata(suggestion),
-          previewContainer
+          result.element
         );
         done();
       });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2685

Since there is a circular dependency between `SuggestionsManager` and `QuerySuggestPreview` that prevents lazy loading, creation of search result previews was delegated to `SuggestionsManager`. `QuerySuggestPreview` is now only responsible for feeding barebones result previews in response to an event (`PopulateSearchResultPreviews`).

To test `QuerySuggestPreview`, here's my test environment:
### ./bin/index.html
```html
<head>
...
  <script>
    document.addEventListener('DOMContentLoaded', function () {
      Coveo.$$(document.body).on('doneBuildingQuery', (_, args) => {
        args.queryBuilder.fieldsToInclude = undefined;
        args.queryBuilder.includeRequiredFields = false;
      });
      Coveo.SearchEndpoint.configureCloudV2Endpoint("coveodemocommerceqmqaepc4", /* TOKENHERE */);
      Coveo.init(document.body);
    });
  </script>
</head>
<body id="search" class='CoveoSearchInterface' data-enable-history="true" data-pipeline="CommerceML">
...
    <div class="CoveoSearchbox" data-enable-omnibox="true"></div>
    <div class="CoveoAnalytics" data-search-hub="CoveoCommerce"></div>
    <div class="CoveoQuerySuggestPreview" data-number-of-preview-results="6">
      <script class="result-template" type="text/html">
        <div class="coveo-result-frame">
          <div class="coveo-result-row">
            <div class="coveo-result-cell">
              <div class="CoveoImageFieldValue" data-field="@image" data-height="56"></div>
            </div>
          </div>
          <div class="coveo-result-row">
            <div class="coveo-result-cell"><a href="" class="CoveoResultLink"></a></div>
          </div>
        </div>
      </script>
    </div>
...
</body>
```

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)