### PR TITLE
JSUI-2785 Add filterFacetCount to the FacetRequest

### DIFF
--- a/src/controllers/DynamicFacetQueryController.ts
+++ b/src/controllers/DynamicFacetQueryController.ts
@@ -82,7 +82,7 @@ export class DynamicFacetQueryController {
 
   public buildFacetRequest(query: IQuery): IFacetRequest {
     return {
-      ...this.requestBuilder.buildRequestForQuery(query),
+      ...this.requestBuilder.buildBaseRequestForQuery(query),
       currentValues: this.currentValues,
       numberOfValues: this.numberOfValues,
       freezeCurrentValues: this.freezeCurrentValues,

--- a/src/controllers/DynamicFacetQueryController.ts
+++ b/src/controllers/DynamicFacetQueryController.ts
@@ -1,7 +1,6 @@
 import { QueryBuilder } from '../ui/Base/QueryBuilder';
 import { Assert } from '../misc/Assert';
 import { IFacetRequest, IFacetRequestValue } from '../rest/Facet/FacetRequest';
-import { FacetSortCriteria } from '../rest/Facet/FacetSortCriteria';
 import { QueryEvents } from '../events/QueryEvents';
 import { findIndex } from 'underscore';
 import { IQueryResults } from '../rest/QueryResults';
@@ -20,7 +19,7 @@ export class DynamicFacetQueryController {
       facetId: this.facet.options.id,
       field: this.facet.fieldName,
       type: this.facet.facetType,
-      sortCriteria: this.facet.options.sortCriteria as FacetSortCriteria,
+      sortCriteria: this.facet.options.sortCriteria,
       injectionDepth: this.facet.options.injectionDepth,
       filterFacetCount: this.facet.options.filterFacetCount
     });

--- a/src/controllers/DynamicFacetRangeQueryController.ts
+++ b/src/controllers/DynamicFacetRangeQueryController.ts
@@ -8,7 +8,7 @@ export class DynamicFacetRangeQueryController extends DynamicFacetQueryControlle
 
   public buildFacetRequest(query: IQuery): IFacetRequest {
     return {
-      ...this.requestBuilder.buildRequestForQuery(query),
+      ...this.requestBuilder.buildBaseRequestForQuery(query),
       currentValues: this.currentValues,
       numberOfValues: this.numberOfValues,
       freezeCurrentValues: this.facet.values.hasValues

--- a/src/controllers/DynamicFacetRangeQueryController.ts
+++ b/src/controllers/DynamicFacetRangeQueryController.ts
@@ -1,20 +1,17 @@
 import { DynamicFacetQueryController } from './DynamicFacetQueryController';
 import { IFacetRequest, IFacetRequestValue } from '../rest/Facet/FacetRequest';
 import { IDynamicFacet } from '../ui/DynamicFacet/IDynamicFacet';
+import { IQuery } from '../rest/Query';
 
 export class DynamicFacetRangeQueryController extends DynamicFacetQueryController {
   protected facet: IDynamicFacet;
 
-  public get facetRequest(): IFacetRequest {
+  public buildFacetRequest(query: IQuery): IFacetRequest {
     return {
-      facetId: this.facet.options.id,
-      field: this.facet.fieldName,
-      type: this.facet.facetType,
+      ...this.requestBuilder.buildRequestForQuery(query),
       currentValues: this.currentValues,
       numberOfValues: this.numberOfValues,
-      freezeCurrentValues: this.facet.values.hasValues,
-      injectionDepth: this.facet.options.injectionDepth,
-      filterFacetCount: this.filterFacetCount
+      freezeCurrentValues: this.facet.values.hasValues
     };
   }
 

--- a/src/controllers/DynamicFacetRangeQueryController.ts
+++ b/src/controllers/DynamicFacetRangeQueryController.ts
@@ -13,7 +13,8 @@ export class DynamicFacetRangeQueryController extends DynamicFacetQueryControlle
       currentValues: this.currentValues,
       numberOfValues: this.numberOfValues,
       freezeCurrentValues: this.facet.values.hasValues,
-      injectionDepth: this.facet.options.injectionDepth
+      injectionDepth: this.facet.options.injectionDepth,
+      filterFacetCount: this.filterFacetCount
     };
   }
 

--- a/src/controllers/DynamicFacetRequestBuilder.ts
+++ b/src/controllers/DynamicFacetRequestBuilder.ts
@@ -14,20 +14,20 @@ export interface IBasicFacetRequestParameters {
 }
 
 export class DynamicFacetRequestBuilder {
-  constructor(private options: IBasicFacetRequestParameters) {}
+  constructor(private request: IFacetRequest) {}
 
-  public buildRequestForQuery(query: IQuery): IFacetRequest {
+  public buildBaseRequestForQuery(query: IQuery): IFacetRequest {
     return {
-      ...this.options,
+      ...this.request,
       filterFacetCount: this.getFilterFacetCount(!!query.filterField)
     };
   }
 
   private getFilterFacetCount(isFoldingEnabled: boolean) {
-    if (Utils.isUndefined(this.options.filterFacetCount)) {
+    if (Utils.isUndefined(this.request.filterFacetCount)) {
       return !isFoldingEnabled;
     }
 
-    return this.options.filterFacetCount;
+    return this.request.filterFacetCount;
   }
 }

--- a/src/controllers/DynamicFacetRequestBuilder.ts
+++ b/src/controllers/DynamicFacetRequestBuilder.ts
@@ -1,0 +1,33 @@
+import { FacetType, IFacetRequest } from '../rest/Facet/FacetRequest';
+import { FacetSortCriteria } from '../rest/Facet/FacetSortCriteria';
+import { IQuery } from '../rest/Query';
+import { Utils } from '../utils/Utils';
+
+export interface IBasicFacetRequestParameters {
+  facetId: string;
+  field: string;
+  type: FacetType;
+  injectionDepth: number;
+  sortCriteria?: FacetSortCriteria;
+  delimitingCharacter?: string;
+  filterFacetCount?: boolean;
+}
+
+export class DynamicFacetRequestBuilder {
+  constructor(private options: IBasicFacetRequestParameters) {}
+
+  public buildRequestForQuery(query: IQuery): IFacetRequest {
+    return {
+      ...this.options,
+      filterFacetCount: this.getFilterFacetCount(!!query.filterField)
+    };
+  }
+
+  private getFilterFacetCount(isFoldingEnabled: boolean) {
+    if (Utils.isUndefined(this.options.filterFacetCount)) {
+      return !isFoldingEnabled;
+    }
+
+    return this.options.filterFacetCount;
+  }
+}

--- a/src/controllers/DynamicHierarchicalFacetQueryController.ts
+++ b/src/controllers/DynamicHierarchicalFacetQueryController.ts
@@ -56,7 +56,7 @@ export class DynamicHierarchicalFacetQueryController {
 
   public buildFacetRequest(query: IQuery): IFacetRequest {
     return {
-      ...this.requestBuilder.buildRequestForQuery(query),
+      ...this.requestBuilder.buildBaseRequestForQuery(query),
       currentValues: this.currentValues,
       numberOfValues: this.facet.values.hasSelectedValue ? 1 : this.numberOfValuesToRequest,
       isFieldExpanded: this.numberOfValuesToRequest > this.facet.options.numberOfValues

--- a/src/controllers/DynamicHierarchicalFacetQueryController.ts
+++ b/src/controllers/DynamicHierarchicalFacetQueryController.ts
@@ -6,14 +6,23 @@ import { FacetValueState } from '../rest/Facet/FacetValueState';
 import { IQueryResults } from '../rest/QueryResults';
 import { findIndex } from 'underscore';
 import { IDynamicHierarchicalFacet, IDynamicHierarchicalFacetValue } from '../ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet';
-import { Utils } from '../utils/Utils';
+import { DynamicFacetRequestBuilder } from './DynamicFacetRequestBuilder';
+import { IQuery } from '../rest/Query';
 
 export class DynamicHierarchicalFacetQueryController {
+  private requestBuilder: DynamicFacetRequestBuilder;
   private numberOfValuesToRequest: number;
   private freezeFacetOrder = false;
-  private hasFolding = false;
 
   constructor(private facet: IDynamicHierarchicalFacet) {
+    this.requestBuilder = new DynamicFacetRequestBuilder({
+      facetId: this.facet.options.id,
+      field: this.facet.fieldName,
+      type: this.facet.facetType,
+      injectionDepth: this.facet.options.injectionDepth,
+      delimitingCharacter: this.facet.options.delimitingCharacter,
+      filterFacetCount: this.facet.options.filterFacetCount
+    });
     this.resetNumberOfValuesToRequest();
     this.resetFreezeCurrentValuesDuringQuery();
   }
@@ -39,25 +48,18 @@ export class DynamicHierarchicalFacetQueryController {
   public putFacetIntoQueryBuilder(queryBuilder: QueryBuilder) {
     Assert.exists(queryBuilder);
 
-    this.hasFolding = !!queryBuilder.filterField;
-
-    queryBuilder.facetRequests.push(this.facetRequest);
+    queryBuilder.facetRequests.push(this.buildFacetRequest(queryBuilder.build()));
     if (this.freezeFacetOrder) {
       queryBuilder.facetOptions.freezeFacetOrder = this.freezeFacetOrder;
     }
   }
 
-  public get facetRequest(): IFacetRequest {
+  public buildFacetRequest(query: IQuery): IFacetRequest {
     return {
-      facetId: this.facet.options.id,
-      field: this.facet.fieldName,
-      type: this.facet.facetType,
+      ...this.requestBuilder.buildRequestForQuery(query),
       currentValues: this.currentValues,
       numberOfValues: this.facet.values.hasSelectedValue ? 1 : this.numberOfValuesToRequest,
-      delimitingCharacter: this.facet.options.delimitingCharacter,
-      isFieldExpanded: this.numberOfValuesToRequest > this.facet.options.numberOfValues,
-      injectionDepth: this.facet.options.injectionDepth,
-      filterFacetCount: this.filterFacetCount
+      isFieldExpanded: this.numberOfValuesToRequest > this.facet.options.numberOfValues
     };
   }
 
@@ -67,26 +69,16 @@ export class DynamicHierarchicalFacetQueryController {
     // it will also alleviate the load on the index
     query.numberOfResults = 0;
 
-    this.hasFolding = !!query.filterField;
-
     const previousFacetRequestIndex = findIndex(query.facets, { facetId: this.facet.options.id });
     if (previousFacetRequestIndex !== -1) {
-      query.facets[previousFacetRequestIndex] = this.facetRequest;
+      query.facets[previousFacetRequestIndex] = this.buildFacetRequest(query);
     } else if (query.facets) {
-      query.facets.push(this.facetRequest);
+      query.facets.push(this.buildFacetRequest(query));
     } else {
-      query.facets = [this.facetRequest];
+      query.facets = [this.buildFacetRequest(query)];
     }
 
     return this.facet.queryController.getEndpoint().search(query);
-  }
-
-  protected get filterFacetCount() {
-    if (Utils.isUndefined(this.facet.options.filterFacetCount)) {
-      return !this.hasFolding;
-    }
-
-    return this.facet.options.filterFacetCount;
   }
 
   private get currentValues(): IFacetRequestValue[] {

--- a/src/rest/Facet/FacetRequest.ts
+++ b/src/rest/Facet/FacetRequest.ts
@@ -186,7 +186,9 @@ export interface IFacetRequest {
    */
   delimitingCharacter?: string;
   /**
-   * TODO: document parameter
+   * Whether to exclude folded result parents when estimating result counts for facet values.
+   *
+   * **Default (Search API):** `true`
    */
   filterFacetCount?: boolean;
 }

--- a/src/rest/Facet/FacetRequest.ts
+++ b/src/rest/Facet/FacetRequest.ts
@@ -185,4 +185,8 @@ export interface IFacetRequest {
    * **Default (Search API):** `;`
    */
   delimitingCharacter?: string;
+  /**
+   * TODO: document parameter
+   */
+  filterFacetCount?: boolean;
 }

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -234,7 +234,18 @@ export class DynamicFacet extends Component implements IDynamicFacet {
      *
      * Setting this option to a higher value may enhance the accuracy of facet value counts at the cost of slower query performance.
      */
-    injectionDepth: ComponentOptions.buildNumberOption({ defaultValue: 1000, min: 0 })
+    injectionDepth: ComponentOptions.buildNumberOption({ defaultValue: 1000, min: 0 }),
+
+    /**
+     * TODO: document option
+     *
+     * By default, the following behavior applies:
+     *
+     * - `True` when folding is not activated for the query.
+     * - `False` when folding is activated for the query.
+     * See [Folding Results](https://docs.coveo.com/en/428/).
+     */
+    filterFacetCount: ComponentOptions.buildBooleanOption({ section: 'Filtering' })
   };
 
   private includedAttributeId: string;

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -237,13 +237,11 @@ export class DynamicFacet extends Component implements IDynamicFacet {
     injectionDepth: ComponentOptions.buildNumberOption({ defaultValue: 1000, min: 0 }),
 
     /**
-     * TODO: document option
+     * Whether to exclude folded result parents when estimating result counts for facet values.
      *
-     * By default, the following behavior applies:
+     * See also the [`Folding`]{@link folding} and [`FoldingForThread`]{@link FoldingForThread} components.
      *
-     * - `True` when folding is not activated for the query.
-     * - `False` when folding is activated for the query.
-     * See [Folding Results](https://docs.coveo.com/en/428/).
+     * **Default:** `true` if folded results are requested;`false` otherwise.
      */
     filterFacetCount: ComponentOptions.buildBooleanOption({ section: 'Filtering' })
   };

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -20,7 +20,7 @@ import { MODEL_EVENTS, IAttributesChangedEventArg } from '../../models/Model';
 import { Assert } from '../../misc/Assert';
 import { IFacetResponse } from '../../rest/Facet/FacetResponse';
 import { IStringMap } from '../../rest/GenericParam';
-import { isFacetSortCriteria } from '../../rest/Facet/FacetSortCriteria';
+import { isFacetSortCriteria, FacetSortCriteria } from '../../rest/Facet/FacetSortCriteria';
 import { l } from '../../strings/Strings';
 import { DeviceUtils } from '../../utils/DeviceUtils';
 import { BreadcrumbEvents, IPopulateBreadcrumbEventArgs } from '../../events/BreadcrumbEvents';
@@ -136,7 +136,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
      * @examples score
      */
     sortCriteria: ComponentOptions.buildStringOption({
-      postProcessing: value => (isFacetSortCriteria(value) ? value : undefined),
+      postProcessing: value => (isFacetSortCriteria(value) ? (value as FacetSortCriteria) : undefined),
       section: 'Sorting'
     }),
 

--- a/src/ui/DynamicFacet/IDynamicFacet.ts
+++ b/src/ui/DynamicFacet/IDynamicFacet.ts
@@ -12,12 +12,13 @@ import { IFacetResponseValue, IFacetResponse } from '../../rest/Facet/FacetRespo
 import { IRangeValue } from '../../rest/RangeValue';
 import { FacetValueState } from '../../rest/Facet/FacetValueState';
 import { DynamicFacetHeader } from './DynamicFacetHeader/DynamicFacetHeader';
+import { FacetSortCriteria } from '../../rest/Facet/FacetSortCriteria';
 
 export interface IDynamicFacetOptions extends IResponsiveComponentOptions {
   id?: string;
   title?: string;
   field?: IFieldOption;
-  sortCriteria?: string;
+  sortCriteria?: FacetSortCriteria;
   numberOfValues?: number;
   enableCollapse?: boolean;
   enableScrollToTop?: boolean;

--- a/src/ui/DynamicFacet/IDynamicFacet.ts
+++ b/src/ui/DynamicFacet/IDynamicFacet.ts
@@ -30,6 +30,7 @@ export interface IDynamicFacetOptions extends IResponsiveComponentOptions {
   valueCaption?: Record<string, string>;
   dependsOn?: string;
   injectionDepth?: number;
+  filterFacetCount?: boolean;
 }
 
 export interface IDynamicFacet extends Component, IDynamicManagerCompatibleFacet, IAutoLayoutAdjustableInsideFacetColumn {

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -197,6 +197,17 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
      * **Default:** `undefined` and the hierarchical facet does not depend on any other facet to be displayed.
      */
     dependsOn: ComponentOptions.buildStringOption(),
+
+    /**
+     * TODO: document option
+     *
+     * By default, the following behavior applies:
+     *
+     * - `True` when folding is not activated for the query.
+     * - `False` when folding is activated for the query.
+     * See [Folding Results](https://docs.coveo.com/en/428/).
+     */
+    filterFacetCount: ComponentOptions.buildBooleanOption({ section: 'Filtering' }),
     ...ResponsiveFacetOptions
   };
 

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -199,13 +199,11 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
     dependsOn: ComponentOptions.buildStringOption(),
 
     /**
-     * TODO: document option
+     * Whether to exclude folded result parents when estimating result counts for facet values.
      *
-     * By default, the following behavior applies:
+     * See also the [`Folding`]{@link folding} and [`FoldingForThread`]{@link FoldingForThread} components.
      *
-     * - `True` when folding is not activated for the query.
-     * - `False` when folding is activated for the query.
-     * See [Folding Results](https://docs.coveo.com/en/428/).
+     * **Default:** `true` if folded results are requested;`false` otherwise.
      */
     filterFacetCount: ComponentOptions.buildBooleanOption({ section: 'Filtering' }),
     ...ResponsiveFacetOptions

--- a/src/ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet.ts
@@ -26,6 +26,7 @@ export interface IDynamicHierarchicalFacetOptions extends IResponsiveComponentOp
   valueCaption?: IStringMap<string>;
   dependsOn?: string;
   includeInBreadcrumb?: boolean;
+  filterFacetCount?: boolean;
 }
 
 export interface IDynamicHierarchicalFacet extends Component, IDynamicManagerCompatibleFacet, IAutoLayoutAdjustableInsideFacetColumn {

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -747,6 +747,9 @@ DynamicFacetSearchValueRendererTest();
 import { DynamicFacetBreadcrumbsTest } from './ui/DynamicFacet/DynamicFacetBreadcrumbsTest';
 DynamicFacetBreadcrumbsTest();
 
+import { DynamicFacetRequestBuilderTest } from './controllers/DynamicFacetRequestBuilderTest';
+DynamicFacetRequestBuilderTest();
+
 import { DynamicFacetQueryControllerTest } from './controllers/DynamicFacetQueryControllerTest';
 DynamicFacetQueryControllerTest();
 

--- a/unitTests/controllers/DynamicFacetQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicFacetQueryControllerTest.ts
@@ -34,7 +34,7 @@ export function DynamicFacetQueryControllerTest() {
     }
 
     function facetRequest() {
-      return dynamicFacetQueryController.facetRequest;
+      return dynamicFacetQueryController.buildFacetRequest(queryBuilder.build());
     }
 
     function queryFacetRequests() {
@@ -63,7 +63,9 @@ export function DynamicFacetQueryControllerTest() {
     });
 
     it('should send the injectionDepth', () => {
-      facet.options.injectionDepth = 15;
+      facetOptions.injectionDepth = 15;
+      initializeComponents();
+
       expect(facetRequest().injectionDepth).toBe(15);
     });
 
@@ -237,7 +239,7 @@ export function DynamicFacetQueryControllerTest() {
         dynamicFacetQueryController.getQueryResults();
         expect(mockEndpoint.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            facets: [dynamicFacetQueryController.facetRequest]
+            facets: [dynamicFacetQueryController.buildFacetRequest(new QueryBuilder().build())]
           })
         );
       });
@@ -251,7 +253,7 @@ export function DynamicFacetQueryControllerTest() {
 
         expect(mockEndpoint.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            facets: [queryFacetRequests()[0], dynamicFacetQueryController.facetRequest]
+            facets: [queryFacetRequests()[0], dynamicFacetQueryController.buildFacetRequest(new QueryBuilder().build())]
           })
         );
       });

--- a/unitTests/controllers/DynamicFacetQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicFacetQueryControllerTest.ts
@@ -50,23 +50,12 @@ export function DynamicFacetQueryControllerTest() {
       expect(queryFacetRequests().length).toBe(1);
     });
 
-    it('should send the facet id', () => {
+    it('should send the right basic facetRequest parameters', () => {
       expect(facetRequest().facetId).toBe(facet.options.id);
-    });
-
-    it('should send the field without the "@"', () => {
-      expect(facetRequest().field).toBe('field');
-    });
-
-    it('should send the facet type', () => {
+      expect(facetRequest().field).toBe(facet.fieldName);
       expect(facetRequest().type).toBe(facet.facetType);
-    });
-
-    it('should send the injectionDepth', () => {
-      facetOptions.injectionDepth = 15;
-      initializeComponents();
-
-      expect(facetRequest().injectionDepth).toBe(15);
+      expect(facetRequest().sortCriteria).toBe(facet.options.sortCriteria);
+      expect(facetRequest().injectionDepth).toBe(facet.options.injectionDepth);
     });
 
     it('should send the current values', () => {

--- a/unitTests/controllers/DynamicFacetRangeQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicFacetRangeQueryControllerTest.ts
@@ -2,6 +2,7 @@ import { DynamicFacetRangeQueryController } from '../../src/controllers/DynamicF
 import { DynamicFacetRangeTestUtils } from '../ui/DynamicFacet/DynamicFacetRangeTestUtils';
 import { DynamicFacetRange } from '../../src/ui/DynamicFacet/DynamicFacetRange';
 import { IDynamicFacetRangeOptions } from '../../src/ui/DynamicFacet/IDynamicFacetRange';
+import { QueryBuilder } from '../../src/Core';
 
 export function DynamicFacetRangeQueryControllerTest() {
   describe('DynamicFacetRangeQueryController', () => {
@@ -22,7 +23,7 @@ export function DynamicFacetRangeQueryControllerTest() {
     }
 
     function facetRequest() {
-      return dynamicFacetRangeQueryController.facetRequest;
+      return dynamicFacetRangeQueryController.buildFacetRequest(new QueryBuilder().build());
     }
 
     function facetValues() {

--- a/unitTests/controllers/DynamicFacetRangeQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicFacetRangeQueryControllerTest.ts
@@ -30,19 +30,11 @@ export function DynamicFacetRangeQueryControllerTest() {
       return facet.values.allFacetValues;
     }
 
-    it('should send the facet id', () => {
+    it('should send the right basic facetRequest parameters', () => {
       expect(facetRequest().facetId).toBe(facet.options.id);
-    });
-
-    it('should send the field without the "@"', () => {
-      expect(facetRequest().field).toBe('field');
-    });
-
-    it('should send the facet type', () => {
+      expect(facetRequest().field).toBe(facet.fieldName);
       expect(facetRequest().type).toBe(facet.facetType);
-    });
-
-    it('should send the injectionDepth', () => {
+      expect(facetRequest().sortCriteria).toBe(facet.options.sortCriteria);
       expect(facetRequest().injectionDepth).toBe(facet.options.injectionDepth);
     });
 

--- a/unitTests/controllers/DynamicFacetRequestBuilderTest.ts
+++ b/unitTests/controllers/DynamicFacetRequestBuilderTest.ts
@@ -16,7 +16,7 @@ export function DynamicFacetRequestBuilderTest() {
 
     describe('testing "filterFacetCount"', () => {
       it(`when "filterFacetCount" is not initially defined
-      when the "query" as no "filterField" defined
+      when the "query" has no "filterField" defined
       "filterFacetCount" should be "true"`, () => {
         initializeRequestBuilder();
         const query = new QueryBuilder().build();
@@ -24,7 +24,7 @@ export function DynamicFacetRequestBuilderTest() {
       });
 
       it(`when "filterFacetCount" is not initially defined
-      when the "query" as a "filterField" defined
+      when the "query" has a "filterField" defined
       "filterFacetCount" should be "false"`, () => {
         initializeRequestBuilder();
         const query = new QueryBuilder().build();

--- a/unitTests/controllers/DynamicFacetRequestBuilderTest.ts
+++ b/unitTests/controllers/DynamicFacetRequestBuilderTest.ts
@@ -1,0 +1,44 @@
+import { DynamicFacetRequestBuilder } from '../../src/controllers/DynamicFacetRequestBuilder';
+import { IFacetRequest } from '../../src/rest/Facet/FacetRequest';
+import { QueryBuilder } from '../../src/Core';
+
+export function DynamicFacetRequestBuilderTest() {
+  describe('DynamicFacetRequestBuilder', () => {
+    let requestBuilder: DynamicFacetRequestBuilder;
+    let facetRequest: IFacetRequest = {
+      facetId: 'id_facet',
+      field: 'field'
+    };
+
+    function initializeRequestBuilder() {
+      requestBuilder = new DynamicFacetRequestBuilder(facetRequest);
+    }
+
+    describe('testing "filterFacetCount"', () => {
+      it(`when "filterFacetCount" is not initially defined
+      when the "query" as no "filterField" defined
+      "filterFacetCount" should be "true"`, () => {
+        initializeRequestBuilder();
+        const query = new QueryBuilder().build();
+        expect(requestBuilder.buildBaseRequestForQuery(query).filterFacetCount).toBe(true);
+      });
+
+      it(`when "filterFacetCount" is not initially defined
+      when the "query" as a "filterField" defined
+      "filterFacetCount" should be "false"`, () => {
+        initializeRequestBuilder();
+        const query = new QueryBuilder().build();
+        query.filterField = '@foldingCollection';
+        expect(requestBuilder.buildBaseRequestForQuery(query).filterFacetCount).toBe(false);
+      });
+
+      it(`when "filterFacetCount" is initially defined
+      "filterFacetCount" should stay the same`, () => {
+        facetRequest.filterFacetCount = false;
+        initializeRequestBuilder();
+        const query = new QueryBuilder().build();
+        expect(requestBuilder.buildBaseRequestForQuery(query).filterFacetCount).toBe(false);
+      });
+    });
+  });
+}

--- a/unitTests/controllers/DynamicHierarchicalFacetQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicHierarchicalFacetQueryControllerTest.ts
@@ -34,7 +34,7 @@ export function DynamicHierarchicalFacetQueryControllerTest() {
     }
 
     function facetRequest() {
-      return dynamicHierarchicalFacetQueryController.facetRequest;
+      return dynamicHierarchicalFacetQueryController.buildFacetRequest(queryBuilder.build());
     }
 
     function queryFacetRequests() {
@@ -180,7 +180,7 @@ export function DynamicHierarchicalFacetQueryControllerTest() {
         dynamicHierarchicalFacetQueryController.getQueryResults();
         expect(mockEndpoint.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            facets: [dynamicHierarchicalFacetQueryController.facetRequest]
+            facets: [dynamicHierarchicalFacetQueryController.buildFacetRequest(new QueryBuilder().build())]
           })
         );
       });
@@ -194,7 +194,7 @@ export function DynamicHierarchicalFacetQueryControllerTest() {
 
         expect(mockEndpoint.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            facets: [queryFacetRequests()[0], dynamicHierarchicalFacetQueryController.facetRequest]
+            facets: [queryFacetRequests()[0], dynamicHierarchicalFacetQueryController.buildFacetRequest(new QueryBuilder().build())]
           })
         );
       });

--- a/unitTests/controllers/DynamicHierarchicalFacetQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicHierarchicalFacetQueryControllerTest.ts
@@ -45,23 +45,11 @@ export function DynamicHierarchicalFacetQueryControllerTest() {
       return queryBuilder.build().facetOptions;
     }
 
-    it('should send the field without the "@"', () => {
-      expect(facetRequest().field).toBe(facet.fieldName);
-    });
-
-    it('should send the facet type', () => {
-      expect(facetRequest().type).toBe(facet.facetType);
-    });
-
-    it('should send the delimitingCharacter', () => {
-      expect(facetRequest().delimitingCharacter).toBe(facet.options.delimitingCharacter);
-    });
-
-    it('should send the facet id', () => {
+    it('should send the right basic facetRequest parameters', () => {
       expect(facetRequest().facetId).toBe(facet.options.id);
-    });
-
-    it('should send the injectionDepth', () => {
+      expect(facetRequest().field).toBe(facet.fieldName);
+      expect(facetRequest().type).toBe(facet.facetType);
+      expect(facetRequest().delimitingCharacter).toBe(facet.options.delimitingCharacter);
       expect(facetRequest().injectionDepth).toBe(facet.options.injectionDepth);
     });
 


### PR DESCRIPTION
After thinking about it, having a "basic" request builder works pretty well in this situation. The refactor wasn't so big (worst is the renaming of `buildFacetRequest` with the additional parameter).
Thanks @olamothe for the suggestion!

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)