### PR TITLE
JSUI-2882 Get value from the list using the passed FacetValue object

### DIFF
--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1182,7 +1182,8 @@ export class Facet extends Component {
         ret = this.options.valueCaption[lookupValue] || ret;
       }
       if (typeof this.options.valueCaption == 'function') {
-        const valueFromList = this.facetValuesList.get(facetValue as FacetValue).facetValue;
+        const fv = facetValue instanceof FacetValue ? facetValue : FacetValue.create(facetValue);
+        const valueFromList = this.facetValuesList.get(fv).facetValue;
         ret = this.options.valueCaption.call(this, valueFromList);
       }
     }

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1175,16 +1175,15 @@ export class Facet extends Component {
   public getValueCaption(facetValue: IIndexFieldValue | FacetValue): string {
     Assert.exists(facetValue);
     const lookupValue = facetValue.lookupValue || facetValue.value;
-    let ret = lookupValue;
-    ret = FacetUtils.tryToGetTranslatedCaption(<string>this.options.field, lookupValue);
+    let ret = FacetUtils.tryToGetTranslatedCaption(<string>this.options.field, lookupValue);
 
     if (Utils.exists(this.options.valueCaption)) {
       if (typeof this.options.valueCaption == 'object') {
         ret = this.options.valueCaption[lookupValue] || ret;
       }
       if (typeof this.options.valueCaption == 'function') {
-        this.values.get(lookupValue);
-        ret = this.options.valueCaption.call(this, this.facetValuesList.get(lookupValue).facetValue);
+        const valueFromList = this.facetValuesList.get(facetValue as FacetValue).facetValue;
+        ret = this.options.valueCaption.call(this, valueFromList);
       }
     }
     return ret;

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -265,6 +265,18 @@ export function FacetTest() {
       expect(test.cmp.getValueCaption(FacetValue.createFromValue('txt'))).toBe('Text');
     });
 
+    it(`when the valueCaption option is a function, when calling getValueCaption,
+    it gets the value from the list using the passed FacetValue object`, () => {
+      test.cmp.options.valueCaption = () => '';
+      test.cmp.createDom();
+
+      const facetValue = FacetValue.createFromValue('foo');
+      const spy = spyOn(test.cmp.facetValuesList, 'get').and.returnValue(facetValue);
+      test.cmp.getValueCaption(facetValue);
+
+      expect(spy).toHaveBeenCalledWith(facetValue);
+    });
+
     describe('with a live query state model', () => {
       beforeEach(() => {
         initializeComponentWithQSM();


### PR DESCRIPTION
The `this.facetValuesList.get` call functions more like a get or create. We were passing a string rather than the facet value, causing counts to be lost when rendering the list.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)