### PR TITLE
JSUI-2820 Checkbox background color the same as foreground when disabled

### DIFF
--- a/sass/coveo-styleguide/scss/controls/_checkboxes.scss
+++ b/sass/coveo-styleguide/scss/controls/_checkboxes.scss
@@ -93,11 +93,10 @@ input[type='checkbox'].coveo-checkbox {
   }
 
   &:disabled + button {
-    background-color: $dark-grey;
     border-color: $dark-grey;
 
     cursor: default;
-    opacity: 0.2;
+    opacity: 0.4;
   }
 }
 

--- a/sass/coveo-styleguide/scss/controls/_checkboxes.scss
+++ b/sass/coveo-styleguide/scss/controls/_checkboxes.scss
@@ -94,9 +94,8 @@ input[type='checkbox'].coveo-checkbox {
 
   &:disabled + button {
     border-color: $dark-grey;
-
     cursor: default;
-    opacity: 0.4;
+    opacity: 0.2;
   }
 }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2820

Example of what it looks like. Not a use case in the JSUI directly but it broke the interface editor checkboxes.
<img width="329" alt="Screen Shot 2020-01-10 at 3 47 52 PM" src="https://user-images.githubusercontent.com/4923043/72185369-a567c480-33c0-11ea-9929-488e82a7174f.png">


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)