### PR TITLE
JSUI-2948 Stop updating the number of values of a "frozen" Facet

### DIFF
--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -2000,6 +2000,10 @@ export class Facet extends Component {
   }
 
   protected updateNumberOfValues() {
+    if (this.keepDisplayedValuesNextTime) {
+      return;
+    }
+
     if (this.currentPage <= 0) {
       // We're on the first page, let's reset the number of values to a minimum.
       this.currentPage = 0;

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -43,6 +43,15 @@ export function FacetTest() {
       test.env.queryStateModel.registerNewAttribute('f:@field:operator', 'or');
     }
 
+    function simulateQueryWithResults(numberOfValues = 10) {
+      const results = FakeResults.createFakeResults();
+      results.groupByResults = [FakeResults.createFakeGroupByResult('@field', 'foo', numberOfValues)];
+
+      Simulate.query(test.env, {
+        results: results
+      });
+    }
+
     afterEach(() => {
       test = null;
     });
@@ -406,12 +415,7 @@ export function FacetTest() {
         });
         test.cmp.selectValue('foo1');
 
-        var results = FakeResults.createFakeResults();
-        results.groupByResults = [FakeResults.createFakeGroupByResult('@field', 'foo', 10)];
-
-        Simulate.query(test.env, {
-          results: results
-        });
+        simulateQueryWithResults();
 
         expect(test.cmp.getEndpoint().search).not.toHaveBeenCalled();
 
@@ -421,9 +425,7 @@ export function FacetTest() {
         });
         test.cmp.selectValue('foo1');
 
-        Simulate.query(test.env, {
-          results: results
-        });
+        simulateQueryWithResults();
 
         expect(test.cmp.getEndpoint().search).toHaveBeenCalled();
       });
@@ -442,6 +444,24 @@ export function FacetTest() {
             })
           ])
         );
+      });
+
+      it(`when a query is successful and "keepDisplayedValuesNextTime" is false
+      the number of value should update`, () => {
+        test.cmp.numberOfValues = 13;
+        test.cmp.keepDisplayedValuesNextTime = false;
+
+        simulateQueryWithResults(test.cmp.options.numberOfValues);
+        expect(test.cmp.numberOfValues).toBe(test.cmp.options.numberOfValues);
+      });
+
+      it(`when a query is successful and "keepDisplayedValuesNextTime" is true
+      the number of value should not change`, () => {
+        test.cmp.numberOfValues = 13;
+        test.cmp.keepDisplayedValuesNextTime = true;
+
+        simulateQueryWithResults(test.cmp.options.numberOfValues);
+        expect(test.cmp.numberOfValues).toBe(13);
       });
 
       it('pageSize should specify the number of values for the more option', () => {
@@ -559,11 +579,7 @@ export function FacetTest() {
           field: '@field',
           customSort: ['foo3', 'foo1']
         });
-        var results = FakeResults.createFakeResults();
-        results.groupByResults = [FakeResults.createFakeGroupByResult('@field', 'foo', 10)];
-        Simulate.query(test.env, {
-          results: results
-        });
+        simulateQueryWithResults();
         expect(test.cmp.getDisplayedFacetValues()[0].value).toBe('foo3');
         expect(test.cmp.getDisplayedFacetValues()[1].value).toBe('foo1');
         expect(test.cmp.getDisplayedFacetValues()[2].value).toBe('foo0');
@@ -885,11 +901,7 @@ export function FacetTest() {
           field: '@field',
           enableMoreLess: true
         });
-        var results = FakeResults.createFakeResults();
-        results.groupByResults = [FakeResults.createFakeGroupByResult('@field', 'foo', 15)];
-        Simulate.query(test.env, {
-          results: results
-        });
+        simulateQueryWithResults(15);
 
         var more = $$(test.cmp.element).find('.coveo-facet-more');
         var less = $$(test.cmp.element).find('.coveo-facet-less');


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2948

When the number of selected/excluded facet values is higher than the numberOfValues option, unselecting/unexcluding a value will hide the last selected/excluded value, because we freeze displayed values on a user action. There is a simple solution, to stop updating the number of values when the facet is supposed to have the same values.

~I'll try to find a way to test this in the UTs although the change didn't make any UT fail 😅. Maybe an integration test might be good for this one too.~ Tests added!

### Before: 
![nonworkingfacetvalues](https://user-images.githubusercontent.com/4923043/80034005-a8904780-84bb-11ea-9a0b-343fc0321bdb.gif)

### After:
![workingfacetvalues](https://user-images.githubusercontent.com/4923043/80034035-b2b24600-84bb-11ea-8539-72db45d43510.gif)




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)