### PR TITLE
JSUI-2873 Put a bigger line-height for facet collapsed values

### DIFF
--- a/sass/DynamicFacet/_DynamicFacetValues.scss
+++ b/sass/DynamicFacet/_DynamicFacetValues.scss
@@ -52,6 +52,7 @@
 }
 
 .coveo-dynamic-facet-collapsed-values {
+  line-height: 1.6em;
   display: none;
 }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2873

<img width="364" alt="Screen Shot 2020-02-24 at 6 06 48 PM" src="https://user-images.githubusercontent.com/4923043/75199255-a0709180-5730-11ea-90da-d6f603ddff68.png">




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)