### PR TITLE
JSUI-2808 Fixed incompatible ARIA property in `DynamicFacetSearch`'s `ComboboxInput`

### DIFF
--- a/src/ui/Combobox/ComboboxInput.ts
+++ b/src/ui/Combobox/ComboboxInput.ts
@@ -50,9 +50,9 @@ export class ComboboxInput {
     this.element.setAttribute('role', 'combobox');
     this.element.setAttribute('aria-owns', listboxId);
     this.element.setAttribute('aria-haspopup', 'listbox');
+    this.element.setAttribute('aria-autocomplete', 'list');
 
     this.inputElement.setAttribute('id', `${this.combobox.id}-input`);
-    this.inputElement.setAttribute('aria-autocomplete', 'list');
     this.inputElement.setAttribute('aria-controls', listboxId);
     this.inputElement.setAttribute('aria-label', this.combobox.options.label);
 

--- a/unitTests/ui/Combobox/ComboboxInputTest.ts
+++ b/unitTests/ui/Combobox/ComboboxInputTest.ts
@@ -89,9 +89,9 @@ export function ComboboxInputTest() {
       expect(comboboxInput.element.getAttribute('aria-owns')).toBe(listboxId);
       expect(comboboxInput.element.getAttribute('aria-haspopup')).toBe('listbox');
       expect(comboboxInput.element.getAttribute('aria-expanded')).toBe('false');
+      expect(comboboxInput.element.getAttribute('aria-autocomplete')).toBe('list');
 
       expect(getInput().getAttribute('id')).toBe(id);
-      expect(getInput().getAttribute('aria-autocomplete')).toBe('list');
       expect(getInput().getAttribute('aria-controls')).toBe(listboxId);
       expect(getInput().getAttribute('aria-activeDescendant')).toBeFalsy();
     });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2808

Moved the `aria-autocomplete` property from `ComboboxInput`'s `<input>` element to its parent div with `role="combobox"`.

According to W3, it seems like `aria-autocomplete` is meant to be defined in elements with the `combobox` role.

Source: https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.0pattern/combobox-autocomplete-list.html#rps_label_textbox

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)