### PR TITLE
JSUI-2842 Analytics Access Token Renewal Fix

### DIFF
--- a/src/rest/AccessToken.ts
+++ b/src/rest/AccessToken.ts
@@ -1,4 +1,3 @@
-import { IErrorResponse } from './EndpointCaller';
 import { Logger } from '../misc/Logger';
 import { debounce } from 'underscore';
 
@@ -23,10 +22,6 @@ export class AccessToken {
       500,
       false
     );
-  }
-
-  public isExpired(error: IErrorResponse) {
-    return error != null && error.statusCode === 419;
   }
 
   public async doRenew(onError?: (error: Error) => void): Promise<Boolean> {

--- a/src/rest/AnalyticsEndpoint.ts
+++ b/src/rest/AnalyticsEndpoint.ts
@@ -115,7 +115,7 @@ export class AnalyticsEndpoint {
       return results.data;
     } catch (error) {
       AnalyticsEndpoint.pendingRequest = null;
-      if (this.options.accessToken.isExpired(error)) {
+      if (this.isAnalyticsTokenExpired(error)) {
         const successfullyRenewed = await this.options.accessToken.doRenew();
         if (successfullyRenewed) {
           return this.sendToService(data, path, paramName);
@@ -124,6 +124,10 @@ export class AnalyticsEndpoint {
 
       throw error;
     }
+  }
+
+  private isAnalyticsTokenExpired(error: IErrorResponse) {
+    return error != null && error.statusCode === 400 && error.data && error.data.type === 'InvalidToken';
   }
 
   private executeRequest(

--- a/src/ui/Analytics/Analytics.ts
+++ b/src/ui/Analytics/Analytics.ts
@@ -215,7 +215,10 @@ export class Analytics extends Component {
       return;
     } else {
       this.options.token = this.accessToken.token;
-      this.accessToken.subscribeToRenewal(newToken => (this.client.endpoint.endpointCaller.options.accessToken = newToken));
+      this.accessToken.subscribeToRenewal(newToken => {
+        this.options.token = newToken;
+        this.client.endpoint.endpointCaller.options.accessToken = newToken;
+      });
     }
 
     this.initializeAnalyticsClient();
@@ -510,10 +513,6 @@ export class Analytics extends Component {
       this.accessToken = this.defaultEndpoint.accessToken;
 
       this.options.token = this.defaultEndpoint.accessToken.token;
-      this.defaultEndpoint.accessToken.subscribeToRenewal(newToken => {
-        this.options.token = newToken;
-        this.initializeAnalyticsClient();
-      });
     }
 
     if (!this.options.organization && this.defaultEndpoint) {

--- a/unitTests/rest/AccessTokenTest.ts
+++ b/unitTests/rest/AccessTokenTest.ts
@@ -9,14 +9,6 @@ export function AccessTokenTest() {
       token = new AccessToken('el accesso tokeno');
     });
 
-    it('should correctly detect an expired status code', () => {
-      expect(token.isExpired({ statusCode: 419 })).toBeTruthy();
-    });
-
-    it('should correctly detect a status code that is not expired', () => {
-      expect(token.isExpired({ statusCode: 500 })).toBeFalsy();
-    });
-
     it('should properly return that the renew was not successful if there is no renew function', async done => {
       const renewSuccessful = await token.doRenew();
       expect(renewSuccessful).toBeFalsy();

--- a/unitTests/ui/AnalyticsTest.ts
+++ b/unitTests/ui/AnalyticsTest.ts
@@ -55,7 +55,8 @@ export function AnalyticsTest() {
         SearchEndpoint.endpoints['default'] = new SearchEndpoint({
           accessToken: 'some token',
           queryStringArguments: { organizationId: 'organization' },
-          restUri: 'some/uri'
+          restUri: 'some/uri',
+          renewAccessToken: async () => 'a renewed token'
         });
         test = Mock.basicComponentSetup<Analytics>(Analytics);
       });
@@ -66,6 +67,15 @@ export function AnalyticsTest() {
 
       it('use access token from default endpoint if not specified', () => {
         expect(test.cmp.options.token).toBe('some token');
+        expect(test.cmp.client.endpoint.endpointCaller.options.accessToken).toBe('some token');
+      });
+
+      it('renews the token correctly', done => {
+        SearchEndpoint.endpoints['default'].accessToken.doRenew().then(() => {
+          expect(test.cmp.options.token).toBe('a renewed token');
+          expect(test.cmp.client.endpoint.endpointCaller.options.accessToken).toBe('a renewed token');
+          done();
+        });
       });
 
       it('uses organization from default endpoint if not specified', () => {


### PR DESCRIPTION
Manage 400 error in the AnalyticsEndpoint directly.
Stop reinitializing Analytics Client on token renewal.

https://coveord.atlassian.net/browse/JSUI-2842
https://discuss.coveo.com/t/support-00058328-client-is-trying-to-automatically-generate-authentication-token/3162/16

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)