### PR TITLE
JSUI-2904 Fixed accessibility for `QuerySummary`'s no results button

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/accessibilityTest/AccessibilityQuerySummary.ts
+++ b/accessibilityTest/AccessibilityQuerySummary.ts
@@ -1,0 +1,27 @@
+import * as axe from 'axe-core';
+import { $$, Component, QuerySummary } from 'coveo-search-ui';
+import { getSummarySection, afterQuerySuccess, addBasicExpression } from './Testing';
+
+export const AccessibilityQuerySummary = () => {
+  describe('QuerySummary', () => {
+    let querySummaryElement: HTMLElement;
+    beforeEach(() => {
+      getSummarySection().appendChild((querySummaryElement = $$('span', { className: Component.computeCssClassName(QuerySummary) }).el));
+    });
+
+    it('should be accessible', async done => {
+      await afterQuerySuccess();
+      const axeResults = await axe.run(getSummarySection());
+      expect(axeResults).toBeAccessible();
+      done();
+    });
+
+    it('should be accessible with no results', async done => {
+      addBasicExpression('b48897e9a2fbf13bc1c3f1455339a74d');
+      await afterQuerySuccess();
+      const axeResults = await axe.run(getSummarySection());
+      expect(axeResults).toBeAccessible();
+      done();
+    });
+  });
+};

--- a/accessibilityTest/Test.ts
+++ b/accessibilityTest/Test.ts
@@ -52,6 +52,7 @@ import { AccessibilityYouTubeThumbnail } from './AccessibilityYouTubeThumbnail';
 import { AccessibilityStarResult } from './AccessibilityStarResult';
 import { AccessibilityResultPreviewsManager } from './AccessibilityResultPreviewsManager';
 import { AccessibilitySettings } from './AccessibilitySettings';
