### PR TITLE
JSUI-2627 The FacetValueSuggestions component is missing a data-expression property, creating invalid suggestions for a filtered search interface

### DIFF
--- a/src/ui/FacetValueSuggestions/FacetValueSuggestions.ts
+++ b/src/ui/FacetValueSuggestions/FacetValueSuggestions.ts
@@ -53,7 +53,7 @@ export class FacetValueSuggestions extends Component {
   static options: IFacetValueSuggestionsOptions = {
     /**
      * The field on whose values the scoped query suggestions should be based.
-     * el campo que tiene los valores en los que las sugerencias estan basadas
+     *
      * Specifying a value for this option is required for the component to work.
      *
      * @examples @productcategory

--- a/src/ui/FacetValueSuggestions/FacetValueSuggestions.ts
+++ b/src/ui/FacetValueSuggestions/FacetValueSuggestions.ts
@@ -23,6 +23,7 @@ export interface IFacetValueSuggestionsOptions {
   useQuerySuggestions?: boolean;
   useValueFromSearchbox?: boolean;
   displayEstimateNumberOfResults?: boolean;
+  expression?: string;
   templateHelper?: (row: IFacetValueSuggestionRow, omnibox: Omnibox) => string;
 }
 
@@ -52,7 +53,7 @@ export class FacetValueSuggestions extends Component {
   static options: IFacetValueSuggestionsOptions = {
     /**
      * The field on whose values the scoped query suggestions should be based.
-     *
+     * el campo que tiene los valores en los que las sugerencias estan basadas
      * Specifying a value for this option is required for the component to work.
      *
      * @examples @productcategory
@@ -141,7 +142,16 @@ export class FacetValueSuggestions extends Component {
      *
      * @examples ;, #
      */
-    categoryFieldDelimitingCharacter: ComponentOptions.buildStringOption({ defaultValue: '|', depend: 'isCategoryField' })
+    categoryFieldDelimitingCharacter: ComponentOptions.buildStringOption({ defaultValue: '|', depend: 'isCategoryField' }),
+    /**
+     * Specifies an expression to add when looking for suggestions on the facet values
+     *
+     * **Example:**
+     *
+     * `@objecttype==Message`
+     *
+     */
+    expression: ComponentOptions.buildQueryExpressionOption()
   };
 
   public facetValueSuggestionsProvider: IFacetValueSuggestionsProvider;
@@ -169,9 +179,9 @@ export class FacetValueSuggestions extends Component {
   }
 
   /**
-   * Creates a new `FieldSuggestions` component.
+   * Creates a new `FacetValueSuggestions` component.
    * @param element The HTMLElement on which to instantiate the component.
-   * @param options The options for the `FieldSuggestions` component.
+   * @param options The options for the `FacetValueSuggestions` component.
    * @param bindings The bindings that the component requires to function normally. If not set, these will be
    * automatically resolved (with a slower execution time).
    */
@@ -181,7 +191,8 @@ export class FacetValueSuggestions extends Component {
     this.options = ComponentOptions.initComponentOptions(element, FacetValueSuggestions, options);
 
     this.facetValueSuggestionsProvider = new FacetValueSuggestionsProvider(this.queryController, {
-      field: <string>this.options.field
+      field: <string>this.options.field,
+      expression: this.options.expression
     });
     this.queryStateFieldFacetId = `f:${this.options.field}`;
 

--- a/src/ui/FacetValueSuggestions/FacetValueSuggestionsProvider.ts
+++ b/src/ui/FacetValueSuggestions/FacetValueSuggestionsProvider.ts
@@ -97,9 +97,16 @@ export class FacetValueSuggestionsProvider implements IFacetValueSuggestionsProv
     // The reference request will be used to get the maximum number of values for a given facet value.
     const referenceValuesRequest = this.buildReferenceFieldValueRequest();
     const queryParts = this.getQueryToExecuteParts();
-    const suggestionValuesRequests = valuesToSearch.map(keyword =>
-      this.buildListFieldValueRequest([...queryParts, ...[this.options.expression].filter(exp => !!exp), keyword.text].join(' '))
-    );
+
+    if (this.options.expression) {
+      queryParts.push(this.options.expression);
+    }
+
+    const suggestionValuesRequests = valuesToSearch.map(keyword => {
+      const queryToExecute = [...queryParts, keyword.text].join(' ');
+      return this.buildListFieldValueRequest(queryToExecute);
+    });
+
     const requests = [...suggestionValuesRequests, referenceValuesRequest];
     const values = await this.queryController.getEndpoint().listFieldValuesBatch({
       batch: requests

--- a/src/ui/FacetValueSuggestions/FacetValueSuggestionsProvider.ts
+++ b/src/ui/FacetValueSuggestions/FacetValueSuggestionsProvider.ts
@@ -57,6 +57,7 @@ type IFacetValueReference = {
  */
 export interface IFacetValueSuggestionsProviderOptions {
   field: string;
+  expression?: string;
 }
 
 /**
@@ -97,7 +98,7 @@ export class FacetValueSuggestionsProvider implements IFacetValueSuggestionsProv
     const referenceValuesRequest = this.buildReferenceFieldValueRequest();
     const queryParts = this.getQueryToExecuteParts();
     const suggestionValuesRequests = valuesToSearch.map(keyword =>
-      this.buildListFieldValueRequest([...queryParts, keyword.text].join(' '))
+      this.buildListFieldValueRequest([...queryParts, ...[this.options.expression].filter(exp => !!exp), keyword.text].join(' '))
     );
     const requests = [...suggestionValuesRequests, referenceValuesRequest];
     const values = await this.queryController.getEndpoint().listFieldValuesBatch({

--- a/unitTests/ui/FacetValueSuggestionsProviderTest.ts
+++ b/unitTests/ui/FacetValueSuggestionsProviderTest.ts
@@ -17,12 +17,6 @@ export function FacetValueSuggestionsProviderTest() {
     const referenceFieldNumberOfResults = 10;
     const suggestion = 'suggestion';
 
-    const baseFieldValueRequest = {
-      field: someField,
-      ignoreAccents: true,
-      maximumNumberOfValues: 3
-    };
-
     const setUpLastQuery = (aq: string = '', cq: string = '') => {
       (<jasmine.Spy>environment.queryController.getLastQuery).and.returnValue({
         aq,
@@ -68,7 +62,9 @@ export function FacetValueSuggestionsProviderTest() {
       expect(environment.searchEndpoint.listFieldValuesBatch).toHaveBeenCalledWith({
         batch: <IListFieldValuesRequest[]>[
           {
-            ...baseFieldValueRequest,
+            field: someField,
+            ignoreAccents: true,
+            maximumNumberOfValues: 3,
             queryOverride: valueToSearch.text
           },
           {
@@ -126,21 +122,17 @@ export function FacetValueSuggestionsProviderTest() {
         });
       });
 
-      it(`should execute listFieldValuesBatch with value to search,
-          the additional expression and reference`, async done => {
+      it(`should execute listFieldValuesBatch with queryOverride containing an additional expression`, async done => {
         await test.getSuggestions([valueToSearch]);
 
         expect(environment.searchEndpoint.listFieldValuesBatch).toHaveBeenCalledWith({
-          batch: <IListFieldValuesRequest[]>[
-            {
-              ...baseFieldValueRequest,
-              queryOverride: `${anExpression} ${valueToSearch.text}`
-            },
-            {
-              field: someField
-            }
-          ]
+          batch: jasmine.arrayContaining([
+            jasmine.objectContaining({
+              queryOverride: jasmine.stringMatching(`${anExpression}`)
+            })
+          ])
         });
+
         done();
       });
     });


### PR DESCRIPTION
Add an expression property to FacetValueSuggestions

Update FacetValueSuggestionProvider to append the expression in queryOverride

Add unit test

https://coveord.atlassian.net/browse/JSUI-2627





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)