### PR TITLE
JSUI-2935 Fixed `AccessibleModal`'s focus on close for VoiceOver and TalkBack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/src/ui/Backdrop/Backdrop.ts
+++ b/src/ui/Backdrop/Backdrop.ts
@@ -11,6 +11,7 @@ import { IFieldOption } from '../Base/IComponentOptions';
 import { Initialization } from '../Base/Initialization';
 import { IResultsComponentBindings } from '../Base/ResultsComponentBindings';
 import { IYouTubeThumbnailOptions, YouTubeThumbnail } from '../YouTube/YouTubeThumbnail';
+import { AccessibleButton } from '../../utils/AccessibleButton';
 
 export interface IBackdropOptions {
   imageUrl?: string;
@@ -127,16 +128,21 @@ export class Backdrop extends Component {
         },
         <IResultsComponentBindings>this.getBindings(),
         this.result,
-        this.ModalBox
+        this.ModalBox,
+        this.element
       );
 
-      $$(this.element).on('click', (e: MouseEvent) => {
-        // Since the backdrop often contain a result link, we must make sure the click did no originate from one.
-        // Otherwise, we might end up opening 2 results at the same time
-        if (!$$(<HTMLElement>e.target).hasClass('CoveoResultLink')) {
-          thumbnailYouTube.openResultLink();
-        }
-      });
+      new AccessibleButton()
+        .withElement(this.element)
+        .withLabel(this.result.title)
+        .withSelectAction(e => {
+          // Since the backdrop often contain a result link, we must make sure the click did no originate from one.
+          // Otherwise, we might end up opening 2 results at the same time
+          if (!$$(<HTMLElement>e.target).hasClass('CoveoResultLink')) {
+            thumbnailYouTube.openResultLink();
+          }
+        })
+        .build();
     }
   }
 }

