### PR TITLE
JSUI-2748 Prevent clearing Searchbox when clicking a field suggestion

### DIFF
--- a/src/ui/FieldSuggestions/FieldSuggestions.ts
+++ b/src/ui/FieldSuggestions/FieldSuggestions.ts
@@ -294,7 +294,6 @@ export class FieldSuggestions extends Component {
   }
 
   private onRowSelection(value: string, args: IPopulateOmniboxEventArgs) {
-    args.clear();
     args.closeOmnibox();
     this.queryStateModel.set(QueryStateModel.attributesEnum.q, value);
     this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.omniboxField, {});


### PR DESCRIPTION
When the Searchbox has the `data-trigger-query-on-clear` option set to true, clicking a FieldSuggestion was clearing the searchbox which would trigger an empty string query rather than one with the selected suggestion.

https://coveord.atlassian.net/browse/JSUI-2748





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)