### PR TITLE
JSUI-2689 Convert templates and option docs to use lowercase sort values

### DIFF
--- a/pages/DynamicsCrm.html
+++ b/pages/DynamicsCrm.html
@@ -30,7 +30,7 @@
     <div class="coveo-facet-column">
       <div class="CoveoFacet" data-title="Type" data-field="@objecttype" data-tab="DynamicsCRM"></div>
       <div class="CoveoFacet" data-title="Parent Account" data-field="@dyparentaccountidstring" data-computed-field="@dytotalamount"
-        data-sort-criteria="ComputedFieldDescending" data-number-of-values="7" data-tab="DynamicsCRM"></div>
+        data-sort-criteria="computedfielddescending" data-number-of-values="7" data-tab="DynamicsCRM"></div>
       <div class="CoveoFacet" data-title="Status" data-field="@dystatuscodestring" data-tab="DynamicsCRM"></div>
       <div class="CoveoFacetSlider" data-title="Created" data-field="@dycreatedon" data-slider-graph-steps="20" data-range-slider="true"
         data-date-field="true" data-tab="DynamicsCRM"></div>

--- a/pages/Salesforce.html
+++ b/pages/Salesforce.html
@@ -31,17 +31,17 @@
       <div class="CoveoFacet" data-title="Type" data-field="@objecttype" data-tab="Salesforce"></div>
       <div class="CoveoFacet" data-title="Status" data-field="@sfstatus" data-tab="Salesforce"></div>
       <div class="CoveoFacet" data-title="Close quarter" data-field="@sfopportunityclosedquarterc" data-computed-field="@sfopportunityamountconverted"
-        data-sort-criteria="AlphaDescending" data-tab="Salesforce"></div>
+        data-sort-criteria="alphadescending" data-tab="Salesforce"></div>
       <div class="CoveoFacet" data-title="Salesforce Account" data-field="@sfaccountname" data-computed-field="@sfopportunityamountconverted"
-        data-sort-criteria="ComputedFieldDescending" data-tab="Salesforce"></div>
+        data-sort-criteria="computedfielddescending" data-tab="Salesforce"></div>
       <div class="CoveoFacet" data-title="Salesforce Owner" data-field="@sfownername" data-computed-field="@sfopportunityamountconverted"
-        data-sort-criteria="ComputedFieldDescending" data-tab="Salesforce"></div>
+        data-sort-criteria="computedfielddescending" data-tab="Salesforce"></div>
       <div class="CoveoFacet" data-title="Opportunity Type" data-field="@sfopportunitytype" data-computed-field="@sfopportunityamountconverted"
-        data-sort-criteria="ComputedFieldDescending" data-tab="Salesforce"></div>
+        data-sort-criteria="computedfielddescending" data-tab="Salesforce"></div>
       <div class="CoveoFacet" data-title="Opportunity Stage" data-field="@sfopportunitystagename" data-computed-field="@sfopportunityamountconverted"
-        data-sort-criteria="ComputedFieldDescending" data-tab="Salesforce"></div>
+        data-sort-criteria="computedfielddescending" data-tab="Salesforce"></div>
       <div class="CoveoFacet" data-title="Lead Source" data-field="@sfleadsource" data-computed-field="@sfopportunityamountconverted"
-        data-sort-criteria="ComputedFieldDescending" data-tab="Salesforce"></div>
+        data-sort-criteria="computedfielddescending" data-tab="Salesforce"></div>
       <div class="CoveoFacet" data-title="Created By" data-field="@sfcreatedbyname" data-tab="Salesforce"></div>
       <div class="CoveoTimespanFacet" data-tab="Salesforce"></div>
     </div>

--- a/pages/ServiceNow.html
+++ b/pages/ServiceNow.html
@@ -29,8 +29,8 @@
   <div class="coveo-main-section">
     <div class="coveo-facet-column">
       <div class="CoveoFacet" data-title="Type" data-field="@objecttype" data-tab="ServiceNow"></div>
-      <div class="CoveoFacet" data-title="Priority" data-field="@snpriority" data-sort-criteria="AlphaAscending" data-tab="ServiceNow"></div>
-      <div class="CoveoFacet" data-title="Urgency" data-field="@snurgency" data-sort-criteria="AlphaAscending" data-tab="ServiceNow"></div>
+      <div class="CoveoFacet" data-title="Priority" data-field="@snpriority" data-sort-criteria="alphaascending" data-tab="ServiceNow"></div>
+      <div class="CoveoFacet" data-title="Urgency" data-field="@snurgency" data-sort-criteria="alphaascending" data-tab="ServiceNow"></div>
       <div class="CoveoFacet" data-title="Opened By" data-field="@snopenedbytitle" data-tab="ServiceNow"></div>
       <div class="CoveoFacet" data-title="State" data-field="@snstate" data-tab="ServiceNow"></div>
       <div class="CoveoFacet" data-title="Category" data-field="@sncategory" data-tab="ServiceNow"></div>

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -257,14 +257,14 @@ export class Facet extends Component {
       section: 'Sorting',
       depend: 'enableSettings',
       values: [
-        'Occurrences',
-        'Score',
-        'AlphaAscending',
-        'AlphaDescending',
-        'ComputedFieldAscending',
-        'ComputedFieldDescending',
-        'ChiSquare',
-        'NoSort'
+        'occurrences',
+        'score',
+        'alphaascending',
+        'alphadescending',
+        'computedfieldascending',
+        'computedfielddescending',
+        'chisquare',
+        'nosort'
       ]
     }),
     /**

--- a/src/ui/Matrix/Matrix.ts
+++ b/src/ui/Matrix/Matrix.ts
@@ -100,9 +100,9 @@ export class Matrix extends Component {
      *
      * See {@link IGroupByRequest.sortCriteria} for the list of possible values.
      *
-     * Default value is `ComputedFieldDescending`.
+     * Default value is `computedfielddescending`.
      */
-    sortCriteria: ComponentOptions.buildStringOption({ defaultValue: 'ComputedFieldDescending' }),
+    sortCriteria: ComponentOptions.buildStringOption({ defaultValue: 'computedfielddescending' }),
 
     /**
      * Specifies the maximum number of rows to display in the Matrix.


### PR DESCRIPTION
While these options support any case, I decided to convert to lowercase to keep the validation code in the Interface Editor simpler.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)