### PR TITLE
JSUI-2860 Fixed accessibility tests configuration

### DIFF
--- a/karma.accessibility.test.conf.js
+++ b/karma.accessibility.test.conf.js
@@ -12,9 +12,6 @@ var configuration = {
   browsers: ['ChromeHeadless-Accessibility'],
   frameworks: ['jasmine'],
   browserNoActivityTimeout: 90000,
-  browserDisconnectTimeout: 120000,
-  captureTimeout: 120000,
-  processKillTimeout: 120000,
   browserDisconnectTolerance: 10,
   files: [
     {

--- a/karma.accessibility.test.conf.js
+++ b/karma.accessibility.test.conf.js
@@ -4,11 +4,17 @@ const revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), Chrom
 
 process.env.CHROME_BIN = revisionInfo.executablePath;
 
+/**
+ * @type {import('karma').ConfigOptions}
+ */
 var configuration = {
   singleRun: true,
-  browsers: ['ChromeHeadless'],
+  browsers: ['ChromeHeadless-Accessibility'],
   frameworks: ['jasmine'],
   browserNoActivityTimeout: 90000,
+  browserDisconnectTimeout: 120000,
+  captureTimeout: 120000,
+  processKillTimeout: 120000,
   browserDisconnectTolerance: 10,
   files: [
     {
@@ -30,7 +36,13 @@ var configuration = {
     }
   ],
   reporters: ['spec'],
-  plugins: ['karma-jasmine', 'karma-chrome-launcher', 'karma-spec-reporter']
+  plugins: ['karma-jasmine', 'karma-chrome-launcher', 'karma-spec-reporter'],
+  customLaunchers: {
+    'ChromeHeadless-Accessibility': {
+      base: 'Chrome',
+      flags: ['--headless', '--remote-debugging-port=9222', '--no-sandbox', '--max_old_space_size=4096']
+    }
+  }
 };
 
 module.exports = function(config) {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2860

On my computer, only 4 tests would run with `gulp && gulp accessibilityTests` before Chrome would disconnect. This PR fixes the configuration file in case this issue may happen to anybody else.

I'm still not sure whether it's a good or bad idea to update the configuration, since I seem to be the only one experiencing this issue so far. I suspect the issue may be related to me using Vivaldi as my default browser instead of Chrome. Before approving, it might be a good idea to checkout this PR and test it out.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)