### PR TITLE
Fixed default template for `QuerySuggestPreview` in Firefox

### DIFF
--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -120,7 +120,7 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
     return HtmlTemplate.create(
       $$(
         'div',
-        { className: 'result-template', type: 'text/html' },
+        { className: 'result-template' },
         $$(
           'div',
           { className: 'coveo-result-frame coveo-default-result-preview' },

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -119,7 +119,7 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
   private buildDefaultSearchResultPreviewTemplate() {
     return HtmlTemplate.create(
       $$(
-        'script',
+        'div',
         { className: 'result-template', type: 'text/html' },
         $$(
           'div',

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -139,6 +139,12 @@ export function QuerySuggestPreviewTest() {
       done();
     });
 
+    it('builds a default template with a div tag', () => {
+      const template = test.cmp['buildDefaultSearchResultPreviewTemplate']();
+      // A div tag is used instead of a script tag because Firefox doesn't support appending elements to a script tag.
+      expect(template.element.tagName).toEqual('div');
+    });
+
     describe('with accessibility', () => {
       describe('with a ResultLink in the template', () => {
         beforeEach(() => {

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -142,7 +142,7 @@ export function QuerySuggestPreviewTest() {
     it('builds a default template with a div tag', () => {
       const template = test.cmp['buildDefaultSearchResultPreviewTemplate']();
       // A div tag is used instead of a script tag because Firefox doesn't support appending elements to a script tag.
-      expect(template.element.tagName).toEqual('div');
+      expect(template.element.tagName.toLowerCase()).toEqual('div');
     });
 
     describe('with accessibility', () => {


### PR DESCRIPTION
Firefox couldn't append children to a `script` tag, so this fix changes `QuerySuggestPreview`'s `script` tag for a `div`.

https://coveord.atlassian.net/browse/JSUI-2768

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)