### PR TITLE
JSUI-2660 Live example of Error Report/ MissingTerms are broken

### DIFF
--- a/docs/playground/src/PlaygroundConfiguration.ts
+++ b/docs/playground/src/PlaygroundConfiguration.ts
@@ -79,7 +79,9 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   ErrorReport: {
     show: true,
     toExecute: () => {
-      Coveo['SearchEndpoint'].endpoints['default'].options.accessToken = 'invalid';
+      $$(getSearchInterfaceElement()).on('buildingQuery', function(e, args) {
+        args.queryBuilder.pipeline = 'invalid';
+      });
     }
   },
   Excerpt: {

--- a/docs/playground/src/PlaygroundConfiguration.ts
+++ b/docs/playground/src/PlaygroundConfiguration.ts
@@ -79,9 +79,12 @@ export const PlaygroundConfiguration: IStringMap<IComponentPlaygroundConfigurati
   ErrorReport: {
     show: true,
     toExecute: () => {
-      $$(getSearchInterfaceElement()).on('buildingQuery', function(e, args) {
-        args.queryBuilder.pipeline = 'invalid';
-      });
+      getSearchInterfaceInstance().queryController.setEndpoint(
+        new SearchEndpoint({
+          restUri: 'https://platform.cloud.coveo.com/rest/search',
+          accessToken: 'invalid'
+        })
+      );
     }
   },
   Excerpt: {

--- a/docs/theme/layouts/default.hbs
+++ b/docs/theme/layouts/default.hbs
@@ -8,21 +8,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Lato:100,300,400,700' rel='stylesheet' type='text/css'/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css" />
-    <link rel="stylesheet" href="https://static.cloud.coveo.com/searchui/v2.6063/css/CoveoFullSearch.min.css" />
+    <link rel="stylesheet" href="https://static.cloud.coveo.com/searchui/v2.7610/css/CoveoFullSearch.min.css" />
     <link rel="stylesheet" href="{{relativeURL "assets/css/main.css"}}">
     <link rel="stylesheet" href="{{relativeURL "assets/css/overrides.css"}}">
     <link rel="stylesheet" href="{{relativeURL "assets/css/coveo-connect-header.css"}}">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script type="text/javascript" src="https://static.cloud.coveo.com/coveo.analytics.js/coveoua.js"></script>
     <script src="{{relativeURL "assets/js/modernizr.js"}}"></script>
-    <script class="coveo-script" src="https://static.cloud.coveo.com/searchui/v2.6063/js/CoveoJsSearch.min.js"></script>
-    <script src="https://static.cloud.coveo.com/searchui/v2.4382/js/templates/templates.js"></script>
+    <script class="coveo-script" src="https://static.cloud.coveo.com/searchui/v2.7610/js/CoveoJsSearch.min.js"></script>
+    <script src="https://static.cloud.coveo.com/searchui/v2.7610/js/templates/templates.js"></script>
     <script src="{{relativeURL "assets/js/coveo-connect-header.js"}}"></script>
     <script src="{{relativeURL "assets/gen/js/playground.js"}}"></script>
     <script src="{{relativeURL "assets/js/searchUIrefDoc.js"}}"></script>
     <link href="https://s3.amazonaws.com/coveostatic/Developers.png" rel="shortcut icon" type="image/png">
     <link href="https://s3.amazonaws.com/coveostatic/Developers.ico" rel="shortcut icon" type="image/x-icon">
-
+    <style>
+        .magic-box {
+            border: 1px solid #9e9e9e;
+        }
+    </style>
 </head>
 <body>
 

--- a/gulpTasks/doc.js
+++ b/gulpTasks/doc.js
@@ -12,7 +12,7 @@ const baseTsConfig = require('../tsconfig.json');
 const docgenJsonPath = './bin/docgen/docgen.json';
 
 gulp.task('doc', done => {
-  runsequence('buildDoc', 'testDoc', done);
+  runsequence('buildDoc', 'testDoc', 'copyDocgenToBin', done);
 });
 
 gulp.task('buildDoc', ['copyBinToDoc', 'buildPlayground'], () => {
@@ -42,6 +42,10 @@ gulp.task('cleanGeneratedThemesFiles', () => {
 
 gulp.task('copyBinToDoc', ['cleanGeneratedThemesFiles'], () => {
   return gulp.src('./bin/{js,image,css}/**/*').pipe(gulp.dest('./docs/theme/assets/gen'));
+});
+
+gulp.task('copyDocgenToBin', () => {
+  return gulp.src('./docgen/**/*').pipe(gulp.dest('./bin/docgen'));
 });
 
 gulp.task('buildPlayground', shell.task(['node node_modules/webpack/bin/webpack.js --config ./webpack.playground.config.js']));


### PR DESCRIPTION
Update configuration for ErrorReport to enforce a failing request and also references to the latest version of the framework were updated on the html doc template.

I had to add a small css rule because the border of QueryBox and Omnibox wasn't being displayed, because in the last css version the border only gets displayed if the components are inside a Searchbox. Should we add `.magic-box { border: 1px solid #9e9e9e; }` to the `MagicBox.scss` so the border gets displayed even if QueryBox/Omnibox are not inside a Searchbox? Though I understand that is not common to have them stand alone.

https://coveord.atlassian.net/browse/JSUI-2660

