### PR TITLE
JSUI-2937 Improved accessibility for `FieldTable`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/src/ui/FieldTable/FieldTable.ts
+++ b/src/ui/FieldTable/FieldTable.ts
@@ -1,5 +1,5 @@
 import 'styling/_FieldTable';
-import { each } from 'underscore';
+import { each, uniqueId } from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 import { IQueryResult } from '../../rest/QueryResult';
 import { l } from '../../strings/Strings';
@@ -97,8 +97,6 @@ export class FieldTable extends Component {
      */
     minimizedByDefault: ComponentOptions.buildBooleanOption({ depend: 'allowMinimization' })
   };
-
-  public isExpanded: boolean;
   private toggleButton: HTMLElement;
   private toggleCaption: HTMLElement;
   private toggleButtonSVGContainer: HTMLElement;
@@ -133,13 +131,22 @@ export class FieldTable extends Component {
     }
 
     if (this.isTogglable()) {
-      this.toggleContainer = $$('div', { className: 'coveo-field-table-toggle-container' }).el;
+      const className = 'coveo-field-table-toggle-container';
+      this.toggleContainer = $$('div', { className, id: uniqueId(className) }).el;
       this.buildToggle();
       $$(this.toggleContainer).insertBefore(this.element);
       this.toggleContainer.appendChild(this.element);
       this.toggleContainer.appendChild(this.toggleButtonInsideTable);
-    } else {
-      this.isExpanded = true;
+    }
+  }
+
+  public get isExpanded() {
+    return !this.toggleButton || this.toggleButton.getAttribute('aria-expanded') === 'true';
+  }
+
+  public set isExpanded(expanded: boolean) {
+    if (this.toggleButton) {
+      this.toggleButton.setAttribute('aria-expanded', expanded.toString());
     }
   }
 
