### PR TITLE
JSUI-2934 Add filterByBasePath=false to the facetRequest

### DIFF
--- a/src/controllers/DynamicHierarchicalFacetQueryController.ts
+++ b/src/controllers/DynamicHierarchicalFacetQueryController.ts
@@ -25,7 +25,9 @@ export class DynamicHierarchicalFacetQueryController {
       injectionDepth: this.facet.options.injectionDepth,
       delimitingCharacter: this.facet.options.delimitingCharacter,
       filterFacetCount: this.facet.options.filterFacetCount,
-      basePath: this.facet.options.basePath
+      basePath: this.facet.options.basePath,
+      // TODO: add configurable option when API has fixed the facet value issue
+      filterByBasePath: false
     });
     this.resetNumberOfValuesToRequest();
     this.resetFlagsDuringQuery();

--- a/src/rest/Facet/FacetRequest.ts
+++ b/src/rest/Facet/FacetRequest.ts
@@ -201,7 +201,9 @@ export interface IFacetRequest {
   basePath?: string[];
 
   /**
-   * Whether to use `basePath` as a filter for the results.
+   * Whether to use the [`basePath`]{@link FacetRequest.basePath} as a filter for the results.
+   *
+   * **Note:** This parameter is ignored unless the facet [`type`]{@link FacetRequest.type} is `hierarchical`.
    *
    * **Default (Search API):** `true`
    */

--- a/src/rest/Facet/FacetRequest.ts
+++ b/src/rest/Facet/FacetRequest.ts
@@ -201,6 +201,13 @@ export interface IFacetRequest {
   basePath?: string[];
 
   /**
+   * Whether to use `basePath` as a filter for the results.
+   *
+   * **Default (Search API):** `true`
+   */
+  filterByBasePath?: boolean;
+
+  /**
    * Whether to prevent Coveo ML from automatically selecting values from that facet.
    *
    * **Default:** `false`

--- a/unitTests/controllers/DynamicHierarchicalFacetQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicHierarchicalFacetQueryControllerTest.ts
@@ -52,6 +52,7 @@ export function DynamicHierarchicalFacetQueryControllerTest() {
       expect(facetRequest().delimitingCharacter).toBe(facet.options.delimitingCharacter);
       expect(facetRequest().injectionDepth).toBe(facet.options.injectionDepth);
       expect(facetRequest().basePath).toBe(facet.options.basePath);
+      expect(facetRequest().filterByBasePath).toBe(false);
     });
 
     it('the facet option freezeFacetOrder should not be defined by default', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2934

There is currently a bug API-side: when another facet has a selected value, the displayed values & count are not affected by the basePath
They have been notified


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)