### PR TITLE
JSUI-2936 Removed `data-color` overrides in some templates

### DIFF
--- a/templates/Email/CardEmailThread.html
+++ b/templates/Email/CardEmailThread.html
@@ -9,24 +9,24 @@
   </div>
   <div class="coveo-result-row">
     <div class="coveo-result-cell" style="margin-right: 10px">
-      <div class="CoveoText" data-value="From" data-weight="bold" data-color="#1D4F76"></div>
+      <div class="CoveoText" data-value="From" data-weight="bold"></div>
       <div class="CoveoFieldValue" style="overflow: hidden; text-overflow: ellipsis;" data-field="@from" data-helper="email" data-html-value="true"></div>
     </div>
     <div class="coveo-result-cell">
-      <div class="CoveoText" data-value="To" data-weight="bold" data-color="#1D4F76"></div>
+      <div class="CoveoText" data-value="To" data-weight="bold"></div>
       <div class="CoveoFieldValue" style="overflow: hidden; text-overflow: ellipsis;" data-field="@recipients" data-helper="email" data-html-value="true"></div>
     </div>
   </div>
   <div class="coveo-result-row">
     <div class="coveo-result-cell" style="padding-top:5px; padding-bottom:5px">
-      <div class="CoveoText" data-value="Description" data-weight="bold" data-color="#1D4F76"> </div>
+      <div class="CoveoText" data-value="Description" data-weight="bold"> </div>
       <span class="CoveoExcerpt">
       </span>
     </div>
   </div>
   <div class="coveo-result-row">
     <div class="coveo-result-cell">
-      <div class="CoveoText" data-value="Date" data-weight="bold" data-color="#1D4F76"></div>
+      <div class="CoveoText" data-value="Date" data-weight="bold"></div>
       <div class="CoveoFieldValue" data-field="@date" data-helper="emailDateTime" data-helper-options-always-include-time="true"></div>
     </div>
   </div>

--- a/templates/GoogleDrive/CardGoogleDrive.html
+++ b/templates/GoogleDrive/CardGoogleDrive.html
@@ -10,20 +10,20 @@
   </div>
   <div class="coveo-result-row">
     <div class="coveo-result-cell" style="padding-top:5px; padding-bottom:5px">
-      <div class="CoveoText" data-value="Description" data-weight="bold" data-color="#1D4F76"></div>
+      <div class="CoveoText" data-value="Description" data-weight="bold"></div>
       <span class="CoveoExcerpt">
       </span>
     </div>
   </div>
   <div class="coveo-result-row">
     <div class="coveo-result-cell">
-      <div class="CoveoText" data-value="Date" data-weight="bold" data-color="#1D4F76"></div>
+      <div class="CoveoText" data-value="Date" data-weight="bold"></div>
       <span class="CoveoFieldValue" data-field="@date" data-helper="date"></span>
     </div>
   </div>
   <div class="coveo-result-row">
     <div class="coveo-result-cell">
-      <div class="CoveoText" data-value="Author" data-weight="bold" data-color="#1D4F76"></div>
+      <div class="CoveoText" data-value="Author" data-weight="bold"></div>
       <span class="CoveoFieldValue" data-field="@author"></span>
     </div>
   </div>


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2936

A previous PR improved the contrast of most templates by changing the heading colors in card templates to be black (like the card on the left) instead of blue (like the card on the right).
![image](https://user-images.githubusercontent.com/54454747/79782993-f5ceb680-830d-11ea-882a-af1ff615a638.png)
Unfortunately, `CardEmailThread` and `CardGoogleDrive` kept the same colors since they explicitly chose their headings' text color using `data-color`. This PR fixes this issue by removing this attribute.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)