### PR TITLE
Removed center alignment on `QuerySuggestPreview`'s header text

### DIFF
--- a/sass/_QuerySuggestPreview.scss
+++ b/sass/_QuerySuggestPreview.scss
@@ -21,17 +21,20 @@
   width: 100%;
   display: flex;
   $suggestionsWidth: 30%;
+  $previewsWidth: 100% - $suggestionsWidth;
 
   .coveo-magicbox-suggestions {
     border: none;
     float: left;
     flex-basis: $suggestionsWidth;
+    max-width: $suggestionsWidth;
   }
 
   .coveo-preview-container {
     border: none;
     background: $white;
-    flex-basis: #{100% - $suggestionsWidth};
+    flex-basis: $previewsWidth;
+    max-width: $previewsWidth;
     .coveo-preview-results {
       $columns: 2;
       display: flex;
@@ -81,6 +84,7 @@
       padding: 10px;
       font-weight: normal;
       margin-top: 0;
+      padding-left: 12px;
     }
     .coveo-preview-selectable.coveo-omnibox-selected,
     .coveo-preview-selectable:hover {

--- a/sass/_QuerySuggestPreview.scss
+++ b/sass/_QuerySuggestPreview.scss
@@ -82,7 +82,7 @@
     }
     .coveo-preview-header {
       padding: 10px;
-      font-weight: normal;
+      font-weight: bold;
       margin-top: 0;
       padding-left: 12px;
     }

--- a/sass/_QuerySuggestPreview.scss
+++ b/sass/_QuerySuggestPreview.scss
@@ -31,6 +31,7 @@
   }
 
   .coveo-preview-container {
+    $margin: 10px;
     border: none;
     background: $white;
     flex-basis: $previewsWidth;
@@ -43,7 +44,6 @@
       overflow: hidden;
       width: 100%;
       .coveo-preview-layout {
-        $margin: 10px;
         box-sizing: border-box;
         margin: $margin;
         padding: 20px;
@@ -81,10 +81,9 @@
       }
     }
     .coveo-preview-header {
-      padding: 10px;
+      padding: $margin;
       font-weight: bold;
       margin-top: 0;
-      padding-left: 12px;
     }
     .coveo-preview-selectable.coveo-omnibox-selected,
     .coveo-preview-selectable:hover {

--- a/sass/_QuerySuggestPreview.scss
+++ b/sass/_QuerySuggestPreview.scss
@@ -81,7 +81,6 @@
       padding: 10px;
       font-weight: normal;
       margin-top: 0;
-      text-align: center;
     }
     .coveo-preview-selectable.coveo-omnibox-selected,
     .coveo-preview-selectable:hover {

--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -204,9 +204,7 @@ export class ResultPreviewsManager {
   }
 
   private updateSearchResultPreviewsHeader(suggestion: string) {
-    this.resultPreviewsHeader.setHtml(
-      this.options.previewHeaderText + ' "' + $$('span', { className: 'coveo-omnibox-hightlight' }, suggestion).el.outerHTML + '"'
-    );
+    this.resultPreviewsHeader.text(`${this.options.previewHeaderText} "${suggestion}"`);
   }
 
   private appendSearchResultPreview(preview: ISearchResultPreview) {

--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -203,8 +203,10 @@ export class ResultPreviewsManager {
     return this.previewsProcessor.processQueries(populateEventArgs.previewsQueries);
   }
 
-  private updateSearchResultPreviewsHeader(text: string) {
-    this.resultPreviewsHeader.text(text);
+  private updateSearchResultPreviewsHeader(suggestion: string) {
+    this.resultPreviewsHeader.setHtml(
+      this.options.previewHeaderText + ' "' + $$('span', { className: 'coveo-omnibox-hightlight' }, suggestion).el.outerHTML + '"'
+    );
   }
 
   private appendSearchResultPreview(preview: ISearchResultPreview) {
@@ -227,6 +229,6 @@ export class ResultPreviewsManager {
       return;
     }
     this.appendSearchResultPreviews(previews);
-    this.updateSearchResultPreviewsHeader(`${this.options.previewHeaderText} "${suggestion.innerText}"`);
+    this.updateSearchResultPreviewsHeader(suggestion.innerText);
   }
 }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7497,8 +7497,8 @@
     "fr": "Aucune valeur trouvée."
   },
   "QuerySuggestPreview": {
-    "en": "Query result item(s) for",
-    "fr": "Résultat(s) de la requête pour"
+    "en": "Product recommendations for",
+    "fr": "Recommendations de produits pour"
   },
   "To": {
     "en": "to",


### PR DESCRIPTION
Re-aligned `QuerySuggestPreview`'s header to the left, highlighted header text and changed header text like such:
![image](https://user-images.githubusercontent.com/54454747/70173951-f4c02400-16a1-11ea-8d4f-f10a65c3582e.png)

https://coveord.atlassian.net/browse/JSUI-2757

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)