### PR TITLE
JSUI-2826 Add `aria-expanded` to `FacetSearch`

### DIFF
--- a/src/ui/CategoryFacet/CategoryFacetSearch.ts
+++ b/src/ui/CategoryFacet/CategoryFacetSearch.ts
@@ -35,7 +35,9 @@ export class CategoryFacetSearch implements IFacetSearch {
     return CategoryFacet.ID;
   }
 
-  public set currentFacetSearchElementId(id: string) {}
+  public setExpandedFacetSearchAccessibilityAttributes(searchResultsElements: HTMLElement) {}
+
+  public setCollapsedFacetSearchAccessibilityAttributes() {}
 
   public build() {
     this.container = $$('div', {

--- a/src/ui/CategoryFacet/CategoryFacetSearch.ts
+++ b/src/ui/CategoryFacet/CategoryFacetSearch.ts
@@ -35,6 +35,8 @@ export class CategoryFacetSearch implements IFacetSearch {
     return CategoryFacet.ID;
   }
 
+  public set currentFacetSearchElementId(id: string) {}
+
   public build() {
     this.container = $$('div', {
       className: 'coveo-category-facet-search-container',

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -782,9 +782,9 @@ export class Facet extends Component {
     }
     const { accessibleElement } = this.searchContainer;
     if (!id) {
-      accessibleElement.removeAttribute('aria-owns');
+      accessibleElement.removeAttribute('aria-controls');
     } else {
-      accessibleElement.setAttribute('aria-owns', id);
+      accessibleElement.setAttribute('aria-controls', id);
     }
     accessibleElement.setAttribute('aria-expanded', (!!id).toString());
   }

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -777,6 +777,9 @@ export class Facet extends Component {
   }
 
   public set currentFacetSearchElementId(id: string) {
+    if (!this.searchContainer) {
+      return;
+    }
     const { accessibleElement } = this.searchContainer;
     if (!id) {
       accessibleElement.removeAttribute('aria-owns');

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -776,6 +776,16 @@ export class Facet extends Component {
     });
   }
 
+  public set currentFacetSearchElementId(id: string) {
+    const { accessibleElement } = this.searchContainer;
+    if (!id) {
+      accessibleElement.removeAttribute('aria-owns');
+    } else {
+      accessibleElement.setAttribute('aria-owns', id);
+    }
+    accessibleElement.setAttribute('aria-expanded', (!!id).toString());
+  }
+
   public isCurrentlyDisplayed() {
     if (!$$(this.element).isVisible()) {
       return false;
@@ -1432,6 +1442,8 @@ export class Facet extends Component {
       .withLabel(l('Search'))
       .withEnterKeyboardAction(e => this.toggleSearchMenu(e))
       .build();
+
+    this.currentFacetSearchElementId = null;
 
     // Mobile do not like label. Use click event
     if (DeviceUtils.isMobileDevice()) {

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -776,17 +776,21 @@ export class Facet extends Component {
     });
   }
 
-  public set currentFacetSearchElementId(id: string) {
+  public setExpandedFacetSearchAccessibilityAttributes(searchResultsElement: HTMLElement) {
     if (!this.searchContainer) {
       return;
     }
+    Assert.exists(searchResultsElement);
     const { accessibleElement } = this.searchContainer;
-    if (!id) {
-      accessibleElement.removeAttribute('aria-controls');
-    } else {
-      accessibleElement.setAttribute('aria-controls', id);
+    accessibleElement.setAttribute('aria-controls', searchResultsElement.id);
+    accessibleElement.setAttribute('aria-expanded', true.toString());
+  }
+
+  public setCollapsedFacetSearchAccessibilityAttributes() {
+    if (!this.searchContainer) {
+      return;
     }
-    accessibleElement.setAttribute('aria-expanded', (!!id).toString());
+    this.searchContainer.accessibleElement.setAttribute('aria-expanded', false.toString());
   }
 
   public isCurrentlyDisplayed() {
@@ -1446,7 +1450,7 @@ export class Facet extends Component {
       .withEnterKeyboardAction(e => this.toggleSearchMenu(e))
       .build();
 
-    this.currentFacetSearchElementId = null;
+    this.setCollapsedFacetSearchAccessibilityAttributes();
 
     // Mobile do not like label. Use click event
     if (DeviceUtils.isMobileDevice()) {

--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -144,6 +144,10 @@ export class FacetSearch implements IFacetSearch {
     this.facetSearchElement.focus();
   }
 
+  public set currentFacetSearchElementId(id: string) {
+    this.facet.currentFacetSearchElementId = id;
+  }
+
   public get searchResults() {
     return this.facetSearchElement.searchResults;
   }

--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -144,10 +144,6 @@ export class FacetSearch implements IFacetSearch {
     this.facetSearchElement.focus();
   }
 
-  public set currentFacetSearchElementId(id: string) {
-    this.facet.currentFacetSearchElementId = id;
-  }
-
   public get searchResults() {
     return this.facetSearchElement.searchResults;
   }
@@ -158,6 +154,14 @@ export class FacetSearch implements IFacetSearch {
 
   public get search() {
     return this.facetSearchElement.search;
+  }
+
+  public setExpandedFacetSearchAccessibilityAttributes(searchResultsElement: HTMLElement) {
+    this.facet.setExpandedFacetSearchAccessibilityAttributes(searchResultsElement);
+  }
+
+  public setCollapsedFacetSearchAccessibilityAttributes() {
+    this.facet.setCollapsedFacetSearchAccessibilityAttributes();
   }
 
   public keyboardEventDefaultHandler() {

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -281,7 +281,7 @@ export class FacetSearchElement {
     this.combobox.setAttribute('role', 'combobox');
     this.combobox.setAttribute('aria-owns', this.facetSearchId);
     this.input.setAttribute('aria-controls', this.facetSearchId);
-    this.facetSearch.currentFacetSearchElementId = this.facetSearchId;
+    this.facetSearch.setExpandedFacetSearchAccessibilityAttributes(this.searchResults);
   }
 
   private removeAriaAttributes() {
@@ -293,6 +293,6 @@ export class FacetSearchElement {
     this.combobox.removeAttribute('aria-owns');
     this.input.removeAttribute('aria-controls');
     this.input.removeAttribute('aria-activedescendant');
-    this.facetSearch.currentFacetSearchElementId = null;
+    this.facetSearch.setCollapsedFacetSearchAccessibilityAttributes();
   }
 }

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -281,6 +281,7 @@ export class FacetSearchElement {
     this.combobox.setAttribute('role', 'combobox');
     this.combobox.setAttribute('aria-owns', this.facetSearchId);
     this.input.setAttribute('aria-controls', this.facetSearchId);
+    this.facetSearch.currentFacetSearchElementId = this.facetSearchId;
   }
 
   private removeAriaAttributes() {
@@ -292,5 +293,6 @@ export class FacetSearchElement {
     this.combobox.removeAttribute('aria-owns');
     this.input.removeAttribute('aria-controls');
     this.input.removeAttribute('aria-activedescendant');
+    this.facetSearch.currentFacetSearchElementId = null;
   }
 }

--- a/src/ui/Facet/IFacetSearch.ts
+++ b/src/ui/Facet/IFacetSearch.ts
@@ -7,6 +7,7 @@ export interface IFacetSearch {
   facetSearchElement: FacetSearchElement;
   facetSearchPromise: Promise<IIndexFieldValue[]>;
   moreValuesToFetch: boolean;
+  currentFacetSearchElementId: string;
 
   dismissSearchResults: () => void;
   getCaptions: () => HTMLElement[];

--- a/src/ui/Facet/IFacetSearch.ts
+++ b/src/ui/Facet/IFacetSearch.ts
@@ -7,8 +7,9 @@ export interface IFacetSearch {
   facetSearchElement: FacetSearchElement;
   facetSearchPromise: Promise<IIndexFieldValue[]>;
   moreValuesToFetch: boolean;
-  currentFacetSearchElementId: string;
 
+  setExpandedFacetSearchAccessibilityAttributes: (searchResultsElement: HTMLElement) => void;
+  setCollapsedFacetSearchAccessibilityAttributes: () => void;
   dismissSearchResults: () => void;
   getCaptions: () => HTMLElement[];
   displayNewValues: (params?) => void;

--- a/unitTests/ui/FacetSearchTest.ts
+++ b/unitTests/ui/FacetSearchTest.ts
@@ -10,16 +10,6 @@ import { IIndexFieldValue } from '../../src/rest/FieldValue';
 import { Simulate } from '../Simulate';
 import { KEYBOARD } from '../../src/utils/KeyboardUtils';
 
-function getSetter<T>(instance: T, propertyName: keyof T) {
-  return Object.getOwnPropertyDescriptor(Object.getPrototypeOf(instance), propertyName).set.bind(instance);
-}
-
-function spyOnSetter<T>(instance: T, propertyName: keyof T) {
-  const spy = jasmine.createSpy(propertyName as string, getSetter(instance, propertyName));
-  Object.defineProperty(instance, propertyName, { set: spy });
-  return spy;
-}
-
 export function FacetSearchTest() {
   describe('FacetSearch', () => {
     var mockFacet: Facet;
@@ -99,10 +89,10 @@ export function FacetSearchTest() {
 
       describe('when calling focus', () => {
         it("should update the accessible element's accessibility properties", () => {
-          const setCurrentFacetSearchElementIdSpy = spyOnSetter(facetSearch, 'currentFacetSearchElementId');
+          const setExpandedFacetSearchAccessibilityAttributes = spyOn(facetSearch, 'setExpandedFacetSearchAccessibilityAttributes');
           facetSearch.focus();
-          expect(setCurrentFacetSearchElementIdSpy).toHaveBeenCalledTimes(1);
-          expect(setCurrentFacetSearchElementIdSpy).toHaveBeenCalledWith(facetSearch.facetSearchElement['facetSearchId']);
+          expect(setExpandedFacetSearchAccessibilityAttributes).toHaveBeenCalledTimes(1);
+          expect(setExpandedFacetSearchAccessibilityAttributes).toHaveBeenCalledWith(facetSearch.facetSearchElement['searchResults']);
         });
       });
 
@@ -134,10 +124,9 @@ export function FacetSearchTest() {
           });
 
           it("should update the accessible element's accessibility properties", () => {
-            const setCurrentFacetSearchElementIdSpy = spyOnSetter(facetSearch, 'currentFacetSearchElementId');
+            const setCollapsedFacetSearchAccessibilityAttributes = spyOn(facetSearch, 'setCollapsedFacetSearchAccessibilityAttributes');
             facetSearch.dismissSearchResults();
-            expect(setCurrentFacetSearchElementIdSpy).toHaveBeenCalledTimes(1);
-            expect(setCurrentFacetSearchElementIdSpy).toHaveBeenCalledWith(null);
+            expect(setCollapsedFacetSearchAccessibilityAttributes).toHaveBeenCalledTimes(1);
           });
         });
       });

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -654,56 +654,99 @@ export function FacetTest() {
         expect(test.cmp.facetSearch).toBeUndefined();
       });
 
-      describe(`given enableFacetSearch is set to 'true',
-      given that searching is not active`, () => {
-        const searchingCssClass = 'coveo-facet-searching';
+      describe('with more results than displayed', () => {
         const oneMoreThanNumberOfDisplayedValues = 6;
-
-        function triggerChangeOnCheckbox() {
-          const changeEvent = new Event('change');
-          test.cmp.searchContainer.checkbox.dispatchEvent(changeEvent);
-        }
 
         beforeEach(() => {
           const options = { field: '@field', enableFacetSearch: true };
           test = Mock.optionsComponentSetup<Facet, IFacetOptions>(Facet, options);
           test.cmp['nbAvailableValues'] = oneMoreThanNumberOfDisplayedValues;
           test.cmp.reset();
-
-          expect(test.cmp.element.className).not.toContain(searchingCssClass);
         });
 
-        it(`when triggering a 'change' event on the searchContainer checkbox,
-        it actives searching`, () => {
-          triggerChangeOnCheckbox();
-          expect(test.cmp.element.className).toContain(searchingCssClass);
+        describe('when setting currentFacetSearchElementId', () => {
+          let accessibleElement: HTMLElement;
+          beforeEach(() => {
+            accessibleElement = test.cmp.searchContainer.accessibleElement;
+          });
+
+          describe('to a non-null value', () => {
+            const id = 'abcdef';
+            beforeEach(() => {
+              test.cmp.currentFacetSearchElementId = null;
+              test.cmp.currentFacetSearchElementId = id;
+            });
+
+            it('should set aria-expanded to true', () => {
+              expect(accessibleElement.getAttribute('aria-expanded')).toEqual(true.toString());
+            });
+
+            it('should set aria-owns to the given id', () => {
+              expect(accessibleElement.getAttribute('aria-owns')).toEqual(id);
+            });
+          });
+
+          describe('to a null value', () => {
+            beforeEach(() => {
+              test.cmp.currentFacetSearchElementId = 'abcdef';
+              test.cmp.currentFacetSearchElementId = null;
+            });
+
+            it('should set aria-expanded to false', () => {
+              expect(accessibleElement.getAttribute('aria-expanded')).toEqual(false.toString());
+            });
+
+            it('should remove aria-owns', () => {
+              expect(accessibleElement.getAttribute('aria-owns')).toBeNull();
+            });
+          });
         });
 
-        describe(`when triggering an 'Enter' keyup event on the searchContainer listItem`, () => {
-          function triggerEnterKeyOnAccessibleElement() {
-            Simulate.keyUp(test.cmp.searchContainer.accessibleElement, KEYBOARD.ENTER);
+        describe(`given enableFacetSearch is set to 'true',
+        given that searching is not active`, () => {
+          const searchingCssClass = 'coveo-facet-searching';
+
+          function triggerChangeOnCheckbox() {
+            const changeEvent = new Event('change');
+            test.cmp.searchContainer.checkbox.dispatchEvent(changeEvent);
           }
 
-          beforeEach(triggerEnterKeyOnAccessibleElement);
+          beforeEach(() => {
+            expect(test.cmp.element.className).not.toContain(searchingCssClass);
+          });
 
-          it('activates searching', () => {
+          it(`when triggering a 'change' event on the searchContainer checkbox,
+          it actives searching`, () => {
+            triggerChangeOnCheckbox();
             expect(test.cmp.element.className).toContain(searchingCssClass);
           });
 
-          it(`sets the checkbox 'checked' attribute`, () => {
-            const checkbox = test.cmp.searchContainer.checkbox;
-            const checkedAttribute = checkbox.getAttribute('checked');
-            expect(checkedAttribute).toBeTruthy();
-          });
+          describe(`when triggering an 'Enter' keyup event on the searchContainer listItem`, () => {
+            function triggerEnterKeyOnAccessibleElement() {
+              Simulate.keyUp(test.cmp.searchContainer.accessibleElement, KEYBOARD.ENTER);
+            }
 
-          it(`when triggering a second 'Enter' keyup event,
-          it removes the checkbox 'checked' attribute`, () => {
-            triggerEnterKeyOnAccessibleElement();
+            beforeEach(triggerEnterKeyOnAccessibleElement);
 
-            const checkbox = test.cmp.searchContainer.checkbox;
-            const checkedAttribute = checkbox.getAttribute('checked');
+            it('activates searching', () => {
+              expect(test.cmp.element.className).toContain(searchingCssClass);
+            });
 
-            expect(checkedAttribute).toBeFalsy();
+            it(`sets the checkbox 'checked' attribute`, () => {
+              const checkbox = test.cmp.searchContainer.checkbox;
+              const checkedAttribute = checkbox.getAttribute('checked');
+              expect(checkedAttribute).toBeTruthy();
+            });
+
+            it(`when triggering a second 'Enter' keyup event,
+            it removes the checkbox 'checked' attribute`, () => {
+              triggerEnterKeyOnAccessibleElement();
+
+              const checkbox = test.cmp.searchContainer.checkbox;
+              const checkedAttribute = checkbox.getAttribute('checked');
+
+              expect(checkedAttribute).toBeFalsy();
+            });
           });
         });
       });

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -664,17 +664,17 @@ export function FacetTest() {
           test.cmp.reset();
         });
 
-        describe('when setting currentFacetSearchElementId', () => {
+        describe('when setting accessibility', () => {
           let accessibleElement: HTMLElement;
           beforeEach(() => {
             accessibleElement = test.cmp.searchContainer.accessibleElement;
           });
 
-          describe('to a non-null value', () => {
-            const id = 'abcdef';
+          describe('expanded', () => {
+            const searchResultsElement = $$('div', { id: 'abcdef' }).el;
             beforeEach(() => {
-              test.cmp.currentFacetSearchElementId = null;
-              test.cmp.currentFacetSearchElementId = id;
+              test.cmp.setCollapsedFacetSearchAccessibilityAttributes();
+              test.cmp.setExpandedFacetSearchAccessibilityAttributes(searchResultsElement);
             });
 
             it('should set aria-expanded to true', () => {
@@ -682,22 +682,18 @@ export function FacetTest() {
             });
 
             it('should set aria-controls to the given id', () => {
-              expect(accessibleElement.getAttribute('aria-controls')).toEqual(id);
+              expect(accessibleElement.getAttribute('aria-controls')).toEqual(searchResultsElement.id);
             });
           });
 
-          describe('to a null value', () => {
+          describe('collapsed', () => {
             beforeEach(() => {
-              test.cmp.currentFacetSearchElementId = 'abcdef';
-              test.cmp.currentFacetSearchElementId = null;
+              test.cmp.setExpandedFacetSearchAccessibilityAttributes($$('div', { id: 'abcdef' }).el);
+              test.cmp.setCollapsedFacetSearchAccessibilityAttributes();
             });
 
             it('should set aria-expanded to false', () => {
               expect(accessibleElement.getAttribute('aria-expanded')).toEqual(false.toString());
-            });
-
-            it('should remove aria-controls', () => {
-              expect(accessibleElement.getAttribute('aria-controls')).toBeNull();
             });
           });
         });

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -681,8 +681,8 @@ export function FacetTest() {
               expect(accessibleElement.getAttribute('aria-expanded')).toEqual(true.toString());
             });
 
-            it('should set aria-owns to the given id', () => {
-              expect(accessibleElement.getAttribute('aria-owns')).toEqual(id);
+            it('should set aria-controls to the given id', () => {
+              expect(accessibleElement.getAttribute('aria-controls')).toEqual(id);
             });
           });
 
@@ -696,8 +696,8 @@ export function FacetTest() {
               expect(accessibleElement.getAttribute('aria-expanded')).toEqual(false.toString());
             });
 
-            it('should remove aria-owns', () => {
-              expect(accessibleElement.getAttribute('aria-owns')).toBeNull();
+            it('should remove aria-controls', () => {
+              expect(accessibleElement.getAttribute('aria-controls')).toBeNull();
             });
           });
         });


### PR DESCRIPTION
Added `aria-expanded` and `aria-controls` to indicate to accessibility tools that `FacetSearch` is opened.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)