### PR TITLE
JSUI-2798 Improved accessibility of `Quickview`

### DIFF
--- a/accessibilityTest/AccessibilityQuickview.ts
+++ b/accessibilityTest/AccessibilityQuickview.ts
@@ -2,49 +2,14 @@ import * as axe from 'axe-core';
 import { $$, Quickview, Component, get, Dom } from 'coveo-search-ui';
 import { afterQuerySuccess, getRoot, testResultElement } from './Testing';
 
-function nodeListToArray<T extends Node>(nodeList: NodeListOf<T>) {
-  const result: T[] = [];
-  for (let i = 0; i < nodeList.length; i++) {
-    result.push(nodeList.item(i));
-  }
-  return result;
-}
-
-function getFocusableElements() {
-  return nodeListToArray<HTMLElement>(
-    document.querySelectorAll(`
-      a[href]:not([tabindex='-1']),
-      area[href]:not([tabindex='-1']),
-      input:not([disabled]):not([tabindex='-1']),
-      select:not([disabled]):not([tabindex='-1']),
-      textarea:not([disabled]):not([tabindex='-1']),
-      button:not([disabled]):not([tabindex='-1']),
-      iframe:not([tabindex='-1']),
-      [tabindex]:not([tabindex='-1']),
-      [contentEditable=true]:not([tabindex='-1'])
-    `)
-  ).sort((a, b) => a.tabIndex - b.tabIndex);
-}
-
-function getNextFocusableElement() {
-  const elements = getFocusableElements();
-  const currentIndex = document.activeElement ? elements.indexOf(document.activeElement as HTMLElement) : -1;
-  return elements[(currentIndex + 1) % elements.length];
-}
-
-function simulateTabKey() {
-  const event = new KeyboardEvent('keydown');
-  Object.defineProperty(event, 'keyCode', { get: () => 9 });
-  document.body.dispatchEvent(event);
-  if (!event.defaultPrevented) {
-    getNextFocusableElement().focus();
-  }
-}
-
 export const AccessibilityQuickview = () => {
   describe('Quickview', () => {
     async function openQuickview() {
       await (get(document.querySelector(`.${Component.computeCssClassName(Quickview)}`)) as Quickview).open();
+    }
+
+    function getQuickviewCloseButton(): HTMLElement {
+      return document.querySelector('.coveo-small-close');
     }
 
     let quickviewElement: Dom;
@@ -73,28 +38,13 @@ export const AccessibilityQuickview = () => {
 
     it('should have a close button when opened', async done => {
       await openQuickview();
-      expect(document.querySelector('.coveo-small-close')).not.toBeNull();
+      expect(getQuickviewCloseButton()).not.toBeNull();
       done();
     });
 
     it('should select the close button when opened', async done => {
       await openQuickview();
-      expect(document.activeElement).toBe(document.querySelector('.coveo-small-close'));
-      done();
-    });
-
-    it('should wrap the focus when pressing tab', async done => {
-      await openQuickview();
-      const container: HTMLElement = document.querySelector('.coveo-modal-container');
-      const initialFocus = document.activeElement;
-      const maxAttempts = 200;
-      for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        simulateTabKey();
-        if (document.activeElement === initialFocus || !container.contains(document.activeElement)) {
-          break;
-        }
-      }
-      expect(document.activeElement.outerHTML).toBe(initialFocus.outerHTML);
+      expect(document.activeElement).toBe(getQuickviewCloseButton());
       done();
     });
   });

--- a/accessibilityTest/AccessibilityQuickview.ts
+++ b/accessibilityTest/AccessibilityQuickview.ts
@@ -1,32 +1,100 @@
 import * as axe from 'axe-core';
-import { $$, Quickview, Component, get } from 'coveo-search-ui';
-import { afterQuerySuccess, getRoot, testResultElement, afterDelay } from './Testing';
+import { $$, Quickview, Component, get, Dom } from 'coveo-search-ui';
+import { afterQuerySuccess, getRoot, testResultElement } from './Testing';
+
+function nodeListToArray<T extends Node>(nodeList: NodeListOf<T>) {
+  const result: T[] = [];
+  for (let i = 0; i < nodeList.length; i++) {
+    result.push(nodeList.item(i));
+  }
+  return result;
+}
+
+function getFocusableElements() {
+  return nodeListToArray<HTMLElement>(
+    document.querySelectorAll(`
+      a[href]:not([tabindex='-1']),
+      area[href]:not([tabindex='-1']),
+      input:not([disabled]):not([tabindex='-1']),
+      select:not([disabled]):not([tabindex='-1']),
+      textarea:not([disabled]):not([tabindex='-1']),
+      button:not([disabled]):not([tabindex='-1']),
+      iframe:not([tabindex='-1']),
+      [tabindex]:not([tabindex='-1']),
+      [contentEditable=true]:not([tabindex='-1'])
+    `)
+  ).sort((a, b) => a.tabIndex - b.tabIndex);
+}
+
+function getNextFocusableElement() {
+  const elements = getFocusableElements();
+  const currentIndex = document.activeElement ? elements.indexOf(document.activeElement as HTMLElement) : -1;
+  return elements[(currentIndex + 1) % elements.length];
+}
+
+function simulateTabKey() {
+  const event = new KeyboardEvent('keydown');
+  Object.defineProperty(event, 'keyCode', { get: () => 9 });
+  document.body.dispatchEvent(event);
+  if (!event.defaultPrevented) {
+    getNextFocusableElement().focus();
+  }
+}
 
 export const AccessibilityQuickview = () => {
   describe('Quickview', () => {
-    it('should be accessible', async done => {
-      const quickviewElement = $$('div', {
+    async function openQuickview() {
+      await (get(document.querySelector(`.${Component.computeCssClassName(Quickview)}`)) as Quickview).open();
+    }
+
+    let quickviewElement: Dom;
+    beforeEach(async done => {
+      quickviewElement = $$('div', {
         className: Component.computeCssClassName(Quickview)
       });
 
       testResultElement(quickviewElement.el);
       await afterQuerySuccess();
+      done();
+    });
+
+    it('should be accessible', async done => {
       const axeResults = await axe.run(getRoot());
       expect(axeResults).toBeAccessible();
       done();
     });
 
     it('should be accessible when opened', async done => {
-      const quickviewElement = $$('div', {
-        className: Component.computeCssClassName(Quickview)
-      });
-
-      testResultElement(quickviewElement.el);
-      await afterQuerySuccess();
-      (get(document.querySelector(`.${Component.computeCssClassName(Quickview)}`)) as Quickview).open();
-      await afterDelay(500);
+      await openQuickview();
       const axeResults = await axe.run(getRoot());
       expect(axeResults).toBeAccessible();
+      done();
+    });
+
+    it('should have a close button when opened', async done => {
+      await openQuickview();
+      expect(document.querySelector('.coveo-small-close')).not.toBeNull();
+      done();
+    });
+
+    it('should select the close button when opened', async done => {
+      await openQuickview();
+      expect(document.activeElement).toBe(document.querySelector('.coveo-small-close'));
+      done();
+    });
+
+    it('should wrap the focus when pressing tab', async done => {
+      await openQuickview();
+      const container: HTMLElement = document.querySelector('.coveo-modal-container');
+      const initialFocus = document.activeElement;
+      const maxAttempts = 200;
+      for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        simulateTabKey();
+        if (document.activeElement === initialFocus || !container.contains(document.activeElement)) {
+          break;
+        }
+      }
+      expect(document.activeElement.outerHTML).toBe(initialFocus.outerHTML);
       done();
     });
   });

--- a/lib/modal-box/index.d.ts
+++ b/lib/modal-box/index.d.ts
@@ -1,96 +1,97 @@
-declare module Coveo.ModalBox {
+declare namespace Coveo.ModalBox {
+  /**
+   * The button to use when creating a ModalBox
+   */
+  enum BUTTON {
+    OK = 1,
+    APPLY = 2,
+    YES = 4,
+    NO = 8,
+    CANCEL = 16
+  }
+  /**
+   * Content of a ModalBox
+   */
+  interface ModalBox {
     /**
-     * The button to use when creating a ModalBox
+     * The modalBox container itself
      */
-    enum BUTTON {
-        OK = 1,
-        APPLY = 2,
-        YES = 4,
-        NO = 8,
-        CANCEL = 16,
-    }
+    modalBox: HTMLElement;
     /**
-     * Content of a ModalBox
+     * The overlay added on the body, which can be clicked to close the modalbox
      */
-    interface ModalBox {
-        /**
-         * The modalBox container itself
-         */
-        modalBox: HTMLElement;
-        /**
-         * The overlay added on the body, which can be clicked to close the modalbox
-         */
-        overlay: HTMLElement;
-        /**
-         * The wrapper of the content
-         */
-        wrapper: HTMLElement;
-        /**
-         * The availables buttons (Ok, Apply, Cancel, etc.)
-         */
-        buttons: HTMLElement;
-        /**
-         * The content itself
-         */
-        content: HTMLElement;
-        /**
-         * The function that can be called to close the modal box. Note that this is also called by validation button such as APPLY, YES, etc.<br/>
-         * Force close will close all open modalbox and skip the validation (if one was provided)
-         * @param button
-         * @param forceClose
-         */
-        close: (button?: BUTTON, forceClose?: boolean) => boolean;
-        open: (content: HTMLElement, options?: Options) => ModalBox;
-    }
+    overlay: HTMLElement;
     /**
-     * Possible options when creating a ModalBox
+     * The wrapper of the content
      */
-    interface Options {
-        /**
-         * Specify if you wish to open the modal box full screen. Default is `false`. If false, the modal box will fit the size of the content.
-         */
-        fullscreen?: boolean;
-        /**
-         * Specify that you wish the modal box to close when the user click on the title. Default is `false`.
-         */
-        titleClose?: boolean;
-        /**
-         * Specify if you wish to close the modal box when the overlay (black background) is clicked. Default is `false`.
-         */
-        overlayClose?: boolean;
-        /**
-         * Specify that you wish to add a prefix to the class name of the modal box container, to not clash with existing css in the page
-         */
-        className?: string;
-        /**
-         * The button you wish to create (Using {@link BUTTON} enum
-         */
-        buttons?: number;
-        /**
-         * Specify a validation function, which receives the button that was pressed.<br/>
-         * If the validation function return true, the modal box closes, otherwise it stays open
-         * @param button
-         */
-        validation?: (button: BUTTON) => boolean;
-        /**
-         * Specify the title of the modal box
-         */
-        title?: string;
-        /**
-         * Specify the content that you wish to put inside the modal box
-         */
-        body?: HTMLElement;
-    }
+    wrapper: HTMLElement;
     /**
-     * Open a modal box with the given content
-     * @param content The content to display, as an HTMLElement
-     * @param options The {@link Options} to use for this modal box
-     * @returns {{modalBox: (HTMLDivElement|HTMLElement), overlay: (HTMLDivElement|HTMLElement), wrapper: (HTMLDivElement|HTMLElement), buttons: HTMLElement, content: HTMLElement, close: (function(BUTTON=, boolean=): (boolean|boolean))}}
+     * The availables buttons (Ok, Apply, Cancel, etc.)
      */
-    function open(content: HTMLElement, options?: Options): ModalBox;
+    buttons: HTMLElement;
     /**
-     * Close all open modal box instance
-     * @param forceClose Will skip validation
+     * The content itself
      */
-    function close(forceClose?: boolean): void;
+    content: HTMLElement;
+    /**
+     * The function that can be called to close the modal box. Note that this is also called by validation button such as APPLY, YES, etc.<br/>
+     * Force close will close all open modalbox and skip the validation (if one was provided)
+     * @param button
+     * @param forceClose
+     */
+    close: (button?: BUTTON, forceClose?: boolean) => boolean;
+    open: (content: HTMLElement, options?: Options) => ModalBox;
+  }
+  /**
+   * Possible options when creating a ModalBox
+   */
+  interface Options {
+    /**
+     * Specify if you wish to open the modal box full screen. Default is `false`. If false, the modal box will fit the size of the content.
+     */
+    fullscreen?: boolean;
+    /**
+     * Specify that you wish the modal box to close when the user click on the title. Default is `false`.
+     */
+    titleClose?: boolean;
+    /**
+     * Specify if you wish to close the modal box when the overlay (black background) is clicked. Default is `false`.
+     */
+    overlayClose?: boolean;
+    /**
+     * Specify that you wish to add a prefix to the class name of the modal box container, to not clash with existing css in the page
+     */
+    className?: string;
+    /**
+     * The button you wish to create (Using {@link BUTTON} enum
+     */
+    buttons?: number;
+    /**
+     * Specify a validation function, which receives the button that was pressed.<br/>
+     * If the validation function return true, the modal box closes, otherwise it stays open
+     * @param button
+     */
+    validation?: (button: BUTTON) => boolean;
+    /**
+     * Specify the title of the modal box
+     */
+    title?: string | HTMLElement;
+    /**
+     * Specify the content that you wish to put inside the modal box
+     */
+    body?: HTMLElement;
+    sizeMod?: 'big';
+  }
+  /**
+   * Open a modal box with the given content
+   * @param content The content to display, as an HTMLElement
+   * @param options The {@link Options} to use for this modal box
+   * @returns {{modalBox: (HTMLDivElement|HTMLElement), overlay: (HTMLDivElement|HTMLElement), wrapper: (HTMLDivElement|HTMLElement), buttons: HTMLElement, content: HTMLElement, close: (function(BUTTON=, boolean=): (boolean|boolean))}}
+   */
+  function open(content: HTMLElement, options?: Options): ModalBox;
+  /**
+   * Close all open modal box instance
+   * @param forceClose Will skip validation
+   */
+  function close(forceClose?: boolean): void;
 }

--- a/src/ui/FocusTrap/FocusTrap.ts
+++ b/src/ui/FocusTrap/FocusTrap.ts
@@ -1,0 +1,112 @@
+import _ = require('underscore');
+import { Defer } from '../../misc/Defer';
+
+export class FocusTrap {
+  private focusInEvent: (e: FocusEvent) => void;
+  private focusOutEvent: (e: FocusEvent) => void;
+  private enabled: boolean;
+
+  private get focusableElements(): HTMLElement[] {
+    return _.sortBy(this.container.querySelectorAll('[tabindex]'), element => element.tabIndex);
+  }
+
+  constructor(private container: HTMLElement) {
+    this.enable();
+  }
+
+  public disable() {
+    document.removeEventListener('focusin', this.focusInEvent);
+    document.removeEventListener('focusout', this.focusOutEvent);
+    this.enabled = false;
+  }
+
+  private enable() {
+    document.addEventListener('focusin', (this.focusInEvent = e => this.onFocusIn(e)));
+    document.addEventListener('focusout', (this.focusOutEvent = e => this.onFocusOut(e)));
+    this.enabled = true;
+  }
+
+  private getSibling(element: HTMLElement, previous = false) {
+    const elements = this.focusableElements;
+    const currentIndex = elements.indexOf(element);
+    if (currentIndex === -1) {
+      return null;
+    }
+    return elements[(currentIndex + (previous ? -1 : 1) + elements.length) % elements.length];
+  }
+
+  private focusSibling(element: HTMLElement, previous = false) {
+    const sibling = this.getSibling(element, previous);
+    if (sibling) {
+      sibling.focus();
+    }
+  }
+
+  private focusFirstElement() {
+    const elements = this.focusableElements;
+    if (elements.length > 0) {
+      elements[0].focus();
+    }
+  }
+
+  private elementIsBefore(oldElement: HTMLElement, newElement: HTMLElement) {
+    if (!newElement) {
+      return false;
+    }
+    return oldElement.compareDocumentPosition(newElement) === Node.DOCUMENT_POSITION_PRECEDING;
+  }
+
+  private onLosingFocus(oldElement: HTMLElement, newElement: HTMLElement) {
+    Defer.defer(() => {
+      if (!this.enabled) {
+        return;
+      }
+      this.enabled = false;
+      if (oldElement && this.focusIsAllowed(oldElement)) {
+        this.focusSibling(oldElement, this.elementIsBefore(oldElement, newElement));
+      } else {
+        this.focusFirstElement();
+      }
+      this.enabled = true;
+    });
+  }
+
+  private focusIsAllowed(element: HTMLElement) {
+    return this.container.contains(element);
+  }
+
+  private elementIsInPage(element: HTMLElement) {
+    return element && element !== document.body.parentElement;
+  }
+
+  private onFocusIn(e: FocusEvent) {
+    if (!this.enabled) {
+      return;
+    }
+    const oldElement = e.relatedTarget as HTMLElement;
+    const handledByFocusOut = this.elementIsInPage(oldElement);
+    if (handledByFocusOut) {
+      return;
+    }
+    const newElement = e.target as HTMLElement;
+    if (!this.elementIsInPage(newElement)) {
+      return;
+    }
+    if (!this.focusIsAllowed(newElement)) {
+      this.onLosingFocus(null, newElement);
+    }
+  }
+
+  private onFocusOut(e: FocusEvent) {
+    if (!this.enabled) {
+      return;
+    }
+    const newElement = e.relatedTarget as HTMLElement;
+    if (!this.elementIsInPage(newElement)) {
+      return;
+    }
+    if (!newElement || !this.focusIsAllowed(newElement)) {
+      this.onLosingFocus(e.target as HTMLElement, newElement);
+    }
+  }
+}

--- a/src/ui/FocusTrap/FocusTrap.ts
+++ b/src/ui/FocusTrap/FocusTrap.ts
@@ -32,9 +32,8 @@ export class FocusTrap {
   }
 
   private showHiddenElements() {
-    let element: HTMLElement;
-    while ((element = this.hiddenElements.pop())) {
-      element.removeAttribute('aria-hidden');
+    while (this.hiddenElements.length) {
+      this.hiddenElements.pop().removeAttribute('aria-hidden');
     }
   }
 
@@ -48,15 +47,17 @@ export class FocusTrap {
 
   private hideSiblings(allowedElement: HTMLElement) {
     const parent = allowedElement.parentElement;
-    without($$(parent).children(), allowedElement).forEach(elementToHide => {
-      this.hideElement(elementToHide);
-    });
+    if (parent) {
+      without($$(parent).children(), allowedElement).forEach(elementToHide => {
+        this.hideElement(elementToHide);
+      });
+    }
   }
 
   private hideAllExcept(allowedElement: HTMLElement) {
     this.hideSiblings(allowedElement);
     const parent = allowedElement.parentElement;
-    if (parent !== document.body) {
+    if (parent && parent !== document.body) {
       this.hideAllExcept(parent);
     }
   }

--- a/src/ui/FocusTrap/FocusTrap.ts
+++ b/src/ui/FocusTrap/FocusTrap.ts
@@ -1,5 +1,5 @@
-import _ = require('underscore');
 import { Defer } from '../../misc/Defer';
+import { sortBy } from 'underscore';
 
 export class FocusTrap {
   private focusInEvent: (e: FocusEvent) => void;
@@ -7,7 +7,7 @@ export class FocusTrap {
   private enabled: boolean;
 
   private get focusableElements(): HTMLElement[] {
-    return _.sortBy(this.container.querySelectorAll('[tabindex]'), element => element.tabIndex);
+    return sortBy(this.container.querySelectorAll('[tabindex]'), element => element.tabIndex);
   }
 
   constructor(private container: HTMLElement) {
@@ -44,7 +44,7 @@ export class FocusTrap {
 
   private focusFirstElement() {
     const elements = this.focusableElements;
-    if (elements.length > 0) {
+    if (elements.length) {
       elements[0].focus();
     }
   }

--- a/unitTests/Simulate.ts
+++ b/unitTests/Simulate.ts
@@ -221,6 +221,31 @@ export class Simulate {
     return modalBox;
   }
 
+  static fullModalBoxModule(): ModalBox {
+    let content: HTMLElement;
+    const container = $$(
+      'div',
+      { className: 'coveo-wrapper coveo-modal-container' },
+      (content = $$(
+        'div',
+        { className: 'coveo-modal-content' },
+        $$('header', { className: 'coveo-modal-header' }, $$('div', { className: 'coveo-quickview-close-button coveo-small-close' })).el
+      ).el)
+    ).el;
+    const backdrop = $$('div', { className: 'coveo-modal-backdrop' }).el;
+    let modalBox = <any>{};
+    modalBox.open = jasmine.createSpy('open');
+    modalBox.close = jasmine.createSpy('close');
+    modalBox.open.and.returnValue({
+      modalBox: container,
+      wrapper: content,
+      overlay: backdrop,
+      content,
+      close: modalBox.close
+    });
+    return modalBox;
+  }
+
   static analyticsStoreModule(actionsHistory = []) {
     return {
       addElement: (query: IQuery) => {},

--- a/unitTests/Simulate.ts
+++ b/unitTests/Simulate.ts
@@ -208,20 +208,6 @@ export class Simulate {
   }
 
   static modalBoxModule(): ModalBox {
-    let modalBox = <any>{};
-    modalBox.open = jasmine.createSpy('open');
-    modalBox.close = jasmine.createSpy('close');
-    modalBox.open.and.returnValue({
-      modalBox: $$('div', undefined, $$('div', { className: 'coveo-wrapper' })).el,
-      wrapper: $$('div', undefined, $$('div', { className: 'coveo-quickview-close-button' })).el,
-      overlay: $$('div').el,
-      content: $$('div').el,
-      close: modalBox.close
-    });
-    return modalBox;
-  }
-
-  static fullModalBoxModule(): ModalBox {
     let content: HTMLElement;
     const container = $$(
       'div',

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -809,3 +809,6 @@ ResultPreviewsManagerTest();
 
 import { CommerceQueryTest } from './ui/CommerceQueryTest';
 CommerceQueryTest();
+
+import { FocusTrapTest } from './ui/FocusTrapTest';
+FocusTrapTest();

--- a/unitTests/ui/FocusTrapTest.ts
+++ b/unitTests/ui/FocusTrapTest.ts
@@ -77,6 +77,10 @@ export function FocusTrapTest() {
       focusTrap.disable();
     });
 
+    it('sets aria-hidden on every sibling', () => {
+      expect(rootContainer.findAll('[aria-hidden="true"]')).toEqual([firstOuterFocusableElement.el, lastOuterFocusableElement.el]);
+    });
+
     describe('when initially focusing an element outside the container', () => {
       it('selects the first element in the trapped container if the focused element is before the trapped container', async done => {
         firstOuterFocusableElement.el.focus();
@@ -150,6 +154,10 @@ export function FocusTrapTest() {
         lastOuterFocusableElement.el.focus();
         await expectSelection(lastOuterFocusableElement);
         done();
+      });
+
+      it('removes aria-hidden from every element', () => {
+        expect(rootContainer.findAll('[aria-hidden]').length).toEqual(0);
       });
     });
   });

--- a/unitTests/ui/FocusTrapTest.ts
+++ b/unitTests/ui/FocusTrapTest.ts
@@ -1,0 +1,156 @@
+import { Dom, $$ } from '../../src/utils/Dom';
+import { FocusTrap } from '../../src/ui/FocusTrap/FocusTrap';
+import { Defer } from '../../src/Core';
+
+export function FocusTrapTest() {
+  describe('FocusTrap', () => {
+    function mockFocusInEvent(oldElement: HTMLElement, newElement: HTMLElement) {
+      return (<Partial<FocusEvent>>{
+        type: 'focusin',
+        target: newElement,
+        relatedTarget: oldElement
+      }) as FocusEvent;
+    }
+
+    function mockFocusOutEvent(oldElement: HTMLElement, newElement: HTMLElement) {
+      return (<Partial<FocusEvent>>{
+        type: 'focusout',
+        target: oldElement,
+        relatedTarget: newElement
+      }) as FocusEvent;
+    }
+
+    function buildFocusable(id: string) {
+      const element = $$('div', { id });
+      element.el.tabIndex = 0;
+      spyOn(element.el, 'focus').and.callFake(() => {
+        focusTrap['onFocusIn'](mockFocusInEvent(currentlyActiveElement, element.el));
+        if (currentlyActiveElement) {
+          focusTrap['onFocusOut'](mockFocusOutEvent(currentlyActiveElement, element.el));
+        }
+        currentlyActiveElement = element.el;
+      });
+      return element;
+    }
+
+    function buildEnvironment() {
+      rootContainer = $$(
+        'div',
+        {},
+        (firstOuterFocusableElement = buildFocusable('out-first')),
+        (trapContainer = $$(
+          'div',
+          {},
+          ...(trappedFocusableElements = [buildFocusable('in-first'), buildFocusable('in-second'), buildFocusable('in-third')])
+        )),
+        (lastOuterFocusableElement = buildFocusable('out-last'))
+      );
+    }
+
+    function expectSelection(actual: Dom | HTMLElement) {
+      return new Promise(resolve => {
+        Defer.defer(() => {
+          const actualElement = actual instanceof Dom ? actual.el : actual;
+          expect(actualElement.focus).toHaveBeenCalledTimes(1);
+          expect(currentlyActiveElement.id).toBe(actualElement.id);
+          resolve();
+        });
+      });
+    }
+
+    let rootContainer: Dom;
+    let firstOuterFocusableElement: Dom;
+    let lastOuterFocusableElement: Dom;
+    let trapContainer: Dom;
+    let trappedFocusableElements: Dom[];
+    let focusTrap: FocusTrap;
+    let currentlyActiveElement: HTMLElement;
+    beforeEach(() => {
+      buildEnvironment();
+      document.body.appendChild(rootContainer.el);
+      focusTrap = new FocusTrap(trapContainer.el);
+      currentlyActiveElement = null;
+    });
+
+    afterEach(() => {
+      rootContainer.remove();
+      focusTrap.disable();
+    });
+
+    describe('when initially focusing an element outside the container', () => {
+      it('selects the first element in the trapped container if the focused element is before the trapped container', async done => {
+        firstOuterFocusableElement.el.focus();
+        await expectSelection(trappedFocusableElements[0]);
+        done();
+      });
+
+      it('selects the first element in the trapped container if the focused element is after the trapped container', async done => {
+        lastOuterFocusableElement.el.focus();
+        await expectSelection(trappedFocusableElements[0]);
+        done();
+      });
+    });
+
+    describe('when initially focusing the first element', () => {
+      beforeEach(() => {
+        trappedFocusableElements[0].el.focus();
+      });
+
+      it('allows the next element to be focused', async done => {
+        trappedFocusableElements[1].el.focus();
+        await expectSelection(trappedFocusableElements[1]);
+        done();
+      });
+
+      it('focuses the next element if an element after the trapped container is focused', async done => {
+        lastOuterFocusableElement.el.focus();
+        await expectSelection(trappedFocusableElements[1]);
+        done();
+      });
+
+      it('wraps the selection if an element before the trapped container is focused', async done => {
+        firstOuterFocusableElement.el.focus();
+        await expectSelection(trappedFocusableElements[2]);
+        done();
+      });
+    });
+
+    describe('when initially focusing the last element', () => {
+      beforeEach(() => {
+        trappedFocusableElements[2].el.focus();
+      });
+
+      it('allows the previous element to be focused', async done => {
+        trappedFocusableElements[1].el.focus();
+        await expectSelection(trappedFocusableElements[1]);
+        done();
+      });
+
+      it('focuses the previous element if an element before the trapped container is focused', async done => {
+        firstOuterFocusableElement.el.focus();
+        await expectSelection(trappedFocusableElements[1]);
+        done();
+      });
+
+      it('wraps the selection if an element after the trapped container is focused', async done => {
+        lastOuterFocusableElement.el.focus();
+        await expectSelection(trappedFocusableElements[0]);
+        done();
+      });
+    });
+
+    describe('when disabled', () => {
+      beforeEach(() => {
+        focusTrap.disable();
+      });
+
+      it('should not prevent selection outside the trapped container', async done => {
+        firstOuterFocusableElement.el.focus();
+        await expectSelection(firstOuterFocusableElement);
+        lastOuterFocusableElement.el.focus();
+        await expectSelection(lastOuterFocusableElement);
+        done();
+      });
+    });
+  });
+}

--- a/unitTests/ui/QuickviewTest.ts
+++ b/unitTests/ui/QuickviewTest.ts
@@ -36,7 +36,7 @@ export function QuickviewTest() {
       env = mockBuilder.build();
       env.queryStateModel.set(QueryStateModel.attributesEnum.layout, layout);
       result = FakeResults.createFakeResult();
-      modalBox = Simulate.modalBoxModule();
+      modalBox = Simulate.fullModalBoxModule();
       return new Quickview(env.element, { contentTemplate: template, ...options }, bindings, result, modalBox);
     };
 

--- a/unitTests/ui/QuickviewTest.ts
+++ b/unitTests/ui/QuickviewTest.ts
@@ -36,7 +36,7 @@ export function QuickviewTest() {
       env = mockBuilder.build();
       env.queryStateModel.set(QueryStateModel.attributesEnum.layout, layout);
       result = FakeResults.createFakeResult();
-      modalBox = Simulate.fullModalBoxModule();
+      modalBox = Simulate.modalBoxModule();
       return new Quickview(env.element, { contentTemplate: template, ...options }, bindings, result, modalBox);
     };
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2798

1. Added label to close button
2. Added tab index to close button for keyboard navigation
3. Locked keyboard focus within `QuickView`'s modal while it's open.
4. Added accessibility tests for QuickView

This was tested with Android's TalkBack and doesn't seem to work. Most tutorials and articles online, even when searching specifically for accessible modals, seem to ignore accessibility altogether by detecting the `tab` key. However, some tutorials using ally.js seem to detect focus/blur for the desktop and add `aria-hidden` for mobile accessibility tools, which seems to be a less radical solution than setting `tabindex="-1"` to every focusable element. There is no guarantee that this works with iOS's VoiceOver either, but setting `aria-hidden` and `aria-modal` seems to be the recommended method by W3 (https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html).

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)