### PR TITLE
Making sure querySuccess is handled in each dynamic facets before the manager

### DIFF
--- a/src/ui/DynamicFacetManager/DynamicFacetManager.ts
+++ b/src/ui/DynamicFacetManager/DynamicFacetManager.ts
@@ -141,7 +141,8 @@ export class DynamicFacetManager extends Component {
   private initEvents() {
     this.bind.onRootElement(InitializationEvents.afterComponentsInitialization, () => this.handleAfterComponentsInitialization());
     this.bind.onRootElement(QueryEvents.doneBuildingQuery, (data: IDoneBuildingQueryEventArgs) => this.handleDoneBuildingQuery(data));
-    this.bind.onRootElement(QueryEvents.querySuccess, (data: IQuerySuccessEventArgs) => this.handleQuerySuccess(data));
+    // Making sure querySuccess is handled in each dynamic facets before the manager
+    this.bind.onRootElement(QueryEvents.querySuccess, (data: IQuerySuccessEventArgs) => setTimeout(() => this.handleQuerySuccess(data), 0));
   }
 
   private isDynamicFacet(component: Component) {


### PR DESCRIPTION
Could of used DeferredQuerySuccess instead, but I can see a small visual glitch sometimes when I do it due to the delay.
https://coveord.atlassian.net/browse/JSUI-2789





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)