### PR TITLE
JSUI-2478 - SortDropdown component

### DIFF
--- a/sass/_SortDropdown.scss
+++ b/sass/_SortDropdown.scss
@@ -9,7 +9,7 @@
     margin: 0;
     border: none;
     cursor: pointer;
-    background-position-y: -4px;
+    background-position-y: -5px;
     font-family: 'Lato', $helvetica, sans-serif;
   }
 

--- a/sass/_SortDropdown.scss
+++ b/sass/_SortDropdown.scss
@@ -1,0 +1,23 @@
+@import 'mixins/resultsHeaderElement';
+@import 'Variables';
+
+.CoveoSortDropdown {
+  .coveo-dropdown {
+    @include resultsHeaderElement();
+
+    text-indent: 0;
+    margin: 0;
+    border: none;
+    cursor: pointer;
+    background-position-y: -4px;
+    font-family: 'Lato', $helvetica, sans-serif;
+  }
+
+  .CoveoSort {
+    display: none;
+  }
+
+  &.coveo-hidden {
+    display: none;
+  }
+}

--- a/sass/_SortDropdown.scss
+++ b/sass/_SortDropdown.scss
@@ -10,14 +10,16 @@
     border: none;
     cursor: pointer;
     background-position-y: -5px;
-    font-family: 'Lato', $helvetica, sans-serif;
+    font-family: inherit;
+
+    &:focus {
+      outline: thin dotted;
+      outline: 5px auto -webkit-focus-ring-color;
+      outline-offset: -2px;
+    }
   }
 
   .CoveoSort {
-    display: none;
-  }
-
-  &.coveo-hidden {
     display: none;
   }
 }

--- a/sass/vapor/_Dropdown.scss
+++ b/sass/vapor/_Dropdown.scss
@@ -9,7 +9,9 @@
   margin: 0 10px;
   @include flex-basis(115px);
   background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHByZXNlcnZlQXNwZWN0UmF0aW89InhNaW5ZTWluIiB2aWV3Qm94PSIwIDAgNC45NSAxMCI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7fS5jbHMtMntmaWxsOiM0NDQ7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5hcnJvd3M8L3RpdGxlPjxyZWN0IGNsYXNzPSJjbHMtMSIgd2lkdGg9IjQuOTUiIGhlaWdodD0iMTAiLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMS40MSA0LjY3IDIuNDggMy4xOCAzLjU0IDQuNjcgMS40MSA0LjY3Ii8+PHBvbHlnb24gY2xhc3M9ImNscy0yIiBwb2ludHM9IjMuNTQgNS4zMyAyLjQ4IDYuODIgMS40MSA1LjMzIDMuNTQgNS4zMyIvPjwvc3ZnPg==)
-    no-repeat 95% 50%;
+    no-repeat;
+  background-position-x: 95%;
+  background-position-y: 50%;
   vertical-align: middle;
   height: 30px;
   min-width: 150px;

--- a/src/Eager.ts
+++ b/src/Eager.ts
@@ -310,3 +310,6 @@ ImageFieldValue.doExport();
 
 import { CommerceQuery } from './ui/CommerceQuery/CommerceQuery';
 CommerceQuery.doExport();
+
+import { SortDropdown } from './ui/SortDropdown/SortDropdown';
+SortDropdown.doExport();

--- a/src/Lazy.ts
+++ b/src/Lazy.ts
@@ -308,3 +308,6 @@ lazyQuerySuggestPreview();
 
 import { lazyCommerceQuery } from './ui/CommerceQuery/LazyCommerceQuery';
 lazyCommerceQuery();
+
+import { lazySortDropdown } from './ui/SortDropdown/LazySortDropdown';
+lazySortDropdown();

