### PR TITLE
feature(JSUI-2845): Expose ResponsiveComponentManager.resizeAllComponentsManager

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
@@ -65,7 +65,6 @@ export class ResponsiveComponentsManager {
         let responsiveComponentsManager = _.find(this.componentManagers, componentManager => root.el == componentManager.coveoRoot.el);
         if (!responsiveComponentsManager) {
           responsiveComponentsManager = new ResponsiveComponentsManager(root);
-          this.componentManagers.push(responsiveComponentsManager);
         }
 
         if (!Utils.isNullOrUndefined(options.enableResponsiveMode) && !options.enableResponsiveMode) {
@@ -151,6 +150,7 @@ export class ResponsiveComponentsManager {
     }
 
     this.bindNukeEvents();
+    ResponsiveComponentsManager.componentManagers.push(this);
   }
 
   public register(

--- a/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
@@ -109,7 +109,7 @@ export class ResponsiveComponentsManager {
     });
   }
 
-  private static resizeAllComponentsManager(): void {
+  public static resizeAllComponentsManager(): void {
     _.each(this.componentManagers, componentManager => {
       componentManager.resizeListener();
     });

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -47,7 +47,7 @@ export function ResponsiveComponentsManagerTest() {
 
       it('should calls handle resize event when resize listener is called', () => {
         root.width = () => 400;
-        responsiveComponentsManager.register(responsiveComponent, root, 'foo', component, {});
+        responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
         responsiveComponentsManager.resizeListener();
         jasmine.clock().tick(250);
         expect(handleResizeEvent).toHaveBeenCalled();

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -8,14 +8,25 @@ import { ValidResponsiveMode } from '../../../src/ui/ResponsiveComponents/Respon
 export function ResponsiveComponentsManagerTest() {
   const SMALL_RESPONSIVE_MODE = 'small';
   let root: Dom;
-  let handleResizeEventSpies: jasmine.Spy[];
-  let registerComponentSpies: jasmine.Spy[];
+  let handleResizeEventSpies: jasmine.Spy[] = [];
+  let registerComponentSpies: jasmine.Spy[] = [];
   let responsiveComponentsManager: ResponsiveComponentsManager;
-  let responsiveComponents: any[];
+  let responsiveComponents: any[] = [];
   let component: any;
   const setResponsiveMode = (mode: ValidResponsiveMode) => {
     (Component.get(root.el, SearchInterface) as SearchInterface).options.responsiveMode = mode;
   };
+
+  function addNewResponsiveComponents() {
+    handleResizeEventSpies.push(jasmine.createSpy('handleResizeEvent'));
+    registerComponentSpies.push(jasmine.createSpy('registerComponent'));
+    responsiveComponents.push(function() {
+      this.needDrodpownWrapper = () => {};
+      this.handleResizeEvent = handleResizeEventSpies[handleResizeEventSpies.length - 1];
+      this.registerComponent = registerComponentSpies[registerComponentSpies.length - 1];
+      this.ID = 'id';
+    });
+  }
 
   describe('ResponsiveComponentsManager', () => {
     beforeEach(() => {
@@ -24,14 +35,7 @@ export function ResponsiveComponentsManagerTest() {
         enableAutomaticResponsiveMode: true
       });
       root = $$(searchInterfaceMock.cmp.root);
-      handleResizeEventSpies.push(jasmine.createSpy('handleResizeEvent'));
-      registerComponentSpies.push(jasmine.createSpy('registerComponent'));
-      responsiveComponents.push(function() {
-        this.needDrodpownWrapper = () => {};
-        this.handleResizeEvent = handleResizeEventSpies[handleResizeEventSpies.length - 1];
-        this.registerComponent = registerComponentSpies[registerComponentSpies.length - 1];
-        this.ID = 'id';
-      });
+      addNewResponsiveComponents();
       component = {};
       responsiveComponentsManager = new ResponsiveComponentsManager(root);
     });
@@ -39,6 +43,7 @@ export function ResponsiveComponentsManagerTest() {
     afterEach(() => {
       handleResizeEventSpies.length = 0;
       registerComponentSpies.length = 0;
+      responsiveComponents.length = 0;
       jasmine.clock().uninstall();
     });
 
@@ -90,6 +95,18 @@ export function ResponsiveComponentsManagerTest() {
           jasmine.clock().tick(250);
           expect(handleResizeEventSpies).toHaveBeenCalled();
         });
+      });
+    });
+
+    it('calls handle resize on all responsiveComponent registered when calling resizeAllComponentsManager', () => {
+      // Add a second responsiveComponent.
+      addNewResponsiveComponents();
+      expect(responsiveComponents.length).toBe(2);
+
+      ResponsiveComponentsManager.resizeAllComponentsManager();
+
+      handleResizeEventSpies.forEach(spy => {
+        expect(spy).toHaveBeenCalled();
       });
     });
 

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -8,10 +8,10 @@ import { ValidResponsiveMode } from '../../../src/ui/ResponsiveComponents/Respon
 export function ResponsiveComponentsManagerTest() {
   const SMALL_RESPONSIVE_MODE = 'small';
   let root: Dom;
-  let handleResizeEvent: any;
-  let registerComponent: any;
+  let handleResizeEventSpies: jasmine.Spy[];
+  let registerComponentSpies: jasmine.Spy[];
   let responsiveComponentsManager: ResponsiveComponentsManager;
-  let responsiveComponent: any;
+  let responsiveComponents: any[];
   let component: any;
   const setResponsiveMode = (mode: ValidResponsiveMode) => {
     (Component.get(root.el, SearchInterface) as SearchInterface).options.responsiveMode = mode;
@@ -24,19 +24,21 @@ export function ResponsiveComponentsManagerTest() {
         enableAutomaticResponsiveMode: true
       });
       root = $$(searchInterfaceMock.cmp.root);
-      handleResizeEvent = jasmine.createSpy('handleResizeEvent');
-      registerComponent = jasmine.createSpy('registerComponent');
-      responsiveComponent = function() {
+      handleResizeEventSpies.push(jasmine.createSpy('handleResizeEvent'));
+      registerComponentSpies.push(jasmine.createSpy('registerComponent'));
+      responsiveComponents.push(function() {
         this.needDrodpownWrapper = () => {};
-        this.handleResizeEvent = handleResizeEvent;
-        this.registerComponent = registerComponent;
+        this.handleResizeEvent = handleResizeEventSpies[handleResizeEventSpies.length - 1];
+        this.registerComponent = registerComponentSpies[registerComponentSpies.length - 1];
         this.ID = 'id';
-      };
+      });
       component = {};
       responsiveComponentsManager = new ResponsiveComponentsManager(root);
     });
 
     afterEach(() => {
+      handleResizeEventSpies.length = 0;
+      registerComponentSpies.length = 0;
       jasmine.clock().uninstall();
     });
 
@@ -47,10 +49,10 @@ export function ResponsiveComponentsManagerTest() {
 
       it('should calls handle resize event when resize listener is called', () => {
         root.width = () => 400;
-        responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+        responsiveComponentsManager.register(responsiveComponents[responsiveComponents.length - 1], root, 'id', component, {});
         responsiveComponentsManager.resizeListener();
         jasmine.clock().tick(250);
-        expect(handleResizeEvent).toHaveBeenCalled();
+        expect(handleResizeEventSpies[handleResizeEventSpies.length - 1]).toHaveBeenCalled();
       });
 
       describe('and the root element width is zero', () => {
@@ -59,15 +61,15 @@ export function ResponsiveComponentsManagerTest() {
         });
 
         it('should  not calls handle resize event when resize listener is called', () => {
-          responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+          responsiveComponentsManager.register(responsiveComponents[responsiveComponents.length - 1], root, 'id', component, {});
           responsiveComponentsManager.resizeListener();
           jasmine.clock().tick(250);
-          expect(handleResizeEvent).not.toHaveBeenCalled();
+          expect(handleResizeEventSpies[handleResizeEventSpies.length - 1]).not.toHaveBeenCalled();
         });
 
         it('should  not calls handle resize event when it registers component', () => {
-          responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
-          expect(handleResizeEvent).not.toHaveBeenCalled();
+          responsiveComponentsManager.register(responsiveComponents[responsiveComponents.length - 1], root, 'id', component, {});
+          expect(handleResizeEventSpies[handleResizeEventSpies.length - 1]).not.toHaveBeenCalled();
         });
       });
     });
