### PR TITLE
JSUI-2709 [DynamicHierarchicalFacet] Add analytics and reduce the differences of implementation with DynamicFacet

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -619,14 +619,10 @@ export class DynamicFacet extends Component implements IDynamicFacet {
 
     if (Utils.isNonEmptyArray(valuesToSelect)) {
       this.selectMultipleValues(valuesToSelect);
-      // Only one search event is sent, pick first facet value
-      this.logAnalyticsEvent(analyticsActionCauseList.dynamicFacetSelect, this.values.get(valuesToSelect[0]).analyticsFacetMeta);
     }
 
     if (Utils.isNonEmptyArray(valuesToDeselect)) {
       this.deselectMultipleValues(valuesToDeselect);
-      // Only one search event is sent, pick first facet value
-      this.logAnalyticsEvent(analyticsActionCauseList.dynamicFacetDeselect, this.values.get(valuesToDeselect[0]).analyticsFacetMeta);
     }
   };
 

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -526,7 +526,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
     this.bind.onRootElement(QueryEvents.duringQuery, () => this.ensureDom());
     this.bind.onRootElement(QueryEvents.doneBuildingQuery, (data: IDoneBuildingQueryEventArgs) => this.handleDoneBuildingQuery(data));
     this.bind.onRootElement(QueryEvents.querySuccess, (data: IQuerySuccessEventArgs) => this.handleQuerySuccess(data.results));