--- a/src/ui/Sort/Sort.ts
+++ b/src/ui/Sort/Sort.ts
@@ -133,7 +133,7 @@ export class Sort extends Component {
   /**
    * Selects this `Sort` component.
    *
-   * Triggers a query if selecting this component toggles its current [`sortCriteria`]{@link Sort.options.sortCriteria}.
+   * Updates the state model if selecting this component toggles its current [`sortCriteria`]{@link Sort.options.sortCriteria}.
    *
    * @param direction The sort direction. Can be one of: `ascending`, `descending`.
    */
@@ -151,6 +151,22 @@ export class Sort extends Component {
     }
 
     this.queryStateModel.set(QueryStateModel.attributesEnum.sort, this.currentCriteria.toString());
+  }
+
+  /**
+   * Selects this `Sort` component, then triggers a query if selecting this component toggles its current [`sortCriteria`]{@link Sort.options.sortCriteria}.
+   *
+   * Also logs an event in the usage analytics with the new current sort criteria.
+   */
+
+  public selectAndExecuteQuery() {
+    var oldCriteria = this.currentCriteria;
+    this.select();
+    if (oldCriteria != this.currentCriteria) {
+      this.queryController.deferExecuteQuery({
+        beforeExecuteQuery: () => logSortEvent(this.usageAnalytics, this.currentCriteria.sort + this.currentCriteria.direction)
+      });
+    }
   }
 
   public enable() {
@@ -242,13 +258,7 @@ export class Sort extends Component {
   }
 
   private handleClick() {
-    var oldCriteria = this.currentCriteria;
-    this.select();
-    if (oldCriteria != this.currentCriteria) {
-      this.queryController.deferExecuteQuery({
-        beforeExecuteQuery: () => logSortEvent(this.usageAnalytics, this.currentCriteria.sort + this.currentCriteria.direction)
-      });
-    }
+    this.selectAndExecuteQuery();
   }
 
   private isToggle(): boolean {

--- a/src/ui/SortDropdown/LazySortDropdown.ts
+++ b/src/ui/SortDropdown/LazySortDropdown.ts
@@ -1,0 +1,19 @@
+import { IComponentDefinition } from '../Base/Component';
+import { LazyInitialization } from '../Base/Initialization';
+import { lazyExport } from '../../GlobalExports';
+
+export function lazySortDropdown() {
+  LazyInitialization.registerLazyComponent('SortDropdown', () => {
+    return new Promise((resolve, reject) => {
+      require.ensure(
+        ['./SortDropdown'],
+        () => {
+          let loaded = require<IComponentDefinition>('./SortDropdown.ts')['SortDropdown'];
+          lazyExport(loaded, resolve);
+        },
+        LazyInitialization.buildErrorCallback('SortDropdown', resolve),
+        'SortDropdown'
+      );
+    });
+  });
+}

--- a/src/ui/SortDropdown/SortDropdown.ts
+++ b/src/ui/SortDropdown/SortDropdown.ts
@@ -119,7 +119,6 @@ export class SortDropdown extends Component {
    * @param sortCriteria The sort criteria to select.
    * @param executeQuery Whether to execute a query after changing the sort criteria
    */
-
   public select(sortCriteria: string, executeQuery: boolean = false) {
     const sortIndex = this.getSortIndex(sortCriteria);
     sortIndex > -1 && this.dropdown.select(sortIndex, executeQuery);

--- a/src/ui/SortDropdown/SortDropdown.ts
+++ b/src/ui/SortDropdown/SortDropdown.ts
@@ -1,0 +1,146 @@
+import 'styling/_SortDropdown';
+import { each, findIndex } from 'underscore';
+import { exportGlobally } from '../../GlobalExports';
+import { IQuerySuccessEventArgs, QueryEvents } from '../../events/QueryEvents';
+import { IAttributeChangedEventArg, MODEL_EVENTS } from '../../models/Model';
+import { QUERY_STATE_ATTRIBUTES, QueryStateModel } from '../../models/QueryStateModel';
+import { $$ } from '../../utils/Dom';
+import { Component } from '../Base/Component';
+import { IComponentBindings } from '../Base/ComponentBindings';
+import { ComponentOptions } from '../Base/ComponentOptions';
+import { Initialization } from '../Base/Initialization';
+import { InitializationEvents } from '../../events/InitializationEvents';
+import { Sort } from '../Sort/Sort';
+import { SortCriteria } from '../Sort/SortCriteria';
+import { Dropdown } from '../FormWidgets/Dropdown';
+import { l } from '../../strings/Strings';
+
+export interface ISortDropdownOptions {}
+
+export interface ISortDropdownItem {
+  criteria: SortCriteria;
+  caption: string;
+}
+
+/**
+ * The `SortDropdown` component renders a dropdown that the end user can interact with to select the criterion to use when sorting query results.
+ */
+export class SortDropdown extends Component {
+  static ID = 'SortDropdown';
+
+  static doExport = () => {
+    exportGlobally({
+      SortDropdown: SortDropdown
+    });
+  };
+
+  /**
+   * Options for the component
+   * @componentOptions
+   */
+  static options: ISortDropdownOptions = {};
+
+  private dropdown: Dropdown;
+  private sortOptions: ISortDropdownItem[] = [];
+
+  /**
+   * Creates a new `SortDropdown` component instance.
+   * @param element The HTMLElement on which to instantiate the component.
+   * @param options The options for this component instance.
+   * @param bindings The bindings that the component requires to function normally. If not set, these will be
+   * automatically resolved (with a slower execution time).
+   */
+  constructor(public element: HTMLElement, public options?: ISortDropdownOptions, bindings?: IComponentBindings) {
+    super(element, SortDropdown.ID, bindings);
+
+    this.options = ComponentOptions.initComponentOptions(element, SortDropdown, options);
+
+    this.bind.oneRootElement(InitializationEvents.afterInitialization, () => this.handleAfterInitialization());
+    this.bind.onQueryState(MODEL_EVENTS.CHANGE_ONE, QUERY_STATE_ATTRIBUTES.SORT, (args: IAttributeChangedEventArg) =>
+      this.handleQueryStateChanged(args)
+    );
+    this.bind.onRootElement(QueryEvents.querySuccess, (args: IQuerySuccessEventArgs) => this.handleQuerySuccess(args));
+  }
+
+  private handleAfterInitialization() {
+    this.buildDropdown();
+  }
+
+  private buildDropdown() {
+    this.sortOptions = this.getSortOptions();
+    this.dropdown = new Dropdown(
+      () => this.handleSelectChange(),
+      this.getValuesForDropdown(),
+      value => this.getCaptionForValue(value),
+      l('SortBy')
+    );
+    this.element.appendChild(this.dropdown.getElement());
+    this.update();
+  }
+
+  private getSortOptions() {
+    const sortOptions: ISortDropdownItem[] = [];
+    const sortElements = $$(this.element).findAll('.CoveoSort');
+
+    each(sortElements, sortEl => {
+      const sortInstance = <Sort>Component.get(sortEl, Sort);
+
+      if (sortInstance.options.sortCriteria.length > 1) {
+        this.logger.warn(
+          `Each Sort component inside a SortDropdown should have only one sort criteria. Disabling ${
+            sortInstance.options.caption
+          } in the SortDropdown.`
+        );
+      } else {
+        sortOptions.push({
+          caption: sortInstance.options.caption,
+          criteria: sortInstance.options.sortCriteria[0]
+        });
+      }
+    });
+
+    return sortOptions;
+  }
+
+  private getValuesForDropdown(): string[] {
+    return this.sortOptions.map(option => option.criteria.toString());
+  }
+
+  private handleQueryStateChanged(data: IAttributeChangedEventArg) {
+    this.update();
+  }
+
+  private update() {
+    if (!this.dropdown) {
+      return;
+    }
+
+    const sortCriteria = <string>this.queryStateModel.get(QueryStateModel.attributesEnum.sort);
+    const optionIndex = this.getSortOptionIndex(sortCriteria);
+    optionIndex > -1 && this.dropdown.select(optionIndex, false);
+
+    $$(this.dropdown.getElement()).toggleClass('coveo-selected', optionIndex > -1);
+  }
+
+  private handleQuerySuccess(data: IQuerySuccessEventArgs) {
+    data.results.results.length == 0 ? $$(this.element).addClass('coveo-hidden') : $$(this.element).removeClass('coveo-hidden');
+  }
+
+  private handleSelectChange() {
+    const selectedValue = this.dropdown.getValue();
+    $$(this.element)
+      .find(`.CoveoSort[data-sort-criteria="${selectedValue}"]`)
+      .click();
+  }
+
+  private getCaptionForValue(option: string) {
+    const index = this.getSortOptionIndex(option);
+    return index > -1 ? this.sortOptions[index].caption : '';
+  }
+
+  private getSortOptionIndex(option: string) {
+    return findIndex(this.sortOptions, sortOption => sortOption.criteria.toString() === option);
+  }
+}
+
+Initialization.registerAutoCreateComponent(SortDropdown);

--- a/src/ui/SortDropdown/SortDropdown.ts
+++ b/src/ui/SortDropdown/SortDropdown.ts
@@ -1,7 +1,7 @@
 import 'styling/_SortDropdown';
 import { each, findIndex } from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
-import { IQuerySuccessEventArgs, QueryEvents } from '../../events/QueryEvents';
+import { IQuerySuccessEventArgs, IQueryErrorEventArgs, QueryEvents } from '../../events/QueryEvents';
 import { IAttributeChangedEventArg, MODEL_EVENTS } from '../../models/Model';
 import { QUERY_STATE_ATTRIBUTES, QueryStateModel } from '../../models/QueryStateModel';
 import { $$ } from '../../utils/Dom';
@@ -60,6 +60,7 @@ export class SortDropdown extends Component {
       this.handleQueryStateChanged(args)
     );
     this.bind.onRootElement(QueryEvents.querySuccess, (args: IQuerySuccessEventArgs) => this.handleQuerySuccess(args));
+    this.bind.onRootElement(QueryEvents.queryError, (args: IQueryErrorEventArgs) => this.handleQueryError(args));
   }
 
   private handleAfterInitialization() {
@@ -124,6 +125,10 @@ export class SortDropdown extends Component {
 
   private handleQuerySuccess(data: IQuerySuccessEventArgs) {
     data.results.results.length == 0 ? $$(this.element).addClass('coveo-hidden') : $$(this.element).removeClass('coveo-hidden');
+  }
+
+  private handleQueryError(data: IQueryErrorEventArgs) {
+    $$(this.element).addClass('coveo-hidden');
   }
 
   private handleSelectChange() {

--- a/src/ui/SortDropdown/SortDropdown.ts
+++ b/src/ui/SortDropdown/SortDropdown.ts
@@ -14,8 +14,6 @@ import { Sort } from '../Sort/Sort';
 import { Dropdown } from '../FormWidgets/Dropdown';
 import { l } from '../../strings/Strings';
 
-export interface ISortDropdownOptions {}
-
 /**
  * The `SortDropdown` component renders a dropdown that the end user can interact with to select the criteria to use when sorting query results.
  *
@@ -31,7 +29,7 @@ export interface ISortDropdownOptions {}
  */
 export class SortDropdown extends Component {
   static ID = 'SortDropdown';
-  static options: ISortDropdownOptions = {};
+  static options: any = {};
 
   static doExport = () => {
     exportGlobally({
@@ -49,7 +47,7 @@ export class SortDropdown extends Component {
    * @param bindings The bindings that the component requires to function normally. If not set, these will be
    * automatically resolved (with a slower execution time).
    */
-  constructor(public element: HTMLElement, public options?: ISortDropdownOptions, bindings?: IComponentBindings) {
+  constructor(public element: HTMLElement, public options?: any, bindings?: IComponentBindings) {
     super(element, SortDropdown.ID, bindings);
 
     this.options = ComponentOptions.initComponentOptions(element, SortDropdown, options);

--- a/src/ui/SortDropdown/SortDropdown.ts
+++ b/src/ui/SortDropdown/SortDropdown.ts
@@ -108,10 +108,19 @@ export class SortDropdown extends Component {
     }
 
     const sortCriteria = <string>this.queryStateModel.get(QueryStateModel.attributesEnum.sort);
-    const itemIndex = this.getSortIndex(sortCriteria);
-    itemIndex > -1 && this.dropdown.select(itemIndex, false);
+    this.select(sortCriteria);
+  }
 
-    $$(this.dropdown.getElement()).toggleClass('coveo-selected', itemIndex > -1);
+  /**
+   * Selects a sort criteria from the options.
+   * @param sortCriteria The sort criteria to select.
+   * @param executeQuery Whether to execute a query after changing the sort criteria
+   */
+
+  public select(sortCriteria: string, executeQuery: boolean = false) {
+    const sortIndex = this.getSortIndex(sortCriteria);
+    sortIndex > -1 && this.dropdown.select(sortIndex, executeQuery);
+    $$(this.dropdown.getElement()).toggleClass('coveo-selected', sortIndex > -1);
   }
 
   private handleQuerySuccess(data: IQuerySuccessEventArgs) {

--- a/src/ui/SortDropdown/SortDropdown.ts
+++ b/src/ui/SortDropdown/SortDropdown.ts
@@ -17,22 +17,27 @@ import { l } from '../../strings/Strings';
 export interface ISortDropdownOptions {}
 
 /**
- * The `SortDropdown` component renders a dropdown that the end user can interact with to select the criterion to use when sorting query results.
+ * The `SortDropdown` component renders a dropdown that the end user can interact with to select the criteria to use when sorting query results.
+ *
+ * It is meant to be a parent of regular [`Sort`]{@link Sort} components. Example:
+ * ```
+ * <div class="CoveoSortDropdown">
+ *   <span class="CoveoSort" data-sort-criteria="relevancy" data-caption="Relevance"></span>
+ *   <span class="CoveoSort" data-sort-criteria="date descending" data-caption="Newest"></span>
+ *   <span class="CoveoSort" data-sort-criteria="date ascending" data-caption="Oldest"></span>
+ * </div>
+ * ```
+ * Each one of the children `Sort` components should have only one sort criteria to prevent the regular toggle behaviour.
  */
 export class SortDropdown extends Component {
   static ID = 'SortDropdown';
+  static options: ISortDropdownOptions = {};
 
   static doExport = () => {
     exportGlobally({
       SortDropdown: SortDropdown
     });
   };
-
-  /**
-   * Options for the component
-   * @componentOptions
-   */
-  static options: ISortDropdownOptions = {};
 
   private dropdown: Dropdown;
   private sortComponents: Sort[] = [];

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -812,3 +812,6 @@ CommerceQueryTest();
 
 import { FocusTrapTest } from './ui/FocusTrapTest';
 FocusTrapTest();
+
+import { SortDropdownTest } from './ui/SortDropdownTest';
+SortDropdownTest();

--- a/unitTests/ui/SortDropdownTest.ts
+++ b/unitTests/ui/SortDropdownTest.ts
@@ -1,0 +1,142 @@
+import { IQuerySuccessEventArgs, QueryEvents } from '../../src/events/QueryEvents';
+import { QUERY_STATE_ATTRIBUTES } from '../../src/models/QueryStateModel';
+import { SortDropdown } from '../../src/ui/SortDropdown/SortDropdown';
+import { Sort } from '../../src/ui/Sort/Sort';
+import { $$ } from '../../src/utils/Dom';
+import * as Mock from '../MockEnvironment';
+import { Simulate } from '../Simulate';
+
+export function SortDropdownTest() {
+  describe('SortDropdown', function() {
+    let sorts: Sort[];
+    var test: Mock.IBasicComponentSetup<SortDropdown>;
+
+    function createFakeSort(sortCriteria: string, caption: string) {
+      const container = $$('div', {
+        'data-sort-criteria': sortCriteria,
+        'data-caption': caption
+      });
+
+      return Mock.advancedComponentSetup<Sort>(Sort, <Mock.AdvancedComponentSetupOptions>{
+        element: container.el
+      });
+    }
+
+    function initializeSorts() {
+      sorts = [createFakeSort('date ascending', 'Newest').cmp, createFakeSort('relevancy', 'Relevancy').cmp];
+    }
+
+    function initializeSortDropdown() {
+      test = Mock.advancedComponentSetup<SortDropdown>(SortDropdown, <Mock.AdvancedComponentSetupOptions>{
+        cmpOptions: {},
+        modifyBuilder: builder => {
+          sorts.forEach(sort => builder.element.appendChild(sort.element));
+          return builder.withLiveQueryStateModel();
+        }
+      });
+    }
+
+    function triggerAfterComponentsInitialization() {
+      sorts.forEach(sort => {
+        Simulate.initialization(sort.getBindings() as Mock.IMockEnvironment);
+      });
+
+      Simulate.initialization(test.env);
+    }
+
+    function triggerQuerySuccessWithResults(results: any[]) {
+      $$(test.env.root).trigger(QueryEvents.querySuccess, <IQuerySuccessEventArgs>{
+        results: {
+          results
+        }
+      });
+    }
+
+    function findSelect() {
+      return $$(test.cmp.element).find('select');
+    }
+
+    beforeEach(() => {
+      initializeSorts();
+      initializeSortDropdown();
+      triggerAfterComponentsInitialization();
+    });
+
+    afterEach(function() {
+      test = null;
+      sorts = [];
+    });
+
+    it('should create a select element after initialization', () => {
+      expect($$(test.cmp.element).find('select')).toBeTruthy();
+    });
+
+    it('should create same number of select options when all sort components are valid, ', () => {
+      expect($$(test.cmp.element).findAll('select > option').length).toEqual(sorts.length);
+    });
+
+    it('should not create an option if the sort criteria is a toggle and warn the user', () => {
+      sorts.push(createFakeSort('@date ascending,@date descending', 'foobar').cmp);
+      initializeSortDropdown();
+      spyOn(test.cmp.logger, 'warn');
+      triggerAfterComponentsInitialization();
+
+      expect($$(test.cmp.element).findAll('select > option').length).toEqual(sorts.length - 1);
+      expect(test.cmp.logger.warn).toHaveBeenCalled();
+    });
+
+    it('should be visible when there are results', function() {
+      triggerQuerySuccessWithResults([{}, {}]);
+
+      expect($$(test.cmp.element).isVisible()).toBe(true);
+    });
+
+    it('should not be visible when there are no results', function() {
+      triggerQuerySuccessWithResults([]);
+
+      expect($$(test.cmp.element).isVisible()).toBe(false);
+    });
+
+    it('should not be visible when there is a query error', function() {
+      $$(test.env.root).trigger(QueryEvents.queryError);
+      expect($$(test.cmp.element).isVisible()).toBe(false);
+    });
+
+    it('should update the select element when the query state changes', function() {
+      const selectElement = <HTMLSelectElement>findSelect();
+
+      test.env.queryStateModel.set(QUERY_STATE_ATTRIBUTES.SORT, 'relevancy');
+      expect(selectElement.value).toEqual('relevancy');
+
+      test.env.queryStateModel.set(QUERY_STATE_ATTRIBUTES.SORT, 'date ascending');
+      expect(selectElement.value).toEqual('date ascending');
+    });
+
+    it('should add a selected class if an option is active', function() {
+      test.env.queryStateModel.set(QUERY_STATE_ATTRIBUTES.SORT, 'relevancy');
+
+      expect($$(findSelect()).hasClass('coveo-selected')).toBe(true);
+    });
+
+    it('should not add a selected class if an option does not exist', function() {
+      test.env.queryStateModel.set(QUERY_STATE_ATTRIBUTES.SORT, '@fieldy');
+
+      expect($$(findSelect()).hasClass('coveo-selected')).toBe(false);
+    });
+
+    it('should change the value of the element on select', function() {
+      const selectElement = <HTMLSelectElement>findSelect();
+      test.cmp.select('relevancy', true);
+
+      expect(selectElement.value).toBe('relevancy');
+    });
+
+    it('should not change the value of the element if an option doesnt exist select', function() {
+      const selectElement = <HTMLSelectElement>findSelect();
+      const prevValue = selectElement.value;
+      test.cmp.select('@aField', true);
+
+      expect(selectElement.value).toBe(prevValue);
+    });
+  });
+}

--- a/unitTests/ui/SortTest.ts
+++ b/unitTests/ui/SortTest.ts
@@ -49,6 +49,15 @@ export function SortTest() {
       expect(test.cmp.select).toHaveBeenCalled();
     });
 
+    it("should trigger 'selectAndExecuteQuery' on click", function() {
+      test = buildSort('relevancy');
+
+      spyOn(test.cmp, 'selectAndExecuteQuery');
+
+      test.env.element.click();
+      expect(test.cmp.selectAndExecuteQuery).toHaveBeenCalled();
+    });
+
     it("should set a 'hidden' CSS class when the results from a querySuccess are empty", function() {
       $$(test.env.root).trigger(QueryEvents.querySuccess, <IQuerySuccessEventArgs>{
         results: {


### PR DESCRIPTION
Here is the most basic approach that implements the SortDropdown by composing an existing `Dropdown` and `Sort` components. I also tried to stick to the current results header look and feel.

The markup looks like this and no options at all for the moment:
```
<div class="CoveoSortDropdown">
  <span class="CoveoSort" data-sort-criteria="relevancy" data-caption="Relevance"></span>
  <span class="CoveoSort" data-sort-criteria="date descending" data-caption="Newest"></span>
  <span class="CoveoSort" data-sort-criteria="date ascending" data-caption="Oldest"></span>
</div>
```
For IEditor, I think it's not necessary to use D&D for the moment and maybe one grid like the one it's being used for _Custom Facet Value Options_ could do the job, but really don't know what option could be more convenient to implement at the moment in IEditor.

Closed:
![image](https://user-images.githubusercontent.com/58610077/72270924-f1e71600-35f3-11ea-8c9e-7a807988ad65.png)

Open:
![image](https://user-images.githubusercontent.com/58610077/72270991-104d1180-35f4-11ea-8c18-c12ec523306e.png)
(Chrome applies also the uppercase transformation to the options which I don't like it. Thinking about a workaround.)

Mobile:
<img src="https://user-images.githubusercontent.com/58610077/72271417-dc262080-35f4-11ea-8e94-260aa06af058.png" alt="drawing" width="300"/>

Thoughts? Maybe I could start exploring the custom dropdown/ui approach now.

https://coveord.atlassian.net/browse/JSUI-2478