### PR TITLE
JSUI-2780 Convert lodash imports to underscore

### DIFF
--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -1,6 +1,6 @@
 import { $$, Dom } from '../utils/Dom';
 import { l } from '../strings/Strings';
-import { defaults, findIndex } from 'lodash';
+import { defaults, findIndex } from 'underscore';
 import { Component } from '../ui/Base/Component';
 import { Direction } from './SuggestionsManager';
 import {

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -36,6 +36,9 @@ L10NTest();
 import { PromisesShimTest } from './misc/PromisesShimTest';
 PromisesShimTest();
 
+import { EnvironmentTest } from './misc/EnvironmentTest';
+EnvironmentTest();
+
 import { ModelTest } from './models/ModelTest';
 ModelTest();
 

--- a/unitTests/magicbox/QueryProcessorTest.ts
+++ b/unitTests/magicbox/QueryProcessorTest.ts
@@ -1,5 +1,5 @@
 import { QueryProcessor, IQueryProcessResult, ProcessingStatus } from '../../src/magicbox/QueryProcessor';
-import { flatten } from 'lodash';
+import { flatten } from 'underscore';
 
 function wait<T = void>(ms?: number, result?: T): Promise<T> {
   return new Promise(resolve => setTimeout(() => resolve(result), ms));

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -5,7 +5,7 @@ import { $$, Dom } from '../../src/utils/Dom';
 import { Utils } from '../../src/utils/Utils';
 import { IMockEnvironment, MockEnvironmentBuilder } from '../MockEnvironment';
 import { OmniboxEvents } from '../../src/Core';
-import { last, first, reverse } from 'lodash';
+import { last, first } from 'underscore';
 import { ISearchResultPreview } from '../../src/magicbox/ResultPreviewsManager';
 import {
   ResultPreviewsManagerEvents,
@@ -392,7 +392,7 @@ export function SuggestionsManagerTest() {
 
         it('moving the focus up multiple times can reach every suggestion', () => {
           suggestionsManager.moveDown();
-          reverse(suggestions).forEach(suggestion => {
+          suggestions.reverse().forEach(suggestion => {
             suggestionsManager.moveUp();
             expect(suggestionsManager.selectedSuggestion.text).toEqual(suggestion.text);
           });
@@ -415,11 +415,11 @@ export function SuggestionsManagerTest() {
 
           const displayAfterDuration = 150;
           function setDisplayAfterDuration() {
-            spyOn(suggestionsManager['resultPreviewsManager'], 'getExternalOptions' as any).and.returnValue(
-              <IUpdateResultPreviewsManagerOptionsEventArgs>{
-                displayAfterDuration
-              }
-            );
+            spyOn(suggestionsManager['resultPreviewsManager'], 'getExternalOptions' as any).and.returnValue(<
+              IUpdateResultPreviewsManagerOptionsEventArgs
+            >{
+              displayAfterDuration
+            });
           }
 
           let populateSpy: jasmine.Spy;

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -622,7 +622,7 @@ export function SuggestionsManagerTest() {
 
               it('moving the focus up multiple times can reach every suggestion', () => {
                 suggestionsManager.moveDown();
-                reverse(suggestions).forEach(suggestion => {
+                suggestions.reverse().forEach(suggestion => {
                   suggestionsManager.moveUp();
                   expect(suggestionsManager.selectedSuggestion.text).toEqual(suggestion.text);
                 });

--- a/unitTests/misc/EnvironmentTest.ts
+++ b/unitTests/misc/EnvironmentTest.ts
@@ -1,0 +1,12 @@
+import * as underscore from 'underscore';
+
+declare const _;
+
+export function EnvironmentTest() {
+  describe('Environment', () => {
+    it(`the '_' global variable should hold the underscore library`, () => {
+      const globalUnderscore = _;
+      expect(globalUnderscore).toEqual(underscore);
+    });
+  });
+}

--- a/unitTests/misc/EnvironmentTest.ts
+++ b/unitTests/misc/EnvironmentTest.ts
@@ -4,9 +4,7 @@ declare const _;
 
 export function EnvironmentTest() {
   describe('Environment', () => {
-    it(`the '_' global variable should hold the underscore library`, () => {
-      // If this test fails, it might be because the global variable is being
-      // overwritten by lodash. Check that there are no lodash imports.
+    it(`the '_' global variable holds underscore (note: importing lodash will overwrite the global)`, () => {
       const globalUnderscore = _;
       expect(globalUnderscore).toEqual(underscore);
     });

--- a/unitTests/misc/EnvironmentTest.ts
+++ b/unitTests/misc/EnvironmentTest.ts
@@ -5,6 +5,8 @@ declare const _;
 export function EnvironmentTest() {
   describe('Environment', () => {
     it(`the '_' global variable should hold the underscore library`, () => {
+      // If this test fails, it might be because the global variable is being
+      // overwritten by lodash. Check that there are no lodash imports.
       const globalUnderscore = _;
       expect(globalUnderscore).toEqual(underscore);
     });


### PR DESCRIPTION
Importing lodash was [overwriting the global](https://github.com/lodash/lodash/issues/1798) `_` variable. Since lodash does not have a method called `findWhere`, when certain code paths were executed by the IEditor tests, they failed with: `findWhere is not a function`


The IEditor run-time did not fail though. The reason is the IEditor webpack config uses `ProvidePlugin`, which sets the `_` variable to underscore when building the bundle.


I think we should hotfix this PR because the last release technically contains a breaking change. Any consumers of the search-ui using an underscore-specific method that does not exist on lodash will have a fatal error when upgrading to the latest search-ui.

https://coveord.atlassian.net/browse/JSUI-2780





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)