--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -256,8 +256,6 @@ export class Quickview extends Component {
 
   private modalbox: AccessibleModal;
 
-  private lastFocusedElement: HTMLElement;
-
   /**
    * Creates a new `Quickview` component.
    * @param element The HTMLElement on which to instantiate the component.
@@ -366,10 +364,7 @@ export class Quickview extends Component {
       Quickview.resultCurrentlyBeingRendered = this.result;
       // activeElement does not exist in LockerService
       if (document.activeElement && document.activeElement instanceof HTMLElement) {
-        this.lastFocusedElement = document.activeElement;
         $$(document.activeElement as HTMLElement).trigger('blur');
-      } else {
-        this.lastFocusedElement = null;
       }
 
       const openerObject = this.prepareOpenQuickviewObject();
@@ -389,9 +384,6 @@ export class Quickview extends Component {
   public close() {
     if (this.modalbox.isOpen) {
       this.modalbox.close();
-      if (this.lastFocusedElement && this.lastFocusedElement.parentElement) {
-        this.lastFocusedElement.focus();
-      }
     }
   }
 
@@ -457,7 +449,8 @@ export class Quickview extends Component {
         () => {
           this.closeQuickview();
           return true;
-        }
+        },
+        this.element
       );
       return computedModalBoxContent;
     });

--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -438,20 +438,20 @@ export class Quickview extends Component {
     computedModalBoxContent.addClass('coveo-computed-modal-box-content');
     return openerObject.content.then(builtContent => {
       computedModalBoxContent.append(builtContent.el);
-      this.modalbox.openResult(
-        this.result,
-        {
+      this.modalbox.openResult({
+        result: this.result,
+        options: {
           showDate: this.options.showDate,
           title: this.options.title
         },
-        this.bindings,
-        computedModalBoxContent.el,
-        () => {
+        bindings: this.bindings,
+        content: computedModalBoxContent.el,
+        validation: () => {
           this.closeQuickview();
           return true;
         },
-        this.element
-      );
+        origin: this.element
+      });
       return computedModalBoxContent;
     });
   }

--- a/src/ui/YouTube/YouTubeThumbnail.ts
+++ b/src/ui/YouTube/YouTubeThumbnail.ts
@@ -78,7 +78,8 @@ export class YouTubeThumbnail extends Component {
     public options?: IYouTubeThumbnailOptions,
     public bindings?: IResultsComponentBindings,
     public result?: IQueryResult,
-    ModalBox = ModalBoxModule
+    ModalBox = ModalBoxModule,
+    private origin?: HTMLElement
   ) {
     super(element, YouTubeThumbnail.ID, bindings);
     this.options = ComponentOptions.initComponentOptions(element, YouTubeThumbnail, options);
@@ -86,6 +87,10 @@ export class YouTubeThumbnail extends Component {
     this.resultLink = $$('a', {
       className: Component.computeCssClassName(ResultLink)
     });
+
+    if (!origin) {
+      this.origin = this.resultLink.el;
+    }
 
     const thumbnailDiv = $$('div', {
       className: 'coveo-youtube-thumbnail-container'
@@ -153,7 +158,7 @@ export class YouTubeThumbnail extends Component {
 
     div.append(iframe.el);
 
-    this.modalbox.openResult(this.result, { showDate: true, title: this.result.title }, this.bindings, div.el, () => true);
+    this.modalbox.openResult(this.result, { showDate: true, title: this.result.title }, this.bindings, div.el, () => true, this.origin);
 
     $$($$(this.modalbox.wrapper).find('.coveo-quickview-close-button')).on('click', () => {
       this.modalbox.close();

--- a/src/ui/YouTube/YouTubeThumbnail.ts
+++ b/src/ui/YouTube/YouTubeThumbnail.ts
@@ -158,7 +158,14 @@ export class YouTubeThumbnail extends Component {
 
     div.append(iframe.el);
 
-    this.modalbox.openResult(this.result, { showDate: true, title: this.result.title }, this.bindings, div.el, () => true, this.origin);
+    this.modalbox.openResult({
+      result: this.result,
+      options: { showDate: true, title: this.result.title },
+      bindings: this.bindings,
+      content: div.el,
+      validation: () => true,
+      origin: this.origin
+    });
 
     $$($$(this.modalbox.wrapper).find('.coveo-quickview-close-button')).on('click', () => {
       this.modalbox.close();

--- a/src/utils/AccessibleModal.ts
+++ b/src/utils/AccessibleModal.ts
@@ -13,6 +13,22 @@ export interface IAccessibleModalOptions {
   sizeMod: 'small' | 'normal' | 'big';
 }
 
+export interface IAccessibleModalOpenParameters {
+  content: HTMLElement;
+  validation: () => boolean;
+  origin?: HTMLElement;
+}
+
+export interface IAccessibleModalOpenResultParameters extends IAccessibleModalOpenParameters {
+  result: IQueryResult;
+  options: IQuickViewHeaderOptions;
+  bindings: IComponentBindings;
+}
+
+export interface IAccessibleModalOpenNormalParameters extends IAccessibleModalOpenParameters {
+  title: HTMLElement;
+}
+
 export class AccessibleModal {
   private focusTrap: FocusTrap;
   private activeModal: Coveo.ModalBox.ModalBox;
@@ -53,37 +69,35 @@ export class AccessibleModal {
     };
   }
 
-  public openResult(
-    result: IQueryResult,
-    options: IQuickViewHeaderOptions,
-    bindings: IComponentBindings,
-    content: HTMLElement,
-    validation: () => boolean,
-    origin?: HTMLElement
-  ) {
+  public openResult(parameters: IAccessibleModalOpenResultParameters) {
     if (this.isOpen) {
       return;
     }
-    this.openModalAndTrap(DomUtils.getQuickviewHeader(result, options, bindings).el, content, validation, origin);
-    this.makeAccessible(options.title || result.title);
+    this.openModalAndTrap({
+      content: parameters.content,
+      validation: parameters.validation,
+      origin: parameters.origin,
+      title: DomUtils.getQuickviewHeader(parameters.result, parameters.options, parameters.bindings).el
+    });
+    this.makeAccessible(parameters.options.title || parameters.result.title);
   }
 
-  public open(title: HTMLElement, content: HTMLElement, validation: () => boolean, origin?: HTMLElement) {
+  public open(parameters: IAccessibleModalOpenNormalParameters) {
     if (this.isOpen) {
       return;
     }
-    this.openModalAndTrap(title, content, validation, origin);
+    this.openModalAndTrap(parameters);
     this.makeAccessible();
   }
 
-  private openModalAndTrap(title: HTMLElement, content: HTMLElement, validation: () => boolean, origin?: HTMLElement) {
-    this.initiallyFocusedElement = origin || (document.activeElement as HTMLElement);
-    this.activeModal = this.modalboxModule.open(content, {
-      title,
+  private openModalAndTrap(parameters: IAccessibleModalOpenNormalParameters) {
+    this.initiallyFocusedElement = parameters.origin || (document.activeElement as HTMLElement);
+    this.activeModal = this.modalboxModule.open(parameters.content, {
+      title: parameters.title,
       className: this.className,
       validation: () => {
         this.onModalClose();
-        return validation();
+        return parameters.validation();
       },
       body: this.ownerBody,
       sizeMod: this.options.sizeMod,

--- a/src/utils/AccessibleModal.ts
+++ b/src/utils/AccessibleModal.ts
@@ -58,25 +58,26 @@ export class AccessibleModal {
     options: IQuickViewHeaderOptions,
     bindings: IComponentBindings,
     content: HTMLElement,
-    validation: () => boolean
+    validation: () => boolean,
+    origin?: HTMLElement
   ) {
     if (this.isOpen) {
       return;
     }
-    this.openModalAndTrap(DomUtils.getQuickviewHeader(result, options, bindings).el, content, validation);
+    this.openModalAndTrap(DomUtils.getQuickviewHeader(result, options, bindings).el, content, validation, origin);
     this.makeAccessible(options.title || result.title);
   }
 
-  public open(title: HTMLElement, content: HTMLElement, validation: () => boolean) {
+  public open(title: HTMLElement, content: HTMLElement, validation: () => boolean, origin?: HTMLElement) {
     if (this.isOpen) {
       return;
     }
-    this.openModalAndTrap(title, content, validation);
+    this.openModalAndTrap(title, content, validation, origin);
     this.makeAccessible();
   }
 
-  private openModalAndTrap(title: HTMLElement, content: HTMLElement, validation: () => boolean) {
-    this.initiallyFocusedElement = document.activeElement as HTMLElement;
+  private openModalAndTrap(title: HTMLElement, content: HTMLElement, validation: () => boolean, origin?: HTMLElement) {
+    this.initiallyFocusedElement = origin || (document.activeElement as HTMLElement);
     this.activeModal = this.modalboxModule.open(content, {
       title,
       className: this.className,

--- a/src/utils/AccessibleModal.ts
+++ b/src/utils/AccessibleModal.ts
@@ -16,7 +16,7 @@ export interface IAccessibleModalOptions {
 export interface IAccessibleModalOpenParameters {
   content: HTMLElement;
   validation: () => boolean;
-  origin?: HTMLElement;
+  origin: HTMLElement;
 }
 
 export interface IAccessibleModalOpenResultParameters extends IAccessibleModalOpenParameters {

--- a/unitTests/ui/BackdropTest.ts
+++ b/unitTests/ui/BackdropTest.ts
@@ -99,13 +99,29 @@ export function BackdropTest() {
     });
 
     describe('for a youtube result', () => {
-      it('should open the youtubethumbnail in a modalbox', () => {
-        fakeResult.raw['ytthumbnailurl'] = 'someurl';
-        let fakeModalBox = Simulate.modalBoxModule();
-        test.cmp = new Backdrop(test.env.root, { imageField: 'thumbnailurl' }, test.cmp.getBindings(), fakeResult, null, fakeModalBox);
+      let fakeModalBox: Coveo.ModalBox.ModalBox;
 
+      beforeEach(() => {
+        fakeResult.raw['ytthumbnailurl'] = 'someurl';
+        fakeModalBox = Simulate.modalBoxModule();
+        test.cmp = new Backdrop(test.env.root, { imageField: 'thumbnailurl' }, test.cmp.getBindings(), fakeResult, null, fakeModalBox);
+      });
+
+      it('should open the youtubethumbnail in a modalbox', () => {
         $$(test.cmp.element).trigger('click');
         expect(fakeModalBox.open).toHaveBeenCalled();
+      });
+
+      it('should have an aria-label', () => {
+        expect(test.cmp.element.getAttribute('aria-label')).toEqual(fakeResult.title);
+      });
+
+      it('should have a tabindex', () => {
+        expect(test.cmp.element.getAttribute('tabindex')).toEqual('0');
+      });
+
+      it('should have the button role', () => {
+        expect(test.cmp.element.getAttribute('role')).toEqual('button');
       });
     });
   });

--- a/unitTests/utils/AccessibleModalTest.ts
+++ b/unitTests/utils/AccessibleModalTest.ts
@@ -48,18 +48,17 @@ export function AccessibleModalTest() {
       let container: HTMLElement;
       let closeButton: HTMLElement;
       let closeButtonClickSpy: jasmine.Spy;
-      let initiallyFocusedElement: HTMLElement;
+      let origin: HTMLElement;
 
-      function createAndAppendInitiallyFocusedElement() {
-        initiallyFocusedElement = $$('button', {}, 'test').el;
-        spyOn(initiallyFocusedElement, 'focus');
-        document.body.appendChild(initiallyFocusedElement);
-        return initiallyFocusedElement;
+      function createOrigin() {
+        origin = $$('button', {}, 'test').el;
+        spyOn(origin, 'focus');
+        document.body.appendChild(origin);
+        return origin;
       }
 
       beforeEach(() => {
-        accessibleModal.open(createTitle(), createContent(), createValidationSpy());
-        accessibleModal['initiallyFocusedElement'] = createAndAppendInitiallyFocusedElement();
+        accessibleModal.open(createTitle(), createContent(), createValidationSpy(), createOrigin());
         focusTrap = accessibleModal['focusTrap'];
         container = accessibleModal.element;
         closeButton = container.querySelector('.coveo-small-close');
@@ -67,7 +66,7 @@ export function AccessibleModalTest() {
       });
 
       afterEach(() => {
-        initiallyFocusedElement.remove();
+        origin.remove();
       });
 
       it('has an element', () => {
@@ -128,8 +127,8 @@ export function AccessibleModalTest() {
           accessibleModal.close();
         });
 
-        it('resets the focus to its initial position', () => {
-          expect(initiallyFocusedElement.focus).toHaveBeenCalledTimes(1);
+        it('resets the focus to its origin', () => {
+          expect(origin.focus).toHaveBeenCalledTimes(1);
         });
 
         it("doesn't have an element", () => {

--- a/unitTests/utils/AccessibleModalTest.ts
+++ b/unitTests/utils/AccessibleModalTest.ts
@@ -58,7 +58,12 @@ export function AccessibleModalTest() {
       }
 
       beforeEach(() => {
-        accessibleModal.open(createTitle(), createContent(), createValidationSpy(), createOrigin());
+        accessibleModal.open({
+          title: createTitle(),
+          content: createContent(),
+          validation: createValidationSpy(),
+          origin: createOrigin()
+        });
         focusTrap = accessibleModal['focusTrap'];
         container = accessibleModal.element;
         closeButton = container.querySelector('.coveo-small-close');


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2935

When a user closes `Quickview`'s modal or `YoutubeThumbnail`'s modal, the focus is expected to jump back to wherever it was before the modal was initially opened.

However, the following issues occurred:
1. On Android, when opening either modal with TalkBack, focus was never returned to its initial location. It seems like this may have been caused by the original location being determined from `document.activeElement`, which was always null on Android.
2. On a mobile device, results are displayed in card view. In card view, `YoutubeThumbnail` elements are replaced with a `Backdrop` element, which open `YoutubeThumbnail`'s modal whenever a card result is clicked anywhere. However, card results aren't focusable. VoiceOver and TalkBack happened to allow the description to be focused and to be able to open the modal from there, but the focus couldn't jump back to the description upon closing the modal. This also caused desktop accessibility users to be unable to open the modal at all when using the card view.

This PR aims to fix those issues by doing the following:
1. Giving `AccessibleModal` the `origin` parameter, which focuses the `origin` element when a modal is closed. This should be fool-proof with any accessibility tool, since it never depends on reading what the focused element is. This also allows the removal of `Quickview`'s `lastFocusedElement` member.
2. Making the `Backdrop` into an accessible button when the result is a Youtube result. This unfortunately prevents VoiceOver users from focusing on the title of Youtube results, since VoiceOver prevents a focusable element inside another focusable element to be focused. However, this isn't very impactful since another title is part of the modal opened by `YoutubeThumbnail` which leads to the same location on click.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)