### PR TITLE
JSUI-2698 Fixed ResultPreviewsManager showing wrong previews when up and down are pressed simultaneously

### DIFF
--- a/src/events/ResultPreviewsManagerEvents.ts
+++ b/src/events/ResultPreviewsManagerEvents.ts
@@ -12,7 +12,7 @@ export interface IPopulateSearchResultPreviewsEventArgs {
    * The result previews query. This must be set synchronously before the event resolves.
    * Setting this to a non-empty array will display the given search result previews.
    */
-  previewsQuery: Promise<ISearchResultPreview[]>;
+  previewsQueries: (ISearchResultPreview[] | Promise<ISearchResultPreview[]>)[];
 }
 
 /**

--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -4,6 +4,7 @@ import { defaults, findIndex } from 'lodash';
 import { Component } from '../ui/Base/Component';
 import { Direction } from './SuggestionsManager';
 import { ResultPreviewsManagerEvents, IPopulateSearchResultPreviewsEventArgs } from '../events/ResultPreviewsManagerEvents';
+import { QueryProcessor, ProcessingStatus } from './QueryProcessor';
 
 export interface ISearchResultPreview {
   element: HTMLElement;
@@ -21,12 +22,13 @@ export class ResultPreviewsManager {
   private suggestionsPreviewContainer: Dom;
   private resultPreviewsHeader: Dom;
   private resultPreviewsContainer: Dom;
-  private lastPreviewsQuery: Promise<ISearchResultPreview[]>;
-  private lastSelectedSuggestion: HTMLElement;
+  private lastQueriedSuggestion: HTMLElement;
+  private lastDisplayedSuggestion: HTMLElement;
+  private previewsProcessor: QueryProcessor<ISearchResultPreview>;
   private root: HTMLElement;
 
   public get previewsOwner() {
-    return this.lastSelectedSuggestion;
+    return this.lastDisplayedSuggestion;
   }
 
   public get hasPreviews() {
@@ -72,12 +74,29 @@ export class ResultPreviewsManager {
       selectedClass: 'magic-box-selected'
     });
     this.root = Component.resolveRoot(element);
+    this.previewsProcessor = new QueryProcessor();
   }
 
   public async displaySearchResultPreviewsForSuggestion(suggestion: HTMLElement) {
-    if (this.lastSelectedSuggestion !== suggestion) {
-      await this.loadSearchResultPreviews(suggestion);
+    if (suggestion && this.lastQueriedSuggestion === suggestion) {
+      return;
     }
+    if (this.lastDisplayedSuggestion === suggestion) {
+      this.previewsProcessor.overrideIfProcessing();
+      this.lastQueriedSuggestion = null;
+      return;
+    }
+    this.lastQueriedSuggestion = suggestion;
+    if (!suggestion) {
+      this.displaySuggestionPreviews(null, []);
+      return;
+    }
+    const { status, results } = await this.getSearchResultPreviewsQuery(suggestion);
+    if (status === ProcessingStatus.Overriden) {
+      return;
+    }
+    this.lastQueriedSuggestion = null;
+    this.displaySuggestionPreviews(suggestion, results);
   }
 
   public getElementInDirection(direction: Direction) {
@@ -153,15 +172,12 @@ export class ResultPreviewsManager {
   }
 
   private getSearchResultPreviewsQuery(suggestion: HTMLElement) {
-    if (!suggestion) {
-      return Promise.resolve([]);
-    }
     const populateEventArgs: IPopulateSearchResultPreviewsEventArgs = {
       suggestionText: suggestion.innerText,
-      previewsQuery: null
+      previewsQueries: []
     };
     $$(this.root).trigger(ResultPreviewsManagerEvents.PopulateSearchResultPreviews, populateEventArgs);
-    return populateEventArgs.previewsQuery;
+    return this.previewsProcessor.processQueries(populateEventArgs.previewsQueries);
   }
 
   private updateSearchResultPreviewsHeader(text: string) {
@@ -184,21 +200,11 @@ export class ResultPreviewsManager {
   private displaySuggestionPreviews(suggestion: HTMLElement, previews: ISearchResultPreview[]) {
     this.setHasPreviews(previews && previews.length > 0);
     this.element.classList.toggle('magic-box-hasPreviews', this.hasPreviews);
-    this.lastPreviewsQuery = null;
-    this.lastSelectedSuggestion = suggestion;
+    this.lastDisplayedSuggestion = suggestion;
     if (!this.hasPreviews) {
       return;
     }
     this.appendSearchResultPreviews(previews);
     this.updateSearchResultPreviewsHeader(`${this.options.previewHeaderText} "${suggestion.innerText}"`);
-  }
-
-  private async loadSearchResultPreviews(suggestion: HTMLElement) {
-    const query = (this.lastPreviewsQuery = this.getSearchResultPreviewsQuery(suggestion));
-    const previews = await this.lastPreviewsQuery;
-    if (this.lastPreviewsQuery !== query) {
-      return;
-    }
-    this.displaySuggestionPreviews(suggestion, previews);
   }
 }

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -110,20 +110,20 @@ export class SuggestionsManager {
     $$(this.root).trigger(OmniboxEvents.querySuggestLoseFocus);
   }
 
-  public moveDown() {
-    this.move(Direction.Down);
+  public async moveDown() {
+    await this.move(Direction.Down);
   }
 
-  public moveUp() {
-    this.move(Direction.Up);
+  public async moveUp() {
+    await this.move(Direction.Up);
   }
 
-  public moveLeft() {
-    this.move(Direction.Left);
+  public async moveLeft() {
+    await this.move(Direction.Left);
   }
 
-  public moveRight() {
-    this.move(Direction.Right);
+  public async moveRight() {
+    await this.move(Direction.Right);
   }
 
   public selectAndReturnKeyboardFocusedElement(): HTMLElement {
@@ -249,11 +249,11 @@ export class SuggestionsManager {
     return null;
   }
 
-  private processKeyboardSelection(suggestion: HTMLElement) {
+  private async processKeyboardSelection(suggestion: HTMLElement) {
     this.addSelectedStatus(suggestion);
-    this.updateSelectedSuggestion(suggestion);
     this.keyboardFocusedElement = suggestion;
     $$(this.inputManager.input).setAttribute('aria-activedescendant', $$(suggestion).getAttribute('id'));
+    await this.updateSelectedSuggestion(suggestion);
   }
 
   private processKeyboardPreviewSelection(preview: HTMLElement) {
@@ -261,7 +261,7 @@ export class SuggestionsManager {
     this.keyboardFocusedElement = preview;
   }
 
-  private processMouseSelection(suggestion: HTMLElement) {
+  private async processMouseSelection(suggestion: HTMLElement) {
     this.addSelectedStatus(suggestion);
     this.updateSelectedSuggestion(suggestion);
     this.keyboardFocusedElement = null;
@@ -334,9 +334,9 @@ export class SuggestionsManager {
     return $$(dom);
   }
 
-  private move(direction: Direction) {
+  private async move(direction: Direction) {
     if (this.resultPreviewsManager.focusedPreviewElement) {
-      this.moveWithinPreview(direction);
+      await this.moveWithinPreview(direction);
       return;
     }
     if (direction === Direction.Right || direction === Direction.Left) {
@@ -346,10 +346,10 @@ export class SuggestionsManager {
         return;
       }
     }
-    this.moveWithinSuggestion(direction);
+    await this.moveWithinSuggestion(direction);
   }
 
-  private moveWithinSuggestion(direction: Direction) {
+  private async moveWithinSuggestion(direction: Direction) {
     const currentlySelected = $$(this.element).find(`.${this.options.selectedClass}`);
     const selectables = $$(this.element).findAll(`.${this.options.suggestionClass}`);
     const currentIndex = indexOf(selectables, currentlySelected);
@@ -357,12 +357,12 @@ export class SuggestionsManager {
     let index = direction === Direction.Up ? currentIndex - 1 : currentIndex + 1;
     index = (index + selectables.length) % selectables.length;
 
-    this.selectQuerySuggest(selectables[index]);
+    await this.selectQuerySuggest(selectables[index]);
   }
 
-  private selectQuerySuggest(suggestion: HTMLElement) {
+  private async selectQuerySuggest(suggestion: HTMLElement) {
     if (suggestion) {
-      this.processKeyboardSelection(suggestion);
+      await this.processKeyboardSelection(suggestion);
     } else {
       this.keyboardFocusedElement = null;
       this.inputManager.input.removeAttribute('aria-activedescendant');
@@ -371,10 +371,10 @@ export class SuggestionsManager {
     return suggestion;
   }
 
-  private moveWithinPreview(direction: Direction) {
+  private async moveWithinPreview(direction: Direction) {
     const newFocusedPreview = this.resultPreviewsManager.getElementInDirection(direction);
     if (!newFocusedPreview) {
-      this.selectQuerySuggest(this.resultPreviewsManager.previewsOwner);
+      await this.selectQuerySuggest(this.resultPreviewsManager.previewsOwner);
       return;
     }
     this.processKeyboardPreviewSelection(newFocusedPreview);
@@ -407,11 +407,11 @@ export class SuggestionsManager {
     this.updateAreaSelectedIfDefined(element, 'true');
   }
 
-  private updateSelectedSuggestion(suggestion: HTMLElement) {
+  private async updateSelectedSuggestion(suggestion: HTMLElement) {
     $$(this.root).trigger(OmniboxEvents.querySuggestGetFocus, <IQuerySuggestSelection>{
       suggestion: suggestion.innerText
     });
-    this.resultPreviewsManager.displaySearchResultPreviewsForSuggestion(suggestion);
+    await this.resultPreviewsManager.displaySearchResultPreviewsForSuggestion(suggestion);
   }
 
   private removeSelectedStatus(suggestion: HTMLElement): void {

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -93,7 +93,7 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
   }
 
   private populateSearchResultPreviews(args: IPopulateSearchResultPreviewsEventArgs) {
-    args.previewsQuery = this.fetchSearchResultPreviews(args.suggestionText);
+    args.previewsQueries.push(this.fetchSearchResultPreviews(args.suggestionText));
   }
 
   private async fetchSearchResultPreviews(suggestionText: string) {

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -424,7 +424,7 @@ export function SuggestionsManagerTest() {
             populateSpy = jasmine.createSpy('PopulateSearchResultPreviews');
             $$(env.root).on(ResultPreviewsManagerEvents.PopulateSearchResultPreviews, (_, args: IPopulateSearchResultPreviewsEventArgs) => {
               populateSpy(args.suggestionText);
-              args.previewsQuery = createPreviewsPromise(textSuggestions.indexOf(args.suggestionText));
+              args.previewsQueries.push(createPreviewsPromise(textSuggestions.indexOf(args.suggestionText)));
             });
           }
 
@@ -456,11 +456,12 @@ export function SuggestionsManagerTest() {
               if (expectedSuggestionId === suggestionId) {
                 return;
               }
+              let lastMove: Promise<void>;
               for (expectedSuggestionId; expectedSuggestionId < suggestionId; expectedSuggestionId++) {
-                suggestionsManager.moveDown();
+                lastMove = suggestionsManager.moveDown();
               }
               jasmine.clock().tick(previewsPromisesWaitTimes[suggestionId]);
-              await deferAsync();
+              await lastMove;
             }
 
             beforeEach(() => {

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -56,9 +56,9 @@ export function QuerySuggestPreviewTest() {
     function triggerPopulateSearchResultPreviews(suggestionText: string = 'test', fakeResults?: IQueryResults) {
       fakeResults = fakeResults || FakeResults.createFakeResults(test.cmp.options.numberOfPreviewResults);
       (test.env.searchEndpoint.search as jasmine.Spy).and.returnValue(Promise.resolve(fakeResults));
-      const event: IPopulateSearchResultPreviewsEventArgs = { suggestionText, previewsQuery: null };
+      const event: IPopulateSearchResultPreviewsEventArgs = { suggestionText, previewsQueries: [] };
       $$(testEnv.root).trigger(ResultPreviewsManagerEvents.PopulateSearchResultPreviews, event);
-      return event.previewsQuery;
+      return event.previewsQueries[0];
     }
 
     function triggerPopulateSearchResultPreviewsAndPassTime(suggestion: string = 'test', fakeResults?: IQueryResults) {


### PR DESCRIPTION
Fixed an issue where `ResultPreviewsManager` would show the wrong previews when the up and down arrow keys are pressed simultaneously.

Also made `SuggestionsManager`'s `move` asynchronous to avoid breaking the unit tests.

https://coveord.atlassian.net/browse/JSUI-2698

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)