### PR TITLE
JSUI-2829 Display collapsed values differently for DynamicFacets

### DIFF
--- a/sass/DynamicFacet/_DynamicFacetValues.scss
+++ b/sass/DynamicFacet/_DynamicFacetValues.scss
@@ -51,6 +51,10 @@
   @include facetShowLess();
 }
 
+.coveo-dynamic-facet-collapsed-values {
+  display: none;
+}
+
 .coveo-dynamic-facet-collapsed {
   .coveo-dynamic-facet-value,
   .coveo-dynamic-facet-show-more,
@@ -58,7 +62,7 @@
     display: none;
   }
 
-  .coveo-dynamic-facet-value.coveo-selected {
+  .coveo-dynamic-facet-collapsed-values {
     display: inherit;
   }
 }

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
@@ -47,6 +47,10 @@ export class DynamicFacetValues implements IDynamicFacetValues {
     return this.facetValues.filter(value => value.isSelected).map(({ value }) => value);
   }
 
+  private get selectedDisplayValues() {
+    return this.facetValues.filter(value => value.isSelected).map(({ displayValue }) => displayValue);
+  }
+
   public get activeValues() {
     return this.facetValues.filter(value => !value.isIdle);
   }
@@ -150,6 +154,24 @@ export class DynamicFacetValues implements IDynamicFacetValues {
     }
   }
 
+  private appendSelectedCollapsedValues(fragment: DocumentFragment) {
+    if (!this.hasSelectedValues) {
+      return;
+    }
+
+    const selectedValues = this.selectedDisplayValues.join(', ');
+    fragment.appendChild(
+      $$(
+        'li',
+        {
+          className: 'coveo-dynamic-facet-collapsed-values',
+          ariaLabel: `${l('CurrentSelections')}: ${selectedValues}`
+        },
+        selectedValues
+      ).el
+    );
+  }
+
   public render() {
     const fragment = document.createDocumentFragment();
     $$(this.list).empty();
@@ -159,6 +181,8 @@ export class DynamicFacetValues implements IDynamicFacetValues {
     });
 
     this.appendShowMoreLess(fragment);
+
+    this.appendSelectedCollapsedValues(fragment);
 
     this.list.appendChild(fragment);
     return this.list;

--- a/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValuesTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValuesTest.ts
@@ -49,6 +49,16 @@ export function DynamicFacetValuesTest() {
       return $$(element).find('.coveo-dynamic-facet-show-less');
     }
 
+    function values() {
+      const element = dynamicFacetValues.render();
+      return $$(element).findAll('.coveo-dynamic-facet-value');
+    }
+
+    function selectedCollapsedValues() {
+      const element = dynamicFacetValues.render();
+      return $$(element).find('.coveo-dynamic-facet-collapsed-values');
+    }
+
     it('should return allFacetValues correctly', () => {
       expect(dynamicFacetValues.allFacetValues.length).toBe(mockFacetValues.length);
       expect(dynamicFacetValues.allFacetValues[0].equals(mockFacetValues[0].value)).toBe(true);
@@ -77,6 +87,11 @@ export function DynamicFacetValuesTest() {
       expect(dynamicFacetValues.hasActiveValues).toBe(true);
     });
 
+    it('when there are selected values, it should append an element for collapsed selected values', () => {
+      expect(selectedCollapsedValues()).toBeTruthy();
+      expect(selectedCollapsedValues().textContent).toBe(dynamicFacetValues.selectedValues.join(', '));
+    });
+
     it('when there are no selected values, hasSelectedValues should return false', () => {
       mockFacetValues = DynamicFacetTestUtils.createFakeFacetValues();
       initializeComponent();
@@ -87,6 +102,12 @@ export function DynamicFacetValuesTest() {
       mockFacetValues = DynamicFacetTestUtils.createFakeFacetValues();
       initializeComponent();
       expect(dynamicFacetValues.hasActiveValues).toBe(false);
+    });
+
+    it('when there are selected values, it should not append an element for collapsed selected values', () => {
+      mockFacetValues = DynamicFacetTestUtils.createFakeFacetValues();
+      initializeComponent();
+      expect(selectedCollapsedValues()).toBeFalsy();
     });
 
     it('when there are idle values, hasIdleValues should return true', () => {
@@ -138,17 +159,15 @@ export function DynamicFacetValuesTest() {
       expect(() => dynamicFacetValues.render()).not.toThrow();
     });
 
-    it('renders the correct number of children', () => {
-      const element = dynamicFacetValues.render();
-      expect(element.childElementCount).toBe(mockFacetValues.length);
+    it('renders the correct number of values', () => {
+      expect(values().length).toBe(mockFacetValues.length);
     });
 
-    it('does not renders children that are idle and without result', () => {
+    it('does not renders values that are idle and without result', () => {
       mockFacetValues[0].numberOfResults = 0;
       initializeComponent();
 
-      const element = dynamicFacetValues.render();
-      expect(element.childElementCount).toBe(mockFacetValues.length - 1);
+      expect(values().length).toBe(mockFacetValues.length - 1);
     });
 
     it(`when moreValuesAvailable is false


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2829

According to UX:
<img width="388" alt="Screen Shot 2020-01-22 at 11 30 20 AM" src="https://user-images.githubusercontent.com/4923043/72913082-9b23bf80-3d0a-11ea-8092-ab04ddd4e9b2.png">




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)