### PR TITLE
JSUI-2857 Removed `aria-controls` attribute from `FacetSearch`'s checkbox

### DIFF
--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -782,7 +782,6 @@ export class Facet extends Component {
     }
     Assert.exists(searchResultsElement);
     const { accessibleElement } = this.searchContainer;
-    accessibleElement.setAttribute('aria-controls', searchResultsElement.id);
     accessibleElement.setAttribute('aria-expanded', true.toString());
   }
 

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -680,10 +680,6 @@ export function FacetTest() {
             it('should set aria-expanded to true', () => {
               expect(accessibleElement.getAttribute('aria-expanded')).toEqual(true.toString());
             });
-
-            it('should set aria-controls to the given id', () => {
-              expect(accessibleElement.getAttribute('aria-controls')).toEqual(searchResultsElement.id);
-            });
           });
 
           describe('collapsed', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2857

This PR removes the `aria-controls` attribute from `FacetSearch`'s checkbox since activating it replaces it with a search bar that already owns the facet search results.

This fixes AXE accessibility errors that were triggered by two `aria-controls` properties owning the same component.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)