### PR TITLE
JSUI-2910 Added a `title` attribute to `ResultLink`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -284,15 +284,10 @@ export class ResultLink extends Component {
   }
   public renderUri(element: HTMLElement, result?: IQueryResult) {
     if (/^\s*$/.test(this.element.innerHTML)) {
-      if (!this.options.titleTemplate) {
-        this.element.innerHTML = this.result.title
-          ? HighlightUtils.highlightString(this.result.title, this.result.titleHighlights, null, 'coveo-highlight')
-          : this.result.clickUri;
-      } else {
-        let newTitle = StringUtils.buildStringTemplateFromResult(this.options.titleTemplate, this.result);
-        this.element.innerHTML = newTitle
-          ? StreamHighlightUtils.highlightStreamText(newTitle, this.result.termsToHighlight, this.result.phrasesToHighlight)
-          : this.result.clickUri;
+      const title = this.getDisplayedTitle(result);
+      this.element.innerHTML = title;
+      if (!this.element.title) {
+        this.element.title = title;
       }
     }
   }
@@ -358,6 +353,19 @@ export class ResultLink extends Component {
       this.setHrefIfNotAlready() ||
       this.openLinkThatIsNotAnAnchor()
     );
+  }
+
+  private getDisplayedTitle(result?: IQueryResult) {
+    if (!this.options.titleTemplate) {
+      return this.result.title
+        ? HighlightUtils.highlightString(this.result.title, this.result.titleHighlights, null, 'coveo-highlight')
+        : this.result.clickUri;
+    } else {
+      let newTitle = StringUtils.buildStringTemplateFromResult(this.options.titleTemplate, this.result);
+      return newTitle
+        ? StreamHighlightUtils.highlightStreamText(newTitle, this.result.termsToHighlight, this.result.phrasesToHighlight)
+        : this.result.clickUri;
+    }
   }
 
   private bindOnClickIfNotUndefined() {

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -284,7 +284,7 @@ export class ResultLink extends Component {
   }
   public renderUri(element: HTMLElement, result?: IQueryResult) {
     if (/^\s*$/.test(this.element.innerHTML)) {
-      const title = this.getDisplayedTitle(result);
+      const title = this.getDisplayedTitle();
       this.element.innerHTML = title;
       if (!this.element.title) {
         this.element.title = title;
@@ -355,7 +355,7 @@ export class ResultLink extends Component {
     );
   }
 
-  private getDisplayedTitle(result?: IQueryResult) {
+  private getDisplayedTitle() {
     if (!this.options.titleTemplate) {
       return this.result.title
         ? HighlightUtils.highlightString(this.result.title, this.result.titleHighlights, null, 'coveo-highlight')

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -58,6 +58,12 @@ export function ResultLinkTest() {
       );
     });
 
+    it('should set the title attribute to the displayed title', () => {
+      expect(test.cmp.element.title).toEqual(
+        HighlightUtils.highlightString(fakeResult.title, fakeResult.titleHighlights, null, 'coveo-highlight')
+      );
+    });
+
     it('should contain the clickUri if the result has no title', () => {
       fakeResult.title = undefined;
       test = Mock.advancedResultComponentSetup<ResultLink>(ResultLink, fakeResult, undefined);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2910

This PR aims to add redundancy with a `title` attribute to `ResultLink`, providing tooltips in case a link is partially hidden by CSS.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)