### PR TITLE
JSUI-2858 Fixed accessibility tests for `DynamicHierarchicalFacet`

### DIFF
--- a/accessibilityTest/AccessibilityDynamicHierarchicalFacet.ts
+++ b/accessibilityTest/AccessibilityDynamicHierarchicalFacet.ts
@@ -1,6 +1,6 @@
 import * as axe from 'axe-core';
 import { $$, Component, DynamicHierarchicalFacet } from 'coveo-search-ui';
-import { afterQuerySuccess, getFacetColumn, getRoot, inDesktopMode, resetMode } from './Testing';
+import { afterDeferredQuerySuccess, getFacetColumn, getRoot, inDesktopMode, resetMode } from './Testing';
 
 export const AccessibilityDynamicHierarchicalFacet = () => {
   describe('DynamicHierarchicalFacet', () => {
@@ -23,11 +23,11 @@ export const AccessibilityDynamicHierarchicalFacet = () => {
 
     it('should be accessible', async done => {
       getFacetColumn().appendChild(dynamicHierarchicalFacet);
-      await afterQuerySuccess();
+      await afterDeferredQuerySuccess();
       $$(dynamicHierarchicalFacet)
         .find('.coveo-dynamic-hierarchical-facet-value')
         .click();
-      await afterQuerySuccess();
+      await afterDeferredQuerySuccess();
       const axeResults = await axe.run(getRoot());
       expect(axeResults).toBeAccessible();
       done();


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2858

This fixed `DynamicHierarchicalFacet`'s accessibility tests by making it wait for `defferedQuerySuccess` instead of `querySuccess`.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)