### PR TITLE
JSUI-2892 Update exponential-backoff to latest

### DIFF
--- a/gulpTasks/definition.js
+++ b/gulpTasks/definition.js
@@ -69,7 +69,7 @@ gulp.task('externalDefs', function() {
       './lib/jstimezonedetect/index.d.ts',
       './lib/coveoanalytics/index.d.ts',
       './lib/map/index.d.ts',
-      './node_modules/exponential-backoff/dist/backoff.d.ts'
+      './node_modules/exponential-backoff/dist/*.d.ts'
     ])
     .pipe(concat('Externals.d.ts'))
     .pipe(replace(/import.*$/gm, ''))

--- a/gulpTasks/definition.js
+++ b/gulpTasks/definition.js
@@ -68,8 +68,7 @@ gulp.task('externalDefs', function() {
       './lib/globalize/index.d.ts',
       './lib/jstimezonedetect/index.d.ts',
       './lib/coveoanalytics/index.d.ts',
-      './lib/map/index.d.ts',
-      './node_modules/exponential-backoff/dist/*.d.ts'
+      './lib/map/index.d.ts'
     ])
     .pipe(concat('Externals.d.ts'))
     .pipe(replace(/import.*$/gm, ''))

--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
     "prepare": "npm run snyk-protect"
   },
   "lint-staged": {
-    "*.{js,ts,json,scss}": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.{js,ts,json,scss}": ["prettier --write", "git add"]
   },
   "prettier": {
     "printWidth": 140,
@@ -39,33 +36,13 @@
     "type": "git",
     "url": "git+https://github.com/coveo/search-ui.git"
   },
-  "keywords": [
-    "coveo",
-    "search",
-    "ui",
-    "framework",
-    "js",
-    "typescript",
-    "jssearch",
-    "jsui"
-  ],
+  "keywords": ["coveo", "search", "ui", "framework", "js", "typescript", "jssearch", "jsui"],
   "author": "Coveo <sandbox_JSUI@coveo.com> (http://source.coveo.com/)",
   "license": "Apache-2.0",
   "bugs": {
     "url": "https://github.com/coveo/search-ui/issues"
   },
