### PR TITLE
JSUI-2893 DynamicHierarchicalFacetValues: Clear selected path when getting a new response

### DIFF
--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValues.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValues.ts
@@ -25,7 +25,7 @@ export class DynamicHierarchicalFacetValues implements IDynamicHierarchicalFacet
   }
 
   public createFromResponse(response: IFacetResponse) {
-    this._selectedPath = [];
+    this.clearPath();
     this.facetValues = response.values.map(responseValue => this.createFacetValueFromResponse(responseValue));
   }
 
@@ -72,7 +72,7 @@ export class DynamicHierarchicalFacetValues implements IDynamicHierarchicalFacet
 
   public resetValues() {
     this.facetValues = [];
-    this._selectedPath = [];
+    this.clearPath();
   }
 
   public clearPath() {

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValues.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValues.ts
@@ -25,6 +25,7 @@ export class DynamicHierarchicalFacetValues implements IDynamicHierarchicalFacet
   }
 
   public createFromResponse(response: IFacetResponse) {
+    this._selectedPath = [];
     this.facetValues = response.values.map(responseValue => this.createFacetValueFromResponse(responseValue));
   }
 

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValuesTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValuesTest.ts
@@ -124,11 +124,19 @@ export function DynamicHierarchicalFacetValuesTest() {
         it('should have the right selectedPath', () => {
           expect(facet.values.selectedPath).toEqual(facet.values.allFacetValues[0].path);
         });
+
+        it('should clear the path if a query with no selected value is returned', () => {
+          response.values = [];
+          facet.values.createFromResponse(response);
+          expect(facet.values.selectedPath).toEqual([]);
+        });
       });
     });
 
     it('resetValues should empty the values and clear the path', () => {
-      facet.values.createFromResponse(DynamicHierarchicalFacetTestUtils.getCompleteFacetResponse(facet));
+      const response = DynamicHierarchicalFacetTestUtils.getCompleteFacetResponse(facet);
+      facet.values.createFromResponse(response);
+      facet.values.selectPath([response.values[0].value]);
       facet.values.resetValues();
 
       expect(facet.values.allFacetValues.length).toBe(0);
@@ -136,7 +144,9 @@ export function DynamicHierarchicalFacetValuesTest() {
     });
 
     it('clearPath should clear the path', () => {
-      facet.values.createFromResponse(DynamicHierarchicalFacetTestUtils.getCompleteFacetResponse(facet));
+      const response = DynamicHierarchicalFacetTestUtils.getCompleteFacetResponse(facet);
+      facet.values.createFromResponse(response);
+      facet.values.selectPath([response.values[0].value]);
       facet.values.clearPath();
 
       expect(facet.values.allFacetValues.length).not.toBe(0);


### PR DESCRIPTION
This will prevent the QSM and breadcrumbs to keep the selection if the API returns no values.

https://coveord.atlassian.net/browse/JSUI-2893




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)