### PR TITLE
JSUI-2785 Add filterFacetCount option to DynamicFacets

### DIFF
--- a/src/controllers/DynamicFacetRangeQueryController.ts
+++ b/src/controllers/DynamicFacetRangeQueryController.ts
@@ -13,7 +13,8 @@ export class DynamicFacetRangeQueryController extends DynamicFacetQueryControlle
       currentValues: this.currentValues,
       numberOfValues: this.numberOfValues,
       freezeCurrentValues: this.facet.values.hasValues,
-      injectionDepth: this.facet.options.injectionDepth
+      injectionDepth: this.facet.options.injectionDepth,
+      filterFacetCount: this.filterFacetCount
     };
   }
 

--- a/src/rest/Facet/FacetRequest.ts
+++ b/src/rest/Facet/FacetRequest.ts
@@ -185,4 +185,8 @@ export interface IFacetRequest {
    * **Default (Search API):** `;`
    */
   delimitingCharacter?: string;
+  /**
+   * TODO: document parameter
+   */
+  filterFacetCount?: boolean;
 }

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -234,7 +234,18 @@ export class DynamicFacet extends Component implements IDynamicFacet {
      *
      * Setting this option to a higher value may enhance the accuracy of facet value counts at the cost of slower query performance.
      */
-    injectionDepth: ComponentOptions.buildNumberOption({ defaultValue: 1000, min: 0 })
+    injectionDepth: ComponentOptions.buildNumberOption({ defaultValue: 1000, min: 0 }),
+
+    /**
+     * TODO: document option
+     *
+     * By default, the following behavior applies:
+     *
+     * - `True` when folding is not activated for the query.
+     * - `False` when folding is activated for the query.
+     * See [Folding Results](https://docs.coveo.com/en/428/).
+     */
+    filterFacetCount: ComponentOptions.buildBooleanOption({ section: 'Filtering' })
   };
 
   private includedAttributeId: string;

--- a/src/ui/DynamicFacet/IDynamicFacet.ts
+++ b/src/ui/DynamicFacet/IDynamicFacet.ts
@@ -30,6 +30,7 @@ export interface IDynamicFacetOptions extends IResponsiveComponentOptions {
   valueCaption?: Record<string, string>;
   dependsOn?: string;
   injectionDepth?: number;
+  filterFacetCount?: boolean;
 }
 
 export interface IDynamicFacet extends Component, IDynamicManagerCompatibleFacet, IAutoLayoutAdjustableInsideFacetColumn {

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -197,6 +197,17 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
      * **Default:** `undefined` and the hierarchical facet does not depend on any other facet to be displayed.
      */
     dependsOn: ComponentOptions.buildStringOption(),
+
+    /**
+     * TODO: document option
+     *
+     * By default, the following behavior applies:
+     *
+     * - `True` when folding is not activated for the query.
+     * - `False` when folding is activated for the query.
+     * See [Folding Results](https://docs.coveo.com/en/428/).
+     */
+    filterFacetCount: ComponentOptions.buildBooleanOption({ section: 'Filtering' }),
     ...ResponsiveFacetOptions
   };
 

--- a/src/ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet.ts
@@ -26,6 +26,7 @@ export interface IDynamicHierarchicalFacetOptions extends IResponsiveComponentOp
   valueCaption?: IStringMap<string>;
   dependsOn?: string;
   includeInBreadcrumb?: boolean;
+  filterFacetCount?: boolean;
 }
 
 export interface IDynamicHierarchicalFacet extends Component, IDynamicManagerCompatibleFacet, IAutoLayoutAdjustableInsideFacetColumn {


### PR DESCRIPTION
It will send the filterFacetCount=false to the API/Index when folding is enabled by default, so it doesn't break count as often for clients
Missing UTs
A few things lack documentation 

https://coveord.atlassian.net/browse/JSUI-2785


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)