### PR TITLE
JSUI-2819 Fixed `DynamicFacetSearch`'s keyboard interaction with Android's TalkBack

### DIFF
--- a/src/ui/Combobox/ComboboxInput.ts
+++ b/src/ui/Combobox/ComboboxInput.ts
@@ -40,9 +40,9 @@ export class ComboboxInput {
     if (!this.combobox.options.clearOnBlur) {
       $$(this.inputElement).on('focus', () => this.combobox.onInputChange(this.textInput.getValue()));
     }
-    $$(this.inputElement).on('blur', () => this.combobox.onInputBlur());
-    $$(this.inputElement).on('keydown', (e: KeyboardEvent) => this.handleKeyboardUpDownArrows(e));
-    $$(this.inputElement).on('keyup', (e: KeyboardEvent) => this.handleKeyboardEnterEscape(e));
+    $$(this.combobox.element).on('focusout', (e: FocusEvent) => this.handleFocusOut(e));
+    $$(this.combobox.element).on('keydown', (e: KeyboardEvent) => this.handleKeyboardUpDownArrows(e));
+    $$(this.combobox.element).on('keyup', (e: KeyboardEvent) => this.handleKeyboardEnterEscape(e));
   }
 
   private addAccessibilityAttributes() {
@@ -71,6 +71,14 @@ export class ComboboxInput {
 
   public clearInput() {
     this.textInput.reset();
+  }
+
+  private handleFocusOut(event: FocusEvent) {
+    const newTarget = event.relatedTarget as HTMLElement;
+    if (newTarget && this.combobox.element.contains(newTarget)) {
+      return;
+    }
+    this.combobox.onInputBlur();
   }
 
   private handleKeyboardUpDownArrows(event: KeyboardEvent) {

--- a/src/ui/Combobox/ComboboxInput.ts
+++ b/src/ui/Combobox/ComboboxInput.ts
@@ -75,7 +75,8 @@ export class ComboboxInput {
 
   private handleFocusOut(event: FocusEvent) {
     const newTarget = event.relatedTarget as HTMLElement;
-    if (newTarget && this.combobox.element.contains(newTarget)) {
+    const isFocusedOnInput = this.combobox.element.contains(newTarget);
+    if (isFocusedOnInput) {
       return;
     }
     this.combobox.onInputBlur();

--- a/src/ui/Combobox/ComboboxValues.ts
+++ b/src/ui/Combobox/ComboboxValues.ts
@@ -46,7 +46,7 @@ export class ComboboxValues {
     this.values.forEach((value, index) => {
       const elementWrapper = $$(
         'li',
-        { id: `${this.combobox.id}-value-${index}`, className: 'coveo-combobox-value', role: 'option' },
+        { id: `${this.combobox.id}-value-${index}`, className: 'coveo-combobox-value', role: 'option', tabindex: 0 },
         value.element
       ).el;
       value.element = elementWrapper;
@@ -76,10 +76,11 @@ export class ComboboxValues {
   }
 
   private addEventListeners() {
-    this.values.forEach(({ element }) => {
-      $$(element).on('mouseenter', () => (this.mouseIsOverValue = true));
-      $$(element).on('mouseleave', () => (this.mouseIsOverValue = false));
-      $$(element).on('click', (e: MouseEvent) => this.onValueClick(e));
+    this.values.forEach(value => {
+      $$(value.element).on('mouseenter', () => (this.mouseIsOverValue = true));
+      $$(value.element).on('mouseleave', () => (this.mouseIsOverValue = false));
+      $$(value.element).on('click', (e: MouseEvent) => this.onValueClick(e));
+      $$(value.element).on('focus', () => this.setKeyboardActiveValue(value));
     });
   }
 
@@ -116,8 +117,10 @@ export class ComboboxValues {
   }
 
   private setKeyboardActiveValue(value: IComboboxValue) {
+    this.resetKeyboardActiveValue();
     this.keyboardActiveValue = value;
     this.activateFocusOnValue(this.keyboardActiveValue);
+    this.updateAccessibilityAttributes();
   }
 
   private resetKeyboardActiveValue() {
@@ -154,9 +157,7 @@ export class ComboboxValues {
     }
 
     const nextActiveValue = this.nextOrFirstValue;
-    this.resetKeyboardActiveValue();
-    this.setKeyboardActiveValue(nextActiveValue);
-    this.updateAccessibilityAttributes();
+    nextActiveValue.element.focus();
   }
 
   public moveActiveValueUp() {
@@ -165,9 +166,7 @@ export class ComboboxValues {
     }
 
     const previousActiveValue = this.previousOrLastValue;
-    this.resetKeyboardActiveValue();
-    this.setKeyboardActiveValue(previousActiveValue);
-    this.updateAccessibilityAttributes();
+    previousActiveValue.element.focus();
   }
 
   private get nextOrFirstValue() {

--- a/unitTests/ui/Combobox/ComboboxInputTest.ts
+++ b/unitTests/ui/Combobox/ComboboxInputTest.ts
@@ -50,35 +50,39 @@ export function ComboboxInputTest() {
 
     it(`when triggering blur on the input
     should call the "onInputBlur" method of the combobox`, () => {
-      $$(getInput()).trigger('blur');
+      const relatedTarget = document.body;
+      const eventData: Partial<FocusEvent> = {
+        relatedTarget
+      };
+      $$(combobox.element).trigger('focusout', eventData);
       expect(combobox.onInputBlur).toHaveBeenCalled();
     });
 
     it(`when pressing the down arrow on the keyboard
     should call the "moveActiveValueDown" method of the combobox values`, () => {
       spyOn(combobox.values, 'moveActiveValueDown');
-      Simulate.keyDown(getInput(), KEYBOARD.DOWN_ARROW);
+      Simulate.keyDown(combobox.element, KEYBOARD.DOWN_ARROW);
       expect(combobox.values.moveActiveValueDown).toHaveBeenCalled();
     });
 
     it(`when pressing the up arrow on the keyboard
     should call the "moveActiveValueUp" method of the combobox values`, () => {
       spyOn(combobox.values, 'moveActiveValueUp');
-      Simulate.keyDown(getInput(), KEYBOARD.UP_ARROW);
+      Simulate.keyDown(combobox.element, KEYBOARD.UP_ARROW);
       expect(combobox.values.moveActiveValueUp).toHaveBeenCalled();
     });
 
     it(`when pressing enter button of the keyboard
     should call the "selectActiveValue" method of the combobox values`, () => {
       spyOn(combobox.values, 'selectActiveValue');
-      Simulate.keyUp(getInput(), KEYBOARD.ENTER);
+      Simulate.keyUp(combobox.element, KEYBOARD.ENTER);
       expect(combobox.values.selectActiveValue).toHaveBeenCalled();
     });
 
     it(`when pressing escape button of the keyboard
     should call the "clearAll" method of the combobox`, () => {
       spyOn(combobox, 'clearAll');
-      Simulate.keyUp(getInput(), KEYBOARD.ESCAPE);
+      Simulate.keyUp(combobox.element, KEYBOARD.ESCAPE);
       expect(combobox.clearAll).toHaveBeenCalled();
     });
 

--- a/unitTests/ui/Combobox/ComboboxValuesTest.ts
+++ b/unitTests/ui/Combobox/ComboboxValuesTest.ts
@@ -23,9 +23,16 @@ export function ComboboxValuesTest() {
       initializeComponent();
     });
 
+    function mockComboboxValuesFocusFunction() {
+      comboboxValues['values'].forEach(value => {
+        spyOn(value.element, 'focus').and.callFake(() => comboboxValues['setKeyboardActiveValue'](value));
+      });
+    }
+
     function triggerRenderFromResponse(newResponse: string[]) {
       response = newResponse;
       comboboxValues.renderFromResponse(response);
+      mockComboboxValuesFocusFunction();
     }
 
     function initializeComponent(additionalOptions?: Partial<IComboboxOptions>) {
@@ -44,6 +51,10 @@ export function ComboboxValuesTest() {
 
     function isChildrenActiveAtIndex(index: number) {
       return $$(getChildren()[index]).hasClass('coveo-focused');
+    }
+
+    function countChildrenFocusedAtIndex(index: number) {
+      return (getChildren()[index].focus as jasmine.Spy).calls.count();
     }
 
     describe('when being initialized', () => {
@@ -94,6 +105,10 @@ export function ComboboxValuesTest() {
         $$(valueElement).trigger('mouseleave');
 
         expect(comboboxValues.mouseIsOverValue).toBe(false);
+      });
+
+      it('should add a tabindex to every value', () => {
+        getChildren().forEach(valueElement => expect(valueElement.tabIndex).toEqual(0));
       });
 
       describe('when a value is clicked', () => {
@@ -179,6 +194,13 @@ export function ComboboxValuesTest() {
         expect(isChildrenActiveAtIndex(0)).toBe(true);
       });
 
+      it(`when no value is active
+      should focus the first value`, () => {
+        comboboxValues.moveActiveValueDown();
+
+        expect(countChildrenFocusedAtIndex(0)).toEqual(1);
+      });
+
       it(`when a value is active
       should activate the next value`, () => {
         comboboxValues.moveActiveValueDown();
@@ -186,6 +208,15 @@ export function ComboboxValuesTest() {
 
         expect(isChildrenActiveAtIndex(0)).toBe(false);
         expect(isChildrenActiveAtIndex(1)).toBe(true);
+      });
+
+      it(`when a value is active
+      should focus the next value`, () => {
+        comboboxValues.moveActiveValueDown();
+        comboboxValues.moveActiveValueDown();
+
+        expect(countChildrenFocusedAtIndex(0)).toEqual(1);
+        expect(countChildrenFocusedAtIndex(1)).toEqual(1);
       });
 
       it(`when the last value is active
@@ -196,6 +227,16 @@ export function ComboboxValuesTest() {
 
         expect(isChildrenActiveAtIndex(1)).toBe(false);
         expect(isChildrenActiveAtIndex(0)).toBe(true);
+      });
+
+      it(`when the last is active
+      should focus the first value`, () => {
+        comboboxValues.moveActiveValueDown();
+        comboboxValues.moveActiveValueDown();
+        comboboxValues.moveActiveValueDown();
+
+        expect(countChildrenFocusedAtIndex(0)).toEqual(2);
+        expect(countChildrenFocusedAtIndex(1)).toEqual(1);
       });
 
       it('should call "updateAccessibilityAttributes" with the rigth attributes', () => {
@@ -223,6 +264,13 @@ export function ComboboxValuesTest() {
         expect(isChildrenActiveAtIndex(1)).toBe(true);
       });
 
+      it(`when no value is active
+      should focus the last value`, () => {
+        comboboxValues.moveActiveValueUp();
+
+        expect(countChildrenFocusedAtIndex(1)).toEqual(1);
+      });
+
       it(`when a value is active
       should activate the previous value`, () => {
         comboboxValues.moveActiveValueUp();
@@ -230,6 +278,15 @@ export function ComboboxValuesTest() {
 
         expect(isChildrenActiveAtIndex(1)).toBe(false);
         expect(isChildrenActiveAtIndex(0)).toBe(true);
+      });
+
+      it(`when a value is active
+      should focus the previous value`, () => {
+        comboboxValues.moveActiveValueUp();
+        comboboxValues.moveActiveValueUp();
+
+        expect(countChildrenFocusedAtIndex(1)).toEqual(1);
+        expect(countChildrenFocusedAtIndex(0)).toEqual(1);
       });
 
       it(`when the last value is active
@@ -240,6 +297,16 @@ export function ComboboxValuesTest() {
 
         expect(isChildrenActiveAtIndex(0)).toBe(false);
         expect(isChildrenActiveAtIndex(1)).toBe(true);
+      });
+
+      it(`when the last value is active
+      should focus the last value`, () => {
+        comboboxValues.moveActiveValueUp();
+        comboboxValues.moveActiveValueUp();
+        comboboxValues.moveActiveValueUp();
+
+        expect(countChildrenFocusedAtIndex(0)).toEqual(1);
+        expect(countChildrenFocusedAtIndex(1)).toEqual(2);
       });
 
       it('should call "updateAccessibilityAttributes" with the right attributes', () => {

--- a/unitTests/ui/Combobox/ComboboxValuesTest.ts
+++ b/unitTests/ui/Combobox/ComboboxValuesTest.ts
@@ -53,7 +53,7 @@ export function ComboboxValuesTest() {
       return $$(getChildren()[index]).hasClass('coveo-focused');
     }
 
-    function countChildrenFocusedAtIndex(index: number) {
+    function getFocusCountAtIndex(index: number) {
       return (getChildren()[index].focus as jasmine.Spy).calls.count();
     }
 
@@ -198,7 +198,7 @@ export function ComboboxValuesTest() {
       should focus the first value`, () => {
         comboboxValues.moveActiveValueDown();
 
-        expect(countChildrenFocusedAtIndex(0)).toEqual(1);
+        expect(getFocusCountAtIndex(0)).toEqual(1);
       });
 
       it(`when a value is active
@@ -215,8 +215,8 @@ export function ComboboxValuesTest() {
         comboboxValues.moveActiveValueDown();
         comboboxValues.moveActiveValueDown();
 
-        expect(countChildrenFocusedAtIndex(0)).toEqual(1);
-        expect(countChildrenFocusedAtIndex(1)).toEqual(1);
+        expect(getFocusCountAtIndex(0)).toEqual(1);
+        expect(getFocusCountAtIndex(1)).toEqual(1);
       });
 
       it(`when the last value is active
@@ -235,8 +235,8 @@ export function ComboboxValuesTest() {
         comboboxValues.moveActiveValueDown();
         comboboxValues.moveActiveValueDown();
 
-        expect(countChildrenFocusedAtIndex(0)).toEqual(2);
-        expect(countChildrenFocusedAtIndex(1)).toEqual(1);
+        expect(getFocusCountAtIndex(0)).toEqual(2);
+        expect(getFocusCountAtIndex(1)).toEqual(1);
       });
 
       it('should call "updateAccessibilityAttributes" with the rigth attributes', () => {
@@ -268,7 +268,7 @@ export function ComboboxValuesTest() {
       should focus the last value`, () => {
         comboboxValues.moveActiveValueUp();
 
-        expect(countChildrenFocusedAtIndex(1)).toEqual(1);
+        expect(getFocusCountAtIndex(1)).toEqual(1);
       });
 
       it(`when a value is active
@@ -285,8 +285,8 @@ export function ComboboxValuesTest() {
         comboboxValues.moveActiveValueUp();
         comboboxValues.moveActiveValueUp();
 
-        expect(countChildrenFocusedAtIndex(1)).toEqual(1);
-        expect(countChildrenFocusedAtIndex(0)).toEqual(1);
+        expect(getFocusCountAtIndex(1)).toEqual(1);
+        expect(getFocusCountAtIndex(0)).toEqual(1);
       });
 
       it(`when the last value is active
@@ -305,8 +305,8 @@ export function ComboboxValuesTest() {
         comboboxValues.moveActiveValueUp();
         comboboxValues.moveActiveValueUp();
 
-        expect(countChildrenFocusedAtIndex(0)).toEqual(1);
-        expect(countChildrenFocusedAtIndex(1)).toEqual(2);
+        expect(getFocusCountAtIndex(0)).toEqual(1);
+        expect(getFocusCountAtIndex(1)).toEqual(2);
       });
 
       it('should call "updateAccessibilityAttributes" with the right attributes', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2819

This fixes an issue where using the arrow keys to navigate through `DynamicFacetSearch`'s results while TalkBack is on wouldn't cause TalkBack to speak the new selection. The issue was caused by the lack of a focus on the new selection, which is required for TalkBack to detect the new selection.

This fix makes sure that `DynamicFacetSearch`'s results are focusable and are focused when using the arrow keys.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)