### PR TITLE
JSUI-2883 Use Location .assign instead of .replace to add current page to browser history

### DIFF
--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -1200,7 +1200,7 @@ export class StandaloneSearchInterface extends SearchInterface {
       this.element
     );
 
-    this._window.location.replace(url);
+    this._window.location.assign(url);
   }
 
   public redirectToSearchPage(searchPage: string) {

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -190,7 +190,7 @@ export function mockWindow(): Window {
     href: '',
     hash: ''
   };
-  mockWindow.location.replace = (newHref: string) => {
+  mockWindow.location.assign = mockWindow.location.replace = (newHref: string) => {
     newHref = newHref || '';
 
     mockWindow.location.href = newHref;
@@ -207,6 +207,7 @@ export function mockWindow(): Window {
     }
   };
   spyOn(mockWindow.location, 'replace').and.callThrough();
+  spyOn(mockWindow.location, 'assign').and.callThrough();
   mockWindow.addEventListener = jasmine.createSpy('addEventListener');
   mockWindow.removeEventListener = jasmine.createSpy('removeEventListener');
   mockWindow.dispatchEvent = jasmine.createSpy('dispatchEvent');


### PR DESCRIPTION
Seems .replace() is not working for everyone

Relevant documentation here:
https://developer.mozilla.org/en-US/docs/Web/API/Location/replace

https://coveord.atlassian.net/browse/JSUI-2883





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)