### PR TITLE
JSUI-2783 Re-deploy patch on another bucket folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,15 @@ deploy:
     upload-dir: proda/StaticCDN/searchui/v$PACKAGE_JSON_VERSION
     acl: public_read
     skip_cleanup: true
+  - provider: s3
+    access_key_id: AKIAYKDJLZIT462WODCI
+    secret_access_key:
+      secure: sT8isIiaAIg/Ic7x8cCD3anwCEHAyzG/IWkngmkf5c128NEwUIUdmsQJ1hi4Bw84zk1OOb3id+yXjeaTuKDgIkxe/jk3e2xZ7xElfLNTOln6QLkgsYpKFtGHiKjROOHOb5+Es6L1mxpHWbXH9ebmEhRduUw/BeHWW2MfZmfb434DgvatViRm8DOeROeqlYnbCda5ZELuT5SdwEs/CbExaiSL0WKVoTvcxbe+At4uVnTuc6SYyOvRoblx/q6Ra6mdRipluMs7Go93eu/Oqo7cZ2akrNSi/WBXGqL/wXxe2pYsziSABWjQaqWXD/jKte1ZBx7OXssn88DUKat/RrL7Ak30WHzgY/goiNV+EPT/wtNYWHP3suAzzGqNNMhsPx0lSI7vSUga72J3hV1TOsX9ORosiRm1c2fnmNB9vJdH7yAX7lWpqH2XuOrldVvvTGazSJYx93eBukDViFCZ6egeb+gMT8VQ38uitwd9BZaMhycoujZgSjhx7JnbHUoUdXkdT3XBNV7fINTozWCNJW81iJN+JuLZzneJ/CbjmjkfGcVoFFPCD9rGSj8DbgvWpt8rkwI4ZfHTNOgO9iWgSklpk9r2wgM7Z87V2Zpu8UX/QCFxy8IREtJUo6X9YG9nBoy21wUa9zia2SWpideur9cXb6U0+q84onHVlA0Ehp/1OYs=
+    bucket: coveo-nprod-binaries
+    local-dir: bin
+    upload-dir: proda/StaticCDN/searchui/v$PACKAGE_JSON_VERSION/$PACKAGE_PATCH_VERSION
+    acl: public_read
+    skip_cleanup: true
     on:
       tags: true
       repo: coveo/search-ui

--- a/read.version.sh
+++ b/read.version.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 export PACKAGE_JSON_VERSION=`cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | sed -E 's/\.[0-9]+$//g' | xargs`
+export PACKAGE_PATCH_VERSION=`cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | sed -E 's/[0-9]\.[0-9]\.//g' | xargs`


### PR DESCRIPTION
To be able to support SRI ( https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity ) we need to tweak how we deploy version to the CDN a bit.

Since we normally deploy patch version over existing CDN version to be able to deploy hotfix, it would be impossible for a client to "lock" a version for ever and ever, and to have a valid integrity attribute.

This adds another deploy step (which is an exact copy of the s3 deploy phase we already have) except it also insert the patch version in the URL.

So on every release, we will keep the way we deploy stuff to the CDN ( `/v{major}{minor}` ) but also add a new deploy to `/v{major}{minor}/{patch}` which won't be overwritten on every new patch release.

I also discussed with @fbeaudoincoveo about how we can auto-generate the correct checksum for all patch version we deploy automatically every time we do new release notes. He will normally be able to handle this on his side when the website gets generated.

This feature will be needed by the ServiceNow package, but could also be used by other clients if they wish to.

https://coveord.atlassian.net/browse/JSUI-2783





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)