### PR TITLE
JSUI-2889 Add autocomplete=off on the input of the Searchbox

### DIFF
--- a/src/magicbox/InputManager.ts
+++ b/src/magicbox/InputManager.ts
@@ -212,6 +212,7 @@ export class InputManager {
   }
 
   private addAccessibilitiesProperties() {
+    this.input.setAttribute('autocomplete', 'off');
     this.input.setAttribute('type', 'text');
     this.input.setAttribute('role', 'combobox');
     this.input.setAttribute('form', 'coveo-dummy-form');


### PR DESCRIPTION
The browser was autocompleting the input with it's previous selected text without respecting the righteous JSUI state!

https://coveord.atlassian.net/browse/JSUI-2889





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)