### PR TITLE
JSUI-2887 Improved the contrast ratio on `DynamicFacet`'s checkboxes

### DIFF
--- a/sass/coveo-styleguide/scss/controls/_checkboxes.scss
+++ b/sass/coveo-styleguide/scss/controls/_checkboxes.scss
@@ -17,10 +17,6 @@
   cursor: pointer;
 }
 
-button.coveo-checkbox-button {
-  @extend .coveo-checkbox-button;
-}
-
 input[type='checkbox'].coveo-checkbox {
   display: none;
 

--- a/sass/coveo-styleguide/scss/controls/_checkboxes.scss
+++ b/sass/coveo-styleguide/scss/controls/_checkboxes.scss
@@ -1,3 +1,5 @@
+@import '../../../Variables';
+
 .coveo-checkbox-button {
   position: relative;
 
@@ -6,13 +8,17 @@
   padding: 0;
 
   background: $pure-white;
-  border: 1px solid $medium-grey;
+  border: 1px solid $color-light-contrast-grey;
   border-radius: $border-radius;
   outline: none;
 
   transition: all 200ms;
 
   cursor: pointer;
+}
+
+button.coveo-checkbox-button {
+  @extend .coveo-checkbox-button;
 }
 
 input[type='checkbox'].coveo-checkbox {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2887

This PR aims to give `DynamicFacet`'s checkboxes a contrast ratio greater than 3:1. However, I've been trying for hours to add an accessibility test to it without success because headless accessibility tests appear to ignore the style applied on this specific component and use the browser's default styling for `button` instead.

Should I merge this without an accessibility test, or should I keep trying to find a way to apply that style?

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)