### PR TITLE
JSUI-2763 – Added compatibility for `QuerySuggestPreview` and `FacetValueSuggestions`

### DIFF
--- a/sass/_QuerySuggestPreview.scss
+++ b/sass/_QuerySuggestPreview.scss
@@ -80,11 +80,6 @@
         }
       }
     }
-    .coveo-preview-header {
-      padding: $margin;
-      font-weight: bold;
-      margin-top: 0;
-    }
     .coveo-preview-selectable.coveo-omnibox-selected,
     .coveo-preview-selectable:hover {
       outline: $default-border;

--- a/src/events/ResultPreviewsManagerEvents.ts
+++ b/src/events/ResultPreviewsManagerEvents.ts
@@ -1,4 +1,5 @@
 import { ISearchResultPreview } from '../magicbox/ResultPreviewsManager';
+import { Suggestion } from '../magicbox/SuggestionsManager';
 
 /**
  * Executed when a {@link Suggestion} is focused before {@link PopulateSearchResultPreviews} is called to fetch more options.
@@ -17,9 +18,9 @@ export interface IUpdateResultPreviewsManagerOptionsEventArgs {
  */
 export interface IPopulateSearchResultPreviewsEventArgs {
   /**
-   * The text to look up search result previews for.
+   * The suggestion to look up search result previews for.
    */
-  suggestionText: string;
+  suggestion: Suggestion;
   /**
    * The result previews query. This must be set synchronously before the event resolves.
    * Setting this to a non-empty array will display the given search result previews.

--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -2,7 +2,7 @@ import { $$, Dom } from '../utils/Dom';
 import { l } from '../strings/Strings';
 import { defaults, findIndex } from 'underscore';
 import { Component } from '../ui/Base/Component';
-import { Direction } from './SuggestionsManager';
+import { Direction, Suggestion } from './SuggestionsManager';
 import {
   ResultPreviewsManagerEvents,
   IPopulateSearchResultPreviewsEventArgs,
@@ -20,6 +20,7 @@ export interface IResultPreviewsManagerOptions {
   previewClass: string;
   selectedClass: string;
   previewHeaderText: string;
+  previewHeaderFieldText: string;
   timeout: number;
 }
 
@@ -28,8 +29,8 @@ export class ResultPreviewsManager {
   private suggestionsPreviewContainer: Dom;
   private resultPreviewsHeader: Dom;
   private resultPreviewsContainer: Dom;
-  private lastQueriedSuggestion: HTMLElement;
-  private lastDisplayedSuggestion: HTMLElement;
+  private lastQueriedSuggestion: Suggestion;
+  private lastDisplayedSuggestion: Suggestion;
   private previewsProcessor: QueryProcessor<ISearchResultPreview>;
   private lastDelay: Promise<void>;
   private root: HTMLElement;
@@ -77,6 +78,7 @@ export class ResultPreviewsManager {
   constructor(private element: HTMLElement, options: Partial<IResultPreviewsManagerOptions> = {}) {
     this.options = defaults(options, <IResultPreviewsManagerOptions>{
       previewHeaderText: l('QuerySuggestPreview'),
+      previewHeaderFieldText: l('QuerySuggestPreviewWithField'),
       previewClass: 'coveo-preview-selectable',
       selectedClass: 'magic-box-selected'
     });
@@ -84,7 +86,7 @@ export class ResultPreviewsManager {
     this.previewsProcessor = new QueryProcessor({ timeout: this.options.timeout });
   }
 
-  public async displaySearchResultPreviewsForSuggestion(suggestion: HTMLElement) {
+  public async displaySearchResultPreviewsForSuggestion(suggestion: Suggestion) {
     const externalOptions = this.getExternalOptions();
     const currentDelay = (this.lastDelay = Utils.resolveAfter(
       Utils.isNullOrUndefined(externalOptions.displayAfterDuration) ? 200 : externalOptions.displayAfterDuration
@@ -194,17 +196,21 @@ export class ResultPreviewsManager {
     return optionsEventArgs;
   }
 
-  private getSearchResultPreviewsQuery(suggestion: HTMLElement) {
+  private getSearchResultPreviewsQuery(suggestion: Suggestion) {
     const populateEventArgs: IPopulateSearchResultPreviewsEventArgs = {
-      suggestionText: suggestion.innerText,
+      suggestion,
       previewsQueries: []
     };
     $$(this.root).trigger(ResultPreviewsManagerEvents.populateSearchResultPreviews, populateEventArgs);
     return this.previewsProcessor.processQueries(populateEventArgs.previewsQueries);
   }
 
-  private updateSearchResultPreviewsHeader(suggestion: string) {
-    this.resultPreviewsHeader.text(`${this.options.previewHeaderText} "${suggestion}"`);
+  private updateSearchResultPreviewsHeader(suggestion: Suggestion) {
+    let text = `${this.options.previewHeaderText} "${suggestion.text}"`;
+    if (suggestion.field) {
+      text += ` ${this.options.previewHeaderFieldText} "${suggestion.field.value}"`;
+    }
+    this.resultPreviewsHeader.text(text);
   }
 
   private appendSearchResultPreview(preview: ISearchResultPreview) {
@@ -219,7 +225,7 @@ export class ResultPreviewsManager {
     previews.forEach(preview => this.appendSearchResultPreview(preview));
   }
 
-  private displaySuggestionPreviews(suggestion: HTMLElement, previews: ISearchResultPreview[]) {
+  private displaySuggestionPreviews(suggestion: Suggestion, previews: ISearchResultPreview[]) {
     this.setHasPreviews(previews && previews.length > 0);
     this.element.classList.toggle('magic-box-hasPreviews', this.hasPreviews);
     this.lastDisplayedSuggestion = suggestion;
@@ -227,6 +233,6 @@ export class ResultPreviewsManager {
       return;
     }
     this.appendSearchResultPreviews(previews);
-    this.updateSearchResultPreviewsHeader(suggestion.innerText);
+    this.updateSearchResultPreviewsHeader(suggestion);
   }
 }

--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -239,9 +239,9 @@ export class ResultPreviewsManager {
   }
 
   private displaySuggestionPreviews(suggestion: Suggestion, previews: ISearchResultPreview[]) {
+    this.lastDisplayedSuggestion = suggestion;
     this.setHasPreviews(previews && previews.length > 0);
     this.element.classList.toggle('magic-box-hasPreviews', this.hasPreviews);
-    this.lastDisplayedSuggestion = suggestion;
     if (!this.hasPreviews) {
       return;
     }

--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -241,6 +241,7 @@ export class ResultPreviewsManager {
   private displaySuggestionPreviews(suggestion: Suggestion, previews: ISearchResultPreview[]) {
     this.setHasPreviews(previews && previews.length > 0);
     this.element.classList.toggle('magic-box-hasPreviews', this.hasPreviews);
+    this.lastDisplayedSuggestion = suggestion;
     if (!this.hasPreviews) {
       return;
     }

--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -27,7 +27,6 @@ export interface IResultPreviewsManagerOptions {
 export class ResultPreviewsManager {
   private options: IResultPreviewsManagerOptions;
   private suggestionsPreviewContainer: Dom;
-  private resultPreviewsHeader: Dom;
   private resultPreviewsContainer: Dom;
   private lastQueriedSuggestion: Suggestion;
   private lastDisplayedSuggestion: Suggestion;
@@ -187,10 +186,6 @@ export class ResultPreviewsManager {
         className: 'coveo-preview-container',
         id: this.previewContainerId
       },
-      (this.resultPreviewsHeader = $$('div', {
-        className: 'coveo-preview-header',
-        role: 'status'
-      })),
       (this.resultPreviewsContainer = $$('div', {
         className: 'coveo-preview-results',
         role: 'listbox',
@@ -212,15 +207,6 @@ export class ResultPreviewsManager {
     };
     $$(this.root).trigger(ResultPreviewsManagerEvents.populateSearchResultPreviews, populateEventArgs);
     return this.previewsProcessor.processQueries(populateEventArgs.previewsQueries);
-  }
-
-  private updateSearchResultPreviewsHeader(suggestion: Suggestion) {
-    let text = `${this.options.previewHeaderText} "${suggestion.text}"`;
-    if (suggestion.field) {
-      text += ` ${this.options.previewHeaderFieldText} "${suggestion.field.values[0]}"`;
-    }
-    this.resultPreviewsHeader.text(text);
-    this.resultPreviewsContainer.setAttribute('summary', text);
   }
 
   private appendSearchResultPreview(preview: ISearchResultPreview, position: number) {
@@ -246,6 +232,5 @@ export class ResultPreviewsManager {
       return;
     }
     this.appendSearchResultPreviews(previews);
-    this.updateSearchResultPreviewsHeader(suggestion);
   }
 }

--- a/src/magicbox/ResultPreviewsManager.ts
+++ b/src/magicbox/ResultPreviewsManager.ts
@@ -217,7 +217,7 @@ export class ResultPreviewsManager {
   private updateSearchResultPreviewsHeader(suggestion: Suggestion) {
     let text = `${this.options.previewHeaderText} "${suggestion.text}"`;
     if (suggestion.field) {
-      text += ` ${this.options.previewHeaderFieldText} "${suggestion.field.value}"`;
+      text += ` ${this.options.previewHeaderFieldText} "${suggestion.field.values[0]}"`;
     }
     this.resultPreviewsHeader.text(text);
     this.resultPreviewsContainer.setAttribute('summary', text);

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -6,18 +6,12 @@ import { InputManager } from './InputManager';
 import { ResultPreviewsManager } from './ResultPreviewsManager';
 import { QueryProcessor, ProcessingStatus } from './QueryProcessor';
 
-export interface ISuggestionField {
-  name: string;
-  values: string[];
-}
-
 export interface Suggestion {
   text?: string;
   index?: number;
   html?: string;
   dom?: HTMLElement;
   separator?: string;
-  field?: ISuggestionField;
   advancedQuery?: string;
   onSelect?: () => void;
 }

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -61,7 +61,7 @@ export class SuggestionsManager {
   }
 
   private get focusedSuggestion() {
-    return find(this.currentSuggestions || <Suggestion[]>[], suggestion => suggestion.dom.classList.contains(this.options.selectedClass));
+    return find(this.currentSuggestions, suggestion => suggestion.dom.classList.contains(this.options.selectedClass));
   }
 
   constructor(

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -62,7 +62,7 @@ export class SuggestionsManager {
   }
 
   private get focusedSuggestion() {
-    return find(this.currentSuggestions || <Suggestion[]>[], suggestion => suggestion.dom.classList.contains(this.options.selectedClass));
+    return find(this.currentSuggestions, suggestion => suggestion.dom.classList.contains(this.options.selectedClass));
   }
 
   constructor(
@@ -297,7 +297,7 @@ export class SuggestionsManager {
   private modifyDomFromExistingSuggestion(dom: HTMLElement) {
     // this need to be done if the selection is in cache and the dom is set in the suggestion
     this.removeSelectedStatus(dom);
-    const found = $$(dom).find('.' + this.options.suggestionClass);
+    const found = dom.classList.contains(this.options.suggestionClass) ? dom : $$(dom).find('.' + this.options.suggestionClass);
     this.removeSelectedStatus(found);
     return $$(dom);
   }

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -22,6 +22,7 @@ export interface Suggestion {
   dom?: HTMLElement;
   separator?: string;
   field?: ISuggestionField;
+  advancedQuery?: string;
   onSelect?: () => void;
 }
 
@@ -61,7 +62,7 @@ export class SuggestionsManager {
   }
 
   private get focusedSuggestion() {
-    return find(this.currentSuggestions, suggestion => suggestion.dom.classList.contains(this.options.selectedClass));
+    return find(this.currentSuggestions || <Suggestion[]>[], suggestion => suggestion.dom.classList.contains(this.options.selectedClass));
   }
 
   constructor(

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -8,11 +8,7 @@ import { QueryProcessor, ProcessingStatus } from './QueryProcessor';
 
 export interface ISuggestionField {
   name: string;
-  value: string;
-}
-
-export interface ISuggestionCategoryField extends ISuggestionField {
-  categoryFieldDelimitingCharacter: string;
+  values: string[];
 }
 
 export interface Suggestion {

--- a/src/ui/FacetValueSuggestions/FacetValueSuggestions.ts
+++ b/src/ui/FacetValueSuggestions/FacetValueSuggestions.ts
@@ -271,18 +271,16 @@ export class FacetValueSuggestions extends Component {
   private mapFacetValueSuggestion(resultToShow: IFacetValueSuggestionRow, omnibox: Omnibox) {
     const suggestion: IOmniboxSuggestion = {
       html: this.buildDisplayNameForRow(resultToShow, omnibox),
-      text: resultToShow.keyword.text,
-      field: {
-        name: this.options.field.toString(),
-        values: this.options.isCategoryField
-          ? resultToShow.value.split(this.options.categoryFieldDelimitingCharacter)
-          : [resultToShow.value]
-      }
+      text: resultToShow.keyword.text
     };
 
-    suggestion.advancedQuery = suggestion.field.values.map(value => `${suggestion.field.name}=="${value}"`).join(' AND ');
+    const fieldValues = this.options.isCategoryField
+      ? resultToShow.value.split(this.options.categoryFieldDelimitingCharacter)
+      : [resultToShow.value];
 
-    suggestion.onSelect = () => this.onSuggestionSelected(suggestion, omnibox);
+    suggestion.advancedQuery = fieldValues.map(value => `${this.options.field}=="${value}"`).join(' AND ');
+
+    suggestion.onSelect = () => this.onSuggestionSelected(suggestion, fieldValues, omnibox);
 
     return suggestion;
   }
@@ -296,14 +294,13 @@ export class FacetValueSuggestions extends Component {
     }
   }
 
-  private onSuggestionSelected(suggestion: Suggestion, omnibox: Omnibox): void {
+  private onSuggestionSelected(suggestion: Suggestion, fieldValues: string[], omnibox: Omnibox): void {
     omnibox.setText(suggestion.text);
     // Copy the state here, else it will directly modify queryStateModel.defaultAttributes.fv.
     const fvState: { [key: string]: string[] } = { ...this.queryStateModel.get(QueryStateModel.attributesEnum.fv) };
     const existingValues: string[] = fvState[this.options.field.toString()] || [];
 
-    const valuesToSetInState = suggestion.field.values;
-    fvState[this.options.field.toString()] = existingValues.concat(valuesToSetInState);
+    fvState[this.options.field.toString()] = existingValues.concat(fieldValues);
 
     this.queryStateModel.set(QueryStateModel.attributesEnum.fv, fvState);
     omnibox.magicBox.blur();

--- a/src/ui/FacetValueSuggestions/FacetValueSuggestions.ts
+++ b/src/ui/FacetValueSuggestions/FacetValueSuggestions.ts
@@ -285,6 +285,8 @@ export class FacetValueSuggestions extends Component {
           }
     };
 
+    suggestion.advancedQuery = `${suggestion.field.name}=="${suggestion.field.value}"`;
+
     suggestion.onSelect = () => this.onSuggestionSelected(suggestion, omnibox);
 
     return suggestion;

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -167,9 +167,7 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
       context,
       numberOfResults: this.options.numberOfPreviewResults,
       q: suggestion.text || suggestion.dom.innerText,
-      ...(suggestion.field && {
-        aq: `${suggestion.field.name}=="${suggestion.field.value}"`
-      })
+      ...(suggestion.advancedQuery && { aq: suggestion.advancedQuery })
     };
   }
 

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7516,6 +7516,10 @@
     "en": "Product recommendations for",
     "fr": "Recommendations de produits pour"
   },
+  "QuerySuggestPreviewWithField": {
+    "en": "under",
+    "fr": "sous"
+  },
   "To": {
     "en": "to",
     "fr": "à"

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7512,14 +7512,6 @@
     "en": "No values found.",
     "fr": "Aucune valeur trouvée."
   },
-  "QuerySuggestPreview": {
-    "en": "Most relevant results for",
-    "fr": "Résultats les plus pertinents pour"
-  },
-  "QuerySuggestPreviewWithField": {
-    "en": "in",
-    "fr": "dans"
-  },
   "To": {
     "en": "to",
     "fr": "à"

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7513,12 +7513,12 @@
     "fr": "Aucune valeur trouvée."
   },
   "QuerySuggestPreview": {
-    "en": "Product recommendations for",
-    "fr": "Recommendations de produits pour"
+    "en": "Most relevant results for",
+    "fr": "Résultats les plus pertinents pour"
   },
   "QuerySuggestPreviewWithField": {
-    "en": "under",
-    "fr": "sous"
+    "en": "in",
+    "fr": "dans"
   },
   "To": {
     "en": "to",

--- a/unitTests/magicbox/ResultPreviewsManagerTest.ts
+++ b/unitTests/magicbox/ResultPreviewsManagerTest.ts
@@ -81,16 +81,9 @@ export function ResultPreviewsManagerTest() {
 
     describe('with accessibility', () => {
       it('builds the preview container with the appropriate roles', async done => {
-        const previewHeader = env.element.querySelector('.coveo-preview-header');
-        expect(previewHeader.getAttribute('role')).toEqual('status');
         const previewResults = env.element.querySelector('.coveo-preview-results');
         expect(previewResults.getAttribute('role')).toEqual('listbox');
         done();
-      });
-
-      it('sets the summary of the results container', () => {
-        const previewResults = env.element.querySelector('.coveo-preview-results');
-        expect(previewResults.getAttribute('summary')).toContain(suggestionText);
       });
 
       it('sets the role of previews to "option"', async done => {

--- a/unitTests/magicbox/ResultPreviewsManagerTest.ts
+++ b/unitTests/magicbox/ResultPreviewsManagerTest.ts
@@ -3,6 +3,7 @@ import { IMockEnvironment, MockEnvironmentBuilder } from '../MockEnvironment';
 import { $$ } from '../../src/utils/Dom';
 import { ResultPreviewsManagerEvents, IPopulateSearchResultPreviewsEventArgs } from '../../src/events/ResultPreviewsManagerEvents';
 import { toArray } from 'underscore';
+import { Suggestion } from '../../src/magicbox/SuggestionsManager';
 
 export function ResultPreviewsManagerTest() {
   describe('ResultPreviewsManager', function() {
@@ -26,8 +27,8 @@ export function ResultPreviewsManagerTest() {
       buildSuggestionsListbox();
     }
 
-    function createTestSuggestion() {
-      return $$('div', {}, suggestionText).el;
+    function createTestSuggestion(): Suggestion {
+      return { dom: $$('div', {}, suggestionText).el };
     }
 
     function createPreviews() {

--- a/unitTests/magicbox/ResultPreviewsManagerTest.ts
+++ b/unitTests/magicbox/ResultPreviewsManagerTest.ts
@@ -28,7 +28,7 @@ export function ResultPreviewsManagerTest() {
     }
 
     function createTestSuggestion(): Suggestion {
-      return { dom: $$('div', {}, suggestionText).el };
+      return { dom: $$('div', {}, suggestionText).el, text: suggestionText };
     }
 
     function createPreviews() {

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -46,6 +46,8 @@ export function SuggestionsManagerTest() {
           selectedClass,
           suggestionClass
         });
+
+        suggestionManager.updateSuggestions([buildSuggestion()]);
       });
 
       it('builds suggestions parent correctly when adding a suggestion', () => {
@@ -264,14 +266,21 @@ export function SuggestionsManagerTest() {
       function buildContainer() {
         container = $$(document.createElement('div'));
         suggestionContainer = $$(document.createElement('div'));
-        suggestion = $$(document.createElement('div'));
-        elementInsideSuggestion = $$(document.createElement('div'));
-
-        suggestion.addClass(suggestionClass);
-        suggestion.setAttribute('aria-selected', 'false');
-        suggestion.el.appendChild(elementInsideSuggestion.el);
-        suggestionContainer.el.appendChild(suggestion.el);
         container.el.appendChild(suggestionContainer.el);
+      }
+
+      function buildSuggestion(): Suggestion {
+        const text = 'abc';
+        suggestion = $$(
+          'div',
+          {
+            className: suggestionClass,
+            'aria-selected': false
+          },
+          (elementInsideSuggestion = $$('div', {}, text))
+        );
+
+        return { dom: suggestion.el, text, onSelect: () => {} };
       }
     });
 

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -415,11 +415,11 @@ export function SuggestionsManagerTest() {
 
           const displayAfterDuration = 150;
           function setDisplayAfterDuration() {
-            spyOn(suggestionsManager['resultPreviewsManager'], 'getExternalOptions' as any).and.returnValue(<
-              IUpdateResultPreviewsManagerOptionsEventArgs
-            >{
-              displayAfterDuration
-            });
+            spyOn(suggestionsManager['resultPreviewsManager'], 'getExternalOptions' as any).and.returnValue(
+              <IUpdateResultPreviewsManagerOptionsEventArgs>{
+                displayAfterDuration
+              }
+            );
           }
 
           let populateSpy: jasmine.Spy;
@@ -429,8 +429,8 @@ export function SuggestionsManagerTest() {
             let onCall: () => any;
             populateSpy = jasmine.createSpy('PopulateSearchResultPreviews');
             $$(env.root).on(ResultPreviewsManagerEvents.populateSearchResultPreviews, (_, args: IPopulateSearchResultPreviewsEventArgs) => {
-              populateSpy(args.suggestionText);
-              args.previewsQueries.push(getPreviews(textSuggestions.indexOf(args.suggestionText)));
+              populateSpy(args.suggestion);
+              args.previewsQueries.push(getPreviews(textSuggestions.indexOf(args.suggestion.text)));
               if (onCall) {
                 onCall();
                 onCall = null;
@@ -597,7 +597,7 @@ export function SuggestionsManagerTest() {
                 jasmine.clock().tick(displayAfterDuration);
                 await deferAsync();
                 expect(populateSpy).toHaveBeenCalledTimes(1);
-                expect(populateSpy).toHaveBeenCalledWith(textSuggestions[1]);
+                expect((populateSpy.calls.mostRecent().args as [Suggestion])[0].text).toEqual(textSuggestions[1]);
                 done();
               });
 

--- a/unitTests/ui/FacetValueSuggestionsTest.ts
+++ b/unitTests/ui/FacetValueSuggestionsTest.ts
@@ -155,6 +155,14 @@ export function FacetValueSuggestionsTest() {
           });
           done();
         });
+
+        it('should put the split field values into the suggestion', async done => {
+          const resultingArgs = await triggerPopulateOmniboxEvent();
+
+          const result = await firstSuggestion(resultingArgs);
+          expect(result[0].field.values).toEqual(['a', 'b', 'c', 'd']);
+          done();
+        });
       });
 
       describe('with a custom delimiter', () => {
@@ -173,6 +181,14 @@ export function FacetValueSuggestionsTest() {
           expect(test.env.queryStateModel.set).toHaveBeenCalledWith(QueryStateModel.attributesEnum.fv, {
             [someField]: ['a', 'b', 'c', 'd']
           });
+          done();
+        });
+
+        it('should put the split field values into the suggestion', async done => {
+          const resultingArgs = await triggerPopulateOmniboxEvent();
+
+          const result = await firstSuggestion(resultingArgs);
+          expect(result[0].field.values).toEqual(['a', 'b', 'c', 'd']);
           done();
         });
       });
@@ -247,6 +263,22 @@ export function FacetValueSuggestionsTest() {
         const result = await firstSuggestion(resultingArgs);
         result[0].onSelect();
         expect(omniboxInstance.setText).toHaveBeenCalledWith(aKeyword.text);
+        done();
+      });
+
+      it('changes the field of the suggestion', async done => {
+        const resultingArgs = await triggerPopulateOmniboxEvent();
+
+        const result = await firstSuggestion(resultingArgs);
+        expect(result[0].field.name).toEqual(someField);
+        done();
+      });
+
+      it('changes the field value of the suggestion', async done => {
+        const resultingArgs = await triggerPopulateOmniboxEvent();
+
+        const result = await firstSuggestion(resultingArgs);
+        expect(result[0].field.values).toEqual([someSuggestionValue]);
         done();
       });
 

--- a/unitTests/ui/FacetValueSuggestionsTest.ts
+++ b/unitTests/ui/FacetValueSuggestionsTest.ts
@@ -156,11 +156,11 @@ export function FacetValueSuggestionsTest() {
           done();
         });
 
-        it('should put the split field values into the suggestion', async done => {
+        it('should set the advanced query to check every field value', async done => {
           const resultingArgs = await triggerPopulateOmniboxEvent();
 
           const result = await firstSuggestion(resultingArgs);
-          expect(result[0].field.values).toEqual(['a', 'b', 'c', 'd']);
+          expect(result[0].advancedQuery).toEqual(`${someField}=="a" AND ${someField}=="b" AND ${someField}=="c" AND ${someField}=="d"`);
           done();
         });
       });
@@ -184,11 +184,11 @@ export function FacetValueSuggestionsTest() {
           done();
         });
 
-        it('should put the split field values into the suggestion', async done => {
+        it('should set the advanced query to check every field value', async done => {
           const resultingArgs = await triggerPopulateOmniboxEvent();
 
           const result = await firstSuggestion(resultingArgs);
-          expect(result[0].field.values).toEqual(['a', 'b', 'c', 'd']);
+          expect(result[0].advancedQuery).toEqual(`${someField}=="a" AND ${someField}=="b" AND ${someField}=="c" AND ${someField}=="d"`);
           done();
         });
       });
@@ -266,19 +266,11 @@ export function FacetValueSuggestionsTest() {
         done();
       });
 
-      it('changes the field of the suggestion', async done => {
+      it('changes the advanced query of the suggestion', async done => {
         const resultingArgs = await triggerPopulateOmniboxEvent();
 
         const result = await firstSuggestion(resultingArgs);
-        expect(result[0].field.name).toEqual(someField);
-        done();
-      });
-
-      it('changes the field value of the suggestion', async done => {
-        const resultingArgs = await triggerPopulateOmniboxEvent();
-
-        const result = await firstSuggestion(resultingArgs);
-        expect(result[0].field.values).toEqual([someSuggestionValue]);
+        expect(result[0].advancedQuery).toEqual(`${someField}=="${someSuggestionValue}"`);
         done();
       });
 

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -64,7 +64,7 @@ export function QuerySuggestPreviewTest() {
     function triggerPopulateSearchResultPreviews(suggestionText: string = 'test', fakeResults?: IQueryResults) {
       fakeResults = fakeResults || FakeResults.createFakeResults(test.cmp.options.numberOfPreviewResults);
       (test.env.searchEndpoint.search as jasmine.Spy).and.returnValue(Promise.resolve(fakeResults));
-      const event: IPopulateSearchResultPreviewsEventArgs = { suggestionText, previewsQueries: [] };
+      const event: IPopulateSearchResultPreviewsEventArgs = { suggestion: { text: suggestionText }, previewsQueries: [] };
       $$(testEnv.root).trigger(ResultPreviewsManagerEvents.populateSearchResultPreviews, event);
       return event.previewsQueries[0];
     }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2763

Added compatibility to ensure that suggestions from `FacetValueSuggestion` apply a filter on previews requested by `QuerySuggestPreview`. Also made sure that `ResultPreviewsManager` shows the correct header when suggestions include a field.

There's many other ways of doing this, don't hesitate to criticize heavily!

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)