### PR TITLE
JSUI-2840 Made `PrintableUri` accessible

### DIFF
--- a/src/ui/PrintableUri/PrintableUri.ts
+++ b/src/ui/PrintableUri/PrintableUri.ts
@@ -53,6 +53,7 @@ export class PrintableUri extends Component {
     this.options = ComponentOptions.initComponentOptions(element, PrintableUri, options);
     this.options = _.extend({}, this.options, this.componentOptionsModel.get(ComponentOptionsModel.attributesEnum.resultLink));
     this.renderUri(this.element, this.result);
+    this.addAccessibilityAttributes();
   }
 
   /**
@@ -89,14 +90,14 @@ export class PrintableUri extends Component {
     } else if (this.options.titleTemplate) {
       const link = new ResultLink(this.buildElementForResultLink(result.printableUri), this.options, this.bindings, this.result);
       this.links.push(link);
-      this.element.appendChild(link.element);
+      this.element.appendChild(this.makeLinkAccessible(link.element));
     } else {
       this.renderShortenedUri();
     }
   }
 
   private buildSeparator(): HTMLElement {
-    const separator = $$('span', { className: 'coveo-printable-uri-separator' }, ' > ');
+    const separator = $$('span', { className: 'coveo-printable-uri-separator', role: 'separator' }, ' > ');
     return separator.el;
   }
 
@@ -127,7 +128,7 @@ export class PrintableUri extends Component {
       const token = this.buildHtmlToken(parent.getAttribute('name'), parent.getAttribute('uri'));
       tokens.push(token);
 
-      element.appendChild(token);
+      element.appendChild(this.makeLinkAccessible(token));
     }
   }
 
@@ -150,12 +151,23 @@ export class PrintableUri extends Component {
     });
     const link = new ResultLink(this.buildElementForResultLink(this.result.printableUri), this.options, this.bindings, resultPart);
     this.links.push(link);
-    this.element.appendChild(link.element);
+    this.element.appendChild(this.makeLinkAccessible(link.element));
+  }
+
+  private makeLinkAccessible(link: HTMLElement) {
+    return $$(
+      'span',
+      {
+        className: 'coveo-printable-uri-part',
+        role: 'listitem'
+      },
+      link
+    ).el;
   }
 
   private buildElementForResultLink(title: string): HTMLElement {
     return $$('a', {
-      className: 'CoveoResultLink coveo-printable-uri-part',
+      className: 'CoveoResultLink',
       title
     }).el;
   }
@@ -167,6 +179,10 @@ export class PrintableUri extends Component {
       this.result.phrasesToHighlight,
       new DefaultStreamHighlightOptions()
     );
+  }
+
+  private addAccessibilityAttributes() {
+    this.element.setAttribute('role', 'list');
   }
 }
 

--- a/unitTests/ui/PrintableUriTest.ts
+++ b/unitTests/ui/PrintableUriTest.ts
@@ -6,6 +6,26 @@ import { $$ } from '../../src/utils/Dom';
 import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
 import { FakeResults } from '../Fake';
 
+interface IParent {
+  name: string;
+  uri: string;
+}
+
+function generateParentsXMLFromList(parents: IParent[]) {
+  return `<?xml version="1.0" encoding="utf-16"?><parents>${parents
+    .map(parent => `<parent name="${parent.name}" uri="${parent.uri}"/>`)
+    .join('')}</parents>`;
+}
+
+const parents: IParent[] = [
+  { name: 'All resources', uri: 'somewebsiteroot.com' },
+  { name: 'Media', uri: 'somewebsiteroot.com/media' },
+  { name: 'Videos', uri: 'somewebsiteroot.com/media-videos' },
+  { name: 'Donut videos', uri: 'somewebsiteroot.com/donuts' }
+];
+
+const parentsXml = generateParentsXMLFromList(parents);
+
 export function PrintableUriTest() {
   describe('PrintableUri', function() {
     let test: Mock.IBasicComponentSetup<PrintableUri>;
@@ -43,6 +63,34 @@ export function PrintableUriTest() {
       test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
       expect($$(test.cmp.element).findAll('.CoveoResultLink.coveo-printable-uri-part')[0].innerText).toEqual('Organization');
       expect($$(test.cmp.element).findAll('.CoveoResultLink.coveo-printable-uri-part')[1].innerText).toEqual('Technical_Article__ka');
+    });
+
+    it('should add the list role to its element', () => {
+      test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
+      expect(test.cmp.element.getAttribute('role')).toEqual('list');
+    });
+
+    it('should seperate every parent element with a separator', () => {
+      fakeResult.raw.parents = parentsXml;
+      test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
+      const elements = $$(test.cmp.element).children();
+      for (let i = 0; i < parents.length * 2 - 1; i++) {
+        expect(elements[i].className.split(' ')).toEqual(i % 2 === 0 ? ['coveo-printable-uri-part'] : ['coveo-printable-uri-separator']);
+      }
+    });
+
+    it('should give the listitem role to every parent', () => {
+      fakeResult.raw.parents = parentsXml;
+      test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
+      const elements = $$(test.cmp.element).findAll('.coveo-printable-uri-part');
+      elements.forEach(element => expect(element.getAttribute('role')).toEqual('listitem'));
+    });
+
+    it('should give the separator role to every separator', () => {
+      fakeResult.raw.parents = parentsXml;
+      test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
+      const elements = $$(test.cmp.element).findAll('.coveo-printable-uri-separator');
+      elements.forEach(element => expect(element.getAttribute('role')).toEqual('separator'));
     });
 
     it('should shorten the printable uri correctly if the title is not a uri', () => {

--- a/unitTests/ui/PrintableUriTest.ts
+++ b/unitTests/ui/PrintableUriTest.ts
@@ -61,8 +61,8 @@ export function PrintableUriTest() {
         '<parent name="Generator became sentient and refuses to cut power"`' +
         ' uri="https://na17.salesforce.com/kA0o00000003Wpk" /><parent name="un autre test" uri="http//:google.ca" /></parents>';
       test = Mock.advancedResultComponentSetup<PrintableUri>(PrintableUri, fakeResult, undefined);
-      expect($$(test.cmp.element).findAll('.CoveoResultLink.coveo-printable-uri-part')[0].innerText).toEqual('Organization');
-      expect($$(test.cmp.element).findAll('.CoveoResultLink.coveo-printable-uri-part')[1].innerText).toEqual('Technical_Article__ka');
+      expect($$(test.cmp.element).findAll('.coveo-printable-uri-part')[0].innerText).toEqual('Organization');
+      expect($$(test.cmp.element).findAll('.coveo-printable-uri-part')[1].innerText).toEqual('Technical_Article__ka');
     });
 
     it('should add the list role to its element', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2840

* Added the "list" role to `PrintableUri`
* Added the "listitem" role to `PrintableUri`'s items
* Added the "separator" role to `PrintableUri`'s separators

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)