### PR TITLE
Fixed accessibility on `ResultsPerPage`'s list

### DIFF
--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -213,7 +213,7 @@ export class ResultsPerPage extends Component {
     this.span = $$(
       'span',
       {
-        id: `coveo-results-per-page-text-${QueryUtils.createGuid()}`,
+        id: `coveo-results-per-page-text-${Math.floor(Math.random() * 10 ** 9)}`,
         className: 'coveo-results-per-page-text'
       },
       l('ResultsPerPage')

--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -17,7 +17,6 @@ import { Component } from '../Base/Component';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { ComponentOptions } from '../Base/ComponentOptions';
 import { Initialization } from '../Base/Initialization';
-import { QueryUtils } from '../../Core';
 
 export interface IResultsPerPageOptions {
   choicesDisplayed?: number[];

--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -17,6 +17,7 @@ import { Component } from '../Base/Component';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { ComponentOptions } from '../Base/ComponentOptions';
 import { Initialization } from '../Base/Initialization';
+import { QueryUtils } from '../../Core';
 
 export interface IResultsPerPageOptions {
   choicesDisplayed?: number[];
@@ -212,13 +213,16 @@ export class ResultsPerPage extends Component {
     this.span = $$(
       'span',
       {
+        id: `coveo-results-per-page-text-${QueryUtils.createGuid()}`,
         className: 'coveo-results-per-page-text'
       },
       l('ResultsPerPage')
     ).el;
     this.element.appendChild(this.span);
     this.list = $$('ul', {
-      className: 'coveo-results-per-page-list'
+      className: 'coveo-results-per-page-list',
+      role: 'group',
+      'aria-labelledby': this.span.id
     }).el;
     this.element.appendChild(this.list);
   }

--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -17,6 +17,7 @@ import { Component } from '../Base/Component';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { ComponentOptions } from '../Base/ComponentOptions';
 import { Initialization } from '../Base/Initialization';
+import { uniqueId } from 'underscore';
 
 export interface IResultsPerPageOptions {
   choicesDisplayed?: number[];
@@ -212,7 +213,7 @@ export class ResultsPerPage extends Component {
     this.span = $$(
       'span',
       {
-        id: `coveo-results-per-page-text-${Math.floor(Math.random() * 10 ** 9)}`,
+        id: uniqueId('coveo-results-per-page-text-'),
         className: 'coveo-results-per-page-text'
       },
       l('ResultsPerPage')

--- a/unitTests/ui/ResultsPerPageTest.ts
+++ b/unitTests/ui/ResultsPerPageTest.ts
@@ -7,6 +7,7 @@ import { FakeResults } from '../Fake';
 import { $$ } from '../../src/utils/Dom';
 import { QueryStateModel } from '../../src/Core';
 import { QUERY_STATE_ATTRIBUTES } from '../../src/models/QueryStateModel';
+import { lab } from 'd3';
 
 export function ResultsPerPageTest() {
   describe('ResultsPerPage', () => {
@@ -22,6 +23,15 @@ export function ResultsPerPageTest() {
     beforeEach(() => (test = buildResultsPerPage()));
 
     afterEach(() => (test = null));
+
+    it('should be accessible', () => {
+      const label = test.cmp['span'];
+      const list = test.cmp['list'];
+
+      expect(label.id).toBeTruthy();
+      expect(list.getAttribute('aria-labelledby')).toEqual(label.id);
+      expect(list.getAttribute('role')).toEqual('group');
+    });
 
     describe('when calling #setResultsPerPage', () => {
       const numOfResults = 50;

--- a/unitTests/ui/ResultsPerPageTest.ts
+++ b/unitTests/ui/ResultsPerPageTest.ts
@@ -7,7 +7,6 @@ import { FakeResults } from '../Fake';
 import { $$ } from '../../src/utils/Dom';
 import { QueryStateModel } from '../../src/Core';
 import { QUERY_STATE_ATTRIBUTES } from '../../src/models/QueryStateModel';
-import { lab } from 'd3';
 
 export function ResultsPerPageTest() {
   describe('ResultsPerPage', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2803

Fixed accessibility on the list generated by `ResultsPerPage` according to Deque's recommendations.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)