### PR TITLE
Uniformize Component.on/one/trigger jQuery detection

### DIFF
--- a/src/ui/Base/Component.ts
+++ b/src/ui/Base/Component.ts
@@ -185,10 +185,10 @@ export class ComponentEvents {
   public trigger(el: Dom, event: string, args?: Object);
   public trigger(arg: any, event: string, args?: Object) {
     this.wrapToCallIfEnabled(() => {
-      if (!this.shouldTreatElementAsJQuery(arg)) {
-        $$(arg).trigger(event, args);
-      } else {
+      if (this.shouldTreatElementAsJQuery(arg)) {
         arg.trigger(event, args);
+      } else {
+        $$(arg).trigger(event, args);
       }
     })(args);
   }

--- a/src/ui/Base/Component.ts
+++ b/src/ui/Base/Component.ts
@@ -95,12 +95,10 @@ export class ComponentEvents {
   public on(el: HTMLElement | Window | Document, event: string, handler: Function);
   public on(el: Dom, event: string, handler: Function);
   public on(arg: any, event: string, handler: Function) {
-    if (!JQueryUtils.getJQuery() || !JQueryUtils.isInstanceOfJQuery(arg)) {
-      var htmlEl: HTMLElement = arg;
-      $$(htmlEl).on(event, this.wrapToCallIfEnabled(handler));
+    if (this.shouldTreatElementAsJQuery(arg)) {
+      arg.on(event, this.wrapToCallIfEnabled(handler));
     } else {
-      var jq: Dom = arg;
-      jq.on(event, this.wrapToCallIfEnabled(handler));
+      $$(arg).on(event, this.wrapToCallIfEnabled(handler));
     }
   }
 
@@ -115,12 +113,10 @@ export class ComponentEvents {
   public one(el: HTMLElement, event: string, handler: Function);
   public one(el: Dom, event: string, handler: Function);
   public one(arg: any, event: string, handler: Function) {
-    if (arg instanceof HTMLElement) {
-      var htmlEl: HTMLElement = arg;
-      $$(htmlEl).one(event, this.wrapToCallIfEnabled(handler));
+    if (this.shouldTreatElementAsJQuery(arg)) {
+      arg.one(event, this.wrapToCallIfEnabled(handler));
     } else {
-      var jq: Dom = arg;
-      jq.one(event, this.wrapToCallIfEnabled(handler));
+      $$(arg).one(event, this.wrapToCallIfEnabled(handler));
     }
   }
 
@@ -189,12 +185,10 @@ export class ComponentEvents {
   public trigger(el: Dom, event: string, args?: Object);
   public trigger(arg: any, event: string, args?: Object) {
     this.wrapToCallIfEnabled(() => {
-      if (arg instanceof HTMLElement) {
-        var htmlEl: HTMLElement = arg;
-        $$(htmlEl).trigger(event, args);
+      if (!this.shouldTreatElementAsJQuery(arg)) {
+        $$(arg).trigger(event, args);
       } else {
-        var jq: Dom = arg;
-        jq.trigger(event, args);
+        arg.trigger(event, args);
       }
     })(args);
   }
@@ -211,7 +205,7 @@ export class ComponentEvents {
           if (args[0].detail) {
             args = [args[0].detail];
           }
-        } else if (args && JQueryUtils.isInstanceOfJqueryEvent(args[0])) {
+        } else if (args && this.shouldTreatEventAsJQuery(args[0])) {
           if (args[1] != undefined) {
             args = [args[1]];
           } else if (args[0].hasOwnProperty('originalEvent')) {
@@ -224,6 +218,25 @@ export class ComponentEvents {
         return func.apply(this.owner, args);
       }
     };
+  }
+
+  private shouldTreatElementAsJQuery(arg: any) {
+    if (Dom.useNativeJavaScriptEvents === true) {
+      return false;
+    }
+
+    if (JQueryUtils.getJQuery() && JQueryUtils.isInstanceOfJQuery(arg)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private shouldTreatEventAsJQuery(arg: any) {
+    if (Dom.useNativeJavaScriptEvents === true) {
+      return false;
+    }
+    return JQueryUtils.getJQuery() && JQueryUtils.isInstanceOfJqueryEvent(arg);
   }
 
   private getQueryStateEventName(eventType: string, attribute?: string): string {

--- a/unitTests/ui/ComponentEventsTest.ts
+++ b/unitTests/ui/ComponentEventsTest.ts
@@ -1,7 +1,7 @@
 import * as Mock from '../MockEnvironment';
 import { NoopComponent } from '../../src/ui/NoopComponent/NoopComponent';
 import { registerCustomMatcher } from '../CustomMatchers';
-import { $$ } from '../../src/utils/Dom';
+import { $$, Dom } from '../../src/utils/Dom';
 import { JQuery as $ } from '../JQueryModule';
 
 export function ComponentEventsTest() {
@@ -63,6 +63,27 @@ export function ComponentEventsTest() {
 
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy).toHaveBeenCalledWith({ bar: 'baz' });
+      });
+
+      describe('when useNativeJavaScriptEvents is set to true', () => {
+        beforeEach(() => {
+          Dom.useNativeJavaScriptEvents = true;
+        });
+        afterEach(() => {
+          Dom.useNativeJavaScriptEvents = null;
+        });
+
+        it('handle native events', () => {
+          test.env.root.click();
+
+          expect(spy).toHaveBeenCalledTimes(1);
+        });
+
+        it('handle jQuery events', () => {
+          $(test.env.root).click();
+
+          expect(spy).toHaveBeenCalled();
+        });
       });
     });
 

--- a/unitTests/ui/ComponentEventsTest.ts
+++ b/unitTests/ui/ComponentEventsTest.ts
@@ -69,6 +69,7 @@ export function ComponentEventsTest() {
         beforeEach(() => {
           Dom.useNativeJavaScriptEvents = true;
         });
+
         afterEach(() => {
           Dom.useNativeJavaScriptEvents = null;
         });
@@ -82,6 +83,11 @@ export function ComponentEventsTest() {
         it('handle jQuery events', () => {
           $(test.env.root).click();
 
+          expect(spy).toHaveBeenCalled();
+        });
+
+        it('allow to trigger event', () => {
+          test.cmp.bind.trigger(test.env.element, 'click');
           expect(spy).toHaveBeenCalled();
         });
       });


### PR DESCRIPTION
This PR should make it more "standard" across various methods inside `ComponentEvents` how to detect if jQuery should be used for event propagation or not.

It also adds some logic to leverage `Dom.useNativeJavaScriptEvents` as an additional condition/check.

https://coveord.atlassian.net/browse/JSUI-2950


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)