### PR TITLE
JSUI-2945 Fix an issue where the more button was not able to open in Salesforce

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveTabs.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveTabs.ts
@@ -33,7 +33,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
 
   private documentClickListener: EventListener;
   private dropdownClickListener: EventListener;
-  private ignoreNextClick = false;
+  private ignoreNextDocumentClick = false;
 
   constructor(private coveoRoot: Dom, public ID: string) {
     this.dropdownHeaderLabel = this.getDropdownHeaderLabel();
@@ -235,7 +235,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
       }
 
       if (event.type === 'click') {
-        this.ignoreNextClick = true;
+        this.ignoreNextDocumentClick = true;
       }
     };
     new AccessibleButton()
@@ -257,15 +257,15 @@ export class ResponsiveTabs implements IResponsiveComponent {
   private bindDropdownContentEvents() {
     this.dropdownClickListener = () => {
       if (this.isDropdownOpen()) {
-        this.ignoreNextClick = true;
+        this.ignoreNextDocumentClick = true;
       }
     };
 
     this.documentClickListener = event => {
-      if (!this.ignoreNextClick) {
+      if (!this.ignoreNextDocumentClick) {
         this.closeDropdown();
       }
-      this.ignoreNextClick = false;
+      this.ignoreNextDocumentClick = false;
     };
     $$(this.dropdownHeader).on('click', this.dropdownClickListener);
     $$(this.dropdownContent).on('click', this.dropdownClickListener);

--- a/src/ui/ResponsiveComponents/ResponsiveTabs.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveTabs.ts
@@ -22,14 +22,18 @@ export class ResponsiveTabs implements IResponsiveComponent {
   private static DROPDOWN_HEADER_LABEL_DEFAULT_VALUE = 'More';
   private static TAB_IN_DROPDOWN_CSS_CLASS = 'coveo-tab-dropdown';
   private static TAB_IN_DROPDOWN_HEADER_CSS_CLASS = `${ResponsiveTabs.TAB_IN_DROPDOWN_CSS_CLASS}-header`;
+  private static ACTIVE_DROPDOWN_CSS_CLASS = 'coveo-dropdown-header-active';
   private static logger: Logger;
   private dropdownHeader: Dom;
   private dropdownContent: Dom;
   private tabSection: Dom;
-  private documentClickListener: EventListener;
   private searchInterface: SearchInterface;
   private dropdownHeaderLabel: string;
   private initialTabOrder: HTMLElement[];
+
+  private documentClickListener: EventListener;
+  private dropdownClickListener: EventListener;
+  private ignoreNextClick = false;
 
   constructor(private coveoRoot: Dom, public ID: string) {
     this.dropdownHeaderLabel = this.getDropdownHeaderLabel();
@@ -66,7 +70,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
       this.removeTabsFromDropdown();
     }
 
-    if (this.dropdownHeader.hasClass('coveo-dropdown-header-active')) {
+    if (this.isDropdownOpen()) {
       this.positionPopup();
     }
   }
@@ -223,12 +227,15 @@ export class ResponsiveTabs implements IResponsiveComponent {
   }
 
   private bindDropdownHeaderEvents() {
-    const toggle = () => {
-      if (!this.dropdownHeader.hasClass('coveo-dropdown-header-active')) {
-        this.positionPopup();
-        this.dropdownHeader.addClass('coveo-dropdown-header-active');
-      } else {
+    const toggle = (event: Event) => {
+      if (this.isDropdownOpen()) {
         this.closeDropdown();
+      } else {
+        this.openDropdown();
+      }
+
+      if (event.type === 'click') {
+        this.ignoreNextClick = true;
       }
     };
     new AccessibleButton()
@@ -248,24 +255,36 @@ export class ResponsiveTabs implements IResponsiveComponent {
   }
 
   private bindDropdownContentEvents() {
-    this.documentClickListener = event => {
-      if (Utils.isHtmlElement(event.target)) {
-        const eventTarget = $$(<HTMLElement>event.target);
-        if (
-          !eventTarget.closest('coveo-tab-list-container') &&
-          !eventTarget.closest(ResponsiveTabs.TAB_IN_DROPDOWN_HEADER_CSS_CLASS) &&
-          !eventTarget.closest(ResponsiveTabs.TAB_IN_DROPDOWN_CSS_CLASS)
-        ) {
-          this.closeDropdown();
-        }
+    this.dropdownClickListener = () => {
+      if (this.isDropdownOpen()) {
+        this.ignoreNextClick = true;
       }
     };
-    $$(document.documentElement).on('click', this.documentClickListener);
+
+    this.documentClickListener = event => {
+      if (!this.ignoreNextClick) {
+        this.closeDropdown();
+      }
+      this.ignoreNextClick = false;
+    };
+    $$(this.dropdownHeader).on('click', this.dropdownClickListener);
+    $$(this.dropdownContent).on('click', this.dropdownClickListener);
+  }
+
+  private isDropdownOpen(): boolean {
+    return this.dropdownHeader.hasClass(ResponsiveTabs.ACTIVE_DROPDOWN_CSS_CLASS);
   }
 
   private closeDropdown(): void {
+    $$(document.documentElement).off('click', this.documentClickListener);
     this.dropdownContent.detach();
-    this.dropdownHeader.removeClass('coveo-dropdown-header-active');
+    this.dropdownHeader.removeClass(ResponsiveTabs.ACTIVE_DROPDOWN_CSS_CLASS);
+  }
+
+  private openDropdown(): void {
+    $$(document.documentElement).on('click', this.documentClickListener);
+    this.positionPopup();
+    this.dropdownHeader.addClass(ResponsiveTabs.ACTIVE_DROPDOWN_CSS_CLASS);
   }
 
   private addToDropdownIfNeeded(tab: HTMLElement) {
@@ -297,7 +316,7 @@ export class ResponsiveTabs implements IResponsiveComponent {
   }
 
   private cleanUpDropdown() {
-    this.dropdownHeader.removeClass('coveo-dropdown-header-active');
+    this.dropdownHeader.removeClass(ResponsiveTabs.ACTIVE_DROPDOWN_CSS_CLASS);
     this.dropdownHeader.detach();
     this.dropdownContent.detach();
   }

--- a/unitTests/ui/ResponsiveComponents/ResponsiveTabsTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveTabsTest.ts
@@ -258,7 +258,7 @@ export function ResponsiveTabsTest() {
           expect(root.find('.coveo-tab-list-container')).not.toBeNull();
         });
 
-        it('should close the dropdown content when the dowpdown header is clicked again', () => {
+        it('should close the dropdown content when the dropdown header is clicked again', () => {
           $$(root.find('.coveo-dropdown-header')).trigger('click');
           expect(root.find('.coveo-tab-list-container')).toBeNull();
         });

--- a/unitTests/ui/ResponsiveComponents/ResponsiveTabsTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveTabsTest.ts
@@ -1,16 +1,18 @@
 import { range, last } from 'underscore';
-import { Component } from '../../../src/Core';
+import { Component, KEYBOARD } from '../../../src/Core';
 import { ResponsiveComponents } from '../../../src/ui/ResponsiveComponents/ResponsiveComponents';
 import { ResponsiveComponentsUtils } from '../../../src/ui/ResponsiveComponents/ResponsiveComponentsUtils';
 import { ResponsiveTabs } from '../../../src/ui/ResponsiveComponents/ResponsiveTabs';
 import { Tab } from '../../../src/ui/Tab/Tab';
 import { $$, Dom } from '../../../src/utils/Dom';
 import { SearchInterface } from '../../../src/ui/SearchInterface/SearchInterface';
+import { Simulate } from '../../Simulate';
 
 export function ResponsiveTabsTest() {
   let root: Dom;
   let responsiveTabs: ResponsiveTabs;
   let tabSection: Dom;
+  let navigableSection: Dom;
   let tabs: Dom[];
 
   describe('ResponsiveTabs', () => {
@@ -18,6 +20,8 @@ export function ResponsiveTabsTest() {
       root = $$('div');
       tabSection = $$('div', { className: 'coveo-tab-section' });
       root.append(tabSection.el);
+      navigableSection = $$('div', { tabIndex: 20 });
+      root.append(navigableSection.el);
       tabs = [];
       range(0, 5).forEach(tabNumber => {
         const tab = $$('div', {
@@ -239,6 +243,36 @@ export function ResponsiveTabsTest() {
 
           const selectedTabInDropdown = container.find(`div[data-id="${lastId}"]`);
           expect(selectedTabInDropdown).toBeNull();
+        });
+      });
+    });
+
+    describe('When tabs are overflowing', () => {
+      describe('When the dropdown header is clicked', () => {
+        beforeEach(() => {
+          responsiveTabs.handleResizeEvent();
+          $$(root.find('.coveo-dropdown-header')).trigger('click');
+        });
+
+        it('should open the dropdown content', () => {
+          expect(root.find('.coveo-tab-list-container')).not.toBeNull();
+        });
+
+        it('should close the dropdown content when the dowpdown header is clicked again', () => {
+          $$(root.find('.coveo-dropdown-header')).trigger('click');
+          expect(root.find('.coveo-tab-list-container')).toBeNull();
+        });
+      });
+
+      describe('When the dropdown header is focused with keyboard navigation', () => {
+        beforeEach(() => {
+          responsiveTabs.handleResizeEvent();
+          $$(root.find('.coveo-dropdown-header')).trigger('focus');
+          Simulate.keyUp(root.find('.coveo-dropdown-header'), KEYBOARD.ENTER);
+        });
+
+        it('should open the dropdown content', () => {
+          expect(root.find('.coveo-tab-list-container')).not.toBeNull();
         });
       });
     });


### PR DESCRIPTION
What was changed ?
Added some wizardry to detect if a click originate from the more button or the more dropdown content.

Why was it changed ?
In Salesforce, event target are not available to event listener attached to document.documentElement.

What was tested ?
Keyboard navigation
Mobile navigation
Mouse navigation
Tested in Salesforce

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)