### PR TITLE
JSUI-2906 Improved accessibility for `CategoryFacet`'s "all categories" button

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -762,11 +762,17 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
 
   private addAllCategoriesButton() {
     const allCategories = this.categoryFacetTemplates.buildAllCategoriesButton();
-    allCategories.on('click', () => {
-      this.reset();
-      this.scrollToTop();
-    });
+    new AccessibleButton()
+      .withElement(allCategories)
+      .withClickAction(() => this.goBackToAllcategories())
+      .withEnterKeyboardAction(() => this.goBackToAllcategories())
+      .build();
     this.categoryValueRoot.listRoot.append(allCategories.el);
+  }
+
+  private goBackToAllcategories() {
+    this.reset();
+    this.scrollToTop();
   }
 
   private isPristine() {

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -764,15 +764,12 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
     const allCategories = this.categoryFacetTemplates.buildAllCategoriesButton();
     new AccessibleButton()
       .withElement(allCategories)
-      .withClickAction(() => this.goBackToAllcategories())
-      .withEnterKeyboardAction(() => this.goBackToAllcategories())
+      .withSelectAction(() => {
+        this.reset();
+        this.scrollToTop();
+      })
       .build();
     this.categoryValueRoot.listRoot.append(allCategories.el);
-  }
-
-  private goBackToAllcategories() {
-    this.reset();
-    this.scrollToTop();
   }
 
   private isPristine() {

--- a/src/ui/CategoryFacet/CategoryFacetTemplates.ts
+++ b/src/ui/CategoryFacet/CategoryFacetTemplates.ts
@@ -30,7 +30,7 @@ export class CategoryFacetTemplates {
   }
 
   public buildAllCategoriesButton() {
-    const allCategoriesCaption = $$('span', { className: 'coveo-category-facet-all-categories-caption', tabindex: 0 }, l('AllCategories'));
+    const allCategoriesCaption = $$('span', { className: 'coveo-category-facet-all-categories-caption' }, l('AllCategories'));
     const allCategories = $$(
       'li',
       { className: 'coveo-category-facet-value coveo-category-facet-all-categories' },

--- a/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
@@ -445,6 +445,16 @@ export function CategoryFacetTest() {
         expect(allCategoriesButton()).not.toBeNull();
       });
 
+      it('gives the all categories button a tabindex', () => {
+        Simulate.query(test.env, simulateQueryData);
+        expect(allCategoriesButton().getAttribute('tabindex')).toEqual('0');
+      });
+
+      it('gives the all categories button a role', () => {
+        Simulate.query(test.env, simulateQueryData);
+        expect(allCategoriesButton().getAttribute('role')).toEqual('button');
+      });
+
       it('does not append an all categories button when there are no parents', () => {
         simulateQueryData.query.categoryFacets[0].path = [];
         Simulate.query(test.env, simulateQueryData);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2906

This PR improves the accessibility of `CategoryFacet`'s "all categories" button. It does so by moving its label's `tabindex` to itself and giving itself a role. This makes the element usable with the keyboard's enter key and recognizable by accessibility tools as a button. This also makes this button more consistent with other buttons in `CategoryFacet` whose focus isn't solely on their label.

# Before
## With "All Categories" focused
![image](https://user-images.githubusercontent.com/54454747/76112052-77ad8f00-5faf-11ea-92a3-16be7acc2347.png)

## With a selected category focused
![image](https://user-images.githubusercontent.com/54454747/76112098-8dbb4f80-5faf-11ea-90fd-9ef95f68e656.png)

## With a category focused
![image](https://user-images.githubusercontent.com/54454747/76112120-9b70d500-5faf-11ea-8271-6dcc47edb923.png)

# After (with "All Categories" focused)
![image](https://user-images.githubusercontent.com/54454747/76112221-c9561980-5faf-11ea-8be4-2a2b3d9f62b9.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)