### PR TITLE
JSUI-2938 Attempt to self-heal toggleContainer height if falsy

### DIFF
--- a/src/ui/FieldTable/FieldTable.ts
+++ b/src/ui/FieldTable/FieldTable.ts
@@ -226,9 +226,7 @@ export class FieldTable extends Component {
       this.isExpanded = !QueryUtils.hasExcerpt(this.result);
     }
 
-    setTimeout(() => {
-      this.updateToggleHeight();
-    }); // Wait until toggleContainer.scrollHeight is computed.
+    this.updateToggleHeight();
 
     const toggleAction = () => this.toggle(true);
 
@@ -246,17 +244,26 @@ export class FieldTable extends Component {
     if (!anim) {
       $$(this.toggleContainer).addClass('coveo-no-transition');
     }
+
     if (visible) {
       this.toggleContainer.style.display = 'block';
-      this.toggleContainer.style.height = this.toggleContainerHeight + 'px';
+      this.toggleContainer.style.height = this.containerHeight;
     } else {
-      this.toggleContainer.style.height = this.toggleContainerHeight + 'px';
+      this.toggleContainer.style.height = this.containerHeight;
       this.toggleContainer.style.height = '0';
     }
     if (!anim) {
       this.toggleContainer.offsetHeight; // Force reflow
       $$(this.toggleContainer).removeClass('coveo-no-transition');
     }
+  }
+
+  private get containerHeight() {
+    if (!this.toggleContainerHeight) {
+      this.updateToggleContainerHeight();
+    }
+
+    return this.toggleContainerHeight + 'px';
   }
 
   private updateToggleContainerHeight() {

--- a/src/ui/FieldTable/FieldTable.ts
+++ b/src/ui/FieldTable/FieldTable.ts
@@ -249,7 +249,6 @@ export class FieldTable extends Component {
       this.toggleContainer.style.display = 'block';
       this.toggleContainer.style.height = this.containerHeight;
     } else {
-      this.toggleContainer.style.height = this.containerHeight;
       this.toggleContainer.style.height = '0';
     }
     if (!anim) {

--- a/unitTests/ui/FieldTableTest.ts
+++ b/unitTests/ui/FieldTableTest.ts
@@ -60,6 +60,14 @@ export function FieldTableTest() {
       });
 
       describe('allowMinimization set to true', function() {
+        function toggleContainer() {
+          return $$(test.env.root).find('.coveo-field-table-toggle-container');
+        }
+
+        function setToggleContainerScrollHeight(height: number) {
+          Object.defineProperty(toggleContainer(), 'scrollHeight', { value: height, writable: true });
+        }
+
         beforeEach(function() {
           createElement();
           test = Mock.advancedResultComponentSetup<FieldTable>(
@@ -138,6 +146,42 @@ export function FieldTableTest() {
           test.cmp.minimize();
           let toggle = $$(test.env.root).find('.coveo-field-table-toggle-caption');
           expect(toggle.textContent).toBe('Details'.toLocaleString());
+        });
+
+        it(`given a toggle container with a zero scrollHeight,
+        when calling #expand after the container has a non-zero scrollHeight,
+        it sets the height of the container to the new value`, () => {
+          const container = toggleContainer();
+
+          expect(container.scrollHeight).toBe(0);
+
+          const newScrollHeight = 100;
+          setToggleContainerScrollHeight(newScrollHeight);
+          test.cmp.expand();
+
+          expect(toggleContainer().style.height).toBe(`${newScrollHeight}px`);
+        });
+
+        it(`given a toggle container with a non-zero scrollHeight,
+        when the container scrollHeight changes,
+        when calling #expand, it keeps the height of the container equal to the initial value`, () => {
+          // When retreiving the scrollHeight on every expand, I saw an animation lag when
+          // expanding and minimizing quickly. I decided to store the value in memory and only attempt to
+          // update it if it is falsy.
+          const scrollHeight1 = 100;
+          const container = toggleContainer();
+
+          setToggleContainerScrollHeight(scrollHeight1);
+          test.cmp.updateToggleHeight();
+
+          expect(scrollHeight1).not.toBe(0);
+          expect(container.scrollHeight).toBe(scrollHeight1);
+
+          const scrollHeight2 = scrollHeight1 + 1;
+          setToggleContainerScrollHeight(scrollHeight2);
+          test.cmp.expand();
+
+          expect(toggleContainer().style.height).toBe(`${scrollHeight1}px`);
         });
 
         it('minimizedByDefault set to true should initialize the table in a minimized state', function() {

--- a/unitTests/ui/FieldTableTest.ts
+++ b/unitTests/ui/FieldTableTest.ts
@@ -166,8 +166,7 @@ export function FieldTableTest() {
         when the container scrollHeight changes,
         when calling #expand, it keeps the height of the container equal to the initial value`, () => {
           // When retreiving the scrollHeight on every expand, I saw an animation lag when
-          // expanding and minimizing quickly. I decided to store the value in memory and only attempt to
-          // update it if it is falsy.
+          // expanding and minimizing quickly. So we use memoization, and only update the value if it is falsy.
           const scrollHeight1 = 100;
           const container = toggleContainer();
 

--- a/unitTests/ui/ThumbnailTest.ts
+++ b/unitTests/ui/ThumbnailTest.ts
@@ -58,7 +58,7 @@ export function ThumbnailTest() {
         fakeFieldTable.cmp.element.appendChild(test.cmp.element);
 
         setTimeout(function() {
-          expect(spyResize).toHaveBeenCalled();
+          expect(spyResize).not.toHaveBeenCalled();
           done();
         }, 0);
       });


### PR DESCRIPTION
The issue is intermittent, but sometimes after performing a query, expanding the field table does not work because the scrollHeight computed after a zero-second `setTimeout` returns `0`. Increasing the timeout could have worked, but rather than choosing an arbitrary number, I opted to self-heal when the user clicks to expand.

I initially tried to avoid using a variable, opting instead to retrieve the scroll height every time. I noticed some lag in the animation though, so reverted back to storing the value in memory.

I tried to add a unit test but hit a brick wall with every approach. I was not able to mock the `scrollHeight` property to a value other than `0`.

Edit: I found it's possible to mock read-only properties like `scrollHeight` by using `Object.defineProperty`. I added unit tests.

https://coveord.atlassian.net/browse/JSUI-2938





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)