### PR TITLE
JSUI-2789 Making sure querySuccess is handled in each dynamic facets before the manager

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -602,9 +602,10 @@ export class DynamicFacet extends Component implements IDynamicFacet {
   public handleQueryResults(results: IQueryResults) {
     const index = findIndex(results.facets, { facetId: this.options.id });
     const facetResponse = index !== -1 ? results.facets[index] : null;
-    this.position = index + 1;
 
+    this.position = facetResponse ? index + 1 : null;
     facetResponse ? this.onNewValues(facetResponse) : this.onNoValues();
+
     this.header.hideLoading();
     this.updateQueryStateModel();
     this.values.render();

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -587,25 +587,33 @@ export class DynamicFacet extends Component implements IDynamicFacet {
   }
 
   private handleQuerySuccess(results: IQueryResults) {
-    this.header.hideLoading();
+    // If there is a DynamicFacetManager, it will take care of handling the results
+    if (this.dynamicFacetManager) {
+      return;
+    }
 
     if (Utils.isNullOrUndefined(results.facets)) {
       return this.notImplementedError();
     }
 
+    this.handleQueryResults(results);
+  }
+
+  public handleQueryResults(results: IQueryResults) {
     const index = findIndex(results.facets, { facetId: this.options.id });
-    const response = index !== -1 ? results.facets[index] : null;
+    const facetResponse = index !== -1 ? results.facets[index] : null;
     this.position = index + 1;
 
-    response ? this.onQueryResponse(response) : this.onNoValues();
+    facetResponse ? this.onNewValues(facetResponse) : this.onNoValues();
+    this.header.hideLoading();
     this.updateQueryStateModel();
     this.values.render();
     this.updateAppearance();
   }
 
-  private onQueryResponse(response: IFacetResponse) {
-    this.moreValuesAvailable = response.moreValuesAvailable;
-    this.values.createFromResponse(response);
+  private onNewValues(facetResponse: IFacetResponse) {
+    this.moreValuesAvailable = facetResponse.moreValuesAvailable;
+    this.values.createFromResponse(facetResponse);
   }
 
   private onNoValues() {
@@ -753,7 +761,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
 
     try {
       const results = await this.dynamicFacetQueryController.getQueryResults();
-      this.handleQuerySuccess(results);
+      this.handleQueryResults(results);
     } catch (e) {
       this.header.hideLoading();
     }

--- a/src/ui/DynamicFacetManager/DynamicFacetManager.ts
+++ b/src/ui/DynamicFacetManager/DynamicFacetManager.ts
@@ -141,7 +141,8 @@ export class DynamicFacetManager extends Component {
   private initEvents() {
     this.bind.onRootElement(InitializationEvents.afterComponentsInitialization, () => this.handleAfterComponentsInitialization());
     this.bind.onRootElement(QueryEvents.doneBuildingQuery, (data: IDoneBuildingQueryEventArgs) => this.handleDoneBuildingQuery(data));
-    this.bind.onRootElement(QueryEvents.querySuccess, (data: IQuerySuccessEventArgs) => this.handleQuerySuccess(data));
+    // Making sure querySuccess is handled in each dynamic facets before the manager
+    this.bind.onRootElement(QueryEvents.querySuccess, (data: IQuerySuccessEventArgs) => setTimeout(() => this.handleQuerySuccess(data), 0));
   }
 
   private isDynamicFacet(component: Component) {

--- a/src/ui/DynamicFacetManager/DynamicFacetManager.ts
+++ b/src/ui/DynamicFacetManager/DynamicFacetManager.ts
@@ -12,6 +12,7 @@ import { Initialization } from '../Base/Initialization';
 import { ComponentsTypes } from '../../utils/ComponentsTypes';
 import { QueryBuilder } from '../Base/QueryBuilder';
 import { IAutoLayoutAdjustableInsideFacetColumn } from '../SearchInterface/FacetColumnAutoLayoutAdjustment';
+import { IQueryResults } from '../../rest/QueryResults';
 
 export interface IDynamicFacetManagerOptions {
   enableReorder?: boolean;
@@ -34,6 +35,7 @@ export interface IDynamicManagerCompatibleFacet extends Component, IAutoLayoutAd
   hasActiveValues: boolean;
   isDynamicFacet: boolean;
 
+  handleQueryResults(results: IQueryResults): void;
   putStateIntoQueryBuilder(queryBuilder: QueryBuilder): void;
   putStateIntoAnalytics(): void;
   expand(): void;
@@ -141,8 +143,7 @@ export class DynamicFacetManager extends Component {
   private initEvents() {
     this.bind.onRootElement(InitializationEvents.afterComponentsInitialization, () => this.handleAfterComponentsInitialization());
     this.bind.onRootElement(QueryEvents.doneBuildingQuery, (data: IDoneBuildingQueryEventArgs) => this.handleDoneBuildingQuery(data));
-    // Making sure querySuccess is handled in each dynamic facets before the manager
-    this.bind.onRootElement(QueryEvents.querySuccess, (data: IQuerySuccessEventArgs) => setTimeout(() => this.handleQuerySuccess(data), 0));
+    this.bind.onRootElement(QueryEvents.querySuccess, (data: IQuerySuccessEventArgs) => this.handleQuerySuccess(data));
   }
 
   private isDynamicFacet(component: Component) {
@@ -185,6 +186,10 @@ export class DynamicFacetManager extends Component {
     if (Utils.isNullOrUndefined(data.results.facets)) {
       return this.notImplementedError();
     }
+
+    this.enabledFacets.forEach(dynamicFacet => {
+      dynamicFacet.handleQueryResults(data.results);
+    });
 
     if (this.options.enableReorder) {
       this.mapResponseToComponents(data.results.facets);

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -322,25 +322,33 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
   }
 
   private handleQuerySuccess(results: IQueryResults) {
-    this.header.hideLoading();
+    // If there is a DynamicFacetManager, it will take care of handling the results
+    if (this.dynamicFacetManager) {
+      return;
+    }
 
     if (Utils.isNullOrUndefined(results.facets)) {
       return this.notImplementedError();
     }
 
+    this.handleQueryResults(results);
+  }
+
+  public handleQueryResults(results: IQueryResults) {
     const index = findIndex(results.facets, { facetId: this.options.id });
-    const response = index !== -1 ? results.facets[index] : null;
+    const facetResponse = index !== -1 ? results.facets[index] : null;
     this.position = index + 1;
 
-    response ? this.onQueryResponse(response) : this.onNoValues();
-    this.values.render();
+    facetResponse ? this.onNewValues(facetResponse) : this.onNoValues();
+    this.header.hideLoading();
     this.updateQueryStateModel(this.values.selectedPath);
+    this.values.render();
     this.updateAppearance();
   }
 
-  private onQueryResponse(response: IFacetResponse) {
-    this.moreValuesAvailable = response.moreValuesAvailable;
-    this.values.createFromResponse(response);
+  private onNewValues(facetResponse: IFacetResponse) {
+    this.moreValuesAvailable = facetResponse.moreValuesAvailable;
+    this.values.createFromResponse(facetResponse);
   }
 
   private onNoValues() {
@@ -370,7 +378,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
 
     try {
       const results = await this.dynamicHierarchicalFacetQueryController.getQueryResults();
-      this.handleQuerySuccess(results);
+      this.handleQueryResults(results);
     } catch (e) {
       this.header.hideLoading();
     }

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -337,9 +337,10 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
   public handleQueryResults(results: IQueryResults) {
     const index = findIndex(results.facets, { facetId: this.options.id });
     const facetResponse = index !== -1 ? results.facets[index] : null;
-    this.position = index + 1;
 
+    this.position = facetResponse ? index + 1 : null;
     facetResponse ? this.onNewValues(facetResponse) : this.onNoValues();
+
     this.header.hideLoading();
     this.updateQueryStateModel(this.values.selectedPath);
     this.values.render();

--- a/unitTests/ui/DynamicFacetManagerTest.ts
+++ b/unitTests/ui/DynamicFacetManagerTest.ts
@@ -131,6 +131,37 @@ export function DynamicFacetManagerTest() {
       expect(test.cmp.disabled).toBe(false);
     });
 
+    it(`on the doneBuildingQuery event
+      should call putStateIntoQueryBuilder on it's facets`, () => {
+      triggerAfterComponentsInitialization();
+      spyOn(facets[2], 'putStateIntoQueryBuilder');
+      $$(test.env.root).trigger(QueryEvents.doneBuildingQuery, {
+        queryBuilder: new QueryBuilder()
+      });
+
+      expect(facets[2].putStateIntoQueryBuilder).toHaveBeenCalledTimes(1);
+    });
+
+    it(`on the doneBuildingQuery event
+      should call putStateIntoAnalytics on it's facets`, () => {
+      triggerAfterComponentsInitialization();
+      spyOn(facets[2], 'putStateIntoAnalytics');
+      $$(test.env.root).trigger(QueryEvents.doneBuildingQuery, {
+        queryBuilder: new QueryBuilder()
+      });
+
+      expect(facets[2].putStateIntoAnalytics).toHaveBeenCalledTimes(1);
+    });
+
+    it(`on the querySuccess event
+      should call handleQueryResults on it's facets`, () => {
+      triggerAfterComponentsInitialization();
+      spyOn(facets[2], 'handleQueryResults').and.callThrough();
+      triggerQuerySuccess(queryFacetsResponse());
+
+      expect(facets[2].handleQueryResults).toHaveBeenCalledTimes(1);
+    });
+
     it(`when a facet is disabled
     should not be sent in the request`, () => {
       const facetIndex = 0;

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTest.ts
@@ -103,18 +103,6 @@ export function DynamicHierarchicalFacetTest() {
       expect(test.cmp.facetType).toBe(FacetType.hierarchical);
     });
 
-    it('facet position should be null by default', () => {
-      expect(test.cmp.position).toBeNull();
-    });
-
-    it(`when getting successful results
-      facet position should be correct`, () => {
-      test.cmp.ensureDom();
-
-      Simulate.query(test.env, { results: fakeResultsWithFacets() });
-      expect(test.cmp.position).toBe(1);
-    });
-
     it(`when not setting a sortCriteria option
       should set it to undefined in the query`, () => {
       expect(getFirstFacetRequest().sortCriteria).toBeUndefined();

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTest.ts
@@ -1,5 +1,6 @@
 import * as Mock from '../../MockEnvironment';
 import { DynamicHierarchicalFacetTestUtils } from './DynamicHierarchicalFacetTestUtils';
+import { DynamicFacetTestUtils } from '../DynamicFacet/DynamicFacetTestUtils';
 import { DynamicHierarchicalFacet } from '../../../src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet';
 import { FacetType } from '../../../src/rest/Facet/FacetRequest';
 import { IPopulateBreadcrumbEventArgs, BreadcrumbEvents } from '../../../src/events/BreadcrumbEvents';
@@ -42,7 +43,10 @@ export function DynamicHierarchicalFacetTest() {
       spyOn(test.cmp, 'triggerNewIsolatedQuery').and.callThrough();
       spyOn(test.cmp, 'reset').and.callThrough();
       spyOn(test.cmp, 'putStateIntoQueryBuilder').and.callThrough();
+      spyOn(test.cmp, 'putStateIntoAnalytics').and.callThrough();
+      spyOn(test.cmp, 'handleQueryResults').and.callThrough();
       spyOn(test.cmp.logger, 'warn').and.callThrough();
+      spyOn(test.cmp.values, 'createFromResponse').and.callThrough();
       spyOn(test.cmp.values, 'render').and.callThrough();
       spyOn(test.cmp.values, 'selectPath').and.callThrough();
       spyOn(test.cmp.values, 'resetValues').and.callThrough();
@@ -69,10 +73,17 @@ export function DynamicHierarchicalFacetTest() {
     function fakeResultsWithFacets() {
       const fakeResultsWithFacets = FakeResults.createFakeResults();
       fakeResultsWithFacets.facets = [
+        DynamicFacetTestUtils.getCompleteFacetResponse(DynamicFacetTestUtils.createAdvancedFakeFacet({ field: '@anotherfield' }).cmp),
         DynamicHierarchicalFacetTestUtils.getCompleteFacetResponse(test.cmp, {
           values: mockFacetValues
         })
       ];
+      return fakeResultsWithFacets;
+    }
+
+    function fakeResultsWithNoFacets() {
+      const fakeResultsWithFacets = FakeResults.createFakeResults();
+      fakeResultsWithFacets.facets = [];
       return fakeResultsWithFacets;
     }
 
@@ -90,14 +101,6 @@ export function DynamicHierarchicalFacetTest() {
 
     it('facet position should be null by default', () => {
       expect(test.cmp.position).toBeNull();
-    });
-
-    it(`when getting successful results
-      facet position should be correct`, () => {
-      test.cmp.ensureDom();
-
-      Simulate.query(test.env, { results: fakeResultsWithFacets() });
-      expect(test.cmp.position).toBe(1);
     });
 
     it('should populate breadcrumbs by default', () => {
@@ -131,7 +134,7 @@ export function DynamicHierarchicalFacetTest() {
       const results = fakeResultsWithFacets();
       Simulate.query(test.env, { results });
 
-      testQueryStateModelValues([results.facets[0].values[0].value]);
+      testQueryStateModelValues([results.facets[1].values[0].value]);
     });
 
     it('should call selectPath when selecting a path through the QueryStateModel', () => {
@@ -375,9 +378,9 @@ export function DynamicHierarchicalFacetTest() {
         expect(test.cmp.header.showLoading).toHaveBeenCalledTimes(1);
       });
 
-      it(`when a query is successful
-      should call "hideLoading" on the header`, () => {
-        Simulate.query(test.env, { results: fakeResultsWithFacets() });
+      it(`when calling handleQueryResults
+        should call "hideLoading" on the header`, () => {
+        test.cmp.handleQueryResults(fakeResultsWithFacets());
         expect(test.cmp.header.hideLoading).toHaveBeenCalledTimes(1);
       });
 
@@ -403,14 +406,6 @@ export function DynamicHierarchicalFacetTest() {
       });
     });
 
-    it(`when calling putStateIntoQueryBuilder
-    should call putStateIntoQueryBuilder on the dynamicHierarchicalFacetQueryController`, () => {
-      spyOn(test.cmp.dynamicHierarchicalFacetQueryController, 'putFacetIntoQueryBuilder');
-      const queryBuilder = new QueryBuilder();
-      test.cmp.putStateIntoQueryBuilder(queryBuilder);
-      expect(test.cmp.dynamicHierarchicalFacetQueryController.putFacetIntoQueryBuilder).toHaveBeenCalledWith(queryBuilder);
-    });
-
     describe('testing putStateIntoQueryBuilder', () => {
       it(`when calling putStateIntoQueryBuilder
       should call putFacetIntoQueryBuilder on the dynamicHierarchicalFacetQueryController`, () => {
@@ -433,6 +428,37 @@ export function DynamicHierarchicalFacetTest() {
         test.cmp.dynamicFacetManager = Mock.mockComponent(DynamicFacetManager);
         $$(test.cmp.root).trigger(QueryEvents.doneBuildingQuery, { queryBuilder: new QueryBuilder() });
         expect(test.cmp.putStateIntoQueryBuilder).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('testing putStateIntoAnalytics', () => {
+      it(`when calling "putStateIntoAnalytics" 
+        should call "getPendingSearchEvent" on the "usageAnalytics" object`, () => {
+        test.cmp.putStateIntoAnalytics();
+
+        expect(test.cmp.usageAnalytics.getPendingSearchEvent).toHaveBeenCalled();
+      });
+
+      it(`when calling "putStateIntoAnalytics" 
+        should call "addFacetState" on the "PendingSearchEvent" with the correct state`, () => {
+        const fakePendingSearchEvent = {
+          addFacetState: jasmine.createSpy('addFacetState')
+        };
+        test.cmp.usageAnalytics.getPendingSearchEvent = jasmine
+          .createSpy('getPendingSearchEvent')
+          .and.callFake(() => fakePendingSearchEvent);
+
+        test.cmp.putStateIntoAnalytics();
+
+        expect(fakePendingSearchEvent.addFacetState).toHaveBeenCalledWith(test.cmp.analyticsFacetState);
+      });
+
+      it(`when facet as a dynamicFacetManager
+      when triggering doneBuildingQuery
+      should not call putStateIntoAnalytics on the facet`, () => {
+        test.cmp.dynamicFacetManager = Mock.mockComponent(DynamicFacetManager);
+        $$(test.cmp.root).trigger(QueryEvents.doneBuildingQuery, { queryBuilder: new QueryBuilder() });
+        expect(test.cmp.putStateIntoAnalytics).not.toHaveBeenCalled();
       });
     });
 
@@ -502,23 +528,65 @@ export function DynamicHierarchicalFacetTest() {
       });
     });
 
-    it(`when calling "putStateIntoAnalytics" 
-      should call "getPendingSearchEvent" on the "usageAnalytics" object`, () => {
-      test.cmp.putStateIntoAnalytics();
+    describe('testing querySuccess', () => {
+      beforeEach(() => {
+        test.cmp.ensureDom();
+      });
 
-      expect(test.cmp.usageAnalytics.getPendingSearchEvent).toHaveBeenCalled();
+      it(`when facet as a dynamicFacetManager
+        should call handleQueryResults on the facet`, () => {
+        $$(test.env.root).trigger(QueryEvents.querySuccess, { results: fakeResultsWithFacets() });
+        expect(test.cmp.handleQueryResults).toHaveBeenCalled();
+      });
+
+      it(`when facet as a dynamicFacetManager
+        should not call handleQueryResults on the facet`, () => {
+        test.cmp.dynamicFacetManager = Mock.mockComponent(DynamicFacetManager);
+        $$(test.env.root).trigger(QueryEvents.querySuccess, { results: fakeResultsWithFacets() });
+        expect(test.cmp.handleQueryResults).not.toHaveBeenCalled();
+      });
     });
 
-    it(`when calling "putStateIntoAnalytics" 
-      should call "addFacetState" on the "PendingSearchEvent" with the correct state`, () => {
-      const fakePendingSearchEvent = {
-        addFacetState: jasmine.createSpy('addFacetState')
-      };
-      test.cmp.usageAnalytics.getPendingSearchEvent = jasmine.createSpy('getPendingSearchEvent').and.callFake(() => fakePendingSearchEvent);
+    describe('testing handleQueryResults', () => {
+      beforeEach(() => {
+        test.cmp.ensureDom();
+      });
 
-      test.cmp.putStateIntoAnalytics();
+      describe('when facet is in the results', () => {
+        beforeEach(() => {
+          test.cmp.handleQueryResults(fakeResultsWithFacets());
+        });
 
-      expect(fakePendingSearchEvent.addFacetState).toHaveBeenCalledWith(test.cmp.analyticsFacetState);
+        it(`facet position should be correct`, () => {
+          expect(test.cmp.position).toBe(2);
+        });
+
+        it(`"createFromResponse" should be called on the values`, () => {
+          expect(test.cmp.values.createFromResponse).toHaveBeenCalledTimes(1);
+        });
+
+        it(`"render" should be called on the values`, () => {
+          expect(test.cmp.values.render).toHaveBeenCalledTimes(2);
+        });
+      });
+
+      describe('when facet is not in the results', () => {
+        beforeEach(() => {
+          test.cmp.handleQueryResults(fakeResultsWithNoFacets());
+        });
+
+        it(`facet position should be "null"`, () => {
+          expect(test.cmp.position).toBeNull();
+        });
+
+        it(`"resetValues" should be called on the values`, () => {
+          expect(test.cmp.values.resetValues).toHaveBeenCalledTimes(1);
+        });
+
+        it(`"render" should be called on the values`, () => {
+          expect(test.cmp.values.render).toHaveBeenCalledTimes(2);
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2789

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)