### PR TITLE
Fixed contrast on `DynamicFacetValue` labels

### DIFF
--- a/accessibilityTest/AccessibilityDynamicFacet.ts
+++ b/accessibilityTest/AccessibilityDynamicFacet.ts
@@ -32,13 +32,25 @@ export const AccessibilityDynamicFacet = () => {
       done();
     });
 
-    it('should have good contrast on the first value', async done => {
+    it('should have good contrast on the first value while focused', async done => {
       getFacetColumn().appendChild(dynamicFacet);
       await afterDeferredQuerySuccess();
 
       const firstValue = getFirstValue();
       firstValue.classList.add('coveo-focused');
       const contrast = ContrastChecker.getContrastWithBackground(firstValue.querySelector('.coveo-checkbox-span-label'));
+      expect(contrast).not.toBeLessThan(ContrastChecker.MinimumHighContrastRatio);
+
+      done();
+    });
+
+    it("should have good contrast on the first value's count while focused", async done => {
+      getFacetColumn().appendChild(dynamicFacet);
+      await afterDeferredQuerySuccess();
+
+      const firstValue = getFirstValue();
+      firstValue.classList.add('coveo-focused');
+      const contrast = ContrastChecker.getContrastWithBackground(firstValue.querySelector('.coveo-checkbox-span-label-suffix'));
       expect(contrast).not.toBeLessThan(ContrastChecker.MinimumHighContrastRatio);
 
       done();

--- a/accessibilityTest/AccessibilityDynamicFacet.ts
+++ b/accessibilityTest/AccessibilityDynamicFacet.ts
@@ -1,7 +1,8 @@
 import * as axe from 'axe-core';
 import { $$, Component, DynamicFacet } from 'coveo-search-ui';
-import { afterQuerySuccess, afterDelay, getFacetColumn, getRoot, inDesktopMode, resetMode } from './Testing';
+import { afterQuerySuccess, afterDelay, getFacetColumn, getRoot, inDesktopMode, resetMode, afterDeferredQuerySuccess } from './Testing';
 import { KEYBOARD } from '../src/Core';
+import { ContrastChecker } from './ContrastChecker';
 
 export const AccessibilityDynamicFacet = () => {
   describe('DynamicFacet', () => {
@@ -31,8 +32,24 @@ export const AccessibilityDynamicFacet = () => {
       done();
     });
 
+    it('should have good contrast on the first value', async done => {
+      getFacetColumn().appendChild(dynamicFacet);
+      await afterDeferredQuerySuccess();
+
+      const firstValue = getFirstValue();
+      firstValue.classList.add('coveo-focused');
+      const contrast = ContrastChecker.getContrastWithBackground(firstValue.querySelector('.coveo-checkbox-span-label'));
+      expect(contrast).not.toBeLessThan(ContrastChecker.MinimumHighContrastRatio);
+
+      done();
+    });
+
     function getInput() {
       return $$(dynamicFacet).find('input');
+    }
+
+    function getFirstValue() {
+      return $$(dynamicFacet).find('.coveo-dynamic-facet-value');
     }
 
     function triggerKeyboardEvent(name: string, key: KEYBOARD, input: HTMLElement) {

--- a/accessibilityTest/ContrastChecker.ts
+++ b/accessibilityTest/ContrastChecker.ts
@@ -64,9 +64,9 @@ export class ContrastChecker {
   public static combineColors(color: IColor, backgroundColor: IColor): IColor {
     const { alphaRatio } = color;
     return {
-      redRatio: backgroundColor.redRatio - alphaRatio * (1 - color.redRatio),
-      greenRatio: backgroundColor.greenRatio - alphaRatio * (1 - color.greenRatio),
-      blueRatio: backgroundColor.blueRatio - alphaRatio * (1 - color.blueRatio),
+      redRatio: (1 - alphaRatio) * backgroundColor.redRatio + alphaRatio * color.redRatio,
+      greenRatio: (1 - alphaRatio) * backgroundColor.greenRatio + alphaRatio * color.greenRatio,
+      blueRatio: (1 - alphaRatio) * backgroundColor.blueRatio + alphaRatio * color.blueRatio,
       alphaRatio: backgroundColor.alphaRatio
     };
   }

--- a/accessibilityTest/ContrastChecker.ts
+++ b/accessibilityTest/ContrastChecker.ts
@@ -10,37 +10,65 @@ export interface IColor {
  */
 export class ContrastChecker {
   public static readonly MinimumContrastRatio = 3;
+  public static readonly MinimumHighContrastRatio = 4.5;
 
   public static getContrastWithBackground(
     element: HTMLElement,
     colorAttributeName: keyof CSSStyleDeclaration = 'color',
     backgroundElement: HTMLElement = element
   ) {
-    const color = ContrastChecker.getColor(element, colorAttributeName);
+    const color = this.getColor(element, colorAttributeName);
     if (!color) {
       return null;
     }
-    const backgroundColor = ContrastChecker.getBackground(backgroundElement);
-    return this.getContrastBetweenRelativeLuminances(this.getRelativeLuminance(color), this.getRelativeLuminance(backgroundColor));
+    const backgroundColor = this.getBackground(backgroundElement);
+    return this.getContrastBetweenColors(color, backgroundColor);
   }
 
   public static getBackground(element: HTMLElement): IColor {
-    const color = ContrastChecker.getColor(element, 'backgroundColor');
+    const color = this.getColor(element, 'backgroundColor');
     if (color && color.alphaRatio !== 0) {
       return color;
     }
     if (element instanceof HTMLBodyElement) {
       return { redRatio: 1, greenRatio: 1, blueRatio: 1, alphaRatio: 1 };
     }
-    return ContrastChecker.getBackground(element.parentElement);
+    return this.getBackground(element.parentElement);
   }
 
   public static getColor(element: HTMLElement, attributeName: keyof CSSStyleDeclaration = 'color') {
-    const rawColor = ContrastChecker.getCSSAttribute(element, attributeName);
+    const rawColor = this.getCSSAttribute(element, attributeName);
     if (!rawColor) {
       return null;
     }
-    return ContrastChecker.parseCSSColor(rawColor);
+    const color = this.parseCSSColor(rawColor);
+    color.alphaRatio *= +this.getCSSAttribute(element, 'opacity');
+    return color;
+  }
+
+  public static getCSSAttribute(element: HTMLElement, attributeName: keyof CSSStyleDeclaration): string {
+    const computedStyle = window.getComputedStyle(element);
+    if (!computedStyle.length) {
+      return null;
+    }
+    return computedStyle[attributeName];
+  }
+
+  public static getContrastBetweenColors(foregroundColor: IColor, backgroundColor: IColor) {
+    return this.getContrastBetweenRelativeLuminances(
+      this.getRelativeLuminance(this.combineColors(foregroundColor, backgroundColor)),
+      this.getRelativeLuminance(backgroundColor)
+    );
+  }
+
+  public static combineColors(color: IColor, backgroundColor: IColor): IColor {
+    const { alphaRatio } = color;
+    return {
+      redRatio: backgroundColor.redRatio - alphaRatio * (1 - color.redRatio),
+      greenRatio: backgroundColor.greenRatio - alphaRatio * (1 - color.greenRatio),
+      blueRatio: backgroundColor.blueRatio - alphaRatio * (1 - color.blueRatio),
+      alphaRatio: backgroundColor.alphaRatio
+    };
   }
 
   private static getContrastBetweenRelativeLuminances(luminance1: number, luminance2: number) {
@@ -50,9 +78,9 @@ export class ContrastChecker {
 
   private static getRelativeLuminance(color: IColor) {
     return (
-      0.2126 * ContrastChecker.convertSRGBToRGB(color.redRatio) +
-      0.7152 * ContrastChecker.convertSRGBToRGB(color.greenRatio) +
-      0.0722 * ContrastChecker.convertSRGBToRGB(color.blueRatio)
+      0.2126 * this.convertSRGBToRGB(color.redRatio) +
+      0.7152 * this.convertSRGBToRGB(color.greenRatio) +
+      0.0722 * this.convertSRGBToRGB(color.blueRatio)
     );
   }
 
@@ -63,19 +91,11 @@ export class ContrastChecker {
     return ((srgbColorRatio + 0.055) / 1.055) ** 2.4;
   }
 
-  private static getCSSAttribute(element: HTMLElement, attributeName: keyof CSSStyleDeclaration): string {
-    const computedStyle = window.getComputedStyle(element);
-    if (!computedStyle.length) {
-      return null;
-    }
-    return computedStyle[attributeName];
-  }
-
   private static parseCSSColor(rawColor: string) {
     return (
-      ContrastChecker.parseColorFromExpression(rawColor, /rgb\(\s?([0-9]{1,3})\s?,\s?([0-9]{1,3})\s?,\s?([0-9]{1,3})/) ||
-      ContrastChecker.parseColorFromExpression(rawColor, /#([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})/, 16) ||
-      ContrastChecker.parseColorFromExpression(rawColor, /rgba\(\s?([0-9]{1,3})\s?,\s?([0-9]{1,3})\s?,\s?([0-9]{1,3}),\s?([0-9\.])/)
+      this.parseColorFromExpression(rawColor, /rgb\(\s?([0-9]{1,3})\s?,\s?([0-9]{1,3})\s?,\s?([0-9]{1,3})/) ||
+      this.parseColorFromExpression(rawColor, /#([0-9A-F]{2})([0-9A-F]{2})([0-9A-F]{2})/, 16) ||
+      this.parseColorFromExpression(rawColor, /rgba\(\s?([0-9]{1,3})\s?,\s?([0-9]{1,3})\s?,\s?([0-9]{1,3}),\s?([0-9\.])/)
     );
   }
 

--- a/sass/DynamicFacet/_DynamicFacetValues.scss
+++ b/sass/DynamicFacet/_DynamicFacetValues.scss
@@ -36,8 +36,7 @@
 
   .coveo-checkbox-label:hover,
   &.coveo-focused {
-    .coveo-checkbox-span-label,
-    .coveo-checkbox-span-label-suffix {
+    .coveo-checkbox-span-label {
       opacity: $active-text-opacity;
     }
   }

--- a/sass/mixins/_dynamicFacet.scss
+++ b/sass/mixins/_dynamicFacet.scss
@@ -1,4 +1,4 @@
-$active-text-opacity: 0.6;
+$active-text-opacity: 0.7;
 
 @mixin facetValues() {
   padding: 10px 0;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2897

This issue aims to give `DynamicFacetValue`'s labels a 4.5:1 contrast ratio while focused.

In addition, this issue makes `ContrastChecker` capable of determining contrast between a transparent foreground and an opaque background.

# Previews
## Before
![image](https://user-images.githubusercontent.com/54454747/75585169-7e805300-5a3f-11ea-902d-6e6b11ac0eab.png)

## After
![image](https://user-images.githubusercontent.com/54454747/75586556-b0df7f80-5a42-11ea-8ecc-ded7324fa807.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)