### PR TITLE
JSUI-2838 Fixed `ResultLink`'s structure to be both a heading and a link

### DIFF
--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -181,9 +181,11 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
 
   private buildResultPreview(suggestion: Suggestion, element: HTMLElement, rank: number): ISearchResultPreview {
     element.classList.add('coveo-preview-selectable');
-    const resultLink = Component.get(element.querySelector(Component.computeSelectorForType(ResultLink.ID)), ResultLink) as ResultLink;
+    const resultLink = element.querySelector(Component.computeSelectorForType(ResultLink.ID)) as HTMLElement;
     if (resultLink) {
-      resultLink.titleElement.removeAttribute('aria-level');
+      element.setAttribute('aria-label', resultLink.textContent);
+      resultLink.setAttribute('role', 'link');
+      resultLink.removeAttribute('aria-level');
     }
     return {
       element,

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -181,11 +181,9 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
 
   private buildResultPreview(suggestion: Suggestion, element: HTMLElement, rank: number): ISearchResultPreview {
     element.classList.add('coveo-preview-selectable');
-    const resultLink = element.querySelector(Component.computeSelectorForType(ResultLink.ID)) as HTMLElement;
+    const resultLink = Component.get(element.querySelector(Component.computeSelectorForType(ResultLink.ID)), ResultLink) as ResultLink;
     if (resultLink) {
-      element.setAttribute('aria-label', resultLink.textContent);
-      resultLink.setAttribute('role', 'link');
-      resultLink.removeAttribute('aria-level');
+      resultLink.titleElement.removeAttribute('aria-level');
     }
     return {
       element,

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -225,7 +225,6 @@ export class ResultLink extends Component {
     })
   };
 
-  public titleElement: HTMLElement;
   private toExecuteOnOpen: (e?: Event) => void;
 
   /**
@@ -253,6 +252,7 @@ export class ResultLink extends Component {
       this.options.openQuickview = result.raw['connectortype'] == 'ExchangeCrawler' && DeviceUtils.isMobileDevice();
     }
     this.element.setAttribute('tabindex', '0');
+    this.addHeadingRoleIfFirstResultLink();
 
     Assert.exists(this.componentOptionsModel);
     Assert.exists(this.result);
@@ -278,18 +278,18 @@ export class ResultLink extends Component {
         }
       });
     }
-    this.build();
     this.renderUri(element, result);
+    this.bindEventToOpen();
   }
   public renderUri(element: HTMLElement, result?: IQueryResult) {
     if (/^\s*$/.test(this.element.innerHTML)) {
       if (!this.options.titleTemplate) {
-        this.titleElement.innerHTML = this.result.title
+        this.element.innerHTML = this.result.title
           ? HighlightUtils.highlightString(this.result.title, this.result.titleHighlights, null, 'coveo-highlight')
           : this.result.clickUri;
       } else {
         let newTitle = StringUtils.buildStringTemplateFromResult(this.options.titleTemplate, this.result);
-        this.titleElement.innerHTML = newTitle
+        this.element.innerHTML = newTitle
           ? StreamHighlightUtils.highlightStreamText(newTitle, this.result.termsToHighlight, this.result.phrasesToHighlight)
           : this.result.clickUri;
       }
@@ -359,19 +359,13 @@ export class ResultLink extends Component {
     );
   }
 
-  private build() {
-    this.element.appendChild((this.titleElement = $$('span', {}, this.result.title).el));
-    this.bindEventToOpen();
-    this.addHeadingRoleIfFirstResultLink();
-  }
-
   private addHeadingRoleIfFirstResultLink() {
     if (!this.isFirstResultLink) {
       return;
     }
 
-    this.titleElement.setAttribute('role', 'heading');
-    this.titleElement.setAttribute('aria-level', '2');
+    this.element.setAttribute('role', 'heading');
+    this.element.setAttribute('aria-level', '2');
   }
 
   private get isFirstResultLink() {
@@ -395,6 +389,7 @@ export class ResultLink extends Component {
 
       new AccessibleButton()
         .withElement(this.element)
+        .withLabel(this.result.title)
         .withSelectAction((e: Event) => this.toExecuteOnOpen(e))
         .build();
 

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -252,7 +252,6 @@ export class ResultLink extends Component {
       this.options.openQuickview = result.raw['connectortype'] == 'ExchangeCrawler' && DeviceUtils.isMobileDevice();
     }
     this.element.setAttribute('tabindex', '0');
-    this.addHeadingRoleIfFirstResultLink();
 
     Assert.exists(this.componentOptionsModel);
     Assert.exists(this.result);
@@ -357,28 +356,6 @@ export class ResultLink extends Component {
       this.setHrefIfNotAlready() ||
       this.openLinkThatIsNotAnAnchor()
     );
-  }
-
-  private addHeadingRoleIfFirstResultLink() {
-    if (!this.isFirstResultLink) {
-      return;
-    }
-
-    this.element.setAttribute('role', 'heading');
-    this.element.setAttribute('aria-level', '2');
-  }
-
-  private get isFirstResultLink() {
-    const resultRoot = $$(this.element).closest('CoveoResult');
-
-    if (!resultRoot) {
-      return false;
-    }
-
-    const resultLinkSelector = `.${Component.computeCssClassNameForType(ResultLink.ID)}`;
-    const firstResultLink = $$(resultRoot).find(resultLinkSelector);
-
-    return firstResultLink === this.element;
   }
 
   private bindOnClickIfNotUndefined() {

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -225,6 +225,7 @@ export class ResultLink extends Component {
     })
   };
 
+  public titleElement: HTMLElement;
   private toExecuteOnOpen: (e?: Event) => void;
 
   /**
@@ -252,7 +253,6 @@ export class ResultLink extends Component {
       this.options.openQuickview = result.raw['connectortype'] == 'ExchangeCrawler' && DeviceUtils.isMobileDevice();
     }
     this.element.setAttribute('tabindex', '0');
-    this.addHeadingRoleIfFirstResultLink();
 
     Assert.exists(this.componentOptionsModel);
     Assert.exists(this.result);
@@ -278,18 +278,18 @@ export class ResultLink extends Component {
         }
       });
     }
+    this.build();
     this.renderUri(element, result);
-    this.bindEventToOpen();
   }
   public renderUri(element: HTMLElement, result?: IQueryResult) {
     if (/^\s*$/.test(this.element.innerHTML)) {
       if (!this.options.titleTemplate) {
-        this.element.innerHTML = this.result.title
+        this.titleElement.innerHTML = this.result.title
           ? HighlightUtils.highlightString(this.result.title, this.result.titleHighlights, null, 'coveo-highlight')
           : this.result.clickUri;
       } else {
         let newTitle = StringUtils.buildStringTemplateFromResult(this.options.titleTemplate, this.result);
-        this.element.innerHTML = newTitle
+        this.titleElement.innerHTML = newTitle
           ? StreamHighlightUtils.highlightStreamText(newTitle, this.result.termsToHighlight, this.result.phrasesToHighlight)
           : this.result.clickUri;
       }
@@ -359,13 +359,19 @@ export class ResultLink extends Component {
     );
   }
 
+  private build() {
+    this.element.appendChild((this.titleElement = $$('span', {}, this.result.title).el));
+    this.bindEventToOpen();
+    this.addHeadingRoleIfFirstResultLink();
+  }
+
   private addHeadingRoleIfFirstResultLink() {
     if (!this.isFirstResultLink) {
       return;
     }
 
-    this.element.setAttribute('role', 'heading');
-    this.element.setAttribute('aria-level', '2');
+    this.titleElement.setAttribute('role', 'heading');
+    this.titleElement.setAttribute('aria-level', '2');
   }
 
   private get isFirstResultLink() {
@@ -389,7 +395,6 @@ export class ResultLink extends Component {
 
       new AccessibleButton()
         .withElement(this.element)
-        .withLabel(this.result.title)
         .withSelectAction((e: Event) => this.toExecuteOnOpen(e))
         .build();
 

--- a/src/ui/Templates/DefaultResultTemplate.ts
+++ b/src/ui/Templates/DefaultResultTemplate.ts
@@ -59,7 +59,9 @@ export class DefaultResultTemplate extends Template {
 
   public getFallbackTemplate(): string {
     let titleContainer = $$('div', {
-      className: 'coveo-title'
+      className: 'coveo-title',
+      role: 'heading',
+      ariaLevel: 2
     });
 
     let resultLink = $$('a', { className: 'CoveoResultLink' });

--- a/templates/All/Card.html
+++ b/templates/All/Card.html
@@ -4,7 +4,7 @@
       <div class="CoveoIcon" data-small="true" data-with-label="false">
       </div>
     </div>
-    <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/All/Default.html
+++ b/templates/All/Default.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Chatter/CardChatter.html
+++ b/templates/Chatter/CardChatter.html
@@ -4,7 +4,7 @@
       <div class="CoveoIcon" data-small="true" data-with-label="false">
       </div>
     </div>
-    <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/Chatter/Chatter.html
+++ b/templates/Chatter/Chatter.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top; padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align: top; font-size: 16px;">
+      <div class="coveo-result-cell" style="vertical-align: top; font-size: 16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Confluence/Confluence.html
+++ b/templates/Confluence/Confluence.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Dropbox/CardDropbox.html
+++ b/templates/Dropbox/CardDropbox.html
@@ -6,7 +6,7 @@
           <div class="CoveoIcon" data-small="true" data-with-label="false">
           </div>
         </div>
-        <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;">
+        <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
           <a class="CoveoResultLink"></a>
         </div>
       </div>

--- a/templates/Dropbox/Dropbox.html
+++ b/templates/Dropbox/Dropbox.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/DynamicsCrm/CardDynamicsCrm.html
+++ b/templates/DynamicsCrm/CardDynamicsCrm.html
@@ -3,7 +3,7 @@
     <div class="coveo-result-cell" style="width:32px; vertical-align:middle; flex-grow:0">
       <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
     </div>
-    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/DynamicsCrm/DynamicsCrm.html
+++ b/templates/DynamicsCrm/DynamicsCrm.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/DynamicsCrmCase/CardDynamicsCrmCase.html
+++ b/templates/DynamicsCrmCase/CardDynamicsCrmCase.html
@@ -6,7 +6,7 @@
           <div class="CoveoIcon" data-small="true" data-with-label="false">
           </div>
         </div>
-        <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;">
+        <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
           <a class="CoveoResultLink"></a>
         </div>
       </div>

--- a/templates/DynamicsCrmCase/DynamicsCrmCase.html
+++ b/templates/DynamicsCrmCase/DynamicsCrmCase.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Email/CardEmailThread.html
+++ b/templates/Email/CardEmailThread.html
@@ -3,7 +3,7 @@
     <div class="coveo-result-cell" style="width: 32px; vertical-align:middle; flex-grow:0">
       <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
     </div>
-    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/Email/EmailThread.html
+++ b/templates/Email/EmailThread.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/GoogleDrive/CardGoogleDrive.html
+++ b/templates/GoogleDrive/CardGoogleDrive.html
@@ -4,7 +4,7 @@
       <div class="CoveoIcon" data-small="true" data-with-label="false">
       </div>
     </div>
-    <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/GoogleDrive/GoogleDrive.html
+++ b/templates/GoogleDrive/GoogleDrive.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Jira/Jira.html
+++ b/templates/Jira/Jira.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
         <span class="CoveoText" data-value=" - "></span>
         <a class="CoveoResultLink" data-title-template="${raw.jikey}"></a>

--- a/templates/Lithium/CardLithiumThread.html
+++ b/templates/Lithium/CardLithiumThread.html
@@ -3,7 +3,7 @@
     <div class="coveo-result-cell" style="width:32px; vertical-align:middle; flex-grow:0">
       <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
     </div>
-    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/Lithium/LithiumThread.html
+++ b/templates/Lithium/LithiumThread.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/People/CardPeople.html
+++ b/templates/People/CardPeople.html
@@ -3,7 +3,7 @@
     <div class="coveo-result-cell" style="width:32px; vertical-align:middle; flex-grow:0">
       <img class="CoveoThumbnail" data-no-thumbnail-class="coveo-sprites-user-small"/>
     </div>
-    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/People/People.html
+++ b/templates/People/People.html
@@ -7,7 +7,7 @@
     </div>
     <div class="coveo-result-cell" style="padding-left:15px">
       <div class="coveo-result-row">
-        <div class="coveo-result-cell" style="font-size:18px">
+        <div class="coveo-result-cell" style="font-size:18px" role="heading" aria-level="2">
           <a class="CoveoResultLink">
           </a>
         </div>

--- a/templates/RSS/CardRSS.html
+++ b/templates/RSS/CardRSS.html
@@ -4,7 +4,7 @@
       <div class="CoveoIcon" data-small="true" data-with-label="false">
       </div>
     </div>
-    <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/RSS/RSS.html
+++ b/templates/RSS/RSS.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/Salesforce/CardSalesforce.html
+++ b/templates/Salesforce/CardSalesforce.html
@@ -3,7 +3,7 @@
     <div class="coveo-result-cell" style="width:32px; vertical-align:middle; flex-grow:0">
       <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
     </div>
-    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/Salesforce/Salesforce.html
+++ b/templates/Salesforce/Salesforce.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/SalesforceB2BProduct/CardSalesforceB2BProduct.html
+++ b/templates/SalesforceB2BProduct/CardSalesforceB2BProduct.html
@@ -3,7 +3,7 @@
       <div class="coveo-result-row">
         <div class="coveo-result-cell">
           <div class="coveo-result-row">
-            <div class="coveo-result-cell" style="text-align:left;">
+            <div class="coveo-result-cell" style="text-align:left;" role="heading" aria-level="2">
               <a class="CoveoResultLink" data-field="@clickableuri"></a>
             </div>
             <div class="coveo-result-cell" style="width:50px">

--- a/templates/SalesforceB2BProduct/SalesforceB2BProduct.html
+++ b/templates/SalesforceB2BProduct/SalesforceB2BProduct.html
@@ -1,7 +1,7 @@
 <div class="coveo-result-frame">
   <div class="coveo-result-cell" style="vertical-align:top; padding-left:16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top; font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top; font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink" data-field="@clickableuri" data-open-quickview="true"></a>
       </div>
     </div>

--- a/templates/SalesforceCase/CardSalesforceCase.html
+++ b/templates/SalesforceCase/CardSalesforceCase.html
@@ -6,7 +6,7 @@
           <div class="CoveoIcon" data-small="true" data-with-label="false">
           </div>
         </div>
-        <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;">
+        <div class="coveo-result-cell" style="text-align:left; padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
           <a class="CoveoResultLink"></a>
         </div>
       </div>

--- a/templates/SalesforceCase/SalesforceCase.html
+++ b/templates/SalesforceCase/SalesforceCase.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink" data-title-template="${title} - ${raw.sfcasenumber}"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/SalesforceCase/SalesforceCaseComment.html
+++ b/templates/SalesforceCase/SalesforceCaseComment.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top; padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align: top; font-size: 16px;">
+      <div class="coveo-result-cell" style="vertical-align: top; font-size: 16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink" data-title-template="# ${raw.sfcasecasenumber}"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/ServiceNow/ServiceNowCase.html
+++ b/templates/ServiceNow/ServiceNowCase.html
@@ -1,7 +1,7 @@
 <div class="coveo-result-frame">
   <div class="coveo-result-cell" style="vertical-align: top;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top; font-size:16px">
+      <div class="coveo-result-cell" style="vertical-align:top; font-size:16px" role="heading" aria-level="2">
         <a class="CoveoResultLink" data-title-template="[${raw.snnumber}] ${raw.title} ">
         </a>
       </div>

--- a/templates/ServiceNow/ServiceNowCatalog.html
+++ b/templates/ServiceNow/ServiceNowCatalog.html
@@ -1,7 +1,7 @@
 <div class="coveo-result-frame">
     <div class="coveo-result-cell" style="vertical-align:bottom;">
         <div class="coveo-result-row">
-            <div class="coveo-result-cell">
+            <div class="coveo-result-cell" role="heading" aria-level="2">
                 <div class="CoveoResultLink"></div>
             </div>
             <div class="coveo-result-cell" style="width:120px;text-align:center;vertical-align:bottom;font-size:12px">

--- a/templates/ServiceNow/ServiceNowHRCase.html
+++ b/templates/ServiceNow/ServiceNowHRCase.html
@@ -1,7 +1,7 @@
 <div class="coveo-result-frame">
     <div class="coveo-result-cell" style="vertical-align: top;">
         <div class="coveo-result-row" style="margin-top:0;">
-            <div class="coveo-result-cell" style="vertical-align:bottom; font-size:16px">
+            <div class="coveo-result-cell" style="vertical-align:bottom; font-size:16px" role="heading" aria-level="2">
                 <a class="CoveoResultLink" data-title-template="[${raw.snnumber}] ${raw.title} ">
                 </a>
             </div>

--- a/templates/ServiceNow/ServiceNowIncident.html
+++ b/templates/ServiceNow/ServiceNowIncident.html
@@ -1,7 +1,7 @@
 <div class="coveo-result-frame">
     <div class="coveo-result-cell" style="vertical-align: top;">
         <div class="coveo-result-row" style="margin-top:0;">
-            <div class="coveo-result-cell" style="vertical-align:bottom; font-size:16px">
+            <div class="coveo-result-cell" style="vertical-align:bottom; font-size:16px" role="heading" aria-level="2">
                 <a class="CoveoResultLink" data-title-template="[${raw.snnumber}] ${raw.title} ">
                 </a>
             </div>

--- a/templates/ServiceNow/ServiceNowKnowledge.html
+++ b/templates/ServiceNow/ServiceNowKnowledge.html
@@ -1,7 +1,7 @@
 <div class="coveo-result-frame">
     <div class="coveo-result-cell" style="vertical-align: top;">
         <div class="coveo-result-row" style="margin-top:0;">
-            <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+            <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
                 <a class="CoveoResultLink"></a>
             </div>
             <div class="coveo-result-cell" style="width:120px; text-align:center; font-size:12px">

--- a/templates/ServiceNow/ServiceNowQuestion.html
+++ b/templates/ServiceNow/ServiceNowQuestion.html
@@ -1,7 +1,7 @@
 <div class="coveo-result-frame">
     <div class="coveo-result-cell" style="vertical-align: top;">
         <div class="coveo-result-row" style="margin-top:0;">
-            <div class="coveo-result-cell" style="vertical-align:bottom; font-size:16px">
+            <div class="coveo-result-cell" style="vertical-align:bottom; font-size:16px" role="heading" aria-level="2">
                 <a class="CoveoResultLink"></a>
             </div>
             <div class="coveo-result-cell" style="width:120px;vertical-align:bottom">

--- a/templates/SharePoint/CardSharePoint.html
+++ b/templates/SharePoint/CardSharePoint.html
@@ -3,7 +3,7 @@
     <div class="coveo-result-cell" style="width:32px; vertical-align:middle; flex-grow:0">
       <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
     </div>
-    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/SharePoint/CardSharePointList.html
+++ b/templates/SharePoint/CardSharePointList.html
@@ -3,7 +3,7 @@
     <div class="coveo-result-cell" style="width:32px; vertical-align:middle; flex-grow:0">
       <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
     </div>
-    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;">
+    <div class="coveo-result-cell" style="padding-left: 10px; vertical-align: middle;" role="heading" aria-level="2">
       <a class="CoveoResultLink"></a>
     </div>
   </div>

--- a/templates/SharePoint/SharePoint.html
+++ b/templates/SharePoint/SharePoint.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/SharePoint/SharePointList.html
+++ b/templates/SharePoint/SharePointList.html
@@ -5,7 +5,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:80px;text-align:right;font-size:12px">

--- a/templates/YouTube/CardYouTubePlaylist.html
+++ b/templates/YouTube/CardYouTubePlaylist.html
@@ -5,7 +5,7 @@
         <div class="coveo-result-cell" style="width: 32px; flex-grow:0">
           <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
         </div>
-        <div class="coveo-result-cell" style="padding-left: 10px; ">
+        <div class="coveo-result-cell" style="padding-left: 10px; " role="heading" aria-level="2">
           <span class="CoveoResultLink" style="color: white"></span>
         </div>
       </div>

--- a/templates/YouTube/CardYouTubePlaylistItem.html
+++ b/templates/YouTube/CardYouTubePlaylistItem.html
@@ -8,7 +8,7 @@
   <div class="coveo-result-row">
     <div class="coveo-result-cell">
       <div class="coveo-result-row">
-        <div class="coveo-result-cell coveo-no-wrap" style="font-size:16x">
+        <div class="coveo-result-cell coveo-no-wrap" style="font-size:16x" role="heading" aria-level="2">
           <a class="CoveoResultLink"></a>
         </div>
       </div>

--- a/templates/YouTube/CardYouTubeVideo.html
+++ b/templates/YouTube/CardYouTubeVideo.html
@@ -5,7 +5,7 @@
         <div class="coveo-result-cell" style="width: 32px; flex-grow:0">
           <span class="CoveoIcon" data-small="true" data-with-label="false"></span>
         </div>
-        <div class="coveo-result-cell" style="padding-left: 10px; ">
+        <div class="coveo-result-cell" style="padding-left: 10px; " role="heading" aria-level="2">
           <span class="CoveoResultLink" style="color: white"></span>
         </div>
       </div>

--- a/templates/YouTube/YouTubePlaylist.html
+++ b/templates/YouTube/YouTubePlaylist.html
@@ -4,7 +4,7 @@
   </div>
   <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
     <div class="coveo-result-row" style="margin-top:0;">
-      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;">
+      <div class="coveo-result-cell coveo-no-wrap" style="vertical-align:top;font-size:16px;" role="heading" aria-level="2">
         <a class="CoveoResultLink"></a>
       </div>
       <div class="coveo-result-cell" style="width:120px;text-align:right;font-size:12px">

--- a/templates/YouTube/YouTubeVideo.html
+++ b/templates/YouTube/YouTubeVideo.html
@@ -6,7 +6,7 @@
     </div>
     <div class="coveo-result-cell" >
       <div class="coveo-result-row">
-        <div class="coveo-result-cell" style="font-size:16px">
+        <div class="coveo-result-cell" style="font-size:16px" role="heading" aria-level="2">
           <a class="CoveoResultLink">
           </a>
         </div>

--- a/unitTests/ui/DefaultResultTemplateTest.ts
+++ b/unitTests/ui/DefaultResultTemplateTest.ts
@@ -4,6 +4,7 @@ import { TemplateCache } from '../../src/ui/Templates/TemplateCache';
 import { Template } from '../../src/ui/Templates/Template';
 import { IQueryResult } from '../../src/rest/QueryResult';
 import { Simulate } from '../Simulate';
+import { $$ } from '../../src/utils/Dom';
 export function DefaultResultTemplateTest() {
   describe('DefaultResultTemplate', () => {
     let result: IQueryResult;
@@ -51,6 +52,15 @@ export function DefaultResultTemplateTest() {
         it('should be able to instantiate to string if there is something in the cache', () => {
           let created = new DefaultResultTemplate().instantiateToString(result);
           expect(created).toEqual(dataToString(result));
+        });
+
+        it('should add accessibility attributes to the fallback template', () => {
+          const fallbackTemplateHTML = new DefaultResultTemplate().getFallbackTemplate();
+          const fallbackTemplateElement = $$('div').el;
+          fallbackTemplateElement.innerHTML = fallbackTemplateHTML;
+          const fallbackTemplateTitleElement: HTMLElement = fallbackTemplateElement.querySelector('.coveo-title');
+          expect(fallbackTemplateTitleElement.getAttribute('role')).toEqual('heading');
+          expect(fallbackTemplateTitleElement.getAttribute('aria-level')).toEqual('2');
         });
 
         describe("if there's template with conditions", () => {

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -45,31 +45,10 @@ export function ResultLinkTest() {
         return $$('div', { className: 'CoveoResultLink' }).el;
       }
 
-      function getResultLinks() {
-        return $$(template).findAll('.CoveoResultLink');
-      }
-
       beforeEach(() => {
         template = buildResultWithTwoResultLinks();
         const result = FakeResults.createFakeResult();
         Initialization.automaticallyCreateComponentsInsideResult(template, result);
-      });
-
-      it('adds a role attribute with value "heading" to the first result link', () => {
-        const [firstLink] = getResultLinks();
-        expect(firstLink.getAttribute('role')).toBe('heading');
-      });
-
-      it('sets the aria-level attribute to "2" to the first result link', () => {
-        const [firstLink] = getResultLinks();
-        expect(firstLink.getAttribute('aria-level')).toBe('2');
-      });
-
-      it(`does not add accessibility attributes to the second result link`, () => {
-        const secondLink = getResultLinks()[1];
-
-        expect(secondLink.getAttribute('role')).toBeNull();
-        expect(secondLink.getAttribute('aria-level')).toBeNull();
       });
     });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2838

# This PR is not intended to be merged
I'm only adding it to ask for opinions because this change could break a **lot** of code.

Deque found a `major` accessibility issue caused by `ResultLink`'s `<a>` element having `role="heading"`, which overwrites the default link role attributed to anchor elements.

Deque's suggestion is to go for either of those solutions:
```html
<a class="CoveoResultLink" tabindex="0" href="https://na74.salesforce.com/0D5o000000GkGQzCAN">
    <span role="heading" aria-level="2"> John DoeChatter </span>
</a>
```
or
```html
<a class="CoveoResultLink" tabindex="0" href="https://na74.salesforce.com/0D5o000000GkGQzCAN">
    <h2> John DoeChatter </h2>
</a>
```

What fix would you guys recommend for this?
1. Going forward with this new structure and patching up the issues that come up?
2. Ignoring the issue for now?
3. Completely removing `role="heading"` and `aria-level`?
4. Removing `role="heading"` and `aria-level` from the code and wrapping the link in a new element with those properties in the default result template?

Or do you have any other idea?

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)