### PR TITLE
JSUI-2853 Improved contrast in Facet and added contrast accessibility tests

### DIFF
--- a/accessibilityTest/AccessibilityFacet.ts
+++ b/accessibilityTest/AccessibilityFacet.ts
@@ -1,6 +1,7 @@
 import * as axe from 'axe-core';
-import { $$, Component, Facet, get } from 'coveo-search-ui';
+import { $$, Component, Facet, get, Dom } from 'coveo-search-ui';
 import { afterDeferredQuerySuccess, afterDelay, getFacetColumn, getRoot, inDesktopMode, resetMode } from './Testing';
+import { ContrastChecker } from './ContrastChecker';
 
 export const AccessibilityFacet = () => {
   describe('Facet', () => {
@@ -24,38 +25,72 @@ export const AccessibilityFacet = () => {
       done();
     });
 
-    it('search should be accessible', async done => {
-      const facetElement = getFacetElement();
-      getFacetColumn().appendChild(facetElement.el);
-      await afterDeferredQuerySuccess();
-      (get(facetElement.el) as Facet).facetSearch.focus();
-      await afterDelay(1000);
-      const axeResults = await axe.run(getRoot());
-      expect(axeResults).toBeAccessible();
-      done();
-    });
+    describe('with facet element', () => {
+      let facetElement: Dom;
 
-    it('should still be accessible when search has been opened', async done => {
-      const facetElement = getFacetElement();
-      getFacetColumn().appendChild(facetElement.el);
-      await afterDeferredQuerySuccess();
-      (get(facetElement.el) as Facet).facetSearch.focus();
-      await afterDelay(1000);
-      (get(facetElement.el) as Facet).facetSearch.dismissSearchResults();
-      await afterDelay(1000);
-      const axeResults = await axe.run(getRoot());
-      expect(axeResults).toBeAccessible();
-      done();
-    });
+      function getMagnifierSVG() {
+        return facetElement.el.querySelector<HTMLElement>('.coveo-facet-search-magnifier-svg');
+      }
 
-    it('settings should be accessible', async done => {
-      const facetElement = getFacetElement();
-      getFacetColumn().appendChild(facetElement.el);
-      await afterDeferredQuerySuccess();
-      facetElement.find('.coveo-facet-header-settings').click();
-      const axeResults = await axe.run(getRoot());
-      expect(axeResults).toBeAccessible();
-      done();
+      function getExcludeIcon() {
+        return facetElement.el.querySelector<HTMLElement>('.coveo-facet-value-exclude-svg');
+      }
+
+      function getSearchButton() {
+        return facetElement.el.querySelector<HTMLElement>('.coveo-facet-search-button .coveo-facet-value-checkbox');
+      }
+
+      beforeEach(async done => {
+        facetElement = getFacetElement();
+        getFacetColumn().appendChild(facetElement.el);
+        await afterDeferredQuerySuccess();
+        done();
+      });
+
+      it('settings should be accessible', async done => {
+        facetElement.find('.coveo-facet-header-settings').click();
+        const axeResults = await axe.run(getRoot());
+        expect(axeResults).toBeAccessible();
+        done();
+      });
+
+      it('should have good contrast on exclude buttons', () => {
+        const borderContrast = ContrastChecker.getContrastWithBackground(getExcludeIcon(), 'borderBottomColor');
+        expect(borderContrast).toBeGreaterThan(ContrastChecker.MinimumContrastRatio);
+      });
+
+      it('should have good contrast on the search button', () => {
+        const borderContrast = ContrastChecker.getContrastWithBackground(getSearchButton(), 'borderBottomColor');
+        expect(borderContrast).toBeGreaterThan(ContrastChecker.MinimumContrastRatio);
+      });
+
+      describe('after focusing on the search button', () => {
+        beforeEach(async done => {
+          (get(facetElement.el) as Facet).facetSearch.focus();
+          await afterDelay(1000);
+          done();
+        });
+
+        it('search should be accessible', async done => {
+          const axeResults = await axe.run(getRoot());
+          expect(axeResults).toBeAccessible();
+          done();
+        });
+
+        it('should still be accessible when search has been opened', async done => {
+          (get(facetElement.el) as Facet).facetSearch.dismissSearchResults();
+          await afterDelay(1000);
+          const axeResults = await axe.run(getRoot());
+          expect(axeResults).toBeAccessible();
+          done();
+        });
+
+        it('should have good contrast on the search icon', async done => {
+          const contrast = ContrastChecker.getContrastWithBackground(getMagnifierSVG());
+          expect(contrast).toBeGreaterThan(ContrastChecker.MinimumContrastRatio);
+          done();
+        });
+      });
     });
   });
 };

--- a/accessibilityTest/ContrastChecker.ts
+++ b/accessibilityTest/ContrastChecker.ts
@@ -1,0 +1,91 @@
+export interface IColor {
+  redRatio: number;
+  greenRatio: number;
+  blueRatio: number;
+  alphaRatio: number;
+}
+
+/**
+ * @see https://www.w3.org/TR/WCAG20-TECHS/G17.html#G17-procedure
+ */
+export class ContrastChecker {
+  public static readonly MinimumContrastRatio = 3;
+
+  public static getContrastWithBackground(element: HTMLElement, colorAttributeName: keyof CSSStyleDeclaration = 'color') {
+    const color = ContrastChecker.getColor(element, colorAttributeName);
+    if (!color) {
+      return null;
+    }
+    const backgroundColor = ContrastChecker.getBackground(element);
+    return this.getContrastBetweenRelativeLuminances(this.getRelativeLuminance(color), this.getRelativeLuminance(backgroundColor));
+  }
+
+  public static getBackground(element: HTMLElement): IColor {
+    const color = ContrastChecker.getColor(element, 'backgroundColor');
+    if (color && color.alphaRatio !== 0) {
+      return color;
+    }
+    if (element instanceof HTMLBodyElement) {
+      return { redRatio: 1, greenRatio: 1, blueRatio: 1, alphaRatio: 1 };
+    }
+    return ContrastChecker.getBackground(element.parentElement);
+  }
+
+  public static getColor(element: HTMLElement, attributeName: keyof CSSStyleDeclaration = 'color') {
+    const rawColor = ContrastChecker.getCSSAttribute(element, attributeName);
+    if (!rawColor) {
+      return null;
+    }
+    return ContrastChecker.parseCSSColor(rawColor);
+  }
+
+  private static getContrastBetweenRelativeLuminances(luminance1: number, luminance2: number) {
+    const [darkerRatio, lighterRatio] = [luminance1, luminance2].sort();
+    return (lighterRatio + 0.05) / (darkerRatio + 0.05);
+  }
+
+  private static getRelativeLuminance(color: IColor) {
+    return (
+      0.2126 * ContrastChecker.convertSRGBToRGB(color.redRatio) +
+      0.7152 * ContrastChecker.convertSRGBToRGB(color.greenRatio) +
+      0.0722 * ContrastChecker.convertSRGBToRGB(color.blueRatio)
+    );
+  }
+
+  private static convertSRGBToRGB(srgbColorRatio: number) {
+    if (srgbColorRatio <= 0.03928) {
+      return srgbColorRatio / 12.92;
+    }
+    return ((srgbColorRatio + 0.055) / 1.055) ** 2.4;
+  }
+
+  private static getCSSAttribute(element: HTMLElement, attributeName: keyof CSSStyleDeclaration): string {
+    const computedStyle = window.getComputedStyle(element);
+    if (!computedStyle.length) {
+      return null;
+    }
+    return computedStyle[attributeName];
+  }
+
+  private static parseCSSColor(rawColor: string) {
+    return (
+      ContrastChecker.parseColorFromExpression(rawColor, /rgb\(\s?([0-9]{1,3})\s?,\s?([0-9]{1,3})\s?,\s?([0-9]{1,3})/) ||
+      ContrastChecker.parseColorFromExpression(rawColor, /#([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})/, 16) ||
+      ContrastChecker.parseColorFromExpression(rawColor, /rgba\(\s?([0-9]{1,3})\s?,\s?([0-9]{1,3})\s?,\s?([0-9]{1,3}),\s?([0-9\.])/)
+    );
+  }
+
+  private static parseColorFromExpression(rawColor: string, expression: RegExp, radix = 10): IColor {
+    const result = expression.exec(rawColor);
+    if (!result) {
+      return null;
+    }
+    const [, rawRed, rawGreen, rawBlue, rawAlpha] = result;
+    return {
+      redRatio: parseInt(rawRed, radix) / 255,
+      greenRatio: parseInt(rawGreen, radix) / 255,
+      blueRatio: parseInt(rawBlue, radix) / 255,
+      alphaRatio: rawAlpha ? parseInt(rawAlpha) : 1
+    };
+  }
+}

--- a/sass/_FacetSearch.scss
+++ b/sass/_FacetSearch.scss
@@ -122,7 +122,7 @@
   margin: 5px 6px 5px 10px;
   width: 10px;
   height: 10px;
-  color: $color-light-greyish-blue;
+  color: $color-blueish-gray;
 }
 
 .coveo-facet-search-wait-animation {
@@ -168,13 +168,13 @@
     svg {
       bottom: 3px;
       .coveo-more-svg {
-        fill: $color-light-grey;
+        fill: grey;
       }
     }
   }
   .coveo-facet-value-checkbox > .coveo-facet-value-checkbox-svg,
   &:hover .coveo-facet-value-checkbox > .coveo-facet-value-checkbox-svg {
-    color: $color-light-grey;
+    color: grey;
     width: 16px;
     height: 11px;
   }

--- a/sass/_FacetValues.scss
+++ b/sass/_FacetValues.scss
@@ -12,6 +12,7 @@
     height: #{$pixel-size};
     box-sizing: content-box;
     @include defaultRoundedBorder();
+    border-color: grey;
     text-align: center;
     vertical-align: middle;
     margin-right: 15px;
@@ -241,6 +242,7 @@
   right: 5px;
   background: white;
   @include defaultRoundedBorder();
+  border-color: grey;
   height: 13px;
   width: 13px;
   opacity: 0;
@@ -261,6 +263,6 @@
   top: 2px;
   left: 2px;
   .coveo-exclusion-svg {
-    fill: $color-light-grey;
+    fill: grey;
   }
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2853

This PR also adds a new class called `ContrastChecker` to test contrasts, since axe is unable to test contrast on borders or svg icons.

# Improved contrasts
## Search button
### Before
![image](https://user-images.githubusercontent.com/54454747/74845153-9435a000-52fc-11ea-8038-d00196bd8326.png)
### After
![image](https://user-images.githubusercontent.com/54454747/74845031-5f294d80-52fc-11ea-8be1-ac645f848e45.png)

## Exclude button
### Before
![image](https://user-images.githubusercontent.com/54454747/74845449-0b6b3400-52fd-11ea-993e-56e9d0438854.png)
### After
![image](https://user-images.githubusercontent.com/54454747/74845061-694b4c00-52fc-11ea-9d68-db567399d3c2.png)

## Magnifier
### Before
![image](https://user-images.githubusercontent.com/54454747/74845487-18882300-52fd-11ea-8ca3-dbe4d643b782.png)
### After
![image](https://user-images.githubusercontent.com/54454747/74845076-710af080-52fc-11ea-8d45-86666384496c.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)