### PR TITLE
JSUI-2796 Added keyboard navigation for `FacetSettings`

### DIFF
--- a/unitTests/ui/FacetSettingsTest.ts
+++ b/unitTests/ui/FacetSettingsTest.ts
@@ -120,6 +120,17 @@ export function FacetSettingsTest() {
         Simulate.keyUp(facetSettings.settingsButton, KEYBOARD.ENTER);
         expect(settingsPopup()).toBeNull();
       });
+
+      it('closes the popup when losing focus', () => {
+        Simulate.keyUp(facetSettings.settingsButton, KEYBOARD.ENTER);
+        $$(settingsPopup()).trigger('focusout');
+        expect(settingsPopup()).toBeNull();
+      });
+
+      it('appends the settings popup after the button', () => {
+        Simulate.keyUp(facetSettings.settingsButton, KEYBOARD.ENTER);
+        expect(settingsPopup().previousSibling).toEqual(facetSettings.settingsButton);
+      });
     });
 
     it('should show collapse/expand section if it is not disabled from the facet', async done => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2796

Added `Tab` and `Shift + Tab` keyboard navigation for `FacetSettings` along with some accessibility attributes.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)