### PR TITLE
JSUI-2900 Should not scroll "to top" when the top of the Search Interface top position is already in the viewport

### DIFF
--- a/src/utils/ResultListUtils.ts
+++ b/src/utils/ResultListUtils.ts
@@ -24,6 +24,11 @@ export class ResultListUtils {
   }
 
   public static scrollToTop(root: HTMLElement) {
+    const isTopOfRootVisible = root.getBoundingClientRect().top >= 0;
+    if (isTopOfRootVisible) {
+      return;
+    }
+
     const resultList = ResultListUtils.getActiveResultList(root);
     if (!resultList) {
       new Logger(this).warn('No active ResultList, scrolling to the top of the Window');

--- a/src/utils/ResultListUtils.ts
+++ b/src/utils/ResultListUtils.ts
@@ -24,21 +24,20 @@ export class ResultListUtils {
   }
 
   public static scrollToTop(root: HTMLElement) {
-    const isTopOfRootVisible = root.getBoundingClientRect().top >= 0;
-    if (isTopOfRootVisible) {
-      return;
-    }
-
     const resultList = ResultListUtils.getActiveResultList(root);
     if (!resultList) {
       new Logger(this).warn('No active ResultList, scrolling to the top of the Window');
       return window.scrollTo(0, 0);
     }
 
+    const searchInterfacePosition = resultList.searchInterface.element.getBoundingClientRect().top;
+    if (searchInterfacePosition > 0) {
+      return;
+    }
+
     const scrollContainer = resultList.options.infiniteScrollContainer;
 
     if (typeof scrollContainer.scrollTo === 'function') {
-      const searchInterfacePosition = resultList.searchInterface.element.getBoundingClientRect().top;
       scrollContainer.scrollTo(0, window.pageYOffset + searchInterfacePosition);
     } else {
       (<HTMLElement>scrollContainer).scrollTop = 0;

--- a/unitTests/utils/ResultListUtilsTest.ts
+++ b/unitTests/utils/ResultListUtilsTest.ts
@@ -10,11 +10,13 @@ export const ResultListUtilsTest = () => {
     const utils = ResultListUtils;
     let root: SearchInterface;
     let cmp: Component;
+    let resultList: Component;
 
     function appendResultListToRoot(options: IResultListOptions = {}, disabled = false) {
-      const resultList = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, options).cmp;
+      resultList = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, options).cmp;
       resultList.disabled = disabled;
       root.element.appendChild(resultList.element);
+      return resultList;
     }
 
     function initSearchInterface() {
@@ -128,6 +130,15 @@ export const ResultListUtilsTest = () => {
 
         utils.scrollToTop(root.element);
         expect(scrollTopSpy).toHaveBeenCalledWith(0);
+      });
+
+      it(`when the top of the searchInterface is in the view port
+      should not scroll`, () => {
+        const resultList = appendResultListToRoot();
+        spyOn(resultList.searchInterface.element, 'getBoundingClientRect').and.returnValue({ top: -100 });
+
+        utils.scrollToTop(root.element);
+        expect(scrollTopSpy).not.toHaveBeenCalled();
       });
     });
   });

--- a/unitTests/utils/ResultListUtilsTest.ts
+++ b/unitTests/utils/ResultListUtilsTest.ts
@@ -16,7 +16,6 @@ export const ResultListUtilsTest = () => {
       resultList = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, options).cmp;
       resultList.disabled = disabled;
       root.element.appendChild(resultList.element);
-      return resultList;
     }
 
     function initSearchInterface() {
@@ -134,7 +133,7 @@ export const ResultListUtilsTest = () => {
 
       it(`when the top of the searchInterface is in the view port
       should not scroll`, () => {
-        const resultList = appendResultListToRoot();
+        appendResultListToRoot();
         spyOn(resultList.searchInterface.element, 'getBoundingClientRect').and.returnValue({ top: -100 });
 
         utils.scrollToTop(root.element);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2900

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)