### PR TITLE
JSUI-2877 Add back CDN with the upcoming JSUI version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,6 @@ deploy:
       tags: true
       repo: coveo/search-ui
       all_branches: true
-      condition: "! $TRAVIS_TAG =~ .*beta.*"
   - provider: s3
     access_key_id: AKIAYKDJLZIT462WODCI
     secret_access_key:
@@ -97,7 +96,6 @@ deploy:
       tags: true
       repo: coveo/search-ui
       all_branches: true
-      condition: "! $TRAVIS_TAG =~ .*beta.*"
 
 after_deploy:
 - node invalidate.cloudfront.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ deploy:
       tags: true
       repo: coveo/search-ui
       all_branches: true
+      condition: "! $TRAVIS_TAG =~ .*beta.*"
   - provider: s3
     access_key_id: AKIAYKDJLZIT462WODCI
     secret_access_key:
@@ -96,6 +97,7 @@ deploy:
       tags: true
       repo: coveo/search-ui
       all_branches: true
+      condition: "! $TRAVIS_TAG =~ .*beta.*"
 
 after_deploy:
 - node invalidate.cloudfront.js

--- a/docs/theme/layouts/default.hbs
+++ b/docs/theme/layouts/default.hbs
@@ -8,15 +8,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href='https://fonts.googleapis.com/css?family=Lato:100,300,400,700' rel='stylesheet' type='text/css'/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css" />
-    <link rel="stylesheet" href="{{relativeURL "assets/gen/css/CoveoFullSearch.css"}}" />
+    <link rel="stylesheet" href="https://static.cloud.coveo.com/searchui/v2.8521/css/CoveoFullSearch.min.css" />
     <link rel="stylesheet" href="{{relativeURL "assets/css/main.css"}}">
     <link rel="stylesheet" href="{{relativeURL "assets/css/overrides.css"}}">
     <link rel="stylesheet" href="{{relativeURL "assets/css/coveo-connect-header.css"}}">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js"></script>
     <script type="text/javascript" src="https://static.cloud.coveo.com/coveo.analytics.js/coveoua.js"></script>
     <script src="{{relativeURL "assets/js/modernizr.js"}}"></script>
-    <script src="{{relativeURL "assets/gen/js/CoveoJsSearch.js"}}"></script>
-    <script src="{{relativeURL "assets/gen/js/templates/templates.js"}}"></script>
+    <script class="coveo-script" src="https://static.cloud.coveo.com/searchui/v2.8521/js/CoveoJsSearch.min.js"></script>
+    <script src="https://static.cloud.coveo.com/searchui/v2.8521/js/templates/templates.js"></script>
     <script src="{{relativeURL "assets/js/coveo-connect-header.js"}}"></script>
     <script src="{{relativeURL "assets/gen/js/playground.js"}}"></script>
     <script src="{{relativeURL "assets/js/searchUIrefDoc.js"}}"></script>


### PR DESCRIPTION
This will fix the playground
https://coveord.atlassian.net/browse/JSUI-2877

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)