### PR TITLE
JSUI-2932 Removed redundant `tabindex` on `Quickview`'s label

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -317,7 +317,7 @@ export class Quickview extends Component {
   }
 
   private buildCaption() {
-    return $$('div', { className: 'coveo-caption-for-icon', tabindex: 0 }, 'Quickview'.toLocaleString()).el;
+    return $$('div', { className: 'coveo-caption-for-icon' }, 'Quickview'.toLocaleString()).el;
   }
 
   private buildTooltipIfNotInCardLayout(icon: HTMLElement, caption: HTMLElement) {

--- a/unitTests/ui/QuickviewTest.ts
+++ b/unitTests/ui/QuickviewTest.ts
@@ -52,6 +52,10 @@ export function QuickviewTest() {
       done();
     });
 
+    it('should not give the caption a tabindex', () => {
+      expect(quickview.element.querySelector('.coveo-caption-for-icon').getAttribute('tabindex')).toBeNull();
+    });
+
     it('when the layout is list, the caption should be positioned (i.e. appear as a tooltip)', done => {
       expect(
         $$(quickview.element)


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2932

This PR removes a redundant `tabindex` on `Quickview`'s label that caused its label to be focused instead of the `Quickview` button itself with Voiceover on iOS.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)