### PR TITLE
JSUI-2881 Improved contrast on `Searchbox` and `Settings`

### DIFF
--- a/accessibilityTest/AccessibilityOmnibox.ts
+++ b/accessibilityTest/AccessibilityOmnibox.ts
@@ -3,6 +3,11 @@ import { $$, Component, Omnibox, get, Dom, Facet, AnalyticsSuggestions, Analytic
 import { afterQuerySuccess, getRoot, getSearchSection, afterDelay, getResultsColumn } from './Testing';
 import { KEYBOARD } from '../src/utils/KeyboardUtils';
 import { times } from 'underscore';
+import { ContrastChecker } from './ContrastChecker';
+
+function getSuggestionsBox() {
+  return getSearchSection().querySelector<HTMLElement>('.coveo-magicbox-suggestions');
+}
 
 export const AccessibilityOmnibox = () => {
   describe('Omnibox', () => {
@@ -70,6 +75,11 @@ export const AccessibilityOmnibox = () => {
         input = omniboxElement.find('input') as HTMLInputElement;
         input.focus();
         done();
+      });
+
+      it('should have good contrast on the border of the suggestions box', () => {
+        const borderContrast = ContrastChecker.getContrastWithBackground(getSuggestionsBox(), 'borderBottomColor');
+        expect(borderContrast).toBeGreaterThan(ContrastChecker.MinimumContrastRatio);
       });
 
       it('should be accessible when navigating using keyboard down arrow once', async done => {

--- a/accessibilityTest/AccessibilitySearchbox.ts
+++ b/accessibilityTest/AccessibilitySearchbox.ts
@@ -1,10 +1,19 @@
 import * as axe from 'axe-core';
-import { $$, Component, Searchbox, get } from 'coveo-search-ui';
+import { $$, Component, Searchbox, get, Omnibox, SearchButton } from 'coveo-search-ui';
 import { afterQuerySuccess, getRoot, getSearchSection } from './Testing';
+import { ContrastChecker } from './ContrastChecker';
 
 export const AccessibilitySearchbox = () => {
   describe('Searchbox', () => {
     let searchBoxElement: HTMLElement;
+
+    function getOmnibox() {
+      return searchBoxElement.querySelector<HTMLElement>(`.${Component.computeCssClassName(Omnibox)}`);
+    }
+
+    function getSearchButton() {
+      return searchBoxElement.querySelector<HTMLElement>(`.${Component.computeCssClassName(SearchButton)}`);
+    }
 
     beforeEach(() => {
       searchBoxElement = $$('div', { className: Component.computeCssClassName(Searchbox) }).el;
@@ -15,6 +24,20 @@ export const AccessibilitySearchbox = () => {
       await afterQuerySuccess();
       const axeResults = await axe.run(getRoot());
       expect(axeResults).toBeAccessible();
+      done();
+    });
+
+    it('should have good contrast on the border of the omnibox', async done => {
+      await afterQuerySuccess();
+      const borderContrast = ContrastChecker.getContrastWithBackground(getOmnibox(), 'borderBottomColor');
+      expect(borderContrast).toBeGreaterThan(ContrastChecker.MinimumContrastRatio);
+      done();
+    });
+
+    it('should have good contrast on the border of the search button', async done => {
+      await afterQuerySuccess();
+      const borderContrast = ContrastChecker.getContrastWithBackground(getSearchButton(), 'borderBottomColor');
+      expect(borderContrast).toBeGreaterThan(ContrastChecker.MinimumContrastRatio);
       done();
     });
 

--- a/accessibilityTest/AccessibilitySettings.ts
+++ b/accessibilityTest/AccessibilitySettings.ts
@@ -1,0 +1,58 @@
+import { inDesktopMode, resetMode, getSearchSection, afterDeferredQuerySuccess, getRoot } from './Testing';
+import { $$, Component, Settings, get } from 'coveo-search-ui';
+import axe = require('axe-core');
+import { ContrastChecker } from './ContrastChecker';
+
+export const AccessibilitySettings = () => {
+  describe('Settings', () => {
+    function getSettingsElement() {
+      return $$('div', {
+        className: Component.computeCssClassName(Settings)
+      }).el;
+    }
+
+    function getSettings() {
+      return get(settingsElement, Settings) as Settings;
+    }
+
+    let settingsElement: HTMLElement;
+    beforeEach(async done => {
+      inDesktopMode();
+      getSearchSection().appendChild((settingsElement = getSettingsElement()));
+      await afterDeferredQuerySuccess();
+      done();
+    });
+
+    afterEach(() => {
+      resetMode();
+    });
+
+    it('should be accessible', async done => {
+      const axeResults = await axe.run(getRoot());
+      expect(axeResults).toBeAccessible();
+      done();
+    });
+
+    it('should have good contrast on the border', () => {
+      const borderContrast = ContrastChecker.getContrastWithBackground(settingsElement, 'borderBottomColor');
+      expect(borderContrast).toBeGreaterThan(ContrastChecker.MinimumContrastRatio);
+    });
+
+    describe('when expanded', () => {
+      beforeEach(() => {
+        settingsElement.click();
+      });
+
+      it('should be accessible', async done => {
+        const axeResults = await axe.run(getRoot());
+        expect(axeResults).toBeAccessible();
+        done();
+      });
+
+      it('should have good contrast on the border of the popup', () => {
+        const borderContrast = ContrastChecker.getContrastWithBackground(getSettings()['menu'], 'borderBottomColor', getSearchSection());
+        expect(borderContrast).toBeGreaterThan(ContrastChecker.MinimumContrastRatio);
+      });
+    });
+  });
+};

--- a/accessibilityTest/ContrastChecker.ts
+++ b/accessibilityTest/ContrastChecker.ts
@@ -11,12 +11,16 @@ export interface IColor {
 export class ContrastChecker {
   public static readonly MinimumContrastRatio = 3;
 
-  public static getContrastWithBackground(element: HTMLElement, colorAttributeName: keyof CSSStyleDeclaration = 'color') {
+  public static getContrastWithBackground(
+    element: HTMLElement,
+    colorAttributeName: keyof CSSStyleDeclaration = 'color',
+    backgroundElement: HTMLElement = element
+  ) {
     const color = ContrastChecker.getColor(element, colorAttributeName);
     if (!color) {
       return null;
     }
-    const backgroundColor = ContrastChecker.getBackground(element);
+    const backgroundColor = ContrastChecker.getBackground(backgroundElement);
     return this.getContrastBetweenRelativeLuminances(this.getRelativeLuminance(color), this.getRelativeLuminance(backgroundColor));
   }
 

--- a/accessibilityTest/Test.ts
+++ b/accessibilityTest/Test.ts
@@ -51,6 +51,7 @@ import { AccessibilityTimespanFacet } from './AccessibilityTimespanFacet';
 import { AccessibilityYouTubeThumbnail } from './AccessibilityYouTubeThumbnail';
 import { AccessibilityStarResult } from './AccessibilityStarResult';
 import { AccessibilityResultPreviewsManager } from './AccessibilityResultPreviewsManager';
+import { AccessibilitySettings } from './AccessibilitySettings';
 
 const initialHTMLSetup = () => {
   const body = jasmine['getGlobal']().document.body;
@@ -146,4 +147,5 @@ describe('Testing ...', () => {
   AccessibilityYouTubeThumbnail();
   AccessibilityStarResult();
   AccessibilityResultPreviewsManager();
+  AccessibilitySettings();
 });

--- a/sass/MagicBox/MagicBox.scss
+++ b/sass/MagicBox/MagicBox.scss
@@ -120,10 +120,10 @@
     .magic-box-suggestions.magic-box-hasSuggestion {
       display: block;
       .coveo-magicbox-suggestions {
-        border: $default-border;
+        border: $default-low-contrast-border;
       }
       .coveo-suggestion-container {
-        border: $default-border;
+        border: $default-low-contrast-border;
         .coveo-magicbox-suggestions {
           border: none;
         }
@@ -222,11 +222,11 @@
       right: 0;
       .coveo-magicbox-suggestions {
         border: none;
-        border-top: $default-border;
+        border-top: $default-low-contrast-border;
       }
       .coveo-suggestion-container {
         border: none;
-        border-top: $default-border;
+        border-top: $default-low-contrast-border;
         .coveo-magicbox-suggestions {
           border-top: none;
         }

--- a/sass/_SearchButton.scss
+++ b/sass/_SearchButton.scss
@@ -2,7 +2,7 @@
 
 .CoveoSearchButton {
   color: white;
-  border: 1px solid $color-light-grey;
+  border: 1px solid $color-light-contrast-grey;
   border-left: none;
   text-decoration: none;
   text-align: center;

--- a/sass/_Searchbox.scss
+++ b/sass/_Searchbox.scss
@@ -31,7 +31,7 @@
     border-bottom-right-radius: $default-border-radius;
   }
   .magic-box {
-    @include defaultRoundedBorder();
+    @include defaultRoundedLowContrastBorder();
     .magic-box-clear-svg {
       width: 15px;
       height: 15px;

--- a/sass/_Settings.scss
+++ b/sass/_Settings.scss
@@ -2,7 +2,7 @@
 .CoveoSettings {
   margin: 0 0 0 36px;
   border-radius: 50%;
-  border: $default-border;
+  border: $default-low-contrast-border;
   width: 40px;
   height: 40px;
   order: 1;
@@ -38,7 +38,7 @@
 .coveo-settings-advanced-menu {
   position: absolute;
   background: $color-blueish-white-grey;
-  @include defaultRoundedBorder();
+  @include defaultRoundedLowContrastBorder();
   min-width: 160px;
   z-index: 11;
   &:before {

--- a/sass/_Variables.scss
+++ b/sass/_Variables.scss
@@ -16,6 +16,7 @@ $color-vibrant-blue: #009ddc;
 $color-teal: #296896;
 $color-greyish-cyan: #cddee9;
 $color-greyish-light-cyan: #cddee9;
+$color-light-contrast-grey: #7e8c9a;
 $color-light-grey: #bcc3ca;
 $color-blueish-white-grey: #e6ecf0;
 $color-blueish-white: #f7f8f9;
@@ -40,8 +41,13 @@ $font-size-smallest: 12px;
 $default-border-radius: 2px;
 $small-border-radius: 1px;
 $default-border: thin solid $color-light-grey;
+$default-low-contrast-border: thin solid $color-light-contrast-grey;
 @mixin defaultRoundedBorder {
   border: $default-border;
+  border-radius: $default-border-radius;
+}
+@mixin defaultRoundedLowContrastBorder {
+  border: $default-low-contrast-border;
   border-radius: $default-border-radius;
 }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2881

Improved the contrast on `Searchbox`/`Omnibox` and `Settings`.

The plan wasn't to fix `Settings` at the same time, but Deque's test page doesn't have the `Settings` component in it. Fixing the contrast on the `Searchbox` component without fixing `Settings` visually looked out of place.

The hue and the saturation of the new color is the same as the old one, only the lightness was changed. It doesn't look too different from before and has a passing contrast ratio of 3.4:1.

# Before (with `#bac2c9`)
![image](https://user-images.githubusercontent.com/54454747/75071404-4a4ae680-54c3-11ea-8cb4-c884ae272491.png)

# After (with `#7e8c9a`)
![image](https://user-images.githubusercontent.com/54454747/75071100-a6613b00-54c2-11ea-8187-16ac9cae543c.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)