### PR TITLE
JSUI-2788 Ignore facets results of dynamic facets outside the manager

### DIFF
--- a/src/ui/DynamicFacetManager/DynamicFacetManager.ts
+++ b/src/ui/DynamicFacetManager/DynamicFacetManager.ts
@@ -193,7 +193,7 @@ export class DynamicFacetManager extends Component {
   }
 
   private mapResponseToComponents(facetsResponse: IFacetResponse[]) {
-    const facetsInResponse = facetsResponse.map(({ facetId }) => this.getFacetComponentById(facetId)).filter(Utils.exists);
+    const facetsInResponse = facetsResponse.map(({ facetId }) => this.getChildFacetWithId(facetId)).filter(Utils.exists);
     const facetsNotInResponse = without(this.childrenFacets, ...facetsInResponse);
 
     facetsInResponse.forEach(facet => facet.enable());
@@ -255,15 +255,8 @@ export class DynamicFacetManager extends Component {
     });
   }
 
-  private getFacetComponentById(id: string) {
-    const facet = find(this.childrenFacets, facet => facet.options.id === id);
-
-    if (!facet) {
-      this.logger.error(`Cannot find facet component with an id equal to "${id}".`);
-      return null;
-    }
-
-    return facet;
+  private getChildFacetWithId(id: string) {
+    return find(this.childrenFacets, facet => facet.options.id === id);
   }
 
   private notImplementedError() {

--- a/unitTests/ui/DynamicFacetManagerTest.ts
+++ b/unitTests/ui/DynamicFacetManagerTest.ts
@@ -145,13 +145,30 @@ export function DynamicFacetManagerTest() {
       expect(facetIsInRequest).toBe(false);
     });
 
-    it('should reorder the facets in the DOM according to order of the query results', () => {
+    it('should reorder the facets in the DOM according to order of the query facets results', () => {
       triggerAfterComponentsInitialization();
       triggerQuerySuccess(queryFacetsResponse());
 
       expect(managerContainerChildren()[0]).toBe(facets[1].element);
       expect(managerContainerChildren()[1]).toBe(facets[2].element);
       expect(managerContainerChildren()[2]).toBe(facets[0].element);
+    });
+
+    it('should not create addional number of facets in the DOM after each results', () => {
+      triggerAfterComponentsInitialization();
+      triggerQuerySuccess(queryFacetsResponse());
+      triggerQuerySuccess(queryFacetsResponse());
+
+      expect(managerContainerChildren().length).toBe(3);
+    });
+
+    it('should ignore query facets results that are not children of the manager', () => {
+      triggerAfterComponentsInitialization();
+      const externalFacet = DynamicFacetTestUtils.createAdvancedFakeFacet({ field: '@anotherField', numberOfValues: 1 }).cmp;
+      const additionalFacetResult = DynamicFacetTestUtils.getCompleteFacetResponse(externalFacet);
+      triggerQuerySuccess([additionalFacetResult, ...queryFacetsResponse()]);
+
+      expect(managerContainerChildren().length).toBe(3);
     });
 
     it(`when the "enableReorder" option is "false"


### PR DESCRIPTION
Remove the uncessary logger error that was logged when a facet response was not in the manager. 
https://coveord.atlassian.net/browse/JSUI-2788





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)