### PR TITLE
JSUI-2859 Fix AXE accessibility error in `InputManager`

### DIFF
--- a/src/magicbox/InputManager.ts
+++ b/src/magicbox/InputManager.ts
@@ -35,10 +35,8 @@ export class InputManager {
   public set activeDescendant(element: HTMLElement) {
     if (element) {
       this.input.setAttribute('aria-activedescendant', element.id);
-      this.input.setAttribute('aria-active-option', element.id);
     } else {
       this.input.removeAttribute('aria-activedescendant');
-      this.input.removeAttribute('aria-active-option');
     }
   }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2859

In this commit (https://github.com/coveo/search-ui/commit/23a0a6c0bc535d627e7614b812302dfeb55ccc6c), I added the `aria-active-option` attribute when trying to give the search bar a similar DOM as search bars from other websites. 
However, W3 only recommends using `aria-activedescendant`.

I could not find any source online recommending to use `aria-active-option` or even any indication that it exists in the first place. I must've added it when trying to mimic other search bars. Given that `aria-active-option` doesn't seem to exist and it's already covered by accessibility tests, are unit tests necessary for this?

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)