### PR TITLE
JSUI-2868 Improved accessibility for the `Sort` component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/src/ui/Sort/Sort.ts
+++ b/src/ui/Sort/Sort.ts
@@ -210,6 +210,7 @@ export class Sort extends Component {
       this.currentCriteria = null;
     }
     this.updateAppearance();
+    this.updateAccessibilityProperties();
   }
 
   private setTextToCaptionIfDefined() {
@@ -221,13 +222,12 @@ export class Sort extends Component {
   }
 
   private addAccessiblityAttributes() {
-    const localizedCaption = l(this.displayedSortText);
-
     new AccessibleButton()
       .withElement(this.element)
       .withSelectAction(() => this.handleClick())
-      .withLabel(l('SortResultsBy', localizedCaption))
+      .withLabel(this.getAccessibleLabel())
       .build();
+    this.updateAccessibleSelectedState();
   }
 
   private get displayedSortText() {
@@ -271,15 +271,46 @@ export class Sort extends Component {
 
   private updateAppearance() {
     $$(this.element).toggleClass('coveo-selected', this.isSelected());
-
     if (this.isToggle()) {
-      var direction = this.currentCriteria ? this.currentCriteria.direction : this.options.sortCriteria[0].direction;
+      const currentDirection = this.currentCriteria ? this.currentCriteria.direction : this.options.sortCriteria[0].direction;
       $$(this.element).removeClass('coveo-ascending');
       $$(this.element).removeClass('coveo-descending');
       if (this.isSelected()) {
-        $$(this.element).addClass(direction === 'ascending' ? 'coveo-ascending' : 'coveo-descending');
+        $$(this.element).addClass(currentDirection === 'ascending' ? 'coveo-ascending' : 'coveo-descending');
       }
     }
+  }
+
+  private updateAccessibilityProperties() {
+    this.updateAccessibleSelectedState();
+    this.updateAccessibleLabel();
+  }
+
+  private updateAccessibleSelectedState() {
+    this.element.setAttribute('aria-pressed', this.isSelected().toString());
+  }
+
+  private updateAccessibleLabel() {
+    this.element.setAttribute('aria-label', this.getAccessibleLabel());
+  }
+
+  private getAccessibleLabel() {
+    return this.isToggle() ? this.getAccessibleLabelWithSort() : this.getAccessibleLabelWithoutSort();
+  }
+
+  private getAccessibleLabelWithSort(): string {
+    const localizedCaption = l(this.displayedSortText);
+    const currentDirection = this.currentCriteria ? this.currentCriteria.direction : this.options.sortCriteria[0].direction;
+    let pressingWillSetToAscendingOrder = currentDirection === 'ascending';
+    if (this.isSelected()) {
+      pressingWillSetToAscendingOrder = !pressingWillSetToAscendingOrder;
+    }
+    return l(pressingWillSetToAscendingOrder ? 'SortResultsByAscending' : 'SortResultsByDescending', localizedCaption);
+  }
+
+  private getAccessibleLabelWithoutSort(): string {
+    const localizedCaption = l(this.displayedSortText);
+    return l('SortResultsBy', localizedCaption);
   }
 }
 

--- a/src/ui/Sort/Sort.ts
+++ b/src/ui/Sort/Sort.ts
@@ -221,6 +221,10 @@ export class Sort extends Component {
     return Utils.isNonEmptyString(this.options.caption);
   }
 
+  private get currentDirection() {
+    return this.currentCriteria ? this.currentCriteria.direction : this.options.sortCriteria[0].direction;
+  }
+
   private addAccessiblityAttributes() {
     new AccessibleButton()
       .withElement(this.element)
@@ -272,11 +276,10 @@ export class Sort extends Component {
   private updateAppearance() {
     $$(this.element).toggleClass('coveo-selected', this.isSelected());
     if (this.isToggle()) {
-      const currentDirection = this.currentCriteria ? this.currentCriteria.direction : this.options.sortCriteria[0].direction;
       $$(this.element).removeClass('coveo-ascending');
       $$(this.element).removeClass('coveo-descending');
       if (this.isSelected()) {
-        $$(this.element).addClass(currentDirection === 'ascending' ? 'coveo-ascending' : 'coveo-descending');
+        $$(this.element).addClass(this.currentDirection === 'ascending' ? 'coveo-ascending' : 'coveo-descending');
       }
     }
   }
@@ -300,12 +303,19 @@ export class Sort extends Component {
 
   private getAccessibleLabelWithSort(): string {
     const localizedCaption = l(this.displayedSortText);
-    const currentDirection = this.currentCriteria ? this.currentCriteria.direction : this.options.sortCriteria[0].direction;
-    let pressingWillSetToAscendingOrder = currentDirection === 'ascending';
     if (this.isSelected()) {
-      pressingWillSetToAscendingOrder = !pressingWillSetToAscendingOrder;
+      if (this.currentDirection === 'ascending') {
+        return l('SortResultsByDescending', localizedCaption);
+      } else {
+        return l('SortResultsByAscending', localizedCaption);
+      }
     }
-    return l(pressingWillSetToAscendingOrder ? 'SortResultsByAscending' : 'SortResultsByDescending', localizedCaption);
+
+    if (this.currentDirection === 'ascending') {
+      return l('SortResultsByAscending', localizedCaption);
+    }
+
+    return l('SortResultsByDescending', localizedCaption);
   }
 
   private getAccessibleLabelWithoutSort(): string {

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7439,12 +7439,12 @@
     "fr": "Trier les résultats par {0}"
   },
   "SortResultsByAscending": {
-    "en": "Sort results by {0} in ascending order",
-    "fr": "Trier les résultats en ordre croissant de {0}"
+    "en": "Sort by {0} in ascending order",
+    "fr": "Trier en ordre croissant de {0}"
   },
   "SortResultsByDescending": {
-    "en": "Sort results by {0} in descending order",
-    "fr": "Trier les résultats en ordre décroissant de {0}"
+    "en": "Sort by {0} in descending order",
+    "fr": "Trier en ordre décroissant de {0}"
   },
   "DisplayResultsAs": {
     "en": "Display results as {0}",

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7438,6 +7438,14 @@
     "en": "Sort results by {0}",
     "fr": "Trier les résultats par {0}"
   },
+  "SortResultsByAscending": {
+    "en": "Sort results by {0} in ascending order",
+    "fr": "Trier les résultats en ordre croissant de {0}"
+  },
+  "SortResultsByDescending": {
+    "en": "Sort results by {0} in descending order",
+    "fr": "Trier les résultats en ordre décroissant de {0}"
+  },
   "DisplayResultsAs": {
     "en": "Display results as {0}",
     "fr": "Afficher les résultats comme {0}"


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2868

This PR aims to improve the accessibility for `Sort` components while keeping them as independent as they already are. It does so by making the following improvements:
* Making each `Sort` component into a toggle-able button by giving them a `role="button"` along with the `aria-pressed` property. Sorts are viewed as toggled when their sort criteria is active.
* Giving each `Sort` component with both an ascending and descending state a label that reflects the state they will take when pressed. E.g.: `Sort results by Date in ascending order` instead of `Sort results by Date`.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)