### PR TITLE
JSUI-2905 Changed color of links to improve contrast with pitch black labels

### DIFF
--- a/sass/_FieldTable.scss
+++ b/sass/_FieldTable.scss
@@ -97,7 +97,7 @@
     display: inline-block;
   }
   .coveo-field-caption {
-    color: $color-blueish-gray;
+    color: black;
     margin-right: 10px;
   }
 }

--- a/sass/_Variables.scss
+++ b/sass/_Variables.scss
@@ -2,7 +2,7 @@
 // https://app.frontify.com/d/GthysWU8RY0Q/brand-guidelines#/basics/colors
 // Corporate Main Colors
 $coveo-orange: #f58020;
-$coveo-blue: #004990;
+$coveo-blue: #0059b3;
 $coveo-red: #dc291e;
 // Complementary Colors Set 1
 $color-dark-grey: #313a45;

--- a/sass/coveo-styleguide/scss/common/_palette.scss
+++ b/sass/coveo-styleguide/scss/common/_palette.scss
@@ -1,5 +1,5 @@
 // Primary palette
-$coveo-blue: #004990;
+$coveo-blue: #0059b3;
 $darker-blue: #193045;
 $dark-blue: #263e55;
 $medium-blue: #1d4f76;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2905

This PR changes the color of every link to have at-least 3:1 contrast with both black and white. Ultimately, this fixes an issue reported by Deque where contrast isn't great enough between `FieldValue`'s label and value when the value is a link.

# Before (`#004990`)
![image](https://user-images.githubusercontent.com/54454747/76426780-e14be580-6381-11ea-9f62-f0327051f859.png)

# After (`#0059b3`)
![image](https://user-images.githubusercontent.com/54454747/76427370-97afca80-6382-11ea-9548-996c25269a78.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)