### PR TITLE
JSUI-2799 Merge options before executing `highlightStreamHTMLv2`

### DIFF
--- a/src/ui/Templates/CoreHelpers.ts
+++ b/src/ui/Templates/CoreHelpers.ts
@@ -569,7 +569,12 @@ TemplateHelpers.registerTemplateHelper(
 );
 
 TemplateHelpers.registerTemplateHelper('highlightStreamHTMLv2', (content: string, options: IHelperStreamHighlightOptions) => {
-  return executeHighlightStreamHTML(content, options);
+  const mergedOptions = {
+    termsToHighlight: resolveTermsToHighlight(),
+    phrasesToHighlight: resolvePhrasesToHighlight(),
+    ...options
+  };
+  return executeHighlightStreamHTML(content, mergedOptions);
 });
 
 TemplateHelpers.registerFieldHelper('number', (value: any, options?: any) => {

--- a/unitTests/ui/CoreHelpersTest.ts
+++ b/unitTests/ui/CoreHelpersTest.ts
@@ -188,7 +188,8 @@ export function CoreHelperTest() {
       it('should work correctly when it "resolves" options automatically through the result list', () => {
         Component.getComponentRef('ResultList').resultCurrentlyBeingRendered = {
           ...FakeResults.createFakeResult(),
-          ...{ termsToHighlight, phrasesToHighlight }
+          termsToHighlight,
+          phrasesToHighlight
         };
         expect(TemplateHelpers.getHelper('highlightStreamHTMLv2')(toHighlight)).toEqual(expectedOutput);
       });

--- a/unitTests/ui/CoreHelpersTest.ts
+++ b/unitTests/ui/CoreHelpersTest.ts
@@ -7,6 +7,7 @@ import { SearchEndpoint } from '../../src/rest/SearchEndpoint';
 import { mockSearchEndpoint, MockEnvironmentBuilder } from '../MockEnvironment';
 import { IQueryResult } from '../../src/rest/QueryResult';
 import { IIconOptions } from '../../src/ui/Icon/Icon';
+import { Component } from '../../src/Core';
 
 export function CoreHelperTest() {
   describe('CoreHelpers', () => {
@@ -164,17 +165,33 @@ export function CoreHelperTest() {
       );
     });
 
-    it('highlightStreamHTMLv2 should work correctly', () => {
+    describe('highlightStreamHTMLv2', () => {
+      const termsToHighlight = { a: [], b: [] };
+      const phrasesToHighlight = {};
+      const expectedOutput =
+        '<div><span class="coveo-highlight" data-highlight-group="1" data-highlight-group-term="a">a</span> <span class="coveo-highlight" data-highlight-group="2" data-highlight-group-term="b">b</span></div>';
       const toHighlight = '<div>a b</div>';
-      const termsToHighlight: IHighlightTerm = { a: [], b: [] };
-      expect(
-        TemplateHelpers.getHelper('highlightStreamHTMLv2')(toHighlight, {
-          termsToHighlight,
-          phrasesToHighlight: {}
-        })
-      ).toEqual(
-        '<div><span class="coveo-highlight" data-highlight-group="1" data-highlight-group-term="a">a</span> <span class="coveo-highlight" data-highlight-group="2" data-highlight-group-term="b">b</span></div>'
-      );
+
+      afterEach(() => {
+        Component.getComponentRef('ResultList').resultCurrentlyBeingRendered = null;
+      });
+
+      it('should work correctly when options are passed explicitely', () => {
+        expect(
+          TemplateHelpers.getHelper('highlightStreamHTMLv2')(toHighlight, {
+            termsToHighlight,
+            phrasesToHighlight
+          })
+        ).toEqual(expectedOutput);
+      });
+
+      it('should work correctly when it "resolves" options automatically through the result list', () => {
+        Component.getComponentRef('ResultList').resultCurrentlyBeingRendered = {
+          ...FakeResults.createFakeResult(),
+          ...{ termsToHighlight, phrasesToHighlight }
+        };
+        expect(TemplateHelpers.getHelper('highlightStreamHTMLv2')(toHighlight)).toEqual(expectedOutput);
+      });
     });
 
     it('number should work correctly', () => {


### PR DESCRIPTION
This is essentially just copying what's already been done for the other `highlighting` functions. 

Not sure why it was absent for this one... 🤔 


https://coveord.atlassian.net/browse/JSUI-2799





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)