### PR TITLE
JSUI-2849 (WIP) Fetch /plan before search page redirection

### DIFF
--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -32,6 +32,7 @@ import { QueryUtils } from '../utils/QueryUtils';
 import { UrlUtils } from '../utils/UrlUtils';
 import { Utils } from '../utils/Utils';
 import { IAnalyticsClient } from '../ui/Analytics/AnalyticsClient';
+import { IPlanResults } from '../rest/Plan';
 
 /**
  * Possible options when performing a query with the query controller
@@ -172,6 +173,20 @@ export class QueryController extends RootComponent {
    */
   public getLastResults() {
     return this.lastQueryResults;
+  }
+
+  /**
+   * Returns the plan of execution of a search
+   * @returns {IPlanResults}
+   */
+  public async fetchQueryExecutionPlan() {
+    const query = this.createQueryBuilder(new DefaultQueryOptions()).build();
+    this.logger.debug('Fetching query execution plan');
+    try {
+      return await this.getEndpoint().plan(query);
+    } catch (error) {
+      return null;
+    }
   }
 
   /**

--- a/src/rest/Plan.ts
+++ b/src/rest/Plan.ts
@@ -1,14 +1,21 @@
-import { ITrigger } from './Trigger';
+import { ITrigger, ITriggerRedirect } from './Trigger';
 
 /**
  * Describes the plan of execution of a search
  */
 export interface IPlanResults {
-  processingOutput: {
+  preprocessingOutput: {
     triggers: ITrigger<any>[];
   };
   parsedInput: {
     basicExpression: string;
     largeExpression: string;
   };
+}
+
+export class ExecutionPlan {
+  static getRedirectTriggers(results: IPlanResults) {
+    const redirects: ITriggerRedirect[] = results.preprocessingOutput.triggers.filter(trigger => trigger.type === 'redirect');
+    return redirects.length ? redirects[0] : null;
+  }
 }


### PR DESCRIPTION
Just wanted an early feedback on this one!

https://coveord.atlassian.net/browse/JSUI-2849

Do you agree with the general behaviour, or should I move the execution somewhere else. Should I reuse and extract some stuff from the Triggers component?



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)