### PR TITLE
feat(JSUI-2701): Update commerce fields and tests

### DIFF
--- a/src/rest/Query.ts
+++ b/src/rest/Query.ts
@@ -34,7 +34,17 @@ export interface ICommerceRequest {
    *
    * **Example:** `46bc4275-e613-4dd5-b1ea-3e5aca1bcd9d`
    */
-  catalogId: string;
+  catalogId?: string;
+  /**
+   * A mandatory query expression applied if and only if a catalog affect the search query.
+   * **Example:** `@storeid==1001`
+   */
+  filter?: string;
+  /**
+   * How the catalog affects the results returned.
+   * **Example:** `selectCatalogObjects`
+   */
+  operation?: 'selectCatalogObjects' | 'excludeCatalogObjects';
 }
 
 /**

--- a/src/rest/Query.ts
+++ b/src/rest/Query.ts
@@ -36,12 +36,12 @@ export interface ICommerceRequest {
    */
   catalogId?: string;
   /**
-   * A mandatory query expression applied if and only if a catalog affect the search query.
+   * A mandatory query expression to apply if the commerce request affects the query.
    * **Example:** `@storeid==1001`
    */
   filter?: string;
   /**
-   * How the catalog affects the results returned.
+   * The way the commerce request should affect query results.
    * **Example:** `selectCatalogObjects`
    */
   operation?: 'selectCatalogObjects' | 'excludeCatalogObjects';

--- a/unitTests/ui/QueryBuilderTest.ts
+++ b/unitTests/ui/QueryBuilderTest.ts
@@ -118,7 +118,9 @@ export function QueryBuilderTest() {
         foo: 'bar'
       };
       queryBuilder.commerce = {
-        catalogId: '14476bd7-0f84-4e05-b554-fb3ac03c0e76'
+        catalogId: '14476bd7-0f84-4e05-b554-fb3ac03c0e76',
+        filter: '@storeid==1001',
+        operation: 'excludeCatalogObjects'
       };
 
       expect(queryBuilder.build().pipeline).toBe('pipeline');
@@ -165,7 +167,9 @@ export function QueryBuilderTest() {
         foo: 'bar'
       });
       expect(queryBuilder.build().commerce).toEqual({
-        catalogId: '14476bd7-0f84-4e05-b554-fb3ac03c0e76'
+        catalogId: '14476bd7-0f84-4e05-b554-fb3ac03c0e76',
+        filter: '@storeid==1001',
+        operation: 'excludeCatalogObjects'
       });
     });
 


### PR DESCRIPTION
Following the changes in the commerce rest parameter done in the backend with https://coveord.atlassian.net/browse/SEARCHAPI-4036, the `ICommerceRequest` interface needs to be updated to keep-up with the new specs.

All fields are considered optional because they can be also set in the search token (e.g: a catalogId is mandatory for any of the other field to be there, but it can be set in the search token, so it can be omitted in the query).

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)