### PR TITLE
JSUI-2898 Attempted to fix accessibility tests' inconsistencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
 - yarn run unitTests
-- yarn run accessibilityTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
 - yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/accessibilityTest/AccessibilityFacet.ts
+++ b/accessibilityTest/AccessibilityFacet.ts
@@ -3,8 +3,6 @@ import { $$, Component, Facet, get, Dom } from 'coveo-search-ui';
 import { afterDeferredQuerySuccess, getFacetColumn, getRoot, inDesktopMode, resetMode, afterQuerySelector } from './Testing';
 import { ContrastChecker } from './ContrastChecker';
 
-const searchContainerSelector = '.coveo-facet-search-results';
-
 export const AccessibilityFacet = () => {
   describe('Facet', () => {
     const getFacetElement = () => {
@@ -69,7 +67,7 @@ export const AccessibilityFacet = () => {
       describe('after focusing on the search button', () => {
         beforeEach(async done => {
           (get(facetElement.el) as Facet).facetSearch.focus();
-          await afterQuerySelector(document.body, searchContainerSelector);
+          await afterQuerySelector(document.body, '.coveo-facet-search-results');
           done();
         });
 

--- a/accessibilityTest/AccessibilityFacet.ts
+++ b/accessibilityTest/AccessibilityFacet.ts
@@ -1,7 +1,9 @@
 import * as axe from 'axe-core';
 import { $$, Component, Facet, get, Dom } from 'coveo-search-ui';
-import { afterDeferredQuerySuccess, afterDelay, getFacetColumn, getRoot, inDesktopMode, resetMode } from './Testing';
+import { afterDeferredQuerySuccess, getFacetColumn, getRoot, inDesktopMode, resetMode, afterQuerySelector } from './Testing';
 import { ContrastChecker } from './ContrastChecker';
+
+const searchContainerSelector = '.coveo-facet-search-results';
 
 export const AccessibilityFacet = () => {
   describe('Facet', () => {
@@ -67,7 +69,7 @@ export const AccessibilityFacet = () => {
       describe('after focusing on the search button', () => {
         beforeEach(async done => {
           (get(facetElement.el) as Facet).facetSearch.focus();
-          await afterDelay(1000);
+          await afterQuerySelector(document.body, searchContainerSelector);
           done();
         });
 
@@ -79,7 +81,6 @@ export const AccessibilityFacet = () => {
 
         it('should still be accessible when search has been opened', async done => {
           (get(facetElement.el) as Facet).facetSearch.dismissSearchResults();
-          await afterDelay(1000);
           const axeResults = await axe.run(getRoot());
           expect(axeResults).toBeAccessible();
           done();

--- a/accessibilityTest/AccessibilityFacet.ts
+++ b/accessibilityTest/AccessibilityFacet.ts
@@ -1,6 +1,6 @@
 import * as axe from 'axe-core';
 import { $$, Component, Facet, get, Dom } from 'coveo-search-ui';
-import { afterDeferredQuerySuccess, getFacetColumn, getRoot, inDesktopMode, resetMode, afterQuerySelector } from './Testing';
+import { afterDeferredQuerySuccess, getFacetColumn, getRoot, inDesktopMode, resetMode, waitUntilSelectorIsPresent } from './Testing';
 import { ContrastChecker } from './ContrastChecker';
 
 export const AccessibilityFacet = () => {
@@ -67,7 +67,7 @@ export const AccessibilityFacet = () => {
       describe('after focusing on the search button', () => {
         beforeEach(async done => {
           (get(facetElement.el) as Facet).facetSearch.focus();
-          await afterQuerySelector(document.body, '.coveo-facet-search-results');
+          await waitUntilSelectorIsPresent(document.body, '.coveo-facet-search-results');
           done();
         });
 

--- a/accessibilityTest/AccessibilityQuickview.ts
+++ b/accessibilityTest/AccessibilityQuickview.ts
@@ -1,6 +1,6 @@
 import * as axe from 'axe-core';
-import { $$, Quickview, Component, get, Dom, Utils } from 'coveo-search-ui';
-import { afterQuerySuccess, getRoot, testResultElement, getModal } from './Testing';
+import { $$, Quickview, Component, get, Dom } from 'coveo-search-ui';
+import { afterQuerySuccess, getRoot, testResultElement, getModal, waitUntilSelectorIsPresent } from './Testing';
 
 export const AccessibilityQuickview = () => {
   describe('Quickview', () => {
@@ -38,7 +38,9 @@ export const AccessibilityQuickview = () => {
 
     it('should open an accessible modal', async done => {
       await openQuickview();
-      await Utils.resolveAfter(500);
+      if (!getModal().querySelector('iframe[title]')) {
+        await waitUntilSelectorIsPresent(getModal(), 'iframe[title]');
+      }
       const axeResults = await axe.run(getModal());
       expect(axeResults).toBeAccessible();
       done();

--- a/accessibilityTest/AccessibilityYouTubeThumbnail.ts
+++ b/accessibilityTest/AccessibilityYouTubeThumbnail.ts
@@ -1,6 +1,6 @@
 import * as axe from 'axe-core';
 import { $$, Component, YouTubeThumbnail, get } from 'coveo-search-ui';
-import { addFieldEqualFilter, afterQuerySuccess, getRoot, testResultElement, getModal } from './Testing';
+import { addFieldEqualFilter, afterQuerySuccess, getRoot, testResultElement, getModal, waitUntilSelectorIsPresent } from './Testing';
 
 export const AccessibilityYouTubeThumbnail = () => {
   describe('YouTubeThumbnail', () => {
@@ -35,6 +35,9 @@ export const AccessibilityYouTubeThumbnail = () => {
 
     it('should open an accessible modal', async done => {
       openVideo();
+      if (!getModal().querySelector('iframe[title]')) {
+        await waitUntilSelectorIsPresent(getModal(), 'iframe[title]');
+      }
       const axeResults = await axe.run(getModal());
       expect(axeResults).toBeAccessible();
       done();

--- a/accessibilityTest/Test.ts
+++ b/accessibilityTest/Test.ts
@@ -88,6 +88,7 @@ describe('Testing ...', () => {
     initialHTMLSetup();
     Coveo.Logger.disable();
     Coveo.SearchEndpoint.configureSampleEndpointV2();
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 15000;
     done();
   });
 

--- a/accessibilityTest/Testing.ts
+++ b/accessibilityTest/Testing.ts
@@ -150,7 +150,7 @@ export const isInit = () => {
   return get(getRoot(), SearchInterface) != null;
 };
 
-export const afterQuerySelector = <T extends Element = Element>(parentNode: HTMLElement, selector: string) => {
+export const waitUntilSelectorIsPresent = <T extends Element = Element>(parentNode: HTMLElement, selector: string) => {
   return observeUntil(
     parentNode,
     {

--- a/accessibilityTest/Testing.ts
+++ b/accessibilityTest/Testing.ts
@@ -150,6 +150,30 @@ export const isInit = () => {
   return get(getRoot(), SearchInterface) != null;
 };
 
+export const afterQuerySelector = <T extends Element = Element>(parentNode: HTMLElement, selector: string) => {
+  return observeUntil(
+    parentNode,
+    {
+      childList: true,
+      subtree: true
+    },
+    () => parentNode.querySelector<T>(selector)
+  );
+};
+
+export const observeUntil = <T>(element: Node, options: MutationObserverInit, callback: (records: MutationRecord[]) => T) => {
+  return new Promise<T>(resolve => {
+    const observer = new MutationObserver(records => {
+      const result = callback(records);
+      if (result) {
+        observer.disconnect();
+        resolve(result);
+      }
+    });
+    observer.observe(element, options);
+  });
+};
+
 const afterEvent = (event: string) => {
   const resolvesAfterEvent = resolve => {
     $$(getRoot()).one(event, async () => {

--- a/accessibilityTest/Testing.ts
+++ b/accessibilityTest/Testing.ts
@@ -47,7 +47,8 @@ export const getResultList = () => {
   }
 
   const newResultList = $$('div', {
-    className: 'CoveoResultList'
+    className: 'CoveoResultList',
+    dataAutoSelectFieldsToInclude: 'true'
   });
 
   getResultsColumn().appendChild(newResultList.el);
@@ -155,7 +156,8 @@ export const waitUntilSelectorIsPresent = <T extends Element = Element>(parentNo
     parentNode,
     {
       childList: true,
-      subtree: true
+      subtree: true,
+      attributes: true
     },
     () => parentNode.querySelector<T>(selector)
   );

--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -446,19 +446,19 @@ export class Quickview extends Component {
     computedModalBoxContent.addClass('coveo-computed-modal-box-content');
     return openerObject.content.then(builtContent => {
       computedModalBoxContent.append(builtContent.el);
-      const title = DomUtils.getQuickviewHeader(
+      this.modalbox.openResult(
         this.result,
         {
           showDate: this.options.showDate,
           title: this.options.title
         },
-        this.bindings
-      ).el;
-
-      this.modalbox.open(title, computedModalBoxContent.el, () => {
-        this.closeQuickview();
-        return true;
-      });
+        this.bindings,
+        computedModalBoxContent.el,
+        () => {
+          this.closeQuickview();
+          return true;
+        }
+      );
       return computedModalBoxContent;
     });
   }

--- a/src/ui/YouTube/YouTubeThumbnail.ts
+++ b/src/ui/YouTube/YouTubeThumbnail.ts
@@ -2,7 +2,6 @@ import { ModalBox as ModalBoxModule } from '../../ExternalModulesShim';
 import { exportGlobally } from '../../GlobalExports';
 import { IQueryResult } from '../../rest/QueryResult';
 import { $$, Dom } from '../../utils/Dom';
-import { DomUtils } from '../../utils/DomUtils';
 import { SVGDom } from '../../utils/SVGDom';
 import { SVGIcons } from '../../utils/SVGIcons';
 import { Utils } from '../../utils/Utils';
@@ -154,11 +153,7 @@ export class YouTubeThumbnail extends Component {
 
     div.append(iframe.el);
 
-    this.modalbox.open(
-      DomUtils.getQuickviewHeader(this.result, { showDate: true, title: this.result.title }, this.bindings).el,
-      div.el,
-      () => true
-    );
+    this.modalbox.openResult(this.result, { showDate: true, title: this.result.title }, this.bindings, div.el, () => true);
 
     $$($$(this.modalbox.wrapper).find('.coveo-quickview-close-button')).on('click', () => {
       this.modalbox.close();

--- a/unitTests/Simulate.ts
+++ b/unitTests/Simulate.ts
@@ -219,7 +219,8 @@ export class Simulate {
         $$(
           'header',
           { className: 'coveo-modal-header' },
-          (closeButton = $$('div', { className: 'coveo-quickview-close-button coveo-small-close' }))
+          (closeButton = $$('div', { className: 'coveo-quickview-close-button coveo-small-close' })),
+          $$('h1')
         ).el
       ).el)
     ).el;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2898

This PR attempts to fix inconsistent build results with accessibility tests, which occasionally time out.

The first fix this PR does is to increment the time out for accessibility tests to 15 seconds, since a 10 seconds time out seemed to be barely enough to succeed every test with a 500ms latency.

The second fix this PR does is to remove the delay in `AccessibilityFacet` and replace it with a new function: `afterQuerySelector`.

If this doesn't make builds more consistent, a third fix could be to make tests run up to 3 times when they fail, but a quick search revealed that most information about such a solution involves using the `protractor-retry` package.

**UPDATE**: I discovered that accessibility tests for modals occasionally broke, due to a valid error sometimes not being detected. I fixed this issue by adding a `aria-label` to the `h1` element of accessible modals. I also limited the fields returned by some queries to improve the execution speed of accessibility tests.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)