### PR TITLE
JSUI-2929 Fix className typo for FacetSlider breadcrumb

### DIFF
--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -607,7 +607,7 @@ export class FacetSlider extends Component {
       className: 'coveo-facet-slider-breadcrumb-value'
     });
     const caption = $$('span', {
-      clasName: 'coveo-facet-slider-breadcrumb-caption'
+      className: 'coveo-facet-slider-breadcrumb-caption'
     });
     caption.text(this.slider.getCaption());
     value.append(caption.el);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2929





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)