### PR TITLE
JSUI-2699 Cleanup part #3: Add back dependsOn / availableValues / visibleParentValues / selectValue / deselectCurrentValue

### DIFF
--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -471,6 +471,8 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
 
   /**
    * Changes the active path.
+   * 
+   * @param path The array of values that represents the path.
    */
   public changeActivePath(path: string[]) {
     this.listenToQueryStateChange = false;
@@ -564,20 +566,46 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
 
   /**
    * Selects a value from the currently available values.
+   * 
+   * Does **not** trigger a query automatically.
+   * Does **not** update the visual of the facet until a query is performed.
+   * 
+   * @param path The value to select.
+   * 
+   * @deprecated
    */
   public selectValue(value: string) {
-    // TODO: reimplement
+    this.selectPath([...this.values.selectedPath, value]);
   }
 
   /**
    * Deselects the last value in the hierarchy that is applied to the query. When at the top of the hierarchy, this method does nothing.
+   
+   * Does **not** trigger a query automatically.
+   * Does **not** update the visual of the facet until a query is performed.
+   * 
+   * @deprecated
    */
   public deselectCurrentValue() {
-    // TODO: reimplement
+    if (!this.values.hasSelectedValue) {
+      return this.logger.warn('No current value to deselect');
+    }
+
+    const pathToSelect = this.values.selectedPath.slice(0, -1);
+    pathToSelect.length  ? this.selectPath(pathToSelect) : this.clear();
   }
 
+  /**
+   * Select a path in the hierarchy.
+   * 
+   * Does **not** trigger a query automatically.
+   * Does **not** update the visual of the facet until a query is performed.
+   * 
+   * @param path The array of values that represents the path.
+   */
   public selectPath(path: string[]) {
     Assert.exists(path);
+    Assert.isLargerThan(0, path.length);
     this.ensureDom();
     this.changeActivePath(path);
     this.values.selectPath(path);
@@ -598,6 +626,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   public clear() {
     this.values.clear();
     this.changeActivePath([]);
+    this.logger.info('Clear facet');
   }
 
   /**

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -308,7 +308,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
     valueCaption: ComponentOptions.buildJsonOption<IStringMap<string>>({ defaultValue: {} }),
 
     /**
-     * The [id](@link Facet.options.id) of another facet in which at least one value must be selected in order
+     * The id of another facet in which at least one value must be selected in order
      * for the dependent category facet to be visible.
      *
      * **Default:** `undefined` and the category facet does not depend on any other facet to be displayed.
@@ -432,14 +432,11 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   }
 
   private updateAppearance() {
-    if (this.disabled || this.isCategoryEmpty) {
-      return this.hide();
-    }
-
     this.header.toggleCollapse(this.isCollapsed);
     $$(this.element).toggleClass('coveo-dynamic-category-facet-collapsed', this.isCollapsed);
     this.show();
     this.dependsOnManager.updateVisibilityBasedOnDependsOn();
+    this.isCategoryEmpty && this.hide();
   }
 
   private handleQuerySuccess(results: IQueryResults) {
@@ -618,15 +615,20 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
    * Automatically triggers a query.
    */
   public reset() {
+    this.ensureDom();
     this.clear();
     this.scrollToTop();
     this.triggerNewQuery(() => this.logAnalyticsEvent(analyticsActionCauseList.categoryFacetClear));
   }
 
   public clear() {
+    if (!this.values.hasSelectedValue) {
+      return;
+    }
+
+    this.logger.info('Clear facet');
     this.values.clear();
     this.changeActivePath([]);
-    this.logger.info('Clear facet');
   }
 
   /**
@@ -783,11 +785,12 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   }
 
   private dependsOnReset() {
-    // TODO: reimplement
+    this.clear();
+    this.updateAppearance();
   }
 
   private toggleDependentFacet(dependentFacet: Component) {
-    this.activePath.length ? dependentFacet.enable() : dependentFacet.disable();
+    this.values.hasSelectedValue ? dependentFacet.enable() : dependentFacet.disable();
   }
 
   private notImplementedError() {

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -36,6 +36,7 @@ import { CategoryFacetValues } from './CategoryFacetValues/CategoryFacetValues';
 import { IFacetResponse } from '../../rest/Facet/FacetResponse';
 import { IQueryOptions } from '../../controllers/QueryController';
 import { IQueryResults } from '../../rest/QueryResults';
+import { CategoryFacetValue } from './CategoryFacetValues/CategoryFacetValue';
 
 export interface ICategoryFacetOptions extends IResponsiveComponentOptions {
   id?: string;
@@ -509,10 +510,27 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   /**
    * Returns all the visible parent values.
    * @returns simple object with three fields: `value`, `count` and `path`.
+   * @deprecated
    */
-  public getVisibleParentValues(): CategoryValueDescriptor[] {
-    // TODO: reimplement
-    return [];
+  public getVisibleParentValues() {
+    return this.mapCategoryValuesToCategoryValueDescriptor(this.values.visibleParentValues);
+  }
+
+  /**
+  * Returns the values at the bottom of the hierarchy. These are the values that are not yet applied to the query.
+  * @returns simple object with three fields: `value`, `count` and `path`.
+  * @deprecated
+  */
+  public getAvailableValues() {
+    return this.mapCategoryValuesToCategoryValueDescriptor(this.values.availableValues);
+  }
+
+  private mapCategoryValuesToCategoryValueDescriptor(values: CategoryFacetValue[]): CategoryValueDescriptor[] {
+    return values.map(facetValue => ({
+      value: facetValue.value,
+      count: facetValue.numberOfResults,
+      path: facetValue.path
+    }));
   }
 
   /**
@@ -542,15 +560,6 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
     this.logger.info('Show less values');
     this.categoryFacetQueryController.resetNumberOfValuesToRequest();
     this.triggerNewIsolatedQuery(() => this.logAnalyticsFacetShowMoreLess(analyticsActionCauseList.facetShowLess));
-  }
-
-  /**
-   * Returns the values at the bottom of the hierarchy. These are the values that are not yet applied to the query.
-   * @returns simple object with three fields: `value`, `count` and `path`.
-   */
-  public getAvailableValues() {
-    // TODO: reimplement
-    return [];
   }
 
   /**

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -469,7 +469,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   /**
    * Changes the active path.
    * 
-   * @param path The array of values that represents the path.
+   * @param path The values representing the path.
    */
   public changeActivePath(path: string[]) {
     this.listenToQueryStateChange = false;
@@ -567,7 +567,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
    * Does **not** trigger a query automatically.
    * Does **not** update the visual of the facet until a query is performed.
    * 
-   * @param path The value to select.
+   * @param value The value to select.
    * 
    * @deprecated
    */
@@ -598,7 +598,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
    * Does **not** trigger a query automatically.
    * Does **not** update the visual of the facet until a query is performed.
    * 
-   * @param path The array of values that represents the path.
+   * @param path The values representing the path.
    */
   public selectPath(path: string[]) {
     Assert.exists(path);

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -308,7 +308,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
     valueCaption: ComponentOptions.buildJsonOption<IStringMap<string>>({ defaultValue: {} }),
 
     /**
-     * The id of another facet in which at least one value must be selected in order
+     * The `id` option value of another facet in which at least one value must be selected in order
      * for the dependent category facet to be visible.
      *
      * **Default:** `undefined` and the category facet does not depend on any other facet to be displayed.

--- a/src/ui/CategoryFacet/CategoryFacetValues/CategoryFacetValues.ts
+++ b/src/ui/CategoryFacet/CategoryFacetValues/CategoryFacetValues.ts
@@ -214,4 +214,26 @@ export class CategoryFacetValues {
     this.list.appendChild(fragment);
     return this.list;
   }
+
+  public get visibleParentValues() {
+    if (!this.hasSelectedValue) {
+      return [];
+    }
+
+    const parentValues: CategoryFacetValue[] = [];
+    let currentParentValue = this.allFacetValues[0];
+
+    for (let i = 0; i < this.selectedPath.length; i++) {
+      parentValues.push(currentParentValue);
+      currentParentValue = currentParentValue.children.length ? currentParentValue.children[0] : null;
+    }
+
+    return parentValues;
+  }
+
+  public get availableValues() {
+    return this.selectedPath.length
+      ? this.getOrCreateFacetValueWithPath(this.selectedPath).children
+      : this.facetValues;
+  }
 }

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -427,12 +427,11 @@ export class DynamicFacet extends Component implements IAutoLayoutAdjustableInsi
    */
   public reset() {
     this.ensureDom();
-    if (!this.values.hasActiveValues) {
-      return;
+    if (this.values.hasActiveValues) {
+      this.logger.info('Deselect all values');
+      this.values.clearAll();
+      this.values.render();
     }
-    this.logger.info('Deselect all values');
-    this.values.clearAll();
-    this.values.render();
     this.updateAppearance();
     this.updateQueryStateModel();
   }

--- a/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
@@ -370,6 +370,43 @@ export function CategoryFacetTest() {
       });
     });
 
+    describe('when calling selectValue', () => {
+      it(`when no path is selected
+      should call selectPath with the correct path`, () => {
+        test.cmp.selectValue('hello');
+        expect(test.cmp.selectPath).toHaveBeenCalledWith(['hello']);
+      });
+
+      it(`when a path is selected
+      should call selectPath with the correct path`, () => {
+        test.cmp.values.selectPath(['hello', 'there']);
+        test.cmp.selectValue('friend');
+        expect(test.cmp.selectPath).toHaveBeenCalledWith(['hello', 'there', 'friend']);
+      });
+    });
+
+    describe('when calling deselectCurrentValue', () => {
+      it(`when no value is selected
+        should warn the user`, () => {
+        test.cmp.deselectCurrentValue();
+        expect(test.cmp.logger.warn).toHaveBeenCalled();
+      });
+
+      it(`when a path with a single value is selected
+        should call clear`, () => {
+        test.cmp.values.selectPath(['hello']);
+        test.cmp.deselectCurrentValue();
+        expect(test.cmp.clear).toHaveBeenCalled();
+      });
+
+      it(`when a path with multiple values is selected
+        should call selectPath with the correct path`, () => {
+        test.cmp.values.selectPath(['hello', 'there', 'friend']);
+        test.cmp.deselectCurrentValue();
+        expect(test.cmp.selectPath).toHaveBeenCalledWith(['hello', 'there']);
+      });
+    });
+
     it('getCaption should return the caption for a value', () => {
       options.valueCaption = { 'test': 'this is a test' };
       initializeComponent();
@@ -413,7 +450,5 @@ export function CategoryFacetTest() {
     describe('testing the DependsOnManager', () => { });
 
     // TODO: JSUI-2709 test logAnalyticsEvent
-    // TODO: test selectValue
-    // TODO: test deselectCurrentValue
   });
 }

--- a/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
@@ -14,7 +14,7 @@ export function CategoryFacetTest() {
   describe('CategoryFacet', () => {
     let test: Mock.IBasicComponentSetup<CategoryFacet>;
     let options: ICategoryFacetOptions;
-    let mockFacetValues: IFacetResponseValue[]
+    let mockFacetValues: IFacetResponseValue[];
 
     beforeEach(() => {
       options = { field: '@dummy' };
@@ -25,9 +25,11 @@ export function CategoryFacetTest() {
       test = CategoryFacetTestUtils.createAdvancedFakeFacet(options);
       mockFacetValues = CategoryFacetTestUtils.createFakeFacetResponseValues(3, 5);
 
-      test.cmp.values.createFromResponse(CategoryFacetTestUtils.getCompleteFacetResponse(test.cmp, {
-        values: mockFacetValues
-      }));
+      test.cmp.values.createFromResponse(
+        CategoryFacetTestUtils.getCompleteFacetResponse(test.cmp, {
+          values: mockFacetValues
+        })
+      );
 
       spyOn(test.cmp, 'selectPath').and.callThrough();
       spyOn(test.cmp, 'scrollToTop').and.callThrough();
@@ -61,9 +63,11 @@ export function CategoryFacetTest() {
 
     function fakeResultsWithFacets() {
       const fakeResultsWithFacets = FakeResults.createFakeResults();
-      fakeResultsWithFacets.facets = [CategoryFacetTestUtils.getCompleteFacetResponse(test.cmp, {
-        values: mockFacetValues
-      })];
+      fakeResultsWithFacets.facets = [
+        CategoryFacetTestUtils.getCompleteFacetResponse(test.cmp, {
+          values: mockFacetValues
+        })
+      ];
       return fakeResultsWithFacets;
     }
 
@@ -133,7 +137,7 @@ export function CategoryFacetTest() {
     should update the QueryStateModel correctly`, () => {
       mockFacetValues[0].children = [];
       mockFacetValues[0].state = FacetValueState.selected;
-      const results = fakeResultsWithFacets()
+      const results = fakeResultsWithFacets();
       Simulate.query(test.env, { results });
 
       testQueryStateModelValues([results.facets[0].values[0].value]);
@@ -245,7 +249,7 @@ export function CategoryFacetTest() {
 
     it('allows to trigger a new isolated query', () => {
       spyOn(test.cmp.categoryFacetQueryController, 'getQueryResults');
-      const beforeExecuteQuery = jasmine.createSpy('beforeExecuteQuery', () => { });
+      const beforeExecuteQuery = jasmine.createSpy('beforeExecuteQuery', () => {});
       test.cmp.ensureDom();
       test.cmp.triggerNewIsolatedQuery(beforeExecuteQuery);
 
@@ -397,7 +401,7 @@ export function CategoryFacetTest() {
         should call clear`, () => {
         test.cmp.values.selectPath(['hello']);
         test.cmp.deselectCurrentValue();
-        expect(test.cmp.clear).toHaveBeenCalled();
+        expect(test.cmp.clear).toHaveBeenCalledTimes(1);
       });
 
       it(`when a path with multiple values is selected
@@ -409,7 +413,7 @@ export function CategoryFacetTest() {
     });
 
     it('getCaption should return the caption for a value', () => {
-      options.valueCaption = { 'test': 'this is a test' };
+      options.valueCaption = { test: 'this is a test' };
       initializeComponent();
       expect(test.cmp.getCaption('test')).toBe('this is a test');
     });

--- a/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
@@ -413,8 +413,6 @@ export function CategoryFacetTest() {
     describe('testing the DependsOnManager', () => { });
 
     // TODO: JSUI-2709 test logAnalyticsEvent
-    // TODO: test getVisibleParentValues
-    // TODO: test getAvailableValues
     // TODO: test selectValue
     // TODO: test deselectCurrentValue
   });

--- a/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
@@ -339,6 +339,7 @@ export function CategoryFacetTest() {
 
     describe('when calling clear', () => {
       beforeEach(() => {
+        test.cmp.values.selectPath(['hey']);
         test.cmp.clear();
       });
 
@@ -446,8 +447,21 @@ export function CategoryFacetTest() {
       });
     });
 
-    // TODO: test the DependsOnManager
-    describe('testing the DependsOnManager', () => { });
+    describe('testing the DependsOnManager', () => {
+      beforeEach(() => {
+        spyOn(test.cmp.dependsOnManager, 'updateVisibilityBasedOnDependsOn');
+      });
+
+      it('should initialize the dependsOnManager', () => {
+        expect(test.cmp.dependsOnManager).toBeTruthy();
+      });
+
+      it(`when facet appearance is updated (e.g. after a successful query)
+      should call the "updateVisibilityBasedOnDependsOn" method of the DependsOnManager`, () => {
+        Simulate.query(test.env, { results: fakeResultsWithFacets() });
+        expect(test.cmp.dependsOnManager.updateVisibilityBasedOnDependsOn).toHaveBeenCalled();
+      });
+    });
 
     // TODO: JSUI-2709 test logAnalyticsEvent
   });

--- a/unitTests/ui/CategoryFacet/CategoryFacetValues/CategoryFacetValuesTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetValues/CategoryFacetValuesTest.ts
@@ -120,6 +120,18 @@ export function CategoryFacetValuesTest() {
         it('should have the right number of children', () => {
           expect(facet.values.allFacetValues[0].children.length).toBe(responseValue.children.length);
         });
+
+        it('should have the right selectedPath', () => {
+          expect(facet.values.selectedPath).toEqual(facet.values.allFacetValues[0].path);
+        });
+
+        it('should have the right visibleParentValues', () => {
+          expect(facet.values.visibleParentValues).toEqual([facet.values.allFacetValues[0]]);
+        });
+
+        it('should have the right availableValues', () => {
+          expect(facet.values.availableValues).toEqual(facet.values.allFacetValues[0].children);
+        });
       });
     });
 
@@ -128,6 +140,7 @@ export function CategoryFacetValuesTest() {
       facet.values.clear();
 
       expect(facet.values.allFacetValues.length).toBe(0);
+      expect(facet.values.selectedPath).toEqual([]);
     });
 
     describe('testing render', () => {
@@ -209,6 +222,18 @@ export function CategoryFacetValuesTest() {
           it('should remove all the others values at first level', () => {
             expect(facet.values.allFacetValues.length).toBe(1);
           });
+
+          it('should have the right selectedPath', () => {
+            expect(facet.values.selectedPath).toEqual([testFacetValue.value]);
+          });
+  
+          it('should have the right visibleParentValues', () => {
+            expect(facet.values.visibleParentValues).toEqual([testFacetValue]);
+          });
+  
+          it('should have the right availableValues', () => {
+            expect(facet.values.availableValues).toEqual(testFacetValue.children);
+          });
         });
 
         describe('when path does not exist', () => {
@@ -227,6 +252,18 @@ export function CategoryFacetValuesTest() {
 
           it('should remove all the others values at first level', () => {
             expect(facet.values.allFacetValues.length).toBe(1);
+          });
+
+          it('should have the right selectedPath', () => {
+            expect(facet.values.selectedPath).toEqual([newValue]);
+          });
+  
+          it('should have the right visibleParentValues', () => {
+            expect(facet.values.visibleParentValues).toEqual([testFacetValue]);
+          });
+  
+          it('should have the right availableValues', () => {
+            expect(facet.values.availableValues).toEqual(testFacetValue.children);
           });
         });
       });
@@ -265,6 +302,18 @@ export function CategoryFacetValuesTest() {
             expect(facet.values.allFacetValues[0].children).toEqual([secondLevelFacetValue]);
             expect(facet.values.allFacetValues[0].children[0].children).toEqual([thirdLevelFacetValue]);
           });
+
+          it('should have the right selectedPath', () => {
+            expect(facet.values.selectedPath).toEqual(thirdLevelFacetValue.path);
+          });
+  
+          it('should have the right visibleParentValues', () => {
+            expect(facet.values.visibleParentValues).toEqual([firstLevelFacetValue, secondLevelFacetValue, thirdLevelFacetValue]);
+          });
+  
+          it('should have the right availableValues', () => {
+            expect(facet.values.availableValues).toEqual(thirdLevelFacetValue.children);
+          });
         });
 
         describe('when path only partially exist', () => {
@@ -296,6 +345,18 @@ export function CategoryFacetValuesTest() {
             expect(facet.values.allFacetValues).toEqual([firstLevelFacetValue]);
             expect(facet.values.allFacetValues[0].children).toEqual([secondLevelFacetValue]);
             expect(facet.values.allFacetValues[0].children[0].children).toEqual([thirdLevelFacetValue]);
+          });
+
+          it('should have the right selectedPath', () => {
+            expect(facet.values.selectedPath).toEqual(thirdLevelFacetValue.path);
+          });
+  
+          it('should have the right visibleParentValues', () => {
+            expect(facet.values.visibleParentValues).toEqual([firstLevelFacetValue, secondLevelFacetValue, thirdLevelFacetValue]);
+          });
+  
+          it('should have the right availableValues', () => {
+            expect(facet.values.availableValues).toEqual(thirdLevelFacetValue.children);
           });
         });
 
@@ -336,6 +397,18 @@ export function CategoryFacetValuesTest() {
             expect(facet.values.allFacetValues).toEqual([firstLevelFacetValue]);
             expect(facet.values.allFacetValues[0].children).toEqual([secondLevelFacetValue]);
             expect(facet.values.allFacetValues[0].children[0].children).toEqual([thirdLevelFacetValue]);
+          });
+
+          it('should have the right selectedPath', () => {
+            expect(facet.values.selectedPath).toEqual(thirdLevelFacetValue.path);
+          });
+  
+          it('should have the right visibleParentValues', () => {
+            expect(facet.values.visibleParentValues).toEqual([firstLevelFacetValue, secondLevelFacetValue, thirdLevelFacetValue]);
+          });
+  
+          it('should have the right availableValues', () => {
+            expect(facet.values.availableValues).toEqual(thirdLevelFacetValue.children);
           });
         });
       });

--- a/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
@@ -222,7 +222,9 @@ export function DynamicFacetTest() {
       testQueryStateModelValues();
     });
 
-    it('when calling reset, should clear and rerender values if there is any active value', () => {
+    it(`when calling reset
+      when there is any active value
+      should clear and rerender values`, () => {
       mockFacetValues[0].state = FacetValueState.selected;
       initializeComponent();
 
@@ -232,7 +234,9 @@ export function DynamicFacetTest() {
       expect(test.cmp.values.render).toHaveBeenCalledTimes(2);
     });
 
-    it('when calling reset, should not clear and rerender values when there are no active values', () => {
+    it(`when calling reset
+      when there are no active values
+      should not clear and rerender values`, () => {
       test.cmp.reset();
 
       expect(test.cmp.values.clearAll).not.toHaveBeenCalled();
@@ -616,7 +620,7 @@ export function DynamicFacetTest() {
 
       it(`when triggering the header "clear" method
       should log an analytics event`, () => {
-        triggerNewQuerySpy.and.callFake((beforeCb: any = () => {}) => beforeCb())
+        triggerNewQuerySpy.and.callFake((beforeCb: any = () => { }) => beforeCb())
         test.cmp.header.options.clear();
         expect(test.cmp.logAnalyticsEvent).toHaveBeenCalledWith(analyticsActionCauseList.dynamicFacetClearAll, test.cmp.basicAnalyticsFacetState);
       });
@@ -635,7 +639,6 @@ export function DynamicFacetTest() {
     describe('testing the DependsOnManager', () => {
       beforeEach(() => {
         spyOn(test.cmp.dependsOnManager, 'updateVisibilityBasedOnDependsOn');
-        spyOn(test.cmp.dependsOnManager, 'listenToParentIfDependentFacet');
       });
 
       it('should initialize the dependsOnManager', () => {
@@ -645,6 +648,12 @@ export function DynamicFacetTest() {
       it(`when facet appearance is updated (e.g. when createDom is called)
       should call the "updateVisibilityBasedOnDependsOn" method of the DependsOnManager`, () => {
         test.cmp.createDom();
+        expect(test.cmp.dependsOnManager.updateVisibilityBasedOnDependsOn).toHaveBeenCalled();
+      });
+
+      it(`when calling reset
+      should call the "updateVisibilityBasedOnDependsOn" method of the DependsOnManager`, () => {
+        test.cmp.reset();
         expect(test.cmp.dependsOnManager.updateVisibilityBasedOnDependsOn).toHaveBeenCalled();
       });
     });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2699

I have deprecated the public documented methods that are now pretty useless internally.




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)