### PR TITLE
Added label to `FacetSearch`'s results

### DIFF
--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -322,6 +322,7 @@ export class FacetSearch implements IFacetSearch {
       $$(elem).setAttribute('role', 'option');
       $$(elem).setAttribute('aria-selected', 'false');
       $$(elem).addClass('coveo-facet-search-selectable');
+      $$(elem).setAttribute('aria-label', elem.querySelector('.coveo-facet-value-checkbox').getAttribute('aria-label'));
     });
   }
 

--- a/unitTests/ui/FacetSearchTest.ts
+++ b/unitTests/ui/FacetSearchTest.ts
@@ -87,6 +87,21 @@ export function FacetSearchTest() {
         });
       });
 
+      it('should add a label to facet search results', async done => {
+        var pr = new Promise((resolve, reject) => {
+          var results = FakeResults.createFakeFieldValues('foo', 10);
+          resolve(results);
+        });
+
+        var params = new FacetSearchParameters(mockFacet);
+        (<jasmine.Spy>mockFacet.facetQueryController.search).and.returnValue(pr);
+        facetSearch.triggerNewFacetSearch(params);
+        await pr;
+        const firstResultWithoutLabel = allSearchResults().find(result => !result.getAttribute('aria-label'));
+        expect(firstResultWithoutLabel).toBeFalsy();
+        done();
+      });
+
       it('should hide facet search results', done => {
         var pr = new Promise((resolve, reject) => {
           var results = FakeResults.createFakeFieldValues('foo', 10);

--- a/unitTests/ui/FacetSearchTest.ts
+++ b/unitTests/ui/FacetSearchTest.ts
@@ -9,6 +9,7 @@ import { FacetSearchParameters } from '../../src/ui/Facet/FacetSearchParameters'
 import { IIndexFieldValue } from '../../src/rest/FieldValue';
 import { Simulate } from '../Simulate';
 import { KEYBOARD } from '../../src/utils/KeyboardUtils';
+import { find } from 'underscore';
 
 export function FacetSearchTest() {
   describe('FacetSearch', () => {
@@ -97,7 +98,7 @@ export function FacetSearchTest() {
         (<jasmine.Spy>mockFacet.facetQueryController.search).and.returnValue(pr);
         facetSearch.triggerNewFacetSearch(params);
         await pr;
-        const firstResultWithoutLabel = allSearchResults().find(result => !result.getAttribute('aria-label'));
+        const firstResultWithoutLabel = find(allSearchResults(), result => !result.getAttribute('aria-label'));
         expect(firstResultWithoutLabel).toBeFalsy();
         done();
       });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2818

Added a label to `FacetSearch`'s results so that Android's TalkBack can read them out.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)