### PR TITLE
JSUI-2746 Fixed the width of the search result previews container

### DIFF
--- a/sass/_QuerySuggestPreview.scss
+++ b/sass/_QuerySuggestPreview.scss
@@ -18,20 +18,18 @@
 }
 
 .coveo-suggestion-container {
-  display: inline-flex;
-  flex-wrap: nowrap;
-  align-items: stretch;
-  min-width: 100%;
+  width: 100%;
 
   .coveo-magicbox-suggestions {
     border: none;
     float: left;
+    width: 30%;
   }
 
   .coveo-preview-container {
     border: none;
     background: $white;
-    width: 0;
+    width: 70%;
     .coveo-preview-results {
       $columns: 2;
       display: flex;

--- a/sass/_QuerySuggestPreview.scss
+++ b/sass/_QuerySuggestPreview.scss
@@ -19,17 +19,18 @@
 
 .coveo-suggestion-container {
   width: 100%;
+  display: flex;
 
   .coveo-magicbox-suggestions {
     border: none;
     float: left;
-    width: 30%;
+    flex-basis: 30%;
   }
 
   .coveo-preview-container {
     border: none;
     background: $white;
-    width: 70%;
+    flex-basis: 70%;
     .coveo-preview-results {
       $columns: 2;
       display: flex;

--- a/sass/_QuerySuggestPreview.scss
+++ b/sass/_QuerySuggestPreview.scss
@@ -20,17 +20,18 @@
 .coveo-suggestion-container {
   width: 100%;
   display: flex;
+  $suggestionsWidth: 30%;
 
   .coveo-magicbox-suggestions {
     border: none;
     float: left;
-    flex-basis: 30%;
+    flex-basis: $suggestionsWidth;
   }
 
   .coveo-preview-container {
     border: none;
     background: $white;
-    flex-basis: 70%;
+    flex-basis: #{100% - $suggestionsWidth};
     .coveo-preview-results {
       $columns: 2;
       display: flex;


### PR DESCRIPTION
A trick used to make the width of the search result previews container responsive caused an issue that prevented any result previews from showing up at all. This PR fixes it by setting the size of that container to 70%.

![image](https://user-images.githubusercontent.com/54454747/69758349-4827f480-112d-11ea-88c6-19ebddd50da6.png)

https://coveord.atlassian.net/browse/JSUI-2746

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)