### PR TITLE
[DOC-7054] Added availablesince tags for new releases

### DIFF
--- a/src/ui/CommerceQuery/CommerceQuery.ts
+++ b/src/ui/CommerceQuery/CommerceQuery.ts
@@ -12,6 +12,8 @@ export interface ICommerceQueryOptions {
 
 /**
  * This component exposes options to handle commerce-related queries.
+ *
+ * @availablesince [March 2020 Release (v2.8521)](https://docs.coveo.com/en/3203/)
  */
 export class CommerceQuery extends Component {
   static ID = 'CommerceQuery';

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -254,6 +254,8 @@ export class DynamicFacet extends Component implements IDynamicFacet {
      * By default, the dependent facet is displayed whenever one or more values are selected in its `dependsOn` facet.
      *
      * @externaldocs [Defining Dependent Facets](https://docs.coveo.com/3210/)
+     *
+     * @availablesince [April 2020 Release (v2.8864)](https://docs.coveo.com/en/3231/)
      */
     dependsOnCondition: ComponentOptions.buildCustomOption<IDependentFacetCondition>(
       () => {
@@ -274,9 +276,11 @@ export class DynamicFacet extends Component implements IDynamicFacet {
     /**
      * Whether to exclude folded result parents when estimating result counts for facet values.
      *
-     * See also the [`Folding`]{@link folding} and [`FoldingForThread`]{@link FoldingForThread} components.
+     * See also the [`Folding`]{@link Folding} and [`FoldingForThread`]{@link FoldingForThread} components.
      *
      * **Default:** `false` if folded results are requested; `true` otherwise.
+     *
+     * @availablesince [March 2020 Release (v2.8521)](https://docs.coveo.com/en/3203/)
      */
     filterFacetCount: ComponentOptions.buildBooleanOption({ section: 'Filtering' })
   };

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -214,6 +214,8 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
      * **Default (Search API):** `occurrences`.
      *
      * @examples alphanumeric
+     *
+     * @availablesince [March 2020 Release (v2.8521)](https://docs.coveo.com/en/3203/)
      */
     sortCriteria: <HierarchicalFacetSortCriteria>ComponentOptions.buildStringOption({
       postProcessing: value => {
@@ -253,6 +255,8 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
      * - Values that do not have the specified base path will not be displayed in the facet.
      *
      * @examples electronics, electronics\,laptops
+     *
+     * @availablesince [April 2020 Release (v2.8864)](https://docs.coveo.com/en/3231/)
      */
     basePath: ComponentOptions.buildListOption<string>({ defaultValue: [] }),
     ...ResponsiveFacetOptions

--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -481,6 +481,8 @@ export class SearchInterface extends RootComponent implements IComponentBindings
     /**
      * Specifies whether to restore the last scroll position when navigating back
      * to the search interface.
+     *
+     * @availablesince [March 2020 Release (v2.8521)](https://docs.coveo.com/en/3203/)
      */
     enableScrollRestoration: ComponentOptions.buildBooleanOption({ defaultValue: false })
   };

--- a/src/ui/SimpleFilter/SimpleFilter.ts
+++ b/src/ui/SimpleFilter/SimpleFilter.ts
@@ -168,6 +168,7 @@ export class SimpleFilter extends Component {
     /**
      * Whether to show a button to clear all selected values.
      *
+     * @availablesince [March 2020 Release (v2.8521)](https://docs.coveo.com/en/3203/)
      */
     enableClearButton: ComponentOptions.buildBooleanOption({ defaultValue: false })
   };

--- a/src/ui/SortDropdown/SortDropdown.ts
+++ b/src/ui/SortDropdown/SortDropdown.ts
@@ -26,6 +26,8 @@ import { l } from '../../strings/Strings';
  * </div>
  * ```
  * Each one of the children `Sort` components should have only one sort criteria to prevent the regular toggle behaviour.
+ *
+ * @availablesince [March 2020 Release (v2.8521)](https://docs.coveo.com/en/3203/)
  */
 export class SortDropdown extends Component {
   static ID = 'SortDropdown';


### PR DESCRIPTION
* Added `@availablesince` tags for components mentioned in March and April 2020 releases.
* Fixed broken link.





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)