-    this.bind.onRootElement(QueryEvents.queryError, () => this.onQueryResponse());
+    this.bind.onRootElement(QueryEvents.queryError, () => this.onNoValues());
   }
 
   private initQueryStateEvents() {
@@ -571,6 +571,8 @@ export class DynamicFacet extends Component implements IDynamicFacet {
   }
 
   private handleQuerySuccess(results: IQueryResults) {
+    this.values.render();
+
     if (Utils.isNullOrUndefined(results.facets)) {
       return this.notImplementedError();
     }
@@ -579,19 +581,18 @@ export class DynamicFacet extends Component implements IDynamicFacet {
     const response = index !== -1 ? results.facets[index] : null;
     this.position = index + 1;
 
-    this.onQueryResponse(response);
+    response ? this.onQueryResponse(response) : this.onNoValues();
     this.updateQueryStateModel();
     this.header.hideLoading();
-    this.values.render();
     this.updateAppearance();
   }
 
-  private onQueryResponse(response?: IFacetResponse) {
-    if (response) {
-      this.moreValuesAvailable = response.moreValuesAvailable;
-      return this.values.createFromResponse(response);
-    }
+  private onQueryResponse(response: IFacetResponse) {
+    this.moreValuesAvailable = response.moreValuesAvailable;
+    this.values.createFromResponse(response);
+  }
 
+  private onNoValues() {
     this.moreValuesAvailable = false;
     this.values.resetValues();
   }
@@ -709,7 +710,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
     $$(this.element).toggleClass('coveo-active', this.values.hasSelectedValues);
     $$(this.element).removeClass('coveo-hidden');
     this.dependsOnManager.updateVisibilityBasedOnDependsOn();
-    !this.values.hasDisplayedValues && $$(this.element).addClass('coveo-hidden');
+    !this.hasDisplayedValues && $$(this.element).addClass('coveo-hidden');
   }
 
   private toggleSearchDisplay() {

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -571,7 +571,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
   }
 
   private handleQuerySuccess(results: IQueryResults) {
-    this.values.render();
+    this.header.hideLoading();
 
     if (Utils.isNullOrUndefined(results.facets)) {
       return this.notImplementedError();
@@ -583,7 +583,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
 
     response ? this.onQueryResponse(response) : this.onNoValues();
     this.updateQueryStateModel();
-    this.header.hideLoading();
+    this.values.render();
     this.updateAppearance();
   }
 

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -763,7 +763,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
   }
 
   private logAnalyticsFacetShowMoreLess(cause: IAnalyticsActionCause) {
-    this.usageAnalytics.logCustomEvent<IAnalyticsFacetState>(cause, this.basicAnalyticsFacetState, this.element);
+    this.usageAnalytics.logCustomEvent<IAnalyticsFacetMeta>(cause, this.basicAnalyticsFacetMeta, this.element);
   }
 
   private clear() {

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -511,7 +511,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
   }
 
   public logAnalyticsEvent(actionCause: IAnalyticsActionCause) {
-    this.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(actionCause, this.basicAnalyticsFacetMeta);
+    this.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(actionCause, this.analyticsFacetMeta);
   }
 
   private get analyticsFacetValue() {
@@ -533,7 +533,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
     ];
   }
 
-  public get basicAnalyticsFacetMeta(): IAnalyticsFacetMeta {
+  public get analyticsFacetMeta(): IAnalyticsFacetMeta {
     return {
       facetField: this.options.field.toString(),
       facetId: this.options.id,
@@ -625,7 +625,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
   }
 
   private logAnalyticsFacetShowMoreLess(cause: IAnalyticsActionCause) {
-    this.usageAnalytics.logCustomEvent<IAnalyticsFacetMeta>(cause, this.basicAnalyticsFacetMeta, this.element);
+    this.usageAnalytics.logCustomEvent<IAnalyticsFacetMeta>(cause, this.analyticsFacetMeta, this.element);
   }
 }
 

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -289,7 +289,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
 
   private verifyCollapsingConfiguration() {
     if (this.options.collapsedByDefault && !this.options.enableCollapse) {
-      this.logger.warn('The "collapsedByDefault" option is "true" while the "enableCollapse" is "false"');
+      this.logger.warn('Setting "collapseByDefault" to "true" has no effect when "enableCollapse" is set to "false"');
     }
   }
 

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -31,6 +31,7 @@ import { IQueryOptions } from '../../controllers/QueryController';
 import { IQueryResults } from '../../rest/QueryResults';
 import { DynamicFacetManager } from '../DynamicFacetManager/DynamicFacetManager';
 import { IAnalyticsFacetState } from '../Analytics/IAnalyticsFacetState';
+import { FacetValueState } from '../../rest/Facet/FacetValueState';
 
 /**
  * The `DynamicHierarchicalFacet` component is a facet that renders values in a hierarchical fashion. It determines the filter to apply depending on the
@@ -519,6 +520,10 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
   }
 
   public get analyticsFacetState(): IAnalyticsFacetState[] {
+    if (!this.values.hasSelectedValue) {
+      return [];
+    }
+
     return [
       {
         field: this.options.field.toString(),
@@ -528,6 +533,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
         facetPosition: this.position,
         value: this.analyticsFacetValue,
         displayValue: this.analyticsFacetValue,
+        state: FacetValueState.selected,
         valuePosition: 1
       }
     ];

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -30,6 +30,7 @@ import { IFacetResponse } from '../../rest/Facet/FacetResponse';
 import { IQueryOptions } from '../../controllers/QueryController';
 import { IQueryResults } from '../../rest/QueryResults';
 import { DynamicFacetManager } from '../DynamicFacetManager/DynamicFacetManager';
+import { IAnalyticsFacetState } from '../Analytics/IAnalyticsFacetState';
 
 /**
  * The `DynamicHierarchicalFacet` component is a facet that renders values in a hierarchical fashion. It determines the filter to apply depending on the
@@ -222,6 +223,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
 
     this.dynamicHierarchicalFacetQueryController = new DynamicHierarchicalFacetQueryController(this);
     this.isCollapsed = this.options.enableCollapse && this.options.collapsedByDefault;
+    this.verifyCollapsingConfiguration();
     this.values = new DynamicHierarchicalFacetValues(this);
 
     ResponsiveFacets.init(this.root, this, this.options);
@@ -256,6 +258,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
     this.bind.onRootElement(QueryEvents.doneBuildingQuery, (data: IDoneBuildingQueryEventArgs) => this.handleDoneBuildingQuery(data));
     this.bind.onRootElement(QueryEvents.querySuccess, (data: IQuerySuccessEventArgs) => this.handleQuerySuccess(data.results));
     this.bind.onRootElement(QueryEvents.duringQuery, () => this.ensureDom());
+    this.bind.onRootElement(QueryEvents.queryError, () => this.onNoValues());
   }
 
   private initBreadCrumbEvents() {
@@ -263,7 +266,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
       this.bind.onRootElement(BreadcrumbEvents.populateBreadcrumb, (args: IPopulateBreadcrumbEventArgs) =>
         this.handlePopulateBreadcrumb(args)
       );
-      this.bind.onRootElement(BreadcrumbEvents.clearBreadcrumb, () => this.clear());
+      this.bind.onRootElement(BreadcrumbEvents.clearBreadcrumb, () => this.reset());
     }
   }
 
@@ -280,6 +283,13 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
     Assert.exists(data);
     Assert.exists(data.queryBuilder);
     this.putStateIntoQueryBuilder(data.queryBuilder);
+    this.putStateIntoAnalytics();
+  }
+
+  private verifyCollapsingConfiguration() {
+    if (this.options.collapsedByDefault && !this.options.enableCollapse) {
+      this.logger.warn('The "collapsedByDefault" option is "true" while the "enableCollapse" is "false"');
+    }
   }
 
   public putStateIntoQueryBuilder(queryBuilder: QueryBuilder) {
@@ -288,7 +298,8 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
   }
 
   public putStateIntoAnalytics() {
-    // TODO: JSUI-2709 add analytics
+    const pendingEvent = this.usageAnalytics.getPendingSearchEvent();
+    pendingEvent && pendingEvent.addFacetState(this.analyticsFacetState);
   }
 
   public scrollToTop() {
@@ -297,16 +308,12 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
     }
   }
 
-  private get isHierarchicalEmpty() {
-    return !this.values.allFacetValues.length;
-  }
-
   private updateAppearance() {
     this.header.toggleCollapse(this.isCollapsed);
     $$(this.element).toggleClass('coveo-dynamic-hierarchical-facet-collapsed', this.isCollapsed);
     $$(this.element).removeClass('coveo-hidden');
     this.dependsOnManager.updateVisibilityBasedOnDependsOn();
-    this.isHierarchicalEmpty && $$(this.element).addClass('coveo-hidden');
+    !this.hasDisplayedValues && $$(this.element).addClass('coveo-hidden');
   }
 
   private handleQuerySuccess(results: IQueryResults) {
@@ -320,20 +327,20 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
     const response = index !== -1 ? results.facets[index] : null;
     this.position = index + 1;
 
-    response ? this.onQueryResponse(response) : this.onNoAdditionalValues();
+    response ? this.onQueryResponse(response) : this.onNoValues();
     this.values.render();
     this.updateQueryStateModel(this.values.selectedPath);
     this.updateAppearance();
   }
 
-  private onQueryResponse(response?: IFacetResponse) {
+  private onQueryResponse(response: IFacetResponse) {
     this.moreValuesAvailable = response.moreValuesAvailable;
     this.values.createFromResponse(response);
   }
 
-  private onNoAdditionalValues() {
+  private onNoValues() {
     this.moreValuesAvailable = false;
-    this.values.clear();
+    this.values.resetValues();
   }
 
   private updateQueryStateModel(path: string[]) {
@@ -372,11 +379,11 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
    * Automatically triggers an isolated query.
    * @param additionalNumberOfValues The number of additional values to request. Minimum value is 1. Defaults to the [numberOfValues]{@link DynamicHierarchicalFacet.options.numberOfValues} option value.
    */
-  public showMore(additionalNumberOfValues = this.options.numberOfValues) {
+  public showMoreValues(additionalNumberOfValues = this.options.numberOfValues) {
     this.ensureDom();
     this.logger.info('Show more values');
     this.dynamicHierarchicalFacetQueryController.increaseNumberOfValuesToRequest(additionalNumberOfValues);
-    this.triggerNewIsolatedQuery(() => this.logAnalyticsFacetShowMoreLess(analyticsActionCauseList.facetShowMore));
+    this.triggerNewIsolatedQuery(() => this.logAnalyticsFacetShowMoreLess(analyticsActionCauseList.dynamicFacetShowMore));
   }
 
   /**
@@ -386,11 +393,11 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
    *
    * Automatically triggers an isolated query.
    */
-  public showLess() {
+  public showLessValues() {
     this.ensureDom();
     this.logger.info('Show less values');
     this.dynamicHierarchicalFacetQueryController.resetNumberOfValuesToRequest();
-    this.triggerNewIsolatedQuery(() => this.logAnalyticsFacetShowMoreLess(analyticsActionCauseList.facetShowLess));
+    this.triggerNewIsolatedQuery(() => this.logAnalyticsFacetShowMoreLess(analyticsActionCauseList.dynamicFacetShowLess));
   }
 
   /**
@@ -410,25 +417,27 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
     this.logger.info('Toggle select facet value at path', path);
   }
 
-  /**
-   * Resets the facet to its initial state.
-   *
-   * Automatically triggers a query.
-   */
-  public reset() {
-    this.ensureDom();
-    this.clear();
+  private clear() {
+    this.reset();
     this.scrollToTop();
     this.triggerNewQuery(() => this.logAnalyticsEvent(analyticsActionCauseList.dynamicFacetClearAll));
   }
 
-  public clear() {
+  /**
+   * Deselects the path in the facet.
+   *
+   * Does **not** trigger a query automatically.
+   * Does **not** update the visual of the facet until a query is performed.
+   */
+  public reset() {
+    this.ensureDom();
+
     if (!this.values.hasSelectedValue) {
       return;
     }
 
-    this.logger.info('Clear facet');
-    this.values.clear();
+    this.logger.info('Deselect facet value');
+    this.values.clearPath();
     this.updateQueryStateModel([]);
   }
 
@@ -501,20 +510,43 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
     return caption ? caption : value;
   }
 
-  public logAnalyticsEvent(eventName: IAnalyticsActionCause, path = this.values.selectedPath) {
-    this.usageAnalytics.logSearchEvent<any>(eventName, {
-      DynamicHierarchicalFacetId: this.options.id,
-      DynamicHierarchicalFacetField: this.options.field.toString(),
-      DynamicHierarchicalFacetPath: path,
-      DynamicHierarchicalFacetTitle: this.options.title
-    });
+  public logAnalyticsEvent(actionCause: IAnalyticsActionCause) {
+    this.usageAnalytics.logSearchEvent<IAnalyticsFacetMeta>(actionCause, this.basicAnalyticsFacetMeta);
+  }
+
+  private get analyticsFacetValue() {
+    return this.values.selectedPath.join(this.options.delimitingCharacter);
+  }
+
+  public get analyticsFacetState(): IAnalyticsFacetState[] {
+    return [
+      {
+        field: this.options.field.toString(),
+        id: this.options.id,
+        title: this.options.title,
+        facetType: this.facetType,
+        facetPosition: this.position,
+        value: this.analyticsFacetValue,
+        displayValue: this.analyticsFacetValue,
+        valuePosition: 1
+      }
+    ];
+  }
+
+  public get basicAnalyticsFacetMeta(): IAnalyticsFacetMeta {
+    return {
+      facetField: this.options.field.toString(),
+      facetId: this.options.id,
+      facetTitle: this.options.title,
+      facetValue: this.analyticsFacetValue
+    };
   }
 
   private buildFacetHeader() {
     this.header = new DynamicFacetHeader({
       title: this.options.title,
       enableCollapse: this.options.enableCollapse,
-      clear: () => this.reset(),
+      clear: () => this.clear(),
       toggleCollapse: () => this.toggleCollapse(),
       expand: () => this.expand(),
       collapse: () => this.collapse()
@@ -532,10 +564,18 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
     }
 
     const path = data.attributes[this.queryStateAttribute];
-    if (this.pathIsValidForSelection(path)) {
-      // TODO: JSUI-2709 add analytics
-      path.length ? this.selectPath(path) : this.clear();
+    if (!this.pathIsValidForSelection(path)) {
+      return;
     }
+
+    if (path.length) {
+      this.selectPath(path);
+      this.logAnalyticsEvent(analyticsActionCauseList.dynamicFacetSelect);
+      return;
+    }
+
+    this.reset();
+    this.logAnalyticsEvent(analyticsActionCauseList.dynamicFacetClearAll);
   }
 
   private initQueryStateEvents() {
@@ -568,9 +608,9 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
   }
 
   private notImplementedError() {
-    const errorMessage = 'Hierarchical Facets are not supported by your current search endpoint. Disabling this component.';
-    this.logger.error(errorMessage);
+    this.logger.error('DynamicHierarchicalFacets are not supported by your current search endpoint. Disabling this component.');
     this.disable();
+    this.updateAppearance();
   }
 
   private handlePopulateBreadcrumb(args: IPopulateBreadcrumbEventArgs) {
@@ -585,15 +625,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
   }
 
   private logAnalyticsFacetShowMoreLess(cause: IAnalyticsActionCause) {
-    this.usageAnalytics.logCustomEvent<IAnalyticsFacetMeta>(
-      cause,
-      {
-        facetId: this.options.id,
-        facetField: this.options.field.toString(),
-        facetTitle: this.options.title
-      },
-      this.element
-    );
+    this.usageAnalytics.logCustomEvent<IAnalyticsFacetMeta>(cause, this.basicAnalyticsFacetMeta, this.element);
   }
 }
 

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -569,19 +569,17 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
       return;
     }
 
-    const path = data.attributes[this.queryStateAttribute];
-    if (!this.pathIsValidForSelection(path)) {
+    const queryStatePath = data.attributes[this.queryStateAttribute];
+
+    if (!this.pathIsValidForSelection(queryStatePath)) {
       return;
     }
 
-    if (path.length) {
-      this.selectPath(path);
-      this.logAnalyticsEvent(analyticsActionCauseList.dynamicFacetSelect);
+    if (Utils.arrayEqual(queryStatePath, this.values.selectedPath)) {
       return;
     }
 
-    this.reset();
-    this.logAnalyticsEvent(analyticsActionCauseList.dynamicFacetClearAll);
+    queryStatePath.length ? this.selectPath(queryStatePath) : this.reset();
   }
 
   private initQueryStateEvents() {

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetBreadcrumb.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetBreadcrumb.ts
@@ -45,7 +45,7 @@ export class DynamicHierarchicalFacetBreadcrumb {
   }
 
   private valueSelectAction() {
-    this.facet.clear();
+    this.facet.reset();
     this.facet.triggerNewQuery(() => this.facet.logAnalyticsEvent(analyticsActionCauseList.breadcrumbFacet));
   }
 }

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValue.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValue.ts
@@ -8,6 +8,7 @@ import {
   IDynamicHierarchicalFacet,
   IDynamicHierarchicalFacetValueProperties
 } from '../IDynamicHierarchicalFacet';
+import { analyticsActionCauseList } from '../../Analytics/AnalyticsActionListMeta';
 
 export class DynamicHierarchicalFacetValue implements IDynamicHierarchicalFacetValue {
   private renderer: DynamicHierarchicalFacetValueRenderer;
@@ -143,6 +144,6 @@ export class DynamicHierarchicalFacetValue implements IDynamicHierarchicalFacetV
   }
 
   public logSelectActionToAnalytics() {
-    // TODO: add Analytics
+    this.facet.logAnalyticsEvent(analyticsActionCauseList.dynamicFacetSelect);
   }
 }

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValues.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValues.ts
@@ -68,8 +68,12 @@ export class DynamicHierarchicalFacetValues implements IDynamicHierarchicalFacet
     return [...this._selectedPath];
   }
 
-  public clear() {
+  public resetValues() {
     this.facetValues = [];
+    this._selectedPath = [];
+  }
+
+  public clearPath() {
     this._selectedPath = [];
   }
 
@@ -147,7 +151,7 @@ export class DynamicHierarchicalFacetValues implements IDynamicHierarchicalFacet
 
   private prependAllCategories() {
     const clear = $$('li', {}, $$('button', { className: 'coveo-dynamic-hierarchical-facet-all' }, l('AllCategories')));
-    clear.on('click', () => this.facet.reset());
+    clear.on('click', () => this.facet.header.options.clear());
     $$(this.list).prepend(clear.el);
   }
 
@@ -158,7 +162,7 @@ export class DynamicHierarchicalFacetValues implements IDynamicHierarchicalFacet
       label: l('ShowLessCategories'),
       action: () => {
         this.facet.enableFreezeFacetOrderFlag();
-        this.facet.showLess();
+        this.facet.showLessValues();
       }
     });
 
@@ -172,7 +176,7 @@ export class DynamicHierarchicalFacetValues implements IDynamicHierarchicalFacet
       label: l('ShowMoreCategories'),
       action: () => {
         this.facet.enableFreezeFacetOrderFlag();
-        this.facet.showMore();
+        this.facet.showMoreValues();
       }
     });
 

--- a/src/ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet.ts
@@ -45,14 +45,13 @@ export interface IDynamicHierarchicalFacet extends Component, IDynamicManagerCom
   scrollToTop(): void;
   triggerNewQuery(beforeExecuteQuery?: () => void): void;
   triggerNewIsolatedQuery(beforeExecuteQuery?: () => void): void;
-  showMore(additionalNumberOfValues?: number): void;
-  showLess(): void;
+  showMoreValues(additionalNumberOfValues?: number): void;
+  showLessValues(): void;
   selectPath(path: string[]): void;
   reset(): void;
-  clear(): void;
   toggleCollapse(): void;
   getCaption(value: string): string;
-  logAnalyticsEvent(eventName: IAnalyticsActionCause, path?: string[]): void;
+  logAnalyticsEvent(eventName: IAnalyticsActionCause): void;
   enableFreezeFacetOrderFlag(): void;
 }
 
@@ -80,7 +79,8 @@ export interface IDynamicHierarchicalFacetValue extends IDynamicHierarchicalFace
 }
 
 export interface IDynamicHierarchicalFacetValues {
-  clear(): void;
+  resetValues(): void;
+  clearPath(): void;
   createFromResponse(response: IFacetResponse): void;
   selectPath(path: string[]): void;
   render(): HTMLElement;

--- a/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
@@ -355,7 +355,6 @@ export function DynamicFacetTest() {
     });
 
     it('should select the needed values using the id', () => {
-      test.env.queryStateModel.registerNewAttribute(`${test.cmp.options.id}`, []);
       test.env.queryStateModel.set(`f:${test.cmp.options.id}`, ['a', 'b', 'c']);
       expect(test.cmp.values.selectedValues).toEqual(['a', 'b', 'c']);
     });
