### PR TITLE
JSUI-2776 Prevent having a RequestedResultsMax error requesting results over the maximumNumberOfResultsFromIndex value

### DIFF
--- a/src/ui/Pager/Pager.ts
+++ b/src/ui/Pager/Pager.ts
@@ -325,14 +325,10 @@ export class Pager extends Component {
       data.queryBuilder.numberOfResults = eventArgs.count;
     }
 
-    // Prevents having a RequestedResultsMax error if we are requesting results over the maximumNumberOfResultsFromIndex option
-    const excessResults = Math.max(
-      0,
-      data.queryBuilder.firstResult + data.queryBuilder.numberOfResults - this.options.maximumNumberOfResultsFromIndex
-    );
-    if (excessResults) {
-      data.queryBuilder.numberOfResults = data.queryBuilder.numberOfResults - excessResults;
-    }
+    const maxResultNumber = data.queryBuilder.firstResult + data.queryBuilder.numberOfResults;
+    const numOfExcessResults = Math.max(0, maxResultNumber - this.options.maximumNumberOfResultsFromIndex);
+
+    data.queryBuilder.numberOfResults -= numOfExcessResults;
   }
 
   private computePagerBoundary(firstResult: number, totalCount: number) {

--- a/src/ui/Pager/Pager.ts
+++ b/src/ui/Pager/Pager.ts
@@ -324,6 +324,15 @@ export class Pager extends Component {
     if (data.queryBuilder.numberOfResults == null) {
       data.queryBuilder.numberOfResults = eventArgs.count;
     }
+
+    // Prevents having a RequestedResultsMax error if we are requesting results over the maximumNumberOfResultsFromIndex option
+    const excessResults = Math.max(
+      0,
+      data.queryBuilder.firstResult + data.queryBuilder.numberOfResults - this.options.maximumNumberOfResultsFromIndex
+    );
+    if (excessResults) {
+      data.queryBuilder.numberOfResults = data.queryBuilder.numberOfResults - excessResults;
+    }
   }
 
   private computePagerBoundary(firstResult: number, totalCount: number) {

--- a/unitTests/ui/PagerTest.ts
+++ b/unitTests/ui/PagerTest.ts
@@ -245,6 +245,18 @@ export function PagerTest() {
           done();
         });
       });
+
+      it(`when having a resultPerPage that is not a divider of maximumNumberOfResultsFromIndex 
+      should prevent requesting more result than the maximumNumberOfResultsFromIndex option`, () => {
+        const resultsPerPage = 12;
+        const pageNumber = 84; // the last page for 1000 results with a resultsPerPage of 12
+        const firstResult = (pageNumber - 1) * resultsPerPage;
+
+        test.cmp.setPage(pageNumber);
+        const { simulation } = execQuery(test, resultsPerPage, firstResult, 0, test.cmp);
+
+        expect(simulation.queryBuilder.numberOfResults).toBe(test.cmp.options.maximumNumberOfResultsFromIndex - firstResult);
+      });
     });
 
     describe('analytics', () => {

--- a/unitTests/ui/PagerTest.ts
+++ b/unitTests/ui/PagerTest.ts
@@ -249,7 +249,7 @@ export function PagerTest() {
       it(`when having a resultPerPage that is not a divider of maximumNumberOfResultsFromIndex 
       should prevent requesting more result than the maximumNumberOfResultsFromIndex option`, () => {
         const resultsPerPage = 12;
-        const pageNumber = 84; // the last page for 1000 results with a resultsPerPage of 12
+        const pageNumber = Math.ceil(test.cmp.options.maximumNumberOfResultsFromIndex / resultsPerPage);
         const firstResult = (pageNumber - 1) * resultsPerPage;
 
         test.cmp.setPage(pageNumber);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2776

You would get an exception for this before. Notice the resultsPerPage component is not used but numberOfResults=12 is set on the interface
<img width="1284" alt="Screen Shot 2019-12-10 at 5 19 19 PM" src="https://user-images.githubusercontent.com/4923043/70574088-428cce80-1b71-11ea-9aaa-d3c9eef8f486.png">

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)
