### PR TITLE
JSUI-2879 Made modal focus reset on close

### DIFF
--- a/src/utils/AccessibleModal.ts
+++ b/src/utils/AccessibleModal.ts
@@ -13,6 +13,7 @@ export class AccessibleModal {
   private focusTrap: FocusTrap;
   private activeModal: Coveo.ModalBox.ModalBox;
   private options: IAccessibleModalOptions;
+  private initiallyFocusedElement: HTMLElement;
 
   public get isOpen() {
     return !!this.focusTrap;
@@ -48,6 +49,7 @@ export class AccessibleModal {
     if (this.isOpen) {
       return;
     }
+    this.initiallyFocusedElement = document.activeElement as HTMLElement;
     this.activeModal = this.modalboxModule.open(content, {
       title,
       className: this.className,
@@ -88,5 +90,8 @@ export class AccessibleModal {
   private onModalClose() {
     this.focusTrap.disable();
     this.focusTrap = null;
+    if (this.initiallyFocusedElement && document.body.contains(this.initiallyFocusedElement)) {
+      this.initiallyFocusedElement.focus();
+    }
   }
 }

--- a/unitTests/utils/AccessibleModalTest.ts
+++ b/unitTests/utils/AccessibleModalTest.ts
@@ -48,13 +48,26 @@ export function AccessibleModalTest() {
       let container: HTMLElement;
       let closeButton: HTMLElement;
       let closeButtonClickSpy: jasmine.Spy;
+      let initiallyFocusedElement: HTMLElement;
+
+      function createAndAppendInitiallyFocusedElement() {
+        initiallyFocusedElement = $$('button', {}, 'test').el;
+        spyOn(initiallyFocusedElement, 'focus');
+        document.body.appendChild(initiallyFocusedElement);
+        return initiallyFocusedElement;
+      }
 
       beforeEach(() => {
         accessibleModal.open(createTitle(), createContent(), createValidationSpy());
+        accessibleModal['initiallyFocusedElement'] = createAndAppendInitiallyFocusedElement();
         focusTrap = accessibleModal['focusTrap'];
         container = accessibleModal.element;
         closeButton = container.querySelector('.coveo-small-close');
         closeButtonClickSpy = spyOn(closeButton, 'click');
+      });
+
+      afterEach(() => {
+        initiallyFocusedElement.remove();
       });
 
       it('has an element', () => {
@@ -113,6 +126,10 @@ export function AccessibleModalTest() {
       describe('then calling close', () => {
         beforeEach(() => {
           accessibleModal.close();
+        });
+
+        it('resets the focus to its initial position', () => {
+          expect(initiallyFocusedElement.focus).toHaveBeenCalledTimes(1);
         });
 
         it("doesn't have an element", () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2879

This PR makes accessible modals reset the keyboard focus back to their original location after they are closed.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)