### PR TITLE
JSUI-2716 Added documentation for QuerySuggestPreview

### DIFF
--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -22,6 +22,26 @@ export interface IQuerySuggestPreview {
   executeQueryDelay?: number;
 }
 
+/**
+ * This component renders a preview of the top query results matching the currently focused query suggestion in the search box.
+ *
+ * As such, this component only works when an [`Omnibox`]{@link Omnibox} whose [`enableQuerySuggestAddon`]{@link Omnibox.options.enableQuerySuggestAddon} option is set to `true` is present in the search interface.
+ *
+ * Moreover, this component requires at least one [result template](https://docs.coveo.com/en/413/) in its markup configuration to be able to render previews.
+ *
+ * **Example**
+ * ```
+ *   <div class="CoveoQuerySuggestPreview">
+ *    <script class="result-template" type="text/html">
+ *      <div class="coveo-result-frame">
+ *        <a class="CoveoResultLink"></a>
+ *      </div>
+ *    </script>
+ *   </div>
+ * ```
+ *
+ * See [Providing Query Suggestion Result Previews](https://docs.coveo.com/en/340/#providing-query-suggestion-result-previews).
+ */
 export class QuerySuggestPreview extends Component implements IComponentBindings {
   static ID = 'QuerySuggestPreview';
 
@@ -31,6 +51,10 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
     });
   };
 
+  /**
+   * The options for the component
+   * @componentOptions
+   */
   static options: IQuerySuggestPreview = {
     resultTemplate: TemplateComponentOptions.buildTemplateOption(),
     /**

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -23,21 +23,15 @@ export interface IQuerySuggestPreview {
 }
 
 /**
- * This component renders a preview of the top query results matching the currently focused query suggestion in the search box.
+ * This component adds previews of the top query results matching the currently focused query suggestion in the search box.
  *
- * As such, this component only works when an [`Omnibox`]{@link Omnibox} whose [`enableQuerySuggestAddon`]{@link Omnibox.options.enableQuerySuggestAddon} option is set to `true` is present in the search interface.
+ * As such, this component only works when an [`Omnibox`]{@link Omnibox} is present in the search interface.
  *
- * Moreover, this component requires at least one [result template](https://docs.coveo.com/en/413/) in its markup configuration to be able to render previews.
+ * Moreover, this component can use a [result template](https://docs.coveo.com/en/413/) in its markup configuration to render previews with.
  *
  * **Example**
  * ```
- *   <div class="CoveoQuerySuggestPreview">
- *    <script class="result-template" type="text/html">
- *      <div class="coveo-result-frame">
- *        <a class="CoveoResultLink"></a>
- *      </div>
- *    </script>
- *   </div>
+ *   <div class="CoveoQuerySuggestPreview"></div>
  * ```
  *
  * See [Providing Query Suggestion Result Previews](https://docs.coveo.com/en/340/#providing-query-suggestion-result-previews).
@@ -56,6 +50,9 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
    * @componentOptions
    */
   static options: IQuerySuggestPreview = {
+    /**
+     * The result template to render each previews with.
+     */
     resultTemplate: TemplateComponentOptions.buildTemplateOption(),
     /**
      * The maximum number of query results to render in the preview.

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -30,7 +30,8 @@ export interface IQuerySuggestPreview {
  * Moreover, this component can use a [result template](https://docs.coveo.com/en/413/) in its markup configuration to render previews with.
  *
  * **Example**
- * ```
+ * This component works independently of its location in the DOM and can be added like such:
+ * ```html
  *   <div class="CoveoQuerySuggestPreview"></div>
  * ```
  *

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -23,11 +23,10 @@ export interface IQuerySuggestPreview {
 }
 
 /**
- * This component adds previews of the top query results matching the currently focused query suggestion in the search box.
+ * This component renders previews of the top query results matching the currently focused query suggestion in the search box.
  *
- * As such, this component only works when an [`Omnibox`]{@link Omnibox} is present in the search interface.
- *
- * Moreover, this component can use a [result template](https://docs.coveo.com/en/413/) in its markup configuration to render previews with.
+ * As such, this component only works when the search interface can
+ * [provide Coveo Machine Learning query suggestions](https://docs.coveo.com/en/340/#providing-coveo-machine-learning-query-suggestions).
  *
  * **Example**
  * This component works independently of its location in the DOM and can be added like such:
@@ -35,7 +34,7 @@ export interface IQuerySuggestPreview {
  *   <div class="CoveoQuerySuggestPreview"></div>
  * ```
  *
- * See [Providing Query Suggestion Result Previews](https://docs.coveo.com/en/340/#providing-query-suggestion-result-previews).
+ * See [Rendering Query Suggestion Result Previews](https://docs.coveo.com/en/340/#rendering-query-suggestion-result-previews).
  */
 export class QuerySuggestPreview extends Component implements IComponentBindings {
   static ID = 'QuerySuggestPreview';
@@ -52,15 +51,23 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
    */
   static options: IQuerySuggestPreview = {
     /**
-     * The result template to render each previews with.
+     * The HTML `id` attribute value, or CSS selector of the previously registered
+     * [result template](https://docs.coveo.com/413/) to apply when rendering the
+     * query suggestion result previews.
+     *
+     * **Examples**
+     * * Specifying the `id` attribute of the target result template:
+     * ```html
+     * <div class="CoveoQuerySuggestPreview" data-template-id="myTemplateId"></div>
+     * ```
+     * * Specifying an equivalent CSS selector:
+     * ```html
+     * <div class="CoveoQuerySuggestPreview" data-template-selector="#myTemplateId"></div>
+     * ```
      */
     resultTemplate: TemplateComponentOptions.buildTemplateOption(),
     /**
      * The maximum number of query results to render in the preview.
-     *
-     * **Minimum:** `1`
-     * **Maximum:** `6`
-     * **Default:** `3`
      */
     numberOfPreviewResults: ComponentOptions.buildNumberOption({
       defaultValue: 3,
@@ -69,8 +76,6 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
     }),
     /**
      *  The amount of focus time (in milliseconds) required on a query suggestion before requesting a preview of its top results.
-     *
-     * **Default:** `200`
      */
     executeQueryDelay: ComponentOptions.buildNumberOption({ defaultValue: 200 })
   };

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -28,11 +28,7 @@ export interface IQuerySuggestPreview {
  * As such, this component only works when the search interface can
  * [provide Coveo Machine Learning query suggestions](https://docs.coveo.com/en/340/#providing-coveo-machine-learning-query-suggestions).
  *
- * **Example**
- * This component works independently of its location in the DOM and can be added like such:
- * ```html
- *   <div class="CoveoQuerySuggestPreview"></div>
- * ```
+ * This component should be initialized on a `div` which can be nested anywhere inside the root element of your search interface.
  *
  * See [Rendering Query Suggestion Result Previews](https://docs.coveo.com/en/340/#rendering-query-suggestion-result-previews).
  */

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -58,11 +58,11 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
      * **Examples**
      * * Specifying the `id` attribute of the target result template:
      * ```html
-     * <div class="CoveoQuerySuggestPreview" data-template-id="myTemplateId"></div>
+     * <div class="CoveoQuerySuggestPreview" data-result-template-id="myTemplateId"></div>
      * ```
      * * Specifying an equivalent CSS selector:
      * ```html
-     * <div class="CoveoQuerySuggestPreview" data-template-selector="#myTemplateId"></div>
+     * <div class="CoveoQuerySuggestPreview" data-result-template-selector="#myTemplateId"></div>
      * ```
      */
     resultTemplate: TemplateComponentOptions.buildTemplateOption(),


### PR DESCRIPTION
Restored the old documentation for `QuerySuggestPreview` then improved it.

https://coveord.atlassian.net/browse/JSUI-2716

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)