### PR TITLE
JSUI-2750 Made `QuerySuggestPreview` create its own query instead of copying the last one

### DIFF
--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -20,6 +20,7 @@ import {
   IPopulateSearchResultPreviewsEventArgs,
   IUpdateResultPreviewsManagerOptionsEventArgs
 } from '../../events/ResultPreviewsManagerEvents';
+import { IQuery } from '../../rest/Query';
 
 export interface IQuerySuggestPreview {
   numberOfPreviewResults?: number;
@@ -144,15 +145,23 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
   }
 
   private async fetchSearchResultPreviews(suggestionText: string) {
-    const previousQueryOptions = this.queryController.getLastQuery();
-    previousQueryOptions.q = suggestionText;
-    previousQueryOptions.numberOfResults = this.options.numberOfPreviewResults;
+    const query = this.buildQuery(suggestionText);
     this.logShowQuerySuggestPreview();
-    const results = await this.queryController.getEndpoint().search(previousQueryOptions);
+    const results = await this.queryController.getEndpoint().search(query);
     if (!results) {
       return [];
     }
     return this.buildResultsPreview(suggestionText, results);
+  }
+
+  private buildQuery(searchQuery: string): IQuery {
+    const { searchHub, pipeline } = this.queryController.getLastQuery();
+    return {
+      searchHub,
+      pipeline,
+      numberOfResults: this.options.numberOfPreviewResults,
+      q: searchQuery
+    };
   }
 
   private async buildResultsPreview(suggestionText: string, results: IQueryResults) {

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -155,10 +155,14 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
   }
 
   private buildQuery(searchQuery: string): IQuery {
-    const { searchHub, pipeline } = this.queryController.getLastQuery();
+    const { searchHub, pipeline, tab, locale, timezone, context } = this.queryController.getLastQuery();
     return {
       searchHub,
       pipeline,
+      tab,
+      locale,
+      timezone,
+      context,
       numberOfResults: this.options.numberOfPreviewResults,
       q: searchQuery
     };

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -84,6 +84,28 @@ export function QuerySuggestPreviewTest() {
       jasmine.clock().uninstall();
     });
 
+    it('uses some options from the last query', async done => {
+      const optionsToTest: Partial<IQuery> = {
+        searchHub: 'some search hub',
+        pipeline: 'a pipeline',
+        tab: 'one tab',
+        locale: 'some locale',
+        timezone: 'a timezone',
+        context: {
+          'the first key': 'the first value',
+          'the second key': 'the second value'
+        }
+      };
+      setupQuerySuggestPreview();
+      (test.cmp.queryController.getLastQuery as jasmine.Spy).and.returnValue(optionsToTest);
+      await triggerPopulateSearchResultPreviewsAndPassTime();
+      const lastSearchQuery = (test.cmp.queryController.getEndpoint().search as jasmine.Spy).calls.mostRecent().args[0] as IQuery;
+      for (let optionName of Object.keys(optionsToTest)) {
+        expect(lastSearchQuery[optionName]).toEqual(optionsToTest[optionName]);
+      }
+      done();
+    });
+
     describe('expose options', () => {
       it('resultTemplate sets the template', async done => {
         setupQuerySuggestPreview();

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -8,6 +8,7 @@ import { IAnalyticsOmniboxSuggestionMeta, analyticsActionCauseList } from '../..
 import { IQueryResults } from '../../src/rest/QueryResults';
 import { last } from 'underscore';
 import { IPopulateSearchResultPreviewsEventArgs, ResultPreviewsManagerEvents } from '../../src/events/ResultPreviewsManagerEvents';
+import { IQuery } from '../../src/rest/Query';
 
 export function initOmniboxAnalyticsMock(omniboxAnalytics: IOmniboxAnalytics) {
   const partialQueries: string[] = [];
@@ -102,7 +103,8 @@ export function QuerySuggestPreviewTest() {
         const numberOfPreviewResults = 5;
         setupQuerySuggestPreview({ numberOfPreviewResults });
         await triggerPopulateSearchResultPreviewsAndPassTime();
-        expect(test.cmp.queryController.getLastQuery().numberOfResults).toBe(numberOfPreviewResults);
+        const lastSearchQuery = (test.cmp.queryController.getEndpoint().search as jasmine.Spy).calls.mostRecent().args[0] as IQuery;
+        expect(lastSearchQuery.numberOfResults).toEqual(numberOfPreviewResults);
         done();
       });
     });


### PR DESCRIPTION
Since `QuerySuggestPreview`'s results were affected by search box's sort, this change makes it create its own query from scratch. 

https://coveord.atlassian.net/browse/JSUI-2750

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)