+import { AccessibilityQuerySummary } from './AccessibilityQuerySummary';
 
 const initialHTMLSetup = () => {
   const body = jasmine['getGlobal']().document.body;
@@ -149,4 +150,5 @@ describe('Testing ...', () => {
   AccessibilityStarResult();
   AccessibilityResultPreviewsManager();
   AccessibilitySettings();
+  AccessibilityQuerySummary();
 });

--- a/accessibilityTest/Testing.ts
+++ b/accessibilityTest/Testing.ts
@@ -24,6 +24,10 @@ export const getSearchSection = () => {
   return document.body.querySelector('.coveo-search-section') as HTMLElement;
 };
 
+export const getSummarySection = () => {
+  return document.body.querySelector('.coveo-summary-section') as HTMLElement;
+};
+
 export const getSortSection = () => {
   return document.body.querySelector('.coveo-sort-section') as HTMLElement;
 };

--- a/src/ui/QuerySummary/QuerySummary.ts
+++ b/src/ui/QuerySummary/QuerySummary.ts
@@ -13,6 +13,7 @@ import { Component } from '../Base/Component';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { ComponentOptions } from '../Base/ComponentOptions';
 import { Initialization } from '../Base/Initialization';
+import { KeyboardUtils, KEYBOARD } from '../../Core';
 
 export interface IQuerySummaryOptions {
   onlyDisplaySearchTips?: boolean;
@@ -255,25 +256,31 @@ export class QuerySummary extends Component {
     const cancelLastAction = $$(
       'div',
       {
-        className: 'coveo-query-summary-cancel-last'
+        className: 'coveo-query-summary-cancel-last',
+        tabindex: '0',
+        role: 'button'
       },
       l('CancelLastAction')
     );
 
-    cancelLastAction.on('click', () => {
-      this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.noResultsBack, {}, this.root);
-      this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.noResultsBack, {});
-      if (this.lastKnownGoodState) {
-        this.queryStateModel.reset();
-        this.queryStateModel.setMultiple(this.lastKnownGoodState);
-        $$(this.root).trigger(QuerySummaryEvents.cancelLastAction);
-        this.queryController.executeQuery();
-      } else {
-        history.back();
-      }
-    });
+    cancelLastAction.on('keyup', KeyboardUtils.keypressAction(KEYBOARD.ENTER, () => this.cancelLastAction()));
+
+    cancelLastAction.on('click', () => this.cancelLastAction());
 
     return cancelLastAction;
+  }
+
+  private cancelLastAction() {
+    this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.noResultsBack, {}, this.root);
+    this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.noResultsBack, {});
+    if (this.lastKnownGoodState) {
+      this.queryStateModel.reset();
+      this.queryStateModel.setMultiple(this.lastKnownGoodState);
+      $$(this.root).trigger(QuerySummaryEvents.cancelLastAction);
+      this.queryController.executeQuery();
+    } else {
+      history.back();
+    }
   }
 
   private getSearchTipsTitleElement() {

--- a/src/ui/QuerySummary/QuerySummary.ts
+++ b/src/ui/QuerySummary/QuerySummary.ts
@@ -13,7 +13,7 @@ import { Component } from '../Base/Component';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { ComponentOptions } from '../Base/ComponentOptions';
 import { Initialization } from '../Base/Initialization';
-import { KeyboardUtils, KEYBOARD } from '../../Core';
+import { AccessibleButton } from '../../utils/AccessibleButton';
 
 export interface IQuerySummaryOptions {
   onlyDisplaySearchTips?: boolean;
@@ -256,16 +256,16 @@ export class QuerySummary extends Component {
     const cancelLastAction = $$(
       'div',
       {
-        className: 'coveo-query-summary-cancel-last',
-        tabindex: '0',
-        role: 'button'
+        className: 'coveo-query-summary-cancel-last'
       },
       l('CancelLastAction')
     );
 
-    cancelLastAction.on('keyup', KeyboardUtils.keypressAction(KEYBOARD.ENTER, () => this.cancelLastAction()));
-
-    cancelLastAction.on('click', () => this.cancelLastAction());
+    new AccessibleButton()
+      .withElement(cancelLastAction)
+      .withClickAction(() => this.cancelLastAction())
+      .withEnterKeyboardAction(() => this.cancelLastAction())
+      .build();
 
     return cancelLastAction;
   }

--- a/src/ui/QuerySummary/QuerySummary.ts
+++ b/src/ui/QuerySummary/QuerySummary.ts
@@ -263,24 +263,21 @@ export class QuerySummary extends Component {
 
     new AccessibleButton()
       .withElement(cancelLastAction)
-      .withClickAction(() => this.cancelLastAction())
-      .withEnterKeyboardAction(() => this.cancelLastAction())
+      .withSelectAction(() => {
+        this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.noResultsBack, {}, this.root);
+        this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.noResultsBack, {});
+        if (this.lastKnownGoodState) {
+          this.queryStateModel.reset();
+          this.queryStateModel.setMultiple(this.lastKnownGoodState);
+          $$(this.root).trigger(QuerySummaryEvents.cancelLastAction);
+          this.queryController.executeQuery();
+        } else {
+          history.back();
+        }
+      })
       .build();
 
     return cancelLastAction;
-  }
-
-  private cancelLastAction() {
-    this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.noResultsBack, {}, this.root);
-    this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.noResultsBack, {});
-    if (this.lastKnownGoodState) {
-      this.queryStateModel.reset();
-      this.queryStateModel.setMultiple(this.lastKnownGoodState);
-      $$(this.root).trigger(QuerySummaryEvents.cancelLastAction);
-      this.queryController.executeQuery();
-    } else {
-      history.back();
-    }
   }
 
   private getSearchTipsTitleElement() {

--- a/unitTests/ui/QuerySummaryTest.ts
+++ b/unitTests/ui/QuerySummaryTest.ts
@@ -170,15 +170,30 @@ export function QuerySummaryTest() {
         expect($$(test.cmp.element).find('.coveo-query-summary-no-results-string')).toBeNull();
       });
 
-      it(`when enableCancelLastAction is set to true,
-          it should display the cancel last action link on no results`, () => {
-        test = Mock.optionsComponentSetup<QuerySummary, IQuerySummaryOptions>(QuerySummary, {
-          enableCancelLastAction: true
+      describe('when enableCancelLastAction is set to true, on no results', () => {
+        function getCancelLastActionLink() {
+          return $$(test.cmp.element).find('.coveo-query-summary-cancel-last');
+        }
+
+        beforeEach(() => {
+          test = Mock.optionsComponentSetup<QuerySummary, IQuerySummaryOptions>(QuerySummary, {
+            enableCancelLastAction: true
+          });
+
+          Simulate.query(test.env, { results: FakeResults.createFakeResults(0) });
         });
 
-        Simulate.query(test.env, { results: FakeResults.createFakeResults(0) });
+        it('should display the cancel last action link', () => {
+          expect(getCancelLastActionLink()).not.toBeNull();
+        });
 
-        expect($$(test.cmp.element).find('.coveo-query-summary-cancel-last')).not.toBeNull();
+        it('should give a tabindex to the cancel last action link', () => {
+          expect(getCancelLastActionLink().getAttribute('tabindex')).toEqual('0');
+        });
+
+        it('should give a role to the cancel last action link', () => {
+          expect(getCancelLastActionLink().getAttribute('role')).toEqual('button');
+        });
       });
 
       it(`when enableCancelLastAction is set to false,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2904

This PR makes the "Cancel last action" button generated by `QuerySummary` usable with the keyboard and accessible.

![image](https://user-images.githubusercontent.com/54454747/76010106-5631a200-5ee0-11ea-88e2-6aacee835ade.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)