@@ -363,7 +362,6 @@ export function DynamicFacetTest() {
     it('should select the needed values using the id', () => {
       options.id = 'my_secret_id';
       initializeComponent();
-      test.env.queryStateModel.registerNewAttribute(`f:${options.id}`, []);
 
       test.env.queryStateModel.set(`f:${options.id}`, ['a', 'b', 'c']);
       expect(test.cmp.values.selectedValues).toEqual(['a', 'b', 'c']);
@@ -379,27 +377,17 @@ export function DynamicFacetTest() {
       testQueryStateModelValues();
     });
 
-    it('should call selectMultipleValues and log an analytics event when selecting a value through the QSM', () => {
-      test.env.queryStateModel.registerNewAttribute(`f:${test.cmp.options.id}`, []);
+    it('should call selectMultipleValues when selecting a value through the QSM', () => {
       test.env.queryStateModel.set(`f:${test.cmp.options.id}`, ['a', 'b', 'c']);
 
       expect(test.cmp.selectMultipleValues).toHaveBeenCalled();
-      expect(test.cmp.logAnalyticsEvent).toHaveBeenCalledWith(
-        analyticsActionCauseList.dynamicFacetSelect,
-        test.cmp.values.get('a').analyticsFacetMeta
-      );
     });
 
-    it('should call deselectMultipleValues and log an analytics event when deselecting a value through the QSM', () => {
-      test.env.queryStateModel.registerNewAttribute(`f:${test.cmp.options.id}`, []);
+    it('should call deselectMultipleValues when deselecting a value through the QSM', () => {
       test.env.queryStateModel.set(`f:${test.cmp.options.id}`, ['a', 'b', 'c']);
       test.env.queryStateModel.set(`f:${test.cmp.options.id}`, []);
 
       expect(test.cmp.deselectMultipleValues).toHaveBeenCalled();
-      expect(test.cmp.logAnalyticsEvent).toHaveBeenCalledWith(
-        analyticsActionCauseList.dynamicFacetDeselect,
-        test.cmp.values.get('a').analyticsFacetMeta
-      );
     });
 
     it('should log an analytics event when showing more results', () => {

--- a/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
@@ -406,7 +406,7 @@ export function DynamicFacetTest() {
       test.cmp.showMoreValues();
       expect(test.cmp.usageAnalytics.logCustomEvent).toHaveBeenCalledWith(
         analyticsActionCauseList.dynamicFacetShowMore,
-        test.cmp.basicAnalyticsFacetState,
+        test.cmp.basicAnalyticsFacetMeta,
         test.cmp.element
       );
     });
@@ -415,7 +415,7 @@ export function DynamicFacetTest() {
       test.cmp.showLessValues();
       expect(test.cmp.usageAnalytics.logCustomEvent).toHaveBeenCalledWith(
         analyticsActionCauseList.dynamicFacetShowLess,
-        test.cmp.basicAnalyticsFacetState,
+        test.cmp.basicAnalyticsFacetMeta,
         test.cmp.element
       );
     });

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetBreadcrumbTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetBreadcrumbTest.ts
@@ -38,10 +38,12 @@ export function DynamicHierarchicalFacetBreadcrumbTest() {
 
     it(`when clicking on a breadcrumb value element
       it should clear the facet value`, () => {
-      spyOn(facet, 'clear');
+      spyOn(facet, 'reset');
+      spyOn(facet, 'triggerNewQuery');
       $$(valueElement()).trigger('click');
 
-      expect(facet.clear).toHaveBeenCalled();
+      expect(facet.reset).toHaveBeenCalled();
+      expect(facet.triggerNewQuery).toHaveBeenCalled();
     });
 
     it(`when clicking on a breadcrumb value element
@@ -49,6 +51,14 @@ export function DynamicHierarchicalFacetBreadcrumbTest() {
       spyOn(facet, 'triggerNewQuery');
       $$(valueElement()).trigger('click');
       expect(facet.triggerNewQuery).toHaveBeenCalled();
+    });
+
+    it(`when clicking on a breadcrumb value element
+      it call reset on the facet`, () => {
+      spyOn(facet, 'reset');
+
+      $$(valueElement()).trigger('click');
+      expect(facet.reset).toHaveBeenCalled();
     });
 
     it(`when clicking on a breadcrumb value element

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTest.ts
@@ -134,20 +134,30 @@ export function DynamicHierarchicalFacetTest() {
       testQueryStateModelValues([results.facets[0].values[0].value]);
     });
 
-    it('should call selectPath and log an analytics event when selecting a path through the QueryStateModel', () => {
-      test.env.queryStateModel.registerNewAttribute(`f:${test.cmp.options.id}`, []);
+    it('should call selectPath when selecting a path through the QueryStateModel', () => {
       test.env.queryStateModel.set(`f:${test.cmp.options.id}`, ['a', 'b', 'c']);
 
       expect(test.cmp.selectPath).toHaveBeenCalledWith(['a', 'b', 'c']);
-      expect(test.cmp.logAnalyticsEvent).toHaveBeenCalledWith(analyticsActionCauseList.dynamicFacetSelect);
     });
 
-    it('should call reset and log an analytics event when clearing the path through the QueryStateModel', () => {
-      test.env.queryStateModel.registerNewAttribute(`f:${test.cmp.options.id}`, ['allo']);
+    it('should not call selectPath when selecting a identical path through the QueryStateModel', () => {
+      test.env.queryStateModel.set(`f:${test.cmp.options.id}`, ['a', 'b', 'c']);
+      test.env.queryStateModel.set(`f:${test.cmp.options.id}`, ['a', 'b', 'c']);
+
+      expect(test.cmp.selectPath).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call reset when clearing the path through the QueryStateModel', () => {
+      test.env.queryStateModel.set(`f:${test.cmp.options.id}`, ['test']);
       test.env.queryStateModel.set(`f:${test.cmp.options.id}`, []);
 
-      expect(test.cmp.reset).toHaveBeenCalled();
-      expect(test.cmp.logAnalyticsEvent).toHaveBeenCalledWith(analyticsActionCauseList.dynamicFacetClearAll);
+      expect(test.cmp.reset).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call reset when clearing an empty path through the QueryStateModel', () => {
+      test.env.queryStateModel.set(`f:${test.cmp.options.id}`, []);
+
+      expect(test.cmp.reset).not.toHaveBeenCalled();
     });
 
     describe('testing collapse/expand', () => {

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTest.ts
@@ -39,12 +39,12 @@ export function DynamicHierarchicalFacetTest() {
       spyOn(test.cmp, 'triggerNewQuery').and.callThrough();
       spyOn(test.cmp, 'triggerNewIsolatedQuery').and.callThrough();
       spyOn(test.cmp, 'reset').and.callThrough();
-      spyOn(test.cmp, 'clear').and.callThrough();
       spyOn(test.cmp, 'putStateIntoQueryBuilder').and.callThrough();
       spyOn(test.cmp.logger, 'warn').and.callThrough();
       spyOn(test.cmp.values, 'render').and.callThrough();
       spyOn(test.cmp.values, 'selectPath').and.callThrough();
-      spyOn(test.cmp.values, 'clear').and.callThrough();
+      spyOn(test.cmp.values, 'resetValues').and.callThrough();
+      spyOn(test.cmp.values, 'clearPath').and.callThrough();
     }
 
     function triggerPopulateBreadcrumbs() {
@@ -139,11 +139,11 @@ export function DynamicHierarchicalFacetTest() {
       // TODO: JSUI-2709 add analytics
     });
 
-    it('should call clear and log an analytics event when clearing the path through the QueryStateModel', () => {
+    it('should call reset and log an analytics event when clearing the path through the QueryStateModel', () => {
       test.env.queryStateModel.registerNewAttribute(`f:${test.cmp.options.id}`, ['allo']);
       test.env.queryStateModel.set(`f:${test.cmp.options.id}`, []);
 
-      expect(test.cmp.clear).toHaveBeenCalled();
+      expect(test.cmp.reset).toHaveBeenCalled();
       // TODO: JSUI-2709 add analytics
     });
 
@@ -252,37 +252,37 @@ export function DynamicHierarchicalFacetTest() {
       expect(test.cmp.values.render).toHaveBeenCalled();
     });
 
-    describe('testing showMore/showLess', () => {
-      it('showMore adds by the numberOfValues option by default', () => {
+    describe('testing showMoreValues/showLessValues', () => {
+      it('showMoreValues adds by the numberOfValues option by default', () => {
         const additionalNumberOfValues = test.cmp.options.numberOfValues;
-        test.cmp.showMore();
+        test.cmp.showMoreValues();
 
         expect(getFirstFacetRequest().numberOfValues).toBe(test.cmp.options.numberOfValues + additionalNumberOfValues);
       });
 
-      it('allows to showMore with a custom amount of values', () => {
+      it('allows to showMoreValues with a custom amount of values', () => {
         const additionalNumberOfValues = 38;
-        test.cmp.showMore(additionalNumberOfValues);
+        test.cmp.showMoreValues(additionalNumberOfValues);
         expect(test.cmp.triggerNewIsolatedQuery).toHaveBeenCalled();
 
         expect(getFirstFacetRequest().numberOfValues).toBe(test.cmp.options.numberOfValues + additionalNumberOfValues);
       });
 
-      it('showMore triggers a query', () => {
-        test.cmp.showMore();
+      it('showMoreValues triggers a query', () => {
+        test.cmp.showMoreValues();
         expect(test.cmp.triggerNewIsolatedQuery).toHaveBeenCalled();
       });
 
-      it('showLess resets the amount of values to the numberOfValues option', () => {
+      it('showLessValues resets the amount of values to the numberOfValues option', () => {
         const additionalNumberOfValues = 38;
-        test.cmp.showMore(additionalNumberOfValues);
-        test.cmp.showLess();
+        test.cmp.showMoreValues(additionalNumberOfValues);
+        test.cmp.showLessValues();
 
         expect(getFirstFacetRequest().numberOfValues).toBe(test.cmp.options.numberOfValues);
       });
 
-      it('showLess triggers a query', () => {
-        test.cmp.showLess();
+      it('showLessValues triggers a query', () => {
+        test.cmp.showLessValues();
         expect(test.cmp.triggerNewIsolatedQuery).toHaveBeenCalled();
       });
     });
@@ -295,32 +295,12 @@ export function DynamicHierarchicalFacetTest() {
 
     describe('when calling reset', () => {
       beforeEach(() => {
+        test.cmp.values.selectPath(['hey']);
         test.cmp.reset();
       });
 
-      it('should call clear', () => {
-        expect(test.cmp.clear).toHaveBeenCalled();
-      });
-
-      it('should call scrollToTop', () => {
-        expect(test.cmp.scrollToTop).toHaveBeenCalled();
-      });
-
-      it('should trigger a new query', () => {
-        expect(test.cmp.triggerNewQuery).toHaveBeenCalled();
-      });
-
-      // TODO: JSUI-2709 add analytics
-    });
-
-    describe('when calling clear', () => {
-      beforeEach(() => {
-        test.cmp.values.selectPath(['hey']);
-        test.cmp.clear();
-      });
-
-      it('should call clear on the values', () => {
-        expect(test.cmp.values.clear).toHaveBeenCalled();
+      it('should call clearPath on the values', () => {
+        expect(test.cmp.values.clearPath).toHaveBeenCalled();
       });
 
       it('should update queryStateModel with an empty array', () => {
@@ -366,6 +346,7 @@ export function DynamicHierarchicalFacetTest() {
       should perform the correct action on the facet`, () => {
         test.cmp.header.options.clear();
         expect(test.cmp.reset).toHaveBeenCalledTimes(1);
+        expect(test.cmp.triggerNewQuery).toHaveBeenCalledTimes(1);
       });
 
       it(`when triggering a query

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTest.ts
@@ -457,7 +457,13 @@ export function DynamicHierarchicalFacetTest() {
       return test.cmp.values.selectedPath.join(test.cmp.options.delimitingCharacter);
     }
 
-    it('returns the correct analyticsFacetState', () => {
+    it(`when a value is not selected
+    returns an empty analyticsFacetState`, () => {
+      expect(test.cmp.analyticsFacetState).toEqual([]);
+    });
+
+    it(`when a value is selected
+    returns the correct analyticsFacetState`, () => {
       test.cmp.selectPath(['foo', 'bar']);
 
       expect(test.cmp.analyticsFacetState).toEqual([
@@ -469,6 +475,7 @@ export function DynamicHierarchicalFacetTest() {
           facetPosition: test.cmp.position,
           value: analyticsValue(),
           displayValue: analyticsValue(),
+          state: FacetValueState.selected,
           valuePosition: 1
         }
       ]);

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTestUtils.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTestUtils.ts
@@ -9,6 +9,7 @@ import {
   IDynamicHierarchicalFacetOptions,
   IDynamicHierarchicalFacetValueProperties
 } from '../../../src/ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet';
+import { DynamicFacetHeader } from '../../../src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeader';
 
 export class DynamicHierarchicalFacetTestUtils {
   static allOptions(options?: IDynamicHierarchicalFacetOptions) {
@@ -103,6 +104,15 @@ export class DynamicHierarchicalFacetTestUtils {
     facet.values = new DynamicHierarchicalFacetValues(facet);
     facet.element = $$('div').el;
     facet.searchInterface = Mock.mockSearchInterface();
+    facet.header = Mock.mock(DynamicFacetHeader);
+    facet.header.options = {
+      clear: () => {},
+      collapse: () => {},
+      expand: () => {},
+      toggleCollapse: () => {},
+      enableCollapse: facet.options.enableCollapse,
+      title: facet.options.title
+    };
 
     return facet;
   }

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValueTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValueTest.ts
@@ -6,6 +6,7 @@ import {
   IDynamicHierarchicalFacet,
   IDynamicHierarchicalFacetValueProperties
 } from '../../../../src/ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet';
+import { analyticsActionCauseList } from '../../../../src/ui/Analytics/AnalyticsActionListMeta';
 
 export function DynamicHierarchicalFacetValueTest() {
   describe('DynamicHierarchicalFacetValue', () => {
@@ -26,6 +27,11 @@ export function DynamicHierarchicalFacetValueTest() {
     it('should select correctly', () => {
       facetValue.select();
       expect(facetValue.isSelected).toBe(true);
+    });
+
+    it('should log the right analytics action', () => {
+      facetValue.logSelectActionToAnalytics();
+      expect(facet.logAnalyticsEvent).toHaveBeenCalledWith(analyticsActionCauseList.dynamicFacetSelect);
     });
 
     it(`when getting formattedCount

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValuesTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValuesTest.ts
@@ -129,11 +129,19 @@ export function DynamicHierarchicalFacetValuesTest() {
       });
     });
 
-    it('clear should empty the values', () => {
+    it('resetValues should empty the values and clear the path', () => {
       facet.values.createFromResponse(DynamicHierarchicalFacetTestUtils.getCompleteFacetResponse(facet));
-      facet.values.clear();
+      facet.values.resetValues();
 
       expect(facet.values.allFacetValues.length).toBe(0);
+      expect(facet.values.selectedPath).toEqual([]);
+    });
+
+    it('clearPath should clear the path', () => {
+      facet.values.createFromResponse(DynamicHierarchicalFacetTestUtils.getCompleteFacetResponse(facet));
+      facet.values.clearPath();
+
+      expect(facet.values.allFacetValues.length).not.toBe(0);
       expect(facet.values.selectedPath).toEqual([]);
     });
 
@@ -190,9 +198,10 @@ export function DynamicHierarchicalFacetValuesTest() {
           expect(getAllCategoriesElement()).toBeTruthy();
         });
 
-        it('clicking on the "All Categories" element should call "reset" on the facet', () => {
+        it('clicking on the "All Categories" element should call "clear" on the facet header', () => {
+          spyOn(facet.header.options, 'clear');
           $$(getAllCategoriesElement()).trigger('click');
-          expect(facet.reset).toHaveBeenCalled();
+          expect(facet.header.options.clear).toHaveBeenCalled();
         });
       });
     });
@@ -389,7 +398,7 @@ export function DynamicHierarchicalFacetValuesTest() {
           should perform the correct actions on the facet`, () => {
           $$(moreButton()).trigger('click');
           expect(facet.enableFreezeFacetOrderFlag).toHaveBeenCalledTimes(1);
-          expect(facet.showMore).toHaveBeenCalledTimes(1);
+          expect(facet.showMoreValues).toHaveBeenCalledTimes(1);
         });
 
         it(`when the facet option enableMoreLess is false
@@ -411,11 +420,11 @@ export function DynamicHierarchicalFacetValuesTest() {
           expect(lessButton()).toBeTruthy();
         });
 
-        it(`when clicking on the "Show more" button
+        it(`when clicking on the "Show less" button
           should perform the correct actions on the facet`, () => {
           $$(lessButton()).trigger('click');
           expect(facet.enableFreezeFacetOrderFlag).toHaveBeenCalledTimes(1);
-          expect(facet.showLess).toHaveBeenCalledTimes(1);
+          expect(facet.showLessValues).toHaveBeenCalledTimes(1);
         });
 
         it(`when the facet option enableMoreLess is false


### PR DESCRIPTION
Renamed clear/reset in order to fit the DynamicFacet's public methods. Would be confusing otherwise. Previously had to follow what the CategoryFacet was doing

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)