### PR TITLE
JSUI-2945 The more button of the reponsive tabs now uses an overlay to capture clickaway

### DIFF
--- a/sass/_ResponsiveTabs.scss
+++ b/sass/_ResponsiveTabs.scss
@@ -63,7 +63,8 @@
 
 .coveo-tab-list-container {
   max-width: 80%;
-  z-index: 11;
+  z-index: 999;
+  box-shadow: 0 7px 15px rgba(0, 0, 0, 0.25);
 
   ol {
     margin: 0;

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
@@ -143,13 +143,13 @@ export class ResponsiveDropdown {
     let dropdownContentPreviousSibling = this.dropdownContent.element.el.previousSibling;
     let dropdownContentParent = this.dropdownContent.element.el.parentElement;
     this.previousSibling = dropdownContentPreviousSibling ? $$(<HTMLElement>dropdownContentPreviousSibling) : null;
-    this.parent = $$(dropdownContentParent);
+    this.parent = dropdownContentParent ? $$(dropdownContentParent) : null;
   }
 
   private restoreContentPosition() {
     if (this.previousSibling) {
       this.dropdownContent.element.insertAfter(this.previousSibling.el);
-    } else {
+    } else if (this.parent) {
       this.parent.prepend(this.dropdownContent.element.el);
     }
   }

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent.ts
@@ -15,6 +15,8 @@ export interface IResponsiveDropdownContent {
 export class ResponsiveDropdownContent implements IResponsiveDropdownContent {
   public static DEFAULT_CSS_CLASS_NAME = 'coveo-dropdown-content';
 
+  public referenceClassname = ResponsiveComponentsManager.DROPDOWN_HEADER_WRAPPER_CSS_CLASS;
+
   private coveoRoot: Dom;
   private cssClassName: string;
 
@@ -89,7 +91,7 @@ export class ResponsiveDropdownContent implements IResponsiveDropdownContent {
   }
 
   private createPopper() {
-    const referenceElement = this.coveoRoot.find(`.${ResponsiveComponentsManager.DROPDOWN_HEADER_WRAPPER_CSS_CLASS}`);
+    const referenceElement = this.coveoRoot.find(`.${this.referenceClassname}`);
     this.popperReference = new PopperJs(referenceElement, this.element.el, {
       placement: 'bottom-end',
       positionFixed: true,

--- a/unitTests/ui/ResponsiveComponents/ResponsiveTabsTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveTabsTest.ts
@@ -1,16 +1,18 @@
 import { range, last } from 'underscore';
-import { Component } from '../../../src/Core';
+import { Component, ResponsiveDropdown, KEYBOARD } from '../../../src/Core';
 import { ResponsiveComponents } from '../../../src/ui/ResponsiveComponents/ResponsiveComponents';
 import { ResponsiveComponentsUtils } from '../../../src/ui/ResponsiveComponents/ResponsiveComponentsUtils';
 import { ResponsiveTabs } from '../../../src/ui/ResponsiveComponents/ResponsiveTabs';
 import { Tab } from '../../../src/ui/Tab/Tab';
 import { $$, Dom } from '../../../src/utils/Dom';
 import { SearchInterface } from '../../../src/ui/SearchInterface/SearchInterface';
+import { Simulate } from '../../Simulate';
 
 export function ResponsiveTabsTest() {
   let root: Dom;
   let responsiveTabs: ResponsiveTabs;
   let tabSection: Dom;
+  let navigableSection: Dom;
   let tabs: Dom[];
 
   describe('ResponsiveTabs', () => {
@@ -18,6 +20,8 @@ export function ResponsiveTabsTest() {
       root = $$('div');
       tabSection = $$('div', { className: 'coveo-tab-section' });
       root.append(tabSection.el);
+      navigableSection = $$('div', { tabIndex: 20 });
+      root.append(navigableSection.el);
       tabs = [];
       range(0, 5).forEach(tabNumber => {
         const tab = $$('div', {
@@ -239,6 +243,42 @@ export function ResponsiveTabsTest() {
 
           const selectedTabInDropdown = container.find(`div[data-id="${lastId}"]`);
           expect(selectedTabInDropdown).toBeNull();
+        });
+      });
+    });
+
+    describe('When tabs are overflowing', () => {
+      describe('When the dropdown header is clicked', () => {
+        beforeEach(() => {
+          responsiveTabs.handleResizeEvent();
+          $$(root.find('.coveo-dropdown-header')).trigger('click');
+        });
+
+        it('should open the dropdown content', () => {
+          expect(root.find('.coveo-dropdown-content')).not.toBeNull();
+          expect(root.find(`.${ResponsiveDropdown.DROPDOWN_BACKGROUND_CSS_CLASS_NAME}`)).not.toBeNull();
+        });
+
+        it('should close the dropdown content when the dowpdown header is clicked again', () => {
+          $$(root.find('.coveo-dropdown-header')).trigger('click');
+          expect(root.find('.coveo-dropdown-content')).toBeNull();
+        });
+
+        it('should close the dropdown content when the dowpdown overlay is clicked', () => {
+          $$(root.find(`.${ResponsiveDropdown.DROPDOWN_BACKGROUND_CSS_CLASS_NAME}`)).trigger('click');
+          expect(root.find('.coveo-dropdown-content')).toBeNull();
+        });
+      });
+
+      describe('When the dropdown header is focused with keyboard navigation', () => {
+        beforeEach(() => {
+          responsiveTabs.handleResizeEvent();
+          $$(root.find('.coveo-dropdown-header')).trigger('focus');
+          Simulate.keyUp(root.find('.coveo-dropdown-header'), KEYBOARD.ENTER);
+        });
+
+        it('should open the dropdown content', () => {
+          expect(root.find('.coveo-dropdown-content')).not.toBeNull();
         });
       });
     });


### PR DESCRIPTION
## What was changed ?
The `more` button of the reponsive tabs now uses an overlay to capture clickaway instead of an event listener on `documentElement`.

See https://share.vidyard.com/watch/H3wvMTCagX1oJMvyHyc2QN?

## Why was it changed ?
In Salesforce, event target are not available to event listener attached to `document.documentElement`.

## What was tested ?
* Keyboard navigation
* Mobile navigation
* Mouse navigation
* Tested in Salesforce

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)