### PR TITLE
JSUI-2884 Disable tab feature for SortDropdown, fix tab feature for it's children

### DIFF
--- a/src/ui/Base/Component.ts
+++ b/src/ui/Base/Component.ts
@@ -363,6 +363,18 @@ export class Component extends BaseComponent {
     return Component.getResult(this.element);
   }
 
+  protected removeTabSupport() {
+    if (this.element.hasAttribute('data-tab')) {
+      this.logger.warn('The "data-tab" attribute is not supported for this component and was removed.');
+      this.element.removeAttribute('data-tab');
+    }
+
+    if (this.element.hasAttribute('data-tab-not')) {
+      this.logger.warn('The "data-tab-not" attribute is not supported for this component and was removed.');
+      this.element.removeAttribute('data-tab-not');
+    }
+  }
+
   private initDebugInfo() {
     $$(this.element).on('dblclick', (e: MouseEvent) => {
       if (e.altKey) {

--- a/src/ui/FormWidgets/Dropdown.ts
+++ b/src/ui/FormWidgets/Dropdown.ts
@@ -95,6 +95,21 @@ export class Dropdown implements IFormWidget, IFormWidgetSettable {
     });
   }
 
+  private findOption(value: string) {
+    const option = $$(this.element).find(`option[value="${value}"]`);
+    return option;
+  }
+
+  public showValue(value: string) {
+    const option = this.findOption(value);
+    option && option.removeAttribute('hidden');
+  }
+
+  public hideValue(value: string) {
+    const option = this.findOption(value);
+    option && option.setAttribute('hidden', 'true');
+  }
+
   private selectOption(option: HTMLOptionElement, executeOnChange = true) {
     this.selectElement.value = option.value;
     if (executeOnChange) {

--- a/src/ui/SortDropdown/SortDropdown.ts
+++ b/src/ui/SortDropdown/SortDropdown.ts
@@ -102,12 +102,6 @@ export class SortDropdown extends Component {
     return this.sortComponents.map(sort => sort.options.sortCriteria.toString());
   }
 
-  private updateValuesVisibility() {
-    const [hiddenSorts, visibleSorts] = partition(this.sortComponents, sortComponent => sortComponent.disabled);
-    hiddenSorts.forEach(hiddenSort => this.dropdown.hideValue(hiddenSort.options.sortCriteria.toString()));
-    visibleSorts.forEach(visibleSorts => this.dropdown.showValue(visibleSorts.options.sortCriteria.toString()));
-  }
-
   private handleQueryStateChanged(data: IAttributeChangedEventArg) {
     this.update();
   }
@@ -133,8 +127,19 @@ export class SortDropdown extends Component {
   }
 
   private handleQuerySuccess(data: IQuerySuccessEventArgs) {
-    this.updateValuesVisibility();
-    data.results.results.length ? this.showElement() : this.hideElement();
+    if (!data.results.results.length) {
+      return this.hideElement();
+    }
+
+    const [hiddenSorts, visibleSorts] = partition(this.sortComponents, sortComponent => sortComponent.disabled);
+    hiddenSorts.forEach(hiddenSort => this.dropdown.hideValue(hiddenSort.options.sortCriteria.toString()));
+    visibleSorts.forEach(visibleSorts => this.dropdown.showValue(visibleSorts.options.sortCriteria.toString()));
+
+    if (!visibleSorts.length) {
+      return this.hideElement();
+    }
+
+    this.showElement();
   }
 
   private handleQueryError(data: IQueryErrorEventArgs) {

--- a/src/ui/SortDropdown/SortDropdown.ts
+++ b/src/ui/SortDropdown/SortDropdown.ts
@@ -1,5 +1,5 @@
 import 'styling/_SortDropdown';
-import { findIndex } from 'underscore';
+import { findIndex, partition } from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 import { IQuerySuccessEventArgs, IQueryErrorEventArgs, QueryEvents } from '../../events/QueryEvents';
 import { IAttributeChangedEventArg, MODEL_EVENTS } from '../../models/Model';
@@ -51,6 +51,7 @@ export class SortDropdown extends Component {
     super(element, SortDropdown.ID, bindings);
 
     this.options = ComponentOptions.initComponentOptions(element, SortDropdown, options);
+    this.removeTabSupport();
 
     this.bind.oneRootElement(InitializationEvents.afterInitialization, () => this.handleAfterInitialization());
     this.bind.onQueryState(MODEL_EVENTS.CHANGE_ONE, QUERY_STATE_ATTRIBUTES.SORT, (args: IAttributeChangedEventArg) =>
@@ -101,6 +102,12 @@ export class SortDropdown extends Component {
     return this.sortComponents.map(sort => sort.options.sortCriteria.toString());
   }
 
+  private updateValuesVisibility() {
+    const [hiddenSorts, visibleSorts] = partition(this.sortComponents, sortComponent => sortComponent.disabled);
+    hiddenSorts.forEach(hiddenSort => this.dropdown.hideValue(hiddenSort.options.sortCriteria.toString()));
+    visibleSorts.forEach(visibleSorts => this.dropdown.showValue(visibleSorts.options.sortCriteria.toString()));
+  }
+
   private handleQueryStateChanged(data: IAttributeChangedEventArg) {
     this.update();
   }
@@ -126,6 +133,7 @@ export class SortDropdown extends Component {
   }
 
   private handleQuerySuccess(data: IQuerySuccessEventArgs) {
+    this.updateValuesVisibility();
     data.results.results.length ? this.showElement() : this.hideElement();
   }
 

--- a/unitTests/ui/DropdownTest.ts
+++ b/unitTests/ui/DropdownTest.ts
@@ -1,4 +1,5 @@
 import { Dropdown } from '../../src/ui/FormWidgets/Dropdown';
+import { $$ } from '../../src/Core';
 
 export function DropdownTest() {
   describe('Dropdown', () => {
@@ -62,6 +63,24 @@ export function DropdownTest() {
       it("should not change selection if the value doesn't exist", () => {
         dropdown.setValue('random');
         expect(dropdown.getValue()).toEqual(values[0]);
+      });
+    });
+
+    describe('hideValue and showValue', () => {
+      function hiddenOption() {
+        return $$(dropdown.getElement()).find('option[hidden][value=three]');
+      }
+
+      it('should hide option with specified value', () => {
+        dropdown.hideValue('three');
+        expect(hiddenOption()).toBeTruthy();
+      });
+
+      it('should show hidden option with specified value', () => {
+        dropdown.hideValue('three');
+        dropdown.showValue('three');
+
+        expect(hiddenOption()).toBeFalsy();
       });
     });
   });

--- a/unitTests/ui/SortDropdownTest.ts
+++ b/unitTests/ui/SortDropdownTest.ts
@@ -138,5 +138,39 @@ export function SortDropdownTest() {
 
       expect(selectElement.value).toBe(prevValue);
     });
+
+    it(`when adding tab attributes
+    should remove them`, () => {
+      test = Mock.advancedComponentSetup<SortDropdown>(SortDropdown, <Mock.AdvancedComponentSetupOptions>{
+        cmpOptions: {},
+        modifyBuilder: builder => {
+          builder.element.setAttribute('data-tab', 'allo');
+          builder.element.setAttribute('data-tab-not', 'bye');
+          return builder.withLiveQueryStateModel();
+        }
+      });
+
+      expect(test.cmp.element.hasAttribute('data-tab')).toBe(false);
+      expect(test.cmp.element.hasAttribute('data-tab-not')).toBe(false);
+    });
+
+    it(`when disabling a Sort component
+      should hide it's corresponding option`, () => {
+      sorts[0].disable();
+      triggerQuerySuccessWithResults([{}, {}]);
+
+      const hiddenSort = $$(test.cmp.element).find(`option[hidden][value="${sorts[0].options.sortCriteria}"]`);
+      expect(hiddenSort).toBeTruthy();
+    });
+
+    it(`when re-enabling a Sort component
+      should show it's corresponding option`, () => {
+      sorts[0].disable();
+      sorts[0].enable();
+      triggerQuerySuccessWithResults([{}, {}]);
+
+      const hiddenSort = $$(test.cmp.element).find(`option[hidden][value="${sorts[0].options.sortCriteria}"]`);
+      expect(hiddenSort).toBeFalsy();
+    });
   });
 }

--- a/unitTests/ui/SortDropdownTest.ts
+++ b/unitTests/ui/SortDropdownTest.ts
@@ -172,5 +172,24 @@ export function SortDropdownTest() {
       const hiddenSort = $$(test.cmp.element).find(`option[hidden][value="${sorts[0].options.sortCriteria}"]`);
       expect(hiddenSort).toBeFalsy();
     });
+
+    it(`when all children Sort components are disabled
+      should hide the parent SortDropdown`, () => {
+      sorts.forEach(sort => sort.disable());
+      triggerQuerySuccessWithResults([{}, {}]);
+
+      expect($$(test.cmp.element).isVisible()).toBe(false);
+    });
+
+    it(`when all children Sort components are disabled then enabled
+      should show the parent SortDropdown`, () => {
+      sorts.forEach(sort => sort.disable());
+      triggerQuerySuccessWithResults([{}, {}]);
+
+      sorts[0].enable();
+      triggerQuerySuccessWithResults([{}, {}]);
+
+      expect($$(test.cmp.element).isVisible()).toBe(true);
+    });
   });
 }


### PR DESCRIPTION
```
<div class="CoveoSortDropdown" data-tab="All">
    <span class="CoveoSort" data-sort-criteria="relevancy" data-caption="Relevance" data-tab="Some"></span>
    <span class="CoveoSort" data-sort-criteria="date descending" data-caption="Newest" data-tab="All"></span>
    <span class="CoveoSort" data-sort-criteria="date ascending" data-caption="Oldest" data-tab="All"></span>
</div>
```

on CoveoSortDropdown, data-tab (or data-tab-not) will be stripped. On CoveoSort, the data-tab (or data-tab-not) will be respected.

https://coveord.atlassian.net/browse/JSUI-2884

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)