@@ -149,10 +156,7 @@ export class FieldTable extends Component {
    * @param anim Specifies whether to show a sliding animation when toggling the display of the FieldTable.
    */
   public toggle(anim = false) {
-    if (this.isTogglable()) {
-      this.isExpanded = !this.isExpanded;
-      this.isExpanded ? this.expand(anim) : this.minimize(anim);
-    }
+    this.isExpanded ? this.minimize(anim) : this.expand(anim);
   }
 
   /**
@@ -204,7 +208,10 @@ export class FieldTable extends Component {
       className: 'coveo-field-table-toggle-caption'
     }).el;
 
-    this.toggleButton = $$('div', { className: 'coveo-field-table-toggle coveo-field-table-toggle-down' }).el;
+    this.toggleButton = $$('div', {
+      className: 'coveo-field-table-toggle coveo-field-table-toggle-down',
+      ariaControls: this.toggleContainer.id
+    }).el;
     this.toggleButtonSVGContainer = $$('span', null, SVGIcons.icons.arrowDown).el;
     SVGDom.addClassToSVGInContainer(this.toggleButtonSVGContainer, 'coveo-field-table-toggle-down-svg');
     this.toggleButton.appendChild(this.toggleCaption);
@@ -236,7 +243,7 @@ export class FieldTable extends Component {
       .withElement(this.toggleButton)
       .withSelectAction(() => toggleAction())
       .withOwner(this.bind)
-      .withLabel(l('Toggle'))
+      .withLabel(l('Details'))
       .build();
 
     $$(this.toggleButtonInsideTable).on('click', toggleAction);

--- a/unitTests/ui/FieldTableTest.ts
+++ b/unitTests/ui/FieldTableTest.ts
@@ -73,12 +73,8 @@ export function FieldTableTest() {
       });
 
       describe('allowMinimization set to true', function() {
-        function toggleContainer() {
-          return $$(test.env.root).find('.coveo-field-table-toggle-container');
-        }
-
         function setToggleContainerScrollHeight(height: number) {
-          Object.defineProperty(toggleContainer(), 'scrollHeight', { value: height, writable: true });
+          Object.defineProperty(findToggleContainer(), 'scrollHeight', { value: height, writable: true });
         }
 
         beforeEach(function() {
@@ -160,7 +156,7 @@ export function FieldTableTest() {
         it(`given a toggle container with a zero scrollHeight,
         when calling #expand after the container has a non-zero scrollHeight,
         it sets the height of the container to the new value`, () => {
-          const container = toggleContainer();
+          const container = findToggleContainer();
 
           expect(container.scrollHeight).toBe(0);
 
@@ -168,7 +164,7 @@ export function FieldTableTest() {
           setToggleContainerScrollHeight(newScrollHeight);
           test.cmp.expand();
 
-          expect(toggleContainer().style.height).toBe(`${newScrollHeight}px`);
+          expect(findToggleContainer().style.height).toBe(`${newScrollHeight}px`);
         });
 
         it(`given a toggle container with a non-zero scrollHeight,
@@ -177,7 +173,7 @@ export function FieldTableTest() {
           // When retreiving the scrollHeight on every expand, I saw an animation lag when
           // expanding and minimizing quickly. So we use memoization, and only update the value if it is falsy.
           const scrollHeight1 = 100;
-          const container = toggleContainer();
+          const container = findToggleContainer();
 
           setToggleContainerScrollHeight(scrollHeight1);
           test.cmp.updateToggleHeight();
@@ -189,7 +185,7 @@ export function FieldTableTest() {
           setToggleContainerScrollHeight(scrollHeight2);
           test.cmp.expand();
 
-          expect(toggleContainer().style.height).toBe(`${scrollHeight1}px`);
+          expect(findToggleContainer().style.height).toBe(`${scrollHeight1}px`);
         });
 
         it('minimizedByDefault set to true should initialize the table in a minimized state', function() {

--- a/unitTests/ui/FieldTableTest.ts
+++ b/unitTests/ui/FieldTableTest.ts
@@ -3,6 +3,7 @@ import { FieldTable } from '../../src/ui/FieldTable/FieldTable';
 import { $$ } from '../../src/utils/Dom';
 import { FakeResults } from '../Fake';
 import { IFieldTableOptions } from '../../src/ui/FieldTable/FieldTable';
+import { l } from '../../src/strings/Strings';
 
 export function FieldTableTest() {
   describe('FieldTable', function() {
@@ -13,6 +14,18 @@ export function FieldTableTest() {
       element = $$('table', { className: 'CoveoFieldTable' }).el;
       element.appendChild($$('tr', { 'data-field': '@author', 'data-caption': 'Author' }).el);
     };
+
+    function findToggleButton() {
+      return $$(test.env.root).find('.coveo-field-table-toggle');
+    }
+
+    function findToggleCaption() {
+      return $$(test.env.root).find('.coveo-field-table-toggle-caption');
+    }
+
+    function findToggleContainer() {
+      return $$(test.env.root).find('.coveo-field-table-toggle-container');
+    }
 
     beforeEach(function() {
       test = Mock.advancedResultComponentSetup<FieldTable>(FieldTable, FakeResults.createFakeResult(), <Mock.AdvancedComponentSetupOptions>{
@@ -42,7 +55,7 @@ export function FieldTableTest() {
         });
 
         it('should not wrap table in a toggle container', function() {
-          expect($$(test.env.element).find('.coveo-field-table-toggle-container')).toBeNull();
+          expect(findToggleContainer()).toBeNull();
         });
 
         it('should be expanded', function() {
@@ -75,15 +88,11 @@ export function FieldTableTest() {
         });
 
         it('should show a toggle link', function() {
-          expect($$(test.env.root).find('.coveo-field-table-toggle')).not.toBeNull();
+          expect(findToggleButton()).not.toBeNull();
         });
 
         it('should put the tabindex to 0 on the toggle caption', function() {
-          expect(
-            $$(test.env.root)
-              .find('.coveo-field-table-toggle')
-              .getAttribute('tabindex')
-          ).toBe('0');
+          expect(findToggleButton().getAttribute('tabindex')).toBe('0');
         });
 
         it('should wrap the table in a toggle container', function() {
@@ -102,7 +111,7 @@ export function FieldTableTest() {
               }
             }
           );
-          let toggle = $$(test.env.root).find('.coveo-field-table-toggle-caption');
+          let toggle = findToggleCaption();
           test.cmp.expand();
           expect(toggle.textContent).toBe('foobar2000');
           test.cmp.minimize();
@@ -111,7 +120,7 @@ export function FieldTableTest() {
 
         it('expandedTitle should be the localized version of "Details" by default', function() {
           test.cmp.expand();
-          let toggle = $$(test.env.root).find('.coveo-field-table-toggle-caption');
+          let toggle = findToggleCaption();
           expect(toggle.textContent).toBe('Details'.toLocaleString());
         });
 
@@ -127,7 +136,7 @@ export function FieldTableTest() {
               }
             }
           );
-          let toggle = $$(test.env.root).find('.coveo-field-table-toggle-caption');
+          let toggle = findToggleCaption();
           test.cmp.minimize();
           expect(toggle.textContent).toBe('foobar2000');
           test.cmp.expand();
@@ -136,7 +145,7 @@ export function FieldTableTest() {
 
         it('minimizedTitle should be the localized version of "Details" by default', function() {
           test.cmp.minimize();
-          let toggle = $$(test.env.root).find('.coveo-field-table-toggle-caption');
+          let toggle = findToggleCaption();
           expect(toggle.textContent).toBe('Details'.toLocaleString());
         });
 
@@ -160,6 +169,26 @@ export function FieldTableTest() {
             FakeResults.createFakeResult()
           );
           expect(test.cmp.isExpanded).toBe(true);
+        });
+
+        it('toggle should set aria-expanded to its expanded state', () => {
+          test.cmp.minimize();
+          test.cmp.toggle();
+          expect(findToggleButton().getAttribute('aria-expanded')).toBe('true');
+          test.cmp.toggle();
+          expect(findToggleButton().getAttribute('aria-expanded')).toBe('false');
+        });
+
+        it('should give the toggleable container a unique id', () => {
+          expect(findToggleContainer().id.match(/[0-9]$/)).not.toBeNull();
+        });
+
+        it('should give the toggle button an aria-controls attribute', () => {
+          expect(findToggleButton().getAttribute('aria-controls')).toEqual(findToggleContainer().id);
+        });
+
+        it('should gibe the toggle button an appropriate label', () => {
+          expect(findToggleButton().getAttribute('aria-label')).toEqual(l('Details'));
         });
       });
     });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2937

This PR improves accessibility for `FieldTable` in its toggleable state by making the following changes:
* Giving the "Details" button a "Details" `aria-label`
* Giving the "Details" button an `aria-expanded` attribute
* Giving the "Details" button an `aria-controls` attribute
* Giving the collapsible details container a unique id

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)