### PR TITLE
JSUI-2925 Added `aria-expanded` attribute to `FacetSearchElement`'s input

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -150,6 +150,7 @@ export class FacetSearchElement {
         this.positionPopUp(nextTo, root);
       }
     }
+    this.addAriaAttributes();
   }
 
   public setAsCurrentResult(toSet: Dom) {
@@ -281,6 +282,7 @@ export class FacetSearchElement {
     this.combobox.setAttribute('role', 'combobox');
     this.combobox.setAttribute('aria-owns', this.facetSearchId);
     this.input.setAttribute('aria-controls', this.facetSearchId);
+    this.input.setAttribute('aria-expanded', true.toString());
     this.facetSearch.setExpandedFacetSearchAccessibilityAttributes(this.searchResults);
   }
 
@@ -293,6 +295,7 @@ export class FacetSearchElement {
     this.combobox.removeAttribute('aria-owns');
     this.input.removeAttribute('aria-controls');
     this.input.removeAttribute('aria-activedescendant');
+    this.input.setAttribute('aria-expanded', false.toString());
     this.facetSearch.setCollapsedFacetSearchAccessibilityAttributes();
   }
 }

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -282,7 +282,7 @@ export class FacetSearchElement {
     this.combobox.setAttribute('role', 'combobox');
     this.combobox.setAttribute('aria-owns', this.facetSearchId);
     this.input.setAttribute('aria-controls', this.facetSearchId);
-    this.input.setAttribute('aria-expanded', true.toString());
+    this.input.setAttribute('aria-expanded', 'true');
     this.facetSearch.setExpandedFacetSearchAccessibilityAttributes(this.searchResults);
   }
 
@@ -295,7 +295,7 @@ export class FacetSearchElement {
     this.combobox.removeAttribute('aria-owns');
     this.input.removeAttribute('aria-controls');
     this.input.removeAttribute('aria-activedescendant');
-    this.input.setAttribute('aria-expanded', false.toString());
+    this.input.setAttribute('aria-expanded', 'false');
     this.facetSearch.setCollapsedFacetSearchAccessibilityAttributes();
   }
 }

--- a/unitTests/ui/FacetSearchTest.ts
+++ b/unitTests/ui/FacetSearchTest.ts
@@ -89,8 +89,10 @@ export function FacetSearchTest() {
 
       describe('when calling focus', () => {
         let setExpandedFacetSearchAccessibilityAttributes: jasmine.Spy;
+        let facetSearchId: string;
         beforeEach(() => {
           setExpandedFacetSearchAccessibilityAttributes = spyOn(facetSearch, 'setExpandedFacetSearchAccessibilityAttributes');
+          facetSearchId = facetSearch.facetSearchElement['facetSearchId'];
           facetSearch.focus();
         });
 
@@ -104,15 +106,15 @@ export function FacetSearchTest() {
         });
 
         it('should give the combobox the aria-owns attribute', () => {
-          expect(facetSearch.facetSearchElement.combobox.getAttribute('aria-owns')).not.toBeNull();
+          expect(facetSearch.facetSearchElement.combobox.getAttribute('aria-owns')).toEqual(facetSearchId);
         });
 
         it('should give the input the aria-controls attribute', () => {
-          expect(facetSearch.facetSearchElement.input.getAttribute('aria-controls')).not.toBeNull();
+          expect(facetSearch.facetSearchElement.input.getAttribute('aria-controls')).toEqual(facetSearchId);
         });
 
         it("should set aria-expanded to true on the input's element", () => {
-          expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual(true.toString());
+          expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual('true');
         });
       });
 
@@ -164,7 +166,7 @@ export function FacetSearchTest() {
           });
 
           it("should set aria-expanded to false on the input's element", () => {
-            expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual(false.toString());
+            expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual('false');
           });
         });
       });

--- a/unitTests/ui/FacetSearchTest.ts
+++ b/unitTests/ui/FacetSearchTest.ts
@@ -88,11 +88,31 @@ export function FacetSearchTest() {
       });
 
       describe('when calling focus', () => {
-        it("should update the accessible element's accessibility properties", () => {
-          const setExpandedFacetSearchAccessibilityAttributes = spyOn(facetSearch, 'setExpandedFacetSearchAccessibilityAttributes');
+        let setExpandedFacetSearchAccessibilityAttributes: jasmine.Spy;
+        beforeEach(() => {
+          setExpandedFacetSearchAccessibilityAttributes = spyOn(facetSearch, 'setExpandedFacetSearchAccessibilityAttributes');
           facetSearch.focus();
+        });
+
+        it("should update the accessible element's accessibility properties", () => {
           expect(setExpandedFacetSearchAccessibilityAttributes).toHaveBeenCalledTimes(1);
           expect(setExpandedFacetSearchAccessibilityAttributes).toHaveBeenCalledWith(facetSearch.facetSearchElement['searchResults']);
+        });
+
+        it('should give the "combobox" role to the combobox', () => {
+          expect(facetSearch.facetSearchElement.combobox.getAttribute('role')).toEqual('combobox');
+        });
+
+        it('should give the combobox the aria-owns attribute', () => {
+          expect(facetSearch.facetSearchElement.combobox.getAttribute('aria-owns')).not.toBeNull();
+        });
+
+        it('should give the input the aria-controls attribute', () => {
+          expect(facetSearch.facetSearchElement.input.getAttribute('aria-controls')).not.toBeNull();
+        });
+
+        it("should set aria-expanded to true on the input's element", () => {
+          expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual(true.toString());
         });
       });
 
@@ -113,20 +133,38 @@ export function FacetSearchTest() {
           done();
         });
 
+        it('should have displayed results', () => {
+          expect(allSearchResults().length).toBe(10);
+          expect(facetSearch.currentlyDisplayedResults.length).toBe(10);
+        });
+
         describe('and calling dismissSearchResults', () => {
-          it('should hide facet search results', done => {
-            expect(allSearchResults().length).toBe(10);
-            expect(facetSearch.currentlyDisplayedResults.length).toBe(10);
+          let setCollapsedFacetSearchAccessibilityAttributes: jasmine.Spy;
+          beforeEach(() => {
+            setCollapsedFacetSearchAccessibilityAttributes = spyOn(facetSearch, 'setCollapsedFacetSearchAccessibilityAttributes');
             facetSearch.dismissSearchResults();
+          });
+
+          it('should hide facet search results', done => {
             expect(allSearchResults().length).toBe(0);
             expect(facetSearch.currentlyDisplayedResults).toBeUndefined();
             done();
           });
 
           it("should update the accessible element's accessibility properties", () => {
-            const setCollapsedFacetSearchAccessibilityAttributes = spyOn(facetSearch, 'setCollapsedFacetSearchAccessibilityAttributes');
-            facetSearch.dismissSearchResults();
             expect(setCollapsedFacetSearchAccessibilityAttributes).toHaveBeenCalledTimes(1);
+          });
+
+          it("should remove the combobox's aria-owns attribute", () => {
+            expect(facetSearch.facetSearchElement.combobox.getAttribute('aria-owns')).toBeNull();
+          });
+
+          it("should remove the input's aria-controls attribute", () => {
+            expect(facetSearch.facetSearchElement.input.getAttribute('aria-controls')).toBeNull();
+          });
+
+          it("should set aria-expanded to false on the input's element", () => {
+            expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual(false.toString());
           });
         });
       });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2925

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)