### PR TITLE
JSUI-2862 Added delay before running accessibility tests on the Quickview modal

### DIFF
--- a/accessibilityTest/AccessibilityQuickview.ts
+++ b/accessibilityTest/AccessibilityQuickview.ts
@@ -1,5 +1,5 @@
 import * as axe from 'axe-core';
-import { $$, Quickview, Component, get, Dom } from 'coveo-search-ui';
+import { $$, Quickview, Component, get, Dom, Utils } from 'coveo-search-ui';
 import { afterQuerySuccess, getRoot, testResultElement, getModal } from './Testing';
 
 export const AccessibilityQuickview = () => {
@@ -38,6 +38,7 @@ export const AccessibilityQuickview = () => {
 
     it('should open an accessible modal', async done => {
       await openQuickview();
+      await Utils.resolveAfter(500);
       const axeResults = await axe.run(getModal());
       expect(axeResults).toBeAccessible();
       done();


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2862

`QuickviewDocument`'s function isn't awaited by `Quickview`'s `open` function. This PR compensates for that by adding a delay before running accessibility tests on a modal.

This fixes one of the accessibility tests error.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)