### PR TITLE
JSUI-2766 Add firstResult value to get result's index back from the API

### DIFF
--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -157,6 +157,7 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
   private buildQuery(searchQuery: string): IQuery {
     const { searchHub, pipeline, tab, locale, timezone, context } = this.queryController.getLastQuery();
     return {
+      firstResult: 0,
       searchHub,
       pipeline,
       tab,

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -90,6 +90,7 @@ export function QuerySuggestPreviewTest() {
 
     it('uses some options from the last query', async done => {
       const optionsToTest: Partial<IQuery> = {
+        firstResult: 0,
         searchHub: 'some search hub',
         pipeline: 'a pipeline',
         tab: 'one tab',


### PR DESCRIPTION
We were sending  documentPosition:null to UA because we weren't getting the index of the results

https://coveord.atlassian.net/browse/JSUI-2766





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)