### PR TITLE
JSUI-2863 Allow configuring options on StandAloneSearchInterface

### DIFF
--- a/src/controllers/LocalStorageHistoryController.ts
+++ b/src/controllers/LocalStorageHistoryController.ts
@@ -6,8 +6,9 @@ import { Assert } from '../misc/Assert';
 import { InitializationEvents } from '../events/InitializationEvents';
 import { RootComponent } from '../ui/Base/RootComponent';
 import { $$ } from '../utils/Dom';
-import * as _ from 'underscore';
+import { each, omit } from 'underscore';
 import { IHistoryManager } from './HistoryManager';
+import { HashUtils } from '../utils/HashUtils';
 
 /**
  * This component acts like the {@link HistoryController} excepts that is saves the {@link QueryStateModel} in the local storage.<br/>
@@ -38,7 +39,7 @@ export class LocalStorageHistoryController extends RootComponent implements IHis
       this.storage = new LocalStorageUtils<{ [key: string]: any }>(LocalStorageHistoryController.ID);
       Assert.exists(this.model);
       Assert.exists(this.queryController);
-      $$(this.element).on(InitializationEvents.restoreHistoryState, () => this.updateModelFromLocalStorage());
+      $$(this.element).on(InitializationEvents.restoreHistoryState, () => this.initModelFromLocalStorageAndUrlHash());
       $$(this.element).on(this.model.getEventName(Model.eventTypes.all), () => this.updateLocalStorageFromModel());
     }
   }
@@ -55,26 +56,45 @@ export class LocalStorageHistoryController extends RootComponent implements IHis
     this.omit = attributes;
   }
 
+  public setState(values: Record<string, any>) {
+    this.storage.save(values);
+  }
+
   private updateLocalStorageFromModel() {
-    const attributes = _.omit(this.model.getAttributes(), this.omit);
+    const attributes = omit(this.model.getAttributes(), this.omit);
     this.setState(attributes);
     this.logger.debug('Saving state to localstorage', attributes);
   }
 
-  private updateModelFromLocalStorage() {
-    const toSet: { [key: string]: any } = {};
-    const loadedFromStorage = this.storage.load();
-    _.each(<_.Dictionary<any>>this.model.attributes, (value, key?, obj?) => {
-      var valToSet = loadedFromStorage ? loadedFromStorage[key] : undefined;
-      if (valToSet == undefined) {
-        valToSet = this.model.defaultAttributes[key];
-      }
-      toSet[key] = valToSet;
-    });
-    this.model.setMultiple(toSet);
+  private initModelFromLocalStorageAndUrlHash() {
+    const model = {
+      ...this.localStorageModel,
+      ...this.urlHashModel
+    };
+
+    this.model.setMultiple(model);
   }
 
-  public setState(values: Record<string, any>) {
-    this.storage.save(values);
+  private get localStorageModel() {
+    const model: Record<string, any> = {};
+    const storedValues = this.storage.load() || {};
+
+    each(this.model.attributes, (value, key) => {
+      const storedValue = storedValues[key];
+      const defaultValue = this.model.defaultAttributes[key];
+      const valueToSet = storedValue == undefined ? defaultValue : storedValue;
+
+      model[key] = valueToSet;
+    });
+
+    return model;
+  }
+
+  private get urlHashModel(): Record<string, any> {
+    const model: Record<string, any> = {};
+    const hash = HashUtils.getHash(this.windoh);
+
+    each(this.model.attributes, (value, key) => (model[key] = HashUtils.getValue(key, hash)));
+    return model;
   }
 }

--- a/src/controllers/LocalStorageHistoryController.ts
+++ b/src/controllers/LocalStorageHistoryController.ts
@@ -8,7 +8,6 @@ import { RootComponent } from '../ui/Base/RootComponent';
 import { $$ } from '../utils/Dom';
 import { each, omit } from 'underscore';
 import { IHistoryManager } from './HistoryManager';
-import { HashUtils } from '../utils/HashUtils';
 
 /**
  * This component acts like the {@link HistoryController} excepts that is saves the {@link QueryStateModel} in the local storage.<br/>
@@ -39,7 +38,7 @@ export class LocalStorageHistoryController extends RootComponent implements IHis
       this.storage = new LocalStorageUtils<{ [key: string]: any }>(LocalStorageHistoryController.ID);
       Assert.exists(this.model);
       Assert.exists(this.queryController);
-      $$(this.element).on(InitializationEvents.restoreHistoryState, () => this.initModelFromLocalStorageAndUrlHash());
+      $$(this.element).on(InitializationEvents.restoreHistoryState, () => this.initModelFromLocalStorage());
       $$(this.element).on(this.model.getEventName(Model.eventTypes.all), () => this.updateLocalStorageFromModel());
     }
   }
@@ -66,12 +65,8 @@ export class LocalStorageHistoryController extends RootComponent implements IHis
     this.logger.debug('Saving state to localstorage', attributes);
   }
 
-  private initModelFromLocalStorageAndUrlHash() {
-    const model = {
-      ...this.localStorageModel,
-      ...this.urlHashModel
-    };
-
+  private initModelFromLocalStorage() {
+    const model = this.localStorageModel;
     this.model.setMultiple(model);
   }
 
@@ -85,21 +80,6 @@ export class LocalStorageHistoryController extends RootComponent implements IHis
       const valueToSet = storedValue == undefined ? defaultValue : storedValue;
 
       model[key] = valueToSet;
-    });
-
-    return model;
-  }
-
-  private get urlHashModel(): Record<string, any> {
-    const model: Record<string, any> = {};
-    const hash = HashUtils.getHash(this.windoh);
-
-    each(this.model.attributes, (value, key) => {
-      const valueInUrl = HashUtils.getValue(key, hash);
-
-      if (valueInUrl) {
-        model[key] = valueInUrl;
-      }
     });
 
     return model;

--- a/src/controllers/LocalStorageHistoryController.ts
+++ b/src/controllers/LocalStorageHistoryController.ts
@@ -94,7 +94,14 @@ export class LocalStorageHistoryController extends RootComponent implements IHis
     const model: Record<string, any> = {};
     const hash = HashUtils.getHash(this.windoh);
 
-    each(this.model.attributes, (value, key) => (model[key] = HashUtils.getValue(key, hash)));
+    each(this.model.attributes, (value, key) => {
+      const valueInUrl = HashUtils.getValue(key, hash);
+
+      if (valueInUrl) {
+        model[key] = valueInUrl;
+      }
+    });
+
     return model;
   }
 }

--- a/src/ui/Base/RegisteredNamedMethods.ts
+++ b/src/ui/Base/RegisteredNamedMethods.ts
@@ -53,6 +53,8 @@ export function initSearchbox(element: HTMLElement, searchPageUri: string, optio
   searchInterfaceOptions.searchPageUri = searchPageUri;
   searchInterfaceOptions.autoTriggerQuery = false;
   searchInterfaceOptions.enableHistory = false;
+  searchInterfaceOptions = { ...searchInterfaceOptions, ...options.StandaloneSearchInterface };
+
   options = _.extend({}, options, { StandaloneSearchInterface: searchInterfaceOptions });
   return Initialization.initializeFramework(element, options, () => {
     return Initialization.initStandaloneSearchInterface(element, options);

--- a/src/utils/HashUtils.ts
+++ b/src/utils/HashUtils.ts
@@ -13,7 +13,7 @@ export class HashUtils {
     arrayEndRegExp: /\]$/
   };
 
-  public static getHash(w = window): string {
+  public static getHash(w: Window = window): string {
     Assert.exists(w);
 
     // window.location.hash returns the DECODED hash on Firefox (it's a well known bug),

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -210,6 +210,8 @@ export function mockWindow(): Window {
   mockWindow.addEventListener = jasmine.createSpy('addEventListener');
   mockWindow.removeEventListener = jasmine.createSpy('removeEventListener');
   mockWindow.dispatchEvent = jasmine.createSpy('dispatchEvent');
+  mockWindow.localStorage = mock<Storage>(localStorage);
+
   return <Window>mockWindow;
 }
 

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -60,6 +60,9 @@ FacetQueryControllerTest();
 import { HistoryControllerTest } from './controllers/HistoryControllerTest';
 HistoryControllerTest();
 
+import { LocalStorageHistoryControllerTest } from './controllers/LocalStorageHistoryControllerTest';
++LocalStorageHistoryControllerTest();
+
 import { QueryControllerTest } from './controllers/QueryControllerTest';
 QueryControllerTest();
 

--- a/unitTests/controllers/LocalStorageHistoryControllerTest.ts
+++ b/unitTests/controllers/LocalStorageHistoryControllerTest.ts
@@ -56,5 +56,21 @@ export function LocalStorageHistoryControllerTest() {
         expect(env.queryStateModel.setMultiple).toHaveBeenCalledWith(jasmine.objectContaining({ q: queryInHash }));
       });
     });
+
+    it('calling #setState saves the passed values in localstorage', () => {
+      const newState = { q: 'hello world' };
+      spyOn(localStorageHistoryController.storage, 'save');
+
+      localStorageHistoryController.setState(newState);
+      expect(localStorageHistoryController.storage.save).toHaveBeenCalledWith(newState);
+    });
+
+    it('calling #replaceState saves the passed values in localstorage', () => {
+      const newState = { q: 'hello world' };
+      spyOn(localStorageHistoryController.storage, 'save');
+
+      localStorageHistoryController.replaceState(newState);
+      expect(localStorageHistoryController.storage.save).toHaveBeenCalledWith(newState);
+    });
   });
 }

--- a/unitTests/controllers/LocalStorageHistoryControllerTest.ts
+++ b/unitTests/controllers/LocalStorageHistoryControllerTest.ts
@@ -47,19 +47,6 @@ export function LocalStorageHistoryControllerTest() {
           jasmine.objectContaining({ [key]: QueryStateModel.defaultAttributes.layout })
         );
       });
-
-      it(`if an attribute has a value in the url hash, it prioritizes the url hash value over the local storage value`, () => {
-        const queryInHash = 'world';
-        const urlHash = `#q=${queryInHash}`;
-        mockWindow.location.replace(urlHash);
-
-        expect(queryInHash).not.toEqual(modelInLocalStorage.q);
-
-        spyOn(env.queryStateModel, 'setMultiple');
-        emitRestoreHistoryStateEvent();
-
-        expect(env.queryStateModel.setMultiple).toHaveBeenCalledWith(jasmine.objectContaining({ q: queryInHash }));
-      });
     });
 
     it('calling #setState saves the passed values in localstorage', () => {

--- a/unitTests/controllers/LocalStorageHistoryControllerTest.ts
+++ b/unitTests/controllers/LocalStorageHistoryControllerTest.ts
@@ -1,0 +1,47 @@
+import * as Mock from '../MockEnvironment';
+import { LocalStorageHistoryController, InitializationEvents, $$ } from '../../src/Core';
+
+export function LocalStorageHistoryControllerTest() {
+  describe('LocalStorageHistoryController', () => {
+    let localStorageHistoryController: LocalStorageHistoryController;
+    let env: Mock.IMockEnvironment;
+    let mockWindow: Window;
+
+    beforeEach(() => {
+      mockWindow = Mock.mockWindow();
+      env = new Mock.MockEnvironmentBuilder().withLiveQueryStateModel().build();
+      localStorageHistoryController = new LocalStorageHistoryController(env.root, mockWindow, env.queryStateModel, env.queryController);
+    });
+
+    describe(`with state in localstorage, when triggering the ${InitializationEvents.restoreHistoryState} event`, () => {
+      const modelInLocalStorage: Record<string, string> = { q: 'localstorage' };
+
+      function emitRestoreHistoryStateEvent() {
+        $$(env.root).trigger(InitializationEvents.restoreHistoryState);
+      }
+
+      beforeEach(() => {
+        spyOn(localStorageHistoryController.storage, 'load').and.returnValue(modelInLocalStorage);
+      });
+
+      it(`initializes the model with the values in localstorage`, () => {
+        spyOn(env.queryStateModel, 'setMultiple');
+        emitRestoreHistoryStateEvent();
+
+        expect(env.queryStateModel.setMultiple).toHaveBeenCalledWith(jasmine.objectContaining(modelInLocalStorage));
+      });
+
+      it(`if an attribute has a value in the url hash, it prioritizes the url hash value over the local storage value`, () => {
+        const hashQueryAttributeValue = 'queryInUrl';
+        const urlHash = `#q=${hashQueryAttributeValue}`;
+        mockWindow.location.replace(urlHash);
+        spyOn(env.queryStateModel, 'setMultiple');
+
+        expect(hashQueryAttributeValue).not.toEqual(modelInLocalStorage.q);
+        emitRestoreHistoryStateEvent();
+
+        expect(env.queryStateModel.setMultiple).toHaveBeenCalledWith(jasmine.objectContaining({ q: hashQueryAttributeValue }));
+      });
+    });
+  });
+}


### PR DESCRIPTION
**Problem**

When redirecting from a stand-alone searchbox to a search page that is using localstorage to manage state, we are using `q` attribute value in local storage to perform the query.

The value in the stand-alone search box is ignored.


**Solution**

With this PR, it is possible to configure history and using localstorage on the stand-alone interface. When the query is set, the value is updated in localstorage and can be retrieved by the main interface on initialization.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)