@@ -83,19 +85,19 @@ export function ResponsiveComponentsManagerTest() {
         });
 
         it('should calls handle resize event when resize listener is called', () => {
-          responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+          responsiveComponentsManager.register(responsiveComponents[responsiveComponents.length - 1], root, 'id', component, {});
           responsiveComponentsManager.resizeListener();
           jasmine.clock().tick(250);
-          expect(handleResizeEvent).toHaveBeenCalled();
+          expect(handleResizeEventSpies).toHaveBeenCalled();
         });
       });
     });
 
     it('registers component even when the corresponding responsive class has already been instanciated', () => {
-      responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
-      responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+      responsiveComponentsManager.register(responsiveComponents[responsiveComponents.length - 1], root, 'id', component, {});
+      responsiveComponentsManager.register(responsiveComponents[responsiveComponents.length - 1], root, 'id', component, {});
 
-      expect(registerComponent).toHaveBeenCalledTimes(2);
+      expect(registerComponentSpies[length - 1]).toHaveBeenCalledTimes(2);
     });
   });
 }

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -47,9 +47,18 @@ export function ResponsiveComponentsManagerTest() {
 
       it('should calls handle resize event when resize listener is called', () => {
         root.width = () => 400;
-        responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+        responsiveComponentsManager.register(responsiveComponent, root, 'foo', component, {});
         responsiveComponentsManager.resizeListener();
         jasmine.clock().tick(250);
+        expect(handleResizeEvent).toHaveBeenCalled();
+      });
+
+      it('should call resize listener of all ResponsiveComponentManager when resizeAllComponentsManager is called', () => {
+        root.width = () => 400;
+        responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+        ResponsiveComponentsManager.resizeAllComponentsManager();
+
+        jasmine.clock().tick(500);
         expect(handleResizeEvent).toHaveBeenCalled();
       });
 
@@ -96,22 +105,6 @@ export function ResponsiveComponentsManagerTest() {
       responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
 
       expect(registerComponent).toHaveBeenCalledTimes(2);
-    });
-
-    it('should call resize listener of all ResponsiveComponentManager when resizeAllComponentsManager is called', () => {
-      let searchInterfaceMock = Mock.optionsSearchInterfaceSetup<SearchInterface, ISearchInterfaceOptions>(SearchInterface, {
-        enableAutomaticResponsiveMode: true
-      });
-      root = $$(searchInterfaceMock.cmp.root);
-      const anotherResponsiveComponentsManager = new ResponsiveComponentsManager(root);
-      const spyResizeListeners = [
-        spyOn(responsiveComponentsManager, 'resizeListener'),
-        spyOn(anotherResponsiveComponentsManager, 'resizeListener')
-      ];
-      ResponsiveComponentsManager.resizeAllComponentsManager();
-      spyResizeListeners.forEach(spy => {
-        expect(spy).toHaveBeenCalled();
-      });
     });
   });
 }


### PR DESCRIPTION
Make the `ResponsiveComponentManager.resizeAllComponentsManager` method public.

To help with UTs, I moved the registration of the ResponsiveComponentManager from `ResponsiveComponentManager.register` into the constructor of `ResponsiveComponentManager`

I think it also makes more sense because this prevent a ResponsiveComponentManager to _not_ be registered. 

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)