### PR TITLE
[DOC-5258] Discouraged FieldSuggestions

### DIFF
--- a/src/ui/FieldSuggestions/FieldSuggestions.ts
+++ b/src/ui/FieldSuggestions/FieldSuggestions.ts
@@ -32,6 +32,9 @@ export interface IFieldSuggestionsOptions extends ISuggestionForOmniboxOptions {
  * use this component to provide auto-complete suggestions while the end user is typing the title of an item.
  *
  * The query suggestions provided by this component appear in the [`Omnibox`]{@link Omnibox} component.
+ *
+ * **Note:** Consider [providing Coveo ML query suggestions](https://docs.coveo.com/en/340/#providing-coveo-machine-learning-query-suggestions)
+ * rather than field suggestions, as the former yields better performance and relevance.
  */
 export class FieldSuggestions extends Component {
   static ID = 'FieldSuggestions';


### PR DESCRIPTION

As the "best practice" should be to use ML Query suggestions only,  I added a brief note to the FiieldSuggestions.ts description to make this clear.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)