-  "files": [
-    "bin",
-    "pages",
-    "gulpTasks",
-    "images",
-    "templates",
-    "strings",
-    "filetypes",
-    "lib",
-    "src",
-    "typings"
-  ],
+  "files": ["bin", "pages", "gulpTasks", "images", "templates", "strings", "filetypes", "lib", "src", "typings"],
   "homepage": "https://github.com/coveo/search-ui#readme",
   "devDependencies": {
     "@salesforce-ux/design-system": "^2.6.0",
@@ -161,7 +138,7 @@
     "d3": "^4.2.1",
     "d3-scale": "^1.0.3",
     "es6-promise": "^4.0.5",
-    "exponential-backoff": "^1.0.5",
+    "exponential-backoff": "^2.2.0",
     "jstimezonedetect": "^1.0.6",
     "latinize": "^0.4.0",
     "modal-box": "^2.0.10",

--- a/src/rest/BackOffRequest.ts
+++ b/src/rest/BackOffRequest.ts
@@ -2,6 +2,11 @@ import { backOff as originalBackOff, IBackOffOptions } from 'exponential-backoff
 
 let backOff = originalBackOff;
 
+export interface IBackOffRequest<T> {
+  fn: () => Promise<T>;
+  options?: Partial<IBackOffOptions>;
+}
+
 export function setBackOffModule(newModule?: (request: () => Promise<any>, options?: Partial<IBackOffOptions>) => Promise<any>) {
   backOff = newModule || originalBackOff;
 }
@@ -10,16 +15,16 @@ export class BackOffRequest {
   private static queue: (() => Promise<any>)[] = [];
   private static clearingQueue = false;
 
-  public static enqueue<T>(request: () => Promise<T>, options: Partial<IBackOffOptions> = {}): Promise<T> {
+  public static enqueue<T>(request: IBackOffRequest<T>): Promise<T> {
     return new Promise((resolve, reject) => {
-      BackOffRequest.enqueueRequest<T>(request, options, resolve, reject);
+      BackOffRequest.enqueueRequest<T>(request, resolve, reject);
       BackOffRequest.clearQueueIfNotAlready();
     });
   }
 
-  private static enqueueRequest<T>(request: () => Promise<T>, options: Partial<IBackOffOptions>, resolve, reject) {
+  private static enqueueRequest<T>(request: IBackOffRequest<T>, resolve, reject) {
     const req = () =>
-      backOff<T>(request, options)
+      backOff<T>(request.fn, request.options)
         .then(resolve)
         .catch(reject);
     BackOffRequest.queue.push(req);

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -37,8 +37,7 @@ import { TimeSpan } from '../utils/TimeSpanUtils';
 import { UrlUtils } from '../utils/UrlUtils';
 import { IGroupByResult } from './GroupByResult';
 import { AccessToken } from './AccessToken';
-import { BackOffRequest } from './BackOffRequest';
-import { IBackOffOptions } from 'exponential-backoff';
+import { BackOffRequest, IBackOffRequest } from './BackOffRequest';
 import { IFacetSearchRequest } from './Facet/FacetSearchRequest';
 import { IFacetSearchResponse } from './Facet/FacetSearchResponse';
 import { IPlanResponse, ExecutionPlan } from './Plan';
@@ -1176,10 +1175,10 @@ export class SearchEndpoint implements ISearchEndpoint {
 
   private async backOffThrottledRequest<T>(request: () => Promise<T>) {
     try {
-      const options: Partial<IBackOffOptions> = {
-        retry: (e, attempt) => this.retryIf429Error(e, attempt)
-      };
-      return await BackOffRequest.enqueue<T>(request, options);
+      const options = { retry: (e, attempt) => this.retryIf429Error(e, attempt) };
+      const backoffRequest: IBackOffRequest<T> = { fn: request, options };
+
+      return await BackOffRequest.enqueue<T>(backoffRequest);
     } catch (e) {
       throw this.handleErrorResponse(e);
     }

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -38,7 +38,7 @@ import { UrlUtils } from '../utils/UrlUtils';
 import { IGroupByResult } from './GroupByResult';
 import { AccessToken } from './AccessToken';
 import { BackOffRequest } from './BackOffRequest';
-import { IBackOffRequest } from 'exponential-backoff';
+import { IBackOffOptions } from 'exponential-backoff';
 import { IFacetSearchRequest } from './Facet/FacetSearchRequest';
 import { IFacetSearchResponse } from './Facet/FacetSearchResponse';
 import { IPlanResponse, ExecutionPlan } from './Plan';
@@ -1176,11 +1176,10 @@ export class SearchEndpoint implements ISearchEndpoint {
 
   private async backOffThrottledRequest<T>(request: () => Promise<T>) {
     try {
-      const backOffRequest: IBackOffRequest<T> = {
-        fn: () => request(),
+      const options: Partial<IBackOffOptions> = {
         retry: (e, attempt) => this.retryIf429Error(e, attempt)
       };
-      return await BackOffRequest.enqueue<T>(backOffRequest);
+      return await BackOffRequest.enqueue<T>(request, options);
     } catch (e) {
       throw this.handleErrorResponse(e);
     }

--- a/unitTests/rest/BackOffRequestTest.ts
+++ b/unitTests/rest/BackOffRequestTest.ts
@@ -22,7 +22,7 @@ export function BackOffRequestTest() {
 
     it(`when calling #enqueue with a request that resolves successfully,
     it returns the successful response`, done => {
-      const request = BackOffRequest.enqueue(() => Promise.resolve(mockSuccessResponse));
+      const request = BackOffRequest.enqueue({ fn: () => Promise.resolve(mockSuccessResponse) });
 
       request.then(response => {
         expect(response).toBe(mockSuccessResponse);
@@ -34,8 +34,8 @@ export function BackOffRequestTest() {
     it processes the requests in series`, done => {
       let firstRequestEnded = false;
 
-      const firstRequest = BackOffRequest.enqueue(() => timeUnitsToResolveIn(2));
-      const secondRequest = BackOffRequest.enqueue(() => timeUnitsToResolveIn(1));
+      const firstRequest = BackOffRequest.enqueue({ fn: () => timeUnitsToResolveIn(2) });
+      const secondRequest = BackOffRequest.enqueue({ fn: () => timeUnitsToResolveIn(1) });
 
       firstRequest.then(() => (firstRequestEnded = true));
       secondRequest.then(() => {
@@ -47,7 +47,7 @@ export function BackOffRequestTest() {
     it(`when calling #enqueue with a request that returns an error,
     it returns a rejected promise with the error`, done => {
       const error = { error: true };
-      const request = BackOffRequest.enqueue(() => Promise.reject(error));
+      const request = BackOffRequest.enqueue({ fn: () => Promise.reject(error) });
 
       request.catch(e => {
         expect(e).toBe(error);

--- a/unitTests/rest/BackOffRequestTest.ts
+++ b/unitTests/rest/BackOffRequestTest.ts
@@ -1,4 +1,3 @@
-import { IBackOffRequest } from 'exponential-backoff';
 import { BackOffRequest, setBackOffModule } from '../../src/rest/BackOffRequest';
 
 export function BackOffRequestTest() {
@@ -9,7 +8,7 @@ export function BackOffRequestTest() {
     afterAll(() => restoreBackOffDependency());
 
     function stubBackOffDependency() {
-      setBackOffModule((request: IBackOffRequest<{}>) => request.fn());
+      setBackOffModule((request: () => Promise<any>) => request());
     }
 
     function restoreBackOffDependency() {
@@ -23,7 +22,7 @@ export function BackOffRequestTest() {
 
     it(`when calling #enqueue with a request that resolves successfully,
     it returns the successful response`, done => {
-      const request = BackOffRequest.enqueue({ fn: () => Promise.resolve(mockSuccessResponse) });
+      const request = BackOffRequest.enqueue(() => Promise.resolve(mockSuccessResponse));
 
       request.then(response => {
         expect(response).toBe(mockSuccessResponse);
@@ -35,8 +34,8 @@ export function BackOffRequestTest() {
     it processes the requests in series`, done => {
       let firstRequestEnded = false;
 
-      const firstRequest = BackOffRequest.enqueue({ fn: () => timeUnitsToResolveIn(2) });
-      const secondRequest = BackOffRequest.enqueue({ fn: () => timeUnitsToResolveIn(1) });
+      const firstRequest = BackOffRequest.enqueue(() => timeUnitsToResolveIn(2));
+      const secondRequest = BackOffRequest.enqueue(() => timeUnitsToResolveIn(1));
 
       firstRequest.then(() => (firstRequestEnded = true));
       secondRequest.then(() => {
@@ -48,7 +47,7 @@ export function BackOffRequestTest() {
     it(`when calling #enqueue with a request that returns an error,
     it returns a rejected promise with the error`, done => {
       const error = { error: true };
-      const request = BackOffRequest.enqueue({ fn: () => Promise.reject(error) });
+      const request = BackOffRequest.enqueue(() => Promise.reject(error));
 
       request.catch(e => {
         expect(e).toBe(error);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2701,9 +2701,9 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-exponential-backoff@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-1.0.5.tgz#bc2efab67b946424cf53b7ab117a59ebe78cb920"
+exponential-backoff@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-2.2.0.tgz#66bd0e6e574f045cb71562332031c3588306eabd"
 
 exports-loader@^0.6.3:
   version "0.6.4"


### PR DESCRIPTION
More than a year ago, I deployed versions of the `exponential-backoff` npm package with missing bin files due to a mistake with Travis-CI.

When people install the search-ui, the installer sometimes does not respect the package-lock version for the `exponential-backoff` package. As a result, they pull a bad version and face errors when they start the project.

e.g. `1.0.5` specified in the lock file is good, but the installer pulls `1.2.0` which is a broken.

By updating the package to the latest, we should avoid this issue.


I will also attempt to [unpublish ](https://www.npmjs.com/policies/unpublish)the packages if possible.




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)