### PR TITLE
JSUI-2917 Improved alignment for search results footer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/pages/All.html
+++ b/pages/All.html
@@ -63,9 +63,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/Chatter.html
+++ b/pages/Chatter.html
@@ -64,9 +64,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/Confluence.html
+++ b/pages/Confluence.html
@@ -64,9 +64,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/Dropbox.html
+++ b/pages/Dropbox.html
@@ -63,9 +63,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/DynamicsCrm.html
+++ b/pages/DynamicsCrm.html
@@ -63,9 +63,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/Email.html
+++ b/pages/Email.html
@@ -64,9 +64,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/GoogleDrive.html
+++ b/pages/GoogleDrive.html
@@ -68,9 +68,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/Jira.html
+++ b/pages/Jira.html
@@ -70,9 +70,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/Lithium.html
+++ b/pages/Lithium.html
@@ -66,9 +66,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/People.html
+++ b/pages/People.html
@@ -64,9 +64,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/Recommendation.html
+++ b/pages/Recommendation.html
@@ -65,8 +65,14 @@
           data-auto-select-fields-to-include="true"></div>
         <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
           data-auto-select-fields-to-include="true"></div>
-        <div class="CoveoPager"></div>
-        <div class="CoveoResultsPerPage"></div>
+        <div class="coveo-results-footer">
+          <div class="coveo-results-footer-left">
+            <div class="CoveoPager"></div>
+          </div>
+          <div class="coveo-results-footer-right">
+            <div class="CoveoResultsPerPage"></div>
+          </div>
+        </div>
       </div>
       <div class="coveo-recommendation-column">
         <div id="recommendationYoutube" class="CoveoRecommendation" data-results-per-page="5">

--- a/pages/Salesforce.html
+++ b/pages/Salesforce.html
@@ -68,9 +68,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/SalesforceCase.html
+++ b/pages/SalesforceCase.html
@@ -62,9 +62,15 @@
       <div class="CoveoErrorReport"></div>
       <div class="CoveoResultList" data-layout="list" data-wait-animation="fade" data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade" data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/ServiceNow.html
+++ b/pages/ServiceNow.html
@@ -66,9 +66,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/SharePoint.html
+++ b/pages/SharePoint.html
@@ -75,9 +75,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/YouTube.html
+++ b/pages/YouTube.html
@@ -60,9 +60,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/pages/index.html
+++ b/pages/index.html
@@ -61,9 +61,15 @@
         data-auto-select-fields-to-include="true"></div>
       <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
         data-auto-select-fields-to-include="true"></div>
-      <div class="CoveoPager"></div>
-      <div class="CoveoLogo"></div>
-      <div class="CoveoResultsPerPage"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
     </div>
   </div>
 </body>

--- a/sass/_FullSearchGrid.scss
+++ b/sass/_FullSearchGrid.scss
@@ -75,6 +75,17 @@ $page-width: 1000px;
       display: none;
     }
   }
+  .coveo-results-footer {
+    &,
+    .coveo-results-footer-left,
+    .coveo-results-footer-right {
+      display: flex;
+      align-items: center;
+    }
+    .coveo-results-footer-left {
+      flex-grow: 1;
+    }
+  }
 }
 
 .coveo-after-initialization {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2917

This PR aims to fix an issue where `Logo` and `ResultsPerPage` would swap order visually relatively to their order in the DOM, which also caused the tab order to be wrong (E.g., if `div.CoveoLogo` preceded `div.CoveoResultsPerPage` in the DOM, it would appear after `ResultsPerPage` visually)

This fix tries to be the least impactful by only adding new sections to the default search pages and only adding CSS to those.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)