### PR TITLE
JSUI-2928 Improved accessibility for `FacetSearch`'s results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/sass/_CategoryFacet.scss
+++ b/sass/_CategoryFacet.scss
@@ -1,9 +1,11 @@
 @import 'Variables';
+@import 'FacetVariables';
 @import 'mixins/breadcrumb';
 @import 'mixins/_facetHeaderAnimation';
 @import 'bourbon/bourbon';
+
 @mixin facetValueLabelPadding {
-  padding: 5px 19px 5px 20px;
+  padding: 5px #{$facet-value-padding - 1px} 5px $facet-value-padding;
 }
 
 @mixin clickableCategoryFacetValue {

--- a/sass/_CategoryFacetSearch.scss
+++ b/sass/_CategoryFacetSearch.scss
@@ -1,7 +1,9 @@
 @import 'Variables';
 @import 'bourbon/bourbon';
+@import 'FacetVariables';
+
 .coveo-category-facet-search-container {
-  padding: 0 20px;
+  padding: 0 $facet-value-padding;
   height: 32px;
   line-height: 30px;
   .coveo-facet-search {

--- a/sass/_FacetSearch.scss
+++ b/sass/_FacetSearch.scss
@@ -5,6 +5,7 @@
 .coveo-facet-search-results {
   position: absolute;
   left: $facet-value-padding;
+  right: $facet-value-padding;
   @include defaultRoundedBorder();
   background-color: white;
   list-style: none;

--- a/sass/_FacetSearch.scss
+++ b/sass/_FacetSearch.scss
@@ -1,8 +1,10 @@
 @import 'Variables';
 @import 'FacetValues';
+@import 'FacetVariables';
+
 .coveo-facet-search-results {
   position: absolute;
-  left: 20px;
+  left: $facet-value-padding;
   @include defaultRoundedBorder();
   background-color: white;
   list-style: none;
@@ -94,7 +96,7 @@
     margin-right: 200px;
   }
   100% {
-    margin-right: 20px;
+    margin-right: $facet-value-padding;
   }
 }
 
@@ -103,7 +105,7 @@
   position: relative;
   background: white;
   display: none;
-  margin: 2px 20px 1px;
+  margin: 2px $facet-value-padding 1px;
   padding: 4px;
   @include animation(grow 0.3s linear);
 }

--- a/sass/_FacetSearch.scss
+++ b/sass/_FacetSearch.scss
@@ -2,6 +2,7 @@
 @import 'FacetValues';
 .coveo-facet-search-results {
   position: absolute;
+  left: 20px;
   @include defaultRoundedBorder();
   background-color: white;
   list-style: none;
@@ -38,6 +39,12 @@
   }
   .coveo-facet-value-label {
     padding-right: 15px;
+  }
+  .CoveoFacet & {
+    margin-top: -1px;
+  }
+  .CoveoCategoryFacet & {
+    line-height: normal;
   }
 }
 

--- a/sass/_FacetValues.scss
+++ b/sass/_FacetValues.scss
@@ -1,4 +1,6 @@
 @import 'Variables';
+@import 'FacetVariables';
+
 @mixin facetValuesCheckboxes($size: 'normal') {
   $pixel-size: '18px';
   @if $size=='smaller' {
@@ -124,7 +126,7 @@
 }
 
 .coveo-facet-value {
-  padding: 0 20px;
+  padding: 0 $facet-value-padding;
   margin: 0;
   line-height: 22px;
   position: relative;

--- a/sass/_FacetVariables.scss
+++ b/sass/_FacetVariables.scss
@@ -1,0 +1,1 @@
+$facet-value-padding: 20px;

--- a/src/ui/CategoryFacet/CategoryFacetSearch.ts
+++ b/src/ui/CategoryFacet/CategoryFacetSearch.ts
@@ -164,11 +164,7 @@ export class CategoryFacetSearch implements IFacetSearch {
       this.setFacetSearchResults(categoryFacetValues);
 
       if (this.shouldPositionSearchResults) {
-        this.facetSearchElement.positionSearchResults(
-          this.categoryFacet.root,
-          this.categoryFacet.element.clientWidth,
-          this.facetSearchElement.search
-        );
+        this.facetSearchElement.positionSearchResults(this.categoryFacet.element.clientWidth, this.facetSearchElement.search);
       }
 
       this.facetSearchElement.hideFacetSearchWaitingAnimation();

--- a/src/ui/CategoryFacet/CategoryFacetSearch.ts
+++ b/src/ui/CategoryFacet/CategoryFacetSearch.ts
@@ -164,7 +164,7 @@ export class CategoryFacetSearch implements IFacetSearch {
       this.setFacetSearchResults(categoryFacetValues);
 
       if (this.shouldPositionSearchResults) {
-        this.facetSearchElement.positionSearchResults(this.facetSearchElement.search);
+        this.facetSearchElement.positionSearchResults();
       }
 
       this.facetSearchElement.hideFacetSearchWaitingAnimation();

--- a/src/ui/CategoryFacet/CategoryFacetSearch.ts
+++ b/src/ui/CategoryFacet/CategoryFacetSearch.ts
@@ -164,7 +164,7 @@ export class CategoryFacetSearch implements IFacetSearch {
       this.setFacetSearchResults(categoryFacetValues);
 
       if (this.shouldPositionSearchResults) {
-        this.facetSearchElement.positionSearchResults(this.categoryFacet.element.clientWidth, this.facetSearchElement.search);
+        this.facetSearchElement.positionSearchResults(this.facetSearchElement.search);
       }
 
       this.facetSearchElement.hideFacetSearchWaitingAnimation();

--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -72,7 +72,7 @@ export class FacetSearch implements IFacetSearch {
    * Position the search results at the footer of the facet.
    */
   public positionSearchResults(nextTo: HTMLElement = this.search) {
-    this.facetSearchElement.positionSearchResults(this.facet.element.clientWidth, nextTo);
+    this.facetSearchElement.positionSearchResults(nextTo);
   }
 
   public fetchMoreValues() {

--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -71,8 +71,8 @@ export class FacetSearch implements IFacetSearch {
   /**
    * Position the search results at the footer of the facet.
    */
-  public positionSearchResults(nextTo: HTMLElement = this.search) {
-    this.facetSearchElement.positionSearchResults(nextTo);
+  public positionSearchResults() {
+    this.facetSearchElement.positionSearchResults();
   }
 
   public fetchMoreValues() {

--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -72,7 +72,7 @@ export class FacetSearch implements IFacetSearch {
    * Position the search results at the footer of the facet.
    */
   public positionSearchResults(nextTo: HTMLElement = this.search) {
-    this.facetSearchElement.positionSearchResults(this.root, this.facet.element.clientWidth, nextTo);
+    this.facetSearchElement.positionSearchResults(this.facet.element.clientWidth, nextTo);
   }
 
   public fetchMoreValues() {

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -127,7 +127,7 @@ export class FacetSearchElement {
     });
   }
 
-  public positionSearchResults(root: HTMLElement, facetWidth: number, nextTo: HTMLElement) {
+  public positionSearchResults(facetWidth: number, nextTo: HTMLElement) {
     if (this.searchResults != null) {
       $$(this.searchResults).insertAfter(nextTo);
       $$(this.searchResults).show();

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -126,9 +126,9 @@ export class FacetSearchElement {
     });
   }
 
-  public positionSearchResults(nextTo: HTMLElement) {
+  public positionSearchResults() {
     if (this.searchResults != null) {
-      $$(this.searchResults).insertAfter(nextTo);
+      $$(this.searchResults).insertAfter(this.search);
       $$(this.searchResults).show();
 
       if ($$(this.searchResults).css('display') == 'none') {

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -22,7 +22,6 @@ export class FacetSearchElement {
   public facetSearchUserInputHandler: FacetSearchUserInputHandler;
 
   private triggeredScroll = false;
-  private static FACET_SEARCH_PADDING = 40;
   private facetSearchId = uniqueId('coveo-facet-search-results');
   private searchDropdownNavigator: ISearchDropdownNavigator;
 
@@ -127,11 +126,10 @@ export class FacetSearchElement {
     });
   }
 
-  public positionSearchResults(facetWidth: number, nextTo: HTMLElement) {
+  public positionSearchResults(nextTo: HTMLElement) {
     if (this.searchResults != null) {
       $$(this.searchResults).insertAfter(nextTo);
       $$(this.searchResults).show();
-      this.searchResults.style.width = facetWidth - FacetSearchElement.FACET_SEARCH_PADDING + 'px';
 
       if ($$(this.searchResults).css('display') == 'none') {
         this.searchResults.style.display = '';

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -4,7 +4,6 @@ import { SVGDom } from '../../utils/SVGDom';
 import { Component } from '../Base/Component';
 import { l } from '../../strings/Strings';
 import { EventsUtils } from '../../utils/EventsUtils';
-import { PopupUtils, PopupHorizontalAlignment, PopupVerticalAlignment } from '../../utils/PopupUtils';
 import { IFacetSearch } from './IFacetSearch';
 import { FacetSearchUserInputHandler } from './FacetSearchUserInputHandler';
 import { uniqueId } from 'underscore';
@@ -130,7 +129,7 @@ export class FacetSearchElement {
 
   public positionSearchResults(root: HTMLElement, facetWidth: number, nextTo: HTMLElement) {
     if (this.searchResults != null) {
-      root.appendChild(this.searchResults);
+      $$(this.searchResults).insertAfter(nextTo);
       $$(this.searchResults).show();
       this.searchResults.style.width = facetWidth - FacetSearchElement.FACET_SEARCH_PADDING + 'px';
 
@@ -143,11 +142,8 @@ export class FacetSearchElement {
           this.searchResults.style.display = '';
         }
         EventsUtils.addPrefixedEvent(this.search, 'AnimationEnd', () => {
-          this.positionPopUp(nextTo, root);
           EventsUtils.removePrefixedEvent(this.search, 'AnimationEnd', this);
         });
-      } else {
-        this.positionPopUp(nextTo, root);
       }
     }
     this.addAriaAttributes();
@@ -257,13 +253,6 @@ export class FacetSearchElement {
       ariaHaspopup: 'true',
       ariaAutocomplete: 'list'
     }).el;
-  }
-
-  private positionPopUp(nextTo: HTMLElement, root: HTMLElement) {
-    PopupUtils.positionPopup(this.searchResults, nextTo, root, {
-      horizontal: PopupHorizontalAlignment.CENTER,
-      vertical: PopupVerticalAlignment.BOTTOM
-    });
   }
 
   private handleScrollEvent() {

--- a/src/ui/Facet/ValueElementRenderer.ts
+++ b/src/ui/Facet/ValueElementRenderer.ts
@@ -171,7 +171,7 @@ export class ValueElementRenderer {
   }
 
   private buildListItem() {
-    this.listItem = $$('li', { className: 'coveo-facet-value coveo-facet-selectable' }).el;
+    this.listItem = $$('li', { className: 'coveo-facet-value coveo-facet-selectable', ariaLabel: this.ariaLabel }).el;
 
     if (!$$(this.listItem).canHandleEvent('touchstart')) {
       $$(this.listItem).addClass('coveo-with-hover');

--- a/unitTests/ui/FacetSearchTest.ts
+++ b/unitTests/ui/FacetSearchTest.ts
@@ -127,6 +127,7 @@ export function FacetSearchTest() {
 
           (<jasmine.Spy>mockFacet.facetQueryController.search).and.returnValue(pr);
 
+          $$('div').append(facetSearch.search);
           var params = new FacetSearchParameters(mockFacet);
           expect(allSearchResults().length).toBe(0);
           expect(facetSearch.currentlyDisplayedResults).toBeUndefined();
@@ -138,6 +139,11 @@ export function FacetSearchTest() {
         it('should have displayed results', () => {
           expect(allSearchResults().length).toBe(10);
           expect(facetSearch.currentlyDisplayedResults.length).toBe(10);
+        });
+
+        it('should append search results immediately after the search box', () => {
+          const { search, searchResults } = facetSearch.facetSearchElement;
+          expect(search.nextSibling).toBe(searchResults);
         });
 
         describe('and calling dismissSearchResults', () => {

--- a/unitTests/ui/ValueElementRendererTest.ts
+++ b/unitTests/ui/ValueElementRendererTest.ts
@@ -67,6 +67,12 @@ export function ValueElementRendererTest() {
       expect(valueRenderer.checkbox.getAttribute('aria-label')).toBeTruthy();
     });
 
+    it('the list item has an aria-label', () => {
+      valueRenderer = new ValueElementRenderer(facet, FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 123)));
+      valueRenderer.build();
+      expect(valueRenderer.listItem.getAttribute('aria-label')).toBeTruthy();
+    });
+
     it('should put the tabindex attribute to 0 on a stylish checkbox', () => {
       valueRenderer = new ValueElementRenderer(facet, FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 123)));
       expect(valueRenderer.build().stylishCheckbox.getAttribute('tabindex')).toBe('0');


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2928

This PR addresses two issues concerning `Facet`'s and `CategoryFacet`'s search results.
1. `FacetSearch`'s results aren't focused when pressing tab from the search box. In this PR, this is fixed by moving its position in the DOM just below the search box.
2. `FacetSearch`'s results aren't read out by TalkBack and VoiceOver. In this PR, this is fixed by giving labels to results.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)