### PR TITLE
JSUI-2801 Fixed accessibility for `SearchBox`

### DIFF
--- a/src/magicbox/InputManager.ts
+++ b/src/magicbox/InputManager.ts
@@ -28,6 +28,20 @@ export class InputManager {
   public onchangecursor: () => void;
   public ontabpress: () => void;
 
+  public set expanded(isExpanded: boolean) {
+    this.input.setAttribute('aria-expanded', isExpanded.toString());
+  }
+
+  public set activeDescendant(element: HTMLElement) {
+    if (element) {
+      this.input.setAttribute('aria-activedescendant', element.id);
+      this.input.setAttribute('aria-active-option', element.id);
+    } else {
+      this.input.removeAttribute('aria-activedescendant');
+      this.input.removeAttribute('aria-active-option');
+    }
+  }
+
   constructor(element: HTMLElement, private onchange: (text: string, wordCompletion: boolean) => void, private magicBox: MagicBoxInstance) {
     this.root = Component.resolveRoot(element);
     this.underlay = document.createElement('div');
@@ -201,7 +215,7 @@ export class InputManager {
 
   private addAccessibilitiesProperties() {
     this.input.setAttribute('type', 'text');
-    this.input.setAttribute('role', 'searchbox');
+    this.input.setAttribute('role', 'combobox');
     this.input.setAttribute('form', 'coveo-dummy-form');
     this.input.setAttribute('aria-autocomplete', 'list');
     this.input.setAttribute('title', `${l('InsertAQuery')}. ${l('PressEnterToSend')}`);

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -30,6 +30,8 @@ export enum Direction {
   Right = 'Right'
 }
 
+export const suggestionListboxID = 'coveo-magicbox-suggestions';
+
 export class SuggestionsManager {
   private suggestionsProcessor: QueryProcessor<Suggestion>;
   private currentSuggestions: Suggestion[];
@@ -225,8 +227,8 @@ export class SuggestionsManager {
 
   private buildSuggestionsContainer() {
     return $$('div', {
-      className: 'coveo-magicbox-suggestions',
-      id: 'coveo-magicbox-suggestions',
+      className: suggestionListboxID,
+      id: suggestionListboxID,
       role: 'listbox'
     });
   }
@@ -401,8 +403,8 @@ export class SuggestionsManager {
 
     this.inputManager.activeDescendant = null;
     this.inputManager.expanded = false;
-    input.setAttribute('aria-owns', 'coveo-magicbox-suggestions');
-    input.setAttribute('aria-controls', 'coveo-magicbox-suggestions');
+    input.setAttribute('aria-owns', suggestionListboxID);
+    input.setAttribute('aria-controls', suggestionListboxID);
   }
 
   private htmlElementIsSuggestion(selected: HTMLElement) {

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -86,7 +86,7 @@ export class SuggestionsManager {
     });
     this.suggestionsListbox = this.buildSuggestionsContainer();
     $$(this.element).append(this.suggestionsListbox.el);
-    this.addAccessibilityPropertiesForCombobox();
+    this.addAccessibilityProperties();
     this.appendEmptySuggestionOption();
   }
 
@@ -169,12 +169,12 @@ export class SuggestionsManager {
 
   public updateSuggestions(suggestions: Suggestion[]) {
     this.suggestionsListbox.empty();
-    this.inputManager.input.removeAttribute('aria-activedescendant');
+    this.inputManager.activeDescendant = null;
 
     this.currentSuggestions = suggestions;
 
     $$(this.element).toggleClass('magic-box-hasSuggestion', this.hasSuggestions);
-    $$(this.magicBoxContainer).setAttribute('aria-expanded', this.hasSuggestions.toString());
+    this.inputManager.expanded = this.hasSuggestions;
 
     this.resultPreviewsManager.displaySearchResultPreviewsForSuggestion(null);
 
@@ -379,23 +379,30 @@ export class SuggestionsManager {
 
   private updateAreaSelectedIfDefined(element: HTMLElement, value: string): void {
     if ($$(element).getAttribute('aria-selected')) {
-      $$(this.inputManager.input).setAttribute('aria-activedescendant', element.id);
+      this.inputManager.activeDescendant = element;
       $$(element).setAttribute('aria-selected', value);
     }
   }
 
-  private addAccessibilityPropertiesForCombobox() {
-    const combobox = $$(this.magicBoxContainer);
+  private addAccessibilityProperties() {
+    this.addAccessibilityPropertiesForMagicBox();
+    this.addAccessibilityPropertiesForInput();
+  }
+
+  private addAccessibilityPropertiesForMagicBox() {
+    const magicBox = $$(this.magicBoxContainer);
+
+    magicBox.setAttribute('role', 'search');
+    magicBox.setAttribute('aria-haspopup', 'listbox');
+  }
+
+  private addAccessibilityPropertiesForInput() {
     const input = $$(this.inputManager.input);
 
-    combobox.setAttribute('aria-expanded', 'false');
-    combobox.setAttribute('role', 'combobox');
-    combobox.setAttribute('aria-owns', 'coveo-magicbox-suggestions');
-    combobox.setAttribute('aria-haspopup', 'listbox');
-
-    input.el.removeAttribute('aria-activedescendant');
+    this.inputManager.activeDescendant = null;
+    this.inputManager.expanded = false;
+    input.setAttribute('aria-owns', 'coveo-magicbox-suggestions');
     input.setAttribute('aria-controls', 'coveo-magicbox-suggestions');
-    input.setAttribute('aria-autocomplete', 'list');
   }
 
   private htmlElementIsSuggestion(selected: HTMLElement) {

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -1,6 +1,6 @@
 import { InputManager } from '../../src/magicbox/InputManager';
 import { MagicBoxInstance } from '../../src/magicbox/MagicBox';
-import { SuggestionsManager, Suggestion } from '../../src/magicbox/SuggestionsManager';
+import { SuggestionsManager, Suggestion, suggestionListboxID } from '../../src/magicbox/SuggestionsManager';
 import { $$, Dom } from '../../src/utils/Dom';
 import { Utils } from '../../src/utils/Utils';
 import { IMockEnvironment, MockEnvironmentBuilder } from '../MockEnvironment';
@@ -298,7 +298,9 @@ export function SuggestionsManagerTest() {
       function mockInputManager() {
         return <InputManager>{
           input: $$('input').el as HTMLInputElement,
-          blur: jasmine.createSpy('blur') as () => void
+          blur: jasmine.createSpy('blur') as () => void,
+          expanded: null,
+          activeDescendant: null
         };
       }
 
@@ -316,6 +318,30 @@ export function SuggestionsManagerTest() {
             timeout
           }
         );
+      });
+
+      it('sets the accesible role of MagicBox', () => {
+        expect(magicBoxContainer.getAttribute('role')).toEqual('search');
+      });
+
+      it('sets aria-haspopup of MagicBox', () => {
+        expect(magicBoxContainer.getAttribute('aria-haspopup')).toEqual('listbox');
+      });
+
+      it("sets aria-owns of InputManager to the id of SuggestionManager's listbox", () => {
+        expect(inputManager.input.getAttribute('aria-owns')).toEqual(suggestionListboxID);
+      });
+
+      it("sets aria-controls of InputManager to the id of SuggestionManager's listbox", () => {
+        expect(inputManager.input.getAttribute('aria-controls')).toEqual(suggestionListboxID);
+      });
+
+      it('sets aria-expanded of InputManager to false', () => {
+        expect(inputManager.expanded).toEqual(false);
+      });
+
+      it("doesn't set activeDescendant in InputManager", () => {
+        expect(inputManager.activeDescendant).toBeNull();
       });
 
       describe('calling mergeSuggestions', () => {
@@ -347,6 +373,19 @@ export function SuggestionsManagerTest() {
           await waitForQuerySuggestRendered();
           suggestionElements = $$(env.root).findClass(suggestionClass);
           done();
+        });
+
+        it("doesn't set activeDescendant in InputManager", () => {
+          expect(inputManager.activeDescendant).toBeNull();
+        });
+
+        it('sets expanded in InputManager', () => {
+          expect(inputManager.expanded).toEqual(true);
+        });
+
+        it('sets activeDescendant in InputManager after focusing a suggestion', () => {
+          mouseFocusSuggestion(1);
+          expect(inputManager.activeDescendant).toEqual(suggestionElements[1]);
         });
 
         it('renders suggestions', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2801

* Moved some accessibility properties from `Omnibox` to `InputManager`'s `input`
* Changed `Omnibox`'s `role` to `search`
* Changed the role of `InputManager`'s `input` to `combobox`

Those changes were made according to some of Deque's recommendations, which I copied over to the JIRA issue above. I also took some inspiration from Google's and Amazon's search bar which also seemed to follow Deque's recommendation but wrapped their search input in a container with `role="search"`.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)