### PR TITLE
fix(JSUI-2744): Dom.ts, Update parent element appending condition

### DIFF
--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -95,7 +95,7 @@ export class MockEnvironmentBuilder {
     if (this.built) {
       return this.getBindings();
     }
-    if (this.element.parentNode == undefined) {
+    if (!this.element.parentNode) {
       this.root.appendChild(this.element);
     }
 


### PR DESCRIPTION
`document.createElement('div').parentNode === null` thus, the condition does not work (Chrome v78). Moreover, a strict condition is not needed, a falsy statement will be more than enough and more permissive.

![image](https://user-images.githubusercontent.com/12366410/69727939-c2ec1200-1123-11ea-86d3-1ee342a3a4a0.png)

You can check https://github.com/coveo/search-ui/blob/master/src/utils/Dom.ts#L49-L50 for how an element is created with `$$`





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)