### PR TITLE
Removed duplicate analytics click event from `QuerySuggestPreview`

### DIFF
--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -211,7 +211,7 @@ export class ResultPreviewsManager {
     this.resultPreviewsContainer.append(preview.element);
     const elementDom = $$(preview.element);
     elementDom.on('click', () => preview.onSelect());
-    elementDom.on('keyboardSelect', () => preview.onSelect());
+    elementDom.on('keyboardSelect', () => elementDom.el.click());
   }
 
   private appendSearchResultPreviews(previews: ISearchResultPreview[]) {

--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -211,7 +211,7 @@ export class ResultPreviewsManager {
     this.resultPreviewsContainer.append(preview.element);
     const elementDom = $$(preview.element);
     elementDom.on('click', () => preview.onSelect());
-    elementDom.on('keyboardSelect', () => elementDom.el.click());
+    elementDom.on('keyboardSelect', () => preview.onSelect());
   }
 
   private appendSearchResultPreviews(previews: ISearchResultPreview[]) {

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -138,6 +138,7 @@ export class SuggestionsManager {
       // By definition, once an element has been "selected" with the keyboard,
       // it is not longer "active" since the event has been processed.
       this.keyboardFocusedElement = null;
+      this.inputManager.blur();
     }
     return selected;
   }

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -186,7 +186,6 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
 
   private handleSelect(suggestionText: string, element: HTMLElement, rank: number) {
     this.logClickQuerySuggestPreview(suggestionText, rank, element);
-    element.click();
     const link = $$(element).find(`.${Component.computeCssClassNameForType('ResultLink')}`);
     if (link) {
       const resultLink = <ResultLink>Component.get(link);

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -286,22 +286,27 @@ export function SuggestionsManagerTest() {
         return (magicBoxContainer = $$('div'));
       }
 
-      let blurSpy: jasmine.Spy;
       function mockInputManager() {
         return <InputManager>{
           input: $$('input').el as HTMLInputElement,
-          blur: (blurSpy = jasmine.createSpy('blur')) as () => void
+          blur: jasmine.createSpy('blur') as () => void
         };
       }
 
       let suggestionsManager: SuggestionsManager;
+      let inputManager: InputManager;
       const timeout = 10;
       beforeEach(() => {
-        suggestionsManager = new SuggestionsManager(buildEnvironment().root, buildMagicBoxContainer().el, mockInputManager(), {
-          selectedClass,
-          suggestionClass,
-          timeout
-        });
+        suggestionsManager = new SuggestionsManager(
+          buildEnvironment().root,
+          buildMagicBoxContainer().el,
+          (inputManager = mockInputManager()),
+          {
+            selectedClass,
+            suggestionClass,
+            timeout
+          }
+        );
       });
 
       describe('calling mergeSuggestions', () => {
@@ -646,6 +651,7 @@ export function SuggestionsManagerTest() {
               });
 
               it('can select every preview of every suggestion', async done => {
+                let blurCount = 0;
                 await forEachAsync(previewsBySuggestion, async (previews, suggestionId) => {
                   await moveDownToSuggestionAndWait(suggestionId);
                   previews.forEach((preview, previewId) => {
@@ -654,10 +660,9 @@ export function SuggestionsManagerTest() {
                       textPreviews[suggestionId][previewId],
                       `Unexpected preview at suggestion #${suggestionId} preview #${previewId}.`
                     );
-                    expect(preview.onSelect).toHaveBeenCalled();
-                    expect(blurSpy).toHaveBeenCalled();
-                    blurSpy.calls.reset();
-                    (preview.onSelect as jasmine.Spy).calls.reset();
+                    expect(preview.onSelect).toHaveBeenCalledTimes(1);
+                    blurCount += 1;
+                    expect(inputManager.blur).toHaveBeenCalledTimes(blurCount);
                   });
                   previews.forEach(() => suggestionsManager.moveLeft());
                 });

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -286,10 +286,11 @@ export function SuggestionsManagerTest() {
         return (magicBoxContainer = $$('div'));
       }
 
+      let blurSpy: jasmine.Spy;
       function mockInputManager() {
         return <InputManager>{
           input: $$('input').el as HTMLInputElement,
-          blur: () => {}
+          blur: (blurSpy = jasmine.createSpy('blur')) as () => void
         };
       }
 
@@ -654,6 +655,8 @@ export function SuggestionsManagerTest() {
                       `Unexpected preview at suggestion #${suggestionId} preview #${previewId}.`
                     );
                     expect(preview.onSelect).toHaveBeenCalled();
+                    expect(blurSpy).toHaveBeenCalled();
+                    blurSpy.calls.reset();
                     (preview.onSelect as jasmine.Spy).calls.reset();
                   });
                   previews.forEach(() => suggestionsManager.moveLeft());

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -287,9 +287,10 @@ export function SuggestionsManagerTest() {
       }
 
       function mockInputManager() {
-        return {
-          input: $$('input').el as HTMLInputElement
-        } as InputManager;
+        return <InputManager>{
+          input: $$('input').el as HTMLInputElement,
+          blur: () => {}
+        };
       }
 
       let suggestionsManager: SuggestionsManager;

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -7,7 +7,6 @@ import { FakeResults } from '../Fake';
 import {
   IAnalyticsOmniboxSuggestionMeta,
   analyticsActionCauseList,
-  IAnalyticsActionCause,
   IAnalyticsClickQuerySuggestPreviewMeta
 } from '../../src/ui/Analytics/AnalyticsActionListMeta';
 import { IQueryResults } from '../../src/rest/QueryResults';
@@ -111,29 +110,24 @@ export function QuerySuggestPreviewTest() {
       done();
     });
 
-    it('on select, logs analytics', async done => {
+    it('on select, logs analytics once', async done => {
       setupQuerySuggestPreview();
       const suggestionText = 'abcdef';
       const previews = await triggerPopulateSearchResultPreviewsAndPassTime(suggestionText);
-      previews[0].onSelect();
-      const spy = test.cmp.usageAnalytics.logCustomEvent as jasmine.Spy;
-      const [actionCause, meta, element] = <[
-        IAnalyticsActionCause,
-        IAnalyticsClickQuerySuggestPreviewMeta,
-        HTMLElement
-      ]>spy.calls.mostRecent().args;
-      expect(actionCause).toEqual(analyticsActionCauseList.clickQuerySuggestPreview);
-      expect(meta.suggestion).toEqual(suggestionText);
-      expect(element).toEqual(previews[0].element);
-      done();
-    });
 
-    it('on select, only logs analytics once', async done => {
-      setupQuerySuggestPreview();
-      const previews = await triggerPopulateSearchResultPreviewsAndPassTime();
-      previews[0].onSelect();
+      const previewIndexToSelect = 0;
+      previews[previewIndexToSelect].onSelect();
+
       const spy = test.cmp.usageAnalytics.logCustomEvent as jasmine.Spy;
       expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(
+        analyticsActionCauseList.clickQuerySuggestPreview,
+        <IAnalyticsClickQuerySuggestPreviewMeta>{
+          suggestion: suggestionText,
+          displayedRank: previewIndexToSelect
+        },
+        previews[previewIndexToSelect].element
+      );
       done();
     });
 


### PR DESCRIPTION
`QuerySuggestPreview` was triggering clicks on elements when selected and `ResultPreviewsManager` was triggering `QuerySuggestPreview`'s selected event on click, making duplicate calls to analytics.

https://coveord.atlassian.net/browse/JSUI-2756

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)