### PR TITLE
JSUI-2951 Part 2 Use new "getAllFacetsFromSearchInterface" throughout the application

### DIFF
--- a/src/ui/Base/InitializationPlaceholder.ts
+++ b/src/ui/Base/InitializationPlaceholder.ts
@@ -167,7 +167,7 @@ export class InitializationPlaceholder {
     // Render an arbitrary number of placeholder facet.
     // Facets should become usable on the first deferredQuerySuccess
 
-    const facetElements = ComponentsTypes.getAllFacetsElements(this.root);
+    const facetElements = ComponentsTypes.getAllFacetElementsFromElement(this.root);
     if (Utils.isNonEmptyArray(facetElements)) {
       const placeholders: Dom[] = [];
       _.each(facetElements, (facetElement: HTMLElement) => $$(facetElement).addClass(InitializationPlaceholder.INITIALIZATION_CLASS));

--- a/src/ui/DynamicFacetManager/DynamicFacetManager.ts
+++ b/src/ui/DynamicFacetManager/DynamicFacetManager.ts
@@ -33,6 +33,7 @@ export interface IDynamicManagerCompatibleFacet extends Component, IAutoLayoutAd
   dynamicFacetManager: DynamicFacetManager;
   hasActiveValues: boolean;
   isDynamicFacet: boolean;
+  isCollapsed: boolean;
 
   handleQueryResults(results: IQueryResults): void;
   putStateIntoQueryBuilder(queryBuilder: QueryBuilder): void;

--- a/src/ui/DynamicFacetManager/DynamicFacetManager.ts
+++ b/src/ui/DynamicFacetManager/DynamicFacetManager.ts
@@ -152,7 +152,7 @@ export class DynamicFacetManager extends Component {
   }
 
   private get allDynamicFacets(): IDynamicManagerCompatibleFacet[] {
-    const allFacetsInComponent = ComponentsTypes.getAllFacetsInstance(this.element);
+    const allFacetsInComponent = ComponentsTypes.getAllFacetInstancesFromElement(this.element);
     return <IDynamicManagerCompatibleFacet[]>allFacetsInComponent.filter(this.isDynamicFacet);
   }
 

--- a/src/ui/DynamicFacetManager/DynamicFacetManager.ts
+++ b/src/ui/DynamicFacetManager/DynamicFacetManager.ts
@@ -33,7 +33,6 @@ export interface IDynamicManagerCompatibleFacet extends Component, IAutoLayoutAd
   dynamicFacetManager: DynamicFacetManager;
   hasActiveValues: boolean;
   isDynamicFacet: boolean;
-  isCollapsed: boolean;
 
   handleQueryResults(results: IQueryResults): void;
   putStateIntoQueryBuilder(queryBuilder: QueryBuilder): void;

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1570,7 +1570,7 @@ export class Facet extends Component {
       return;
     }
 
-    const masterFacetComponent = ComponentsTypes.getAllFacetsInstance(this.root).filter((cmp: Facet) => {
+    const masterFacetComponent = ComponentsTypes.getAllFacetInstancesFromElement(this.root).filter((cmp: Facet) => {
       const idFacet = cmp instanceof Facet;
       return idFacet && cmp.options.id === this.options.dependsOn;
     }) as Facet[];

--- a/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
@@ -211,7 +211,7 @@ export class ResponsiveFacetColumn implements IResponsiveComponent {
 
   private getDropdownHeaderLabel() {
     let dropdownHeaderLabel: string;
-    ComponentsTypes.getAllFacetsInstance(this.coveoRoot.find('.coveo-facet-column')).forEach(facet => {
+    ComponentsTypes.getAllFacetInstancesFromElement(this.coveoRoot.find('.coveo-facet-column')).forEach(facet => {
       const options = facet.options as IResponsiveComponentOptions;
 
       if (!dropdownHeaderLabel && options.dropdownHeaderLabel) {

--- a/src/utils/ComponentsTypes.ts
+++ b/src/utils/ComponentsTypes.ts
@@ -24,7 +24,7 @@ export class ComponentsTypes {
     return ComponentsTypes.allFacetsType.map(type => `Coveo${type}`);
   }
 
-  public static getAllFacetsElements(root: HTMLElement | Dom) {
+  public static getAllFacetElementsFromElement(root: HTMLElement | Dom) {
     const selectors = ComponentsTypes.allFacetsClassname.map(className => `.${className}`).join(', ');
     const hasNoFacetChild = (element: HTMLElement) => !$$(element).findAll(selectors).length;
 
@@ -33,8 +33,8 @@ export class ComponentsTypes {
       .filter(hasNoFacetChild);
   }
 
-  public static getAllFacetsInstance(root: HTMLElement | Dom) {
-    return ComponentsTypes.getAllFacetsElements(root).map(element => Component.get(element) as Component);
+  public static getAllFacetInstancesFromElement(root: HTMLElement | Dom) {
+    return ComponentsTypes.getAllFacetElementsFromElement(root).map(element => Component.get(element) as Component);
   }
 
   public static getAllFacetsFromSearchInterface(searchInterface: IComponentsTypesSearchInterface) {

--- a/src/utils/DependsOnManager.ts
+++ b/src/utils/DependsOnManager.ts
@@ -78,7 +78,7 @@ export class DependsOnManager {
   }
 
   private get allFacetsInInterface() {
-    return ComponentsTypes.getAllFacetsInstance(this.facet.ref.root) as IDependsOnCompatibleFacet[];
+    return ComponentsTypes.getAllFacetsFromSearchInterface(this.facet.ref.searchInterface) as IDependsOnCompatibleFacet[];
   }
 
   private getParentFacet(component: IDependsOnCompatibleFacet) {

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -91,6 +91,11 @@ export class MockEnvironmentBuilder {
     return this;
   }
 
+  public withSearchInterface(searchInterface: SearchInterface) {
+    this.searchInterface = searchInterface ? searchInterface : this.searchInterface;
+    return this;
+  }
+
   public build(): IMockEnvironment {
     if (this.built) {
       return this.getBindings();
@@ -232,8 +237,18 @@ export function mockSearchInterface(): SearchInterface {
   m.getBindings = () => {
     return new MockEnvironmentBuilder().build() as any;
   };
+  mockComponentRegistration(m);
   m.ariaLive = mockAriaLive();
   return m;
+}
+
+function mockComponentRegistration(searchInterface: SearchInterface) {
+  const attachedComponents: { [type: string]: BaseComponent[] } = {};
+
+  (searchInterface.attachComponent as jasmine.Spy).and.callFake((type: string, component: BaseComponent) => {
+    attachedComponents[type] = attachedComponents[type] ? [...attachedComponents[type], component] : [component];
+  });
+  (searchInterface.getComponents as jasmine.Spy).and.callFake((type: string) => attachedComponents[type] || []);
 }
 
 function mockAriaLive(): IAriaLive {

--- a/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetTest.ts
@@ -650,6 +650,7 @@ export function CategoryFacetTest() {
             (builder: Mock.MockEnvironmentBuilder) => {
               builder.withQueryStateModel(test.env.queryStateModel);
               builder.withRoot(test.env.root);
+              builder.withSearchInterface(test.env.searchInterface);
               return builder;
             }
           )

--- a/unitTests/ui/DynamicFacet/DynamicFacetTestUtils.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetTestUtils.ts
@@ -35,9 +35,10 @@ export class DynamicFacetTestUtils {
           return builder;
         }
 
-        builder.withRoot(env.root);
-        builder.withQueryStateModel(env.queryStateModel);
-        builder.withSearchInterface(env.searchInterface);
+        builder
+          .withRoot(env.root)
+          .withQueryStateModel(env.queryStateModel)
+          .withSearchInterface(env.searchInterface);
         return builder;
       },
 

--- a/unitTests/ui/DynamicFacet/DynamicFacetTestUtils.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetTestUtils.ts
@@ -31,12 +31,13 @@ export class DynamicFacetTestUtils {
     return Mock.advancedComponentSetup<DynamicFacet>(DynamicFacet, <Mock.AdvancedComponentSetupOptions>{
       modifyBuilder: builder => {
         if (!env) {
-          builder = builder.withLiveQueryStateModel();
+          builder.withLiveQueryStateModel();
           return builder;
         }
 
-        builder = builder.withRoot(env.root);
-        builder = builder.withQueryStateModel(env.queryStateModel);
+        builder.withRoot(env.root);
+        builder.withQueryStateModel(env.queryStateModel);
+        builder.withSearchInterface(env.searchInterface);
         return builder;
       },
 

--- a/unitTests/ui/DynamicFacetManagerTest.ts
+++ b/unitTests/ui/DynamicFacetManagerTest.ts
@@ -20,6 +20,7 @@ export function DynamicFacetManagerTest() {
     let options: IDynamicFacetManagerOptions;
     let facets: DynamicFacet[];
     const getAllFacetsInstance = ComponentsTypes.getAllFacetsInstance;
+    const getAllFacetsFromSearchInterface = ComponentsTypes.getAllFacetsFromSearchInterface;
 
     beforeEach(() => {
       options = {};
@@ -29,6 +30,7 @@ export function DynamicFacetManagerTest() {
 
     afterAll(() => {
       ComponentsTypes.getAllFacetsInstance = getAllFacetsInstance;
+      ComponentsTypes.getAllFacetsFromSearchInterface = getAllFacetsFromSearchInterface;
     });
 
     function initializeFacets() {
@@ -56,6 +58,7 @@ export function DynamicFacetManagerTest() {
       spyOn(test.cmp.logger, 'warn');
 
       ComponentsTypes.getAllFacetsInstance = () => facets as any[];
+      ComponentsTypes.getAllFacetsFromSearchInterface = () => facets as any[];
     }
 
     function triggerAfterComponentsInitialization() {

--- a/unitTests/ui/DynamicFacetManagerTest.ts
+++ b/unitTests/ui/DynamicFacetManagerTest.ts
@@ -19,7 +19,7 @@ export function DynamicFacetManagerTest() {
     let test: Mock.IBasicComponentSetup<DynamicFacetManager>;
     let options: IDynamicFacetManagerOptions;
     let facets: DynamicFacet[];
-    const getAllFacetsInstance = ComponentsTypes.getAllFacetsInstance;
+    const getAllFacetInstancesFromElement = ComponentsTypes.getAllFacetInstancesFromElement;
     const getAllFacetsFromSearchInterface = ComponentsTypes.getAllFacetsFromSearchInterface;
 
     beforeEach(() => {
@@ -29,7 +29,7 @@ export function DynamicFacetManagerTest() {
     });
 
     afterAll(() => {
-      ComponentsTypes.getAllFacetsInstance = getAllFacetsInstance;
+      ComponentsTypes.getAllFacetInstancesFromElement = getAllFacetInstancesFromElement;
       ComponentsTypes.getAllFacetsFromSearchInterface = getAllFacetsFromSearchInterface;
     });
 
@@ -57,7 +57,7 @@ export function DynamicFacetManagerTest() {
       spyOn(test.cmp.logger, 'error');
       spyOn(test.cmp.logger, 'warn');
 
-      ComponentsTypes.getAllFacetsInstance = () => facets as any[];
+      ComponentsTypes.getAllFacetInstancesFromElement = () => facets as any[];
       ComponentsTypes.getAllFacetsFromSearchInterface = () => facets as any[];
     }
 
@@ -119,7 +119,7 @@ export function DynamicFacetManagerTest() {
       });
 
       it('should disable the component if it contains no DynamicFacet child', () => {
-        ComponentsTypes.getAllFacetsInstance = () => [];
+        ComponentsTypes.getAllFacetInstancesFromElement = () => [];
         triggerAfterComponentsInitialization();
         expect(test.cmp.disabled).toBe(true);
       });

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTestUtils.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTestUtils.ts
@@ -120,12 +120,13 @@ export class DynamicHierarchicalFacetTestUtils {
     return Mock.advancedComponentSetup<DynamicHierarchicalFacet>(DynamicHierarchicalFacet, <Mock.AdvancedComponentSetupOptions>{
       modifyBuilder: builder => {
         if (!env) {
-          builder = builder.withLiveQueryStateModel();
+          builder.withLiveQueryStateModel();
           return builder;
         }
 
-        builder = builder.withRoot(env.root);
-        builder = builder.withQueryStateModel(env.queryStateModel);
+        builder.withRoot(env.root);
+        builder.withQueryStateModel(env.queryStateModel);
+        builder.withSearchInterface(env.searchInterface);
         return builder;
       },
 

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTestUtils.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTestUtils.ts
@@ -124,9 +124,10 @@ export class DynamicHierarchicalFacetTestUtils {
           return builder;
         }
 
-        builder.withRoot(env.root);
-        builder.withQueryStateModel(env.queryStateModel);
-        builder.withSearchInterface(env.searchInterface);
+        builder
+          .withRoot(env.root)
+          .withQueryStateModel(env.queryStateModel)
+          .withSearchInterface(env.searchInterface);
         return builder;
       },
 

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -995,6 +995,7 @@ export function FacetTest() {
             (builder: Mock.MockEnvironmentBuilder) => {
               builder.withQueryStateModel(test.env.queryStateModel);
               builder.withRoot(test.env.root);
+              builder.withSearchInterface(test.env.searchInterface);
               return builder;
             }
           )

--- a/unitTests/utils/ComponentsTypesTest.ts
+++ b/unitTests/utils/ComponentsTypesTest.ts
@@ -40,14 +40,14 @@ export function ComponentsTypesTest() {
       });
 
       it('should be able to return all top level facets element', () => {
-        const allFacetsElements = ComponentsTypes.getAllFacetsElements(root);
+        const allFacetsElements = ComponentsTypes.getAllFacetElementsFromElement(root);
 
         expect(allFacetsElements.length).toBe(expectedFacets.length);
         allFacetsElements.forEach(element => expect(element instanceof HTMLDivElement).toBe(true));
       });
 
       it('should be able to return all top level facets instance', () => {
-        const allFacetsInstance = ComponentsTypes.getAllFacetsInstance(root);
+        const allFacetsInstance = ComponentsTypes.getAllFacetInstancesFromElement(root);
 
         expect(allFacetsInstance.length).toBe(expectedFacets.length);
         allFacetsInstance.forEach(facetInstance => expect(facetInstance instanceof Component).toBe(true));

--- a/unitTests/utils/DependsOnManagerTest.ts
+++ b/unitTests/utils/DependsOnManagerTest.ts
@@ -1,6 +1,8 @@
 import { $$ } from '../Test';
 import { IDependentFacet, DependsOnManager, IDependentFacetCondition, IDependsOnCompatibleFacet } from '../../src/utils/DependsOnManager';
 import { QueryStateModel, Component, QueryEvents, InitializationEvents } from '../../src/Core';
+import { mockSearchInterface } from '../MockEnvironment';
+import { SearchInterface } from '../../src/Eager';
 import { ComponentsTypes } from '../../src/utils/ComponentsTypes';
 
 export interface IDependsOnManagerTestMock {
@@ -11,14 +13,14 @@ export interface IDependsOnManagerTestMock {
 export function DependsOnManagerTest() {
   describe('DependsOnManager', () => {
     let root: HTMLElement;
+    let searchInterface: SearchInterface;
     let queryStateModel: QueryStateModel;
     let parentMock: IDependsOnManagerTestMock;
     let dependentMock: IDependsOnManagerTestMock;
-    const getAllFacetsInstance = ComponentsTypes.getAllFacetsInstance;
 
     function createMock(id: string, dependsOn?: string): IDependsOnManagerTestMock {
       const element = document.createElement('div');
-      const component = new Component(element, 'typeoffacet', { root }) as IDependsOnCompatibleFacet;
+      const component = new Component(element, ComponentsTypes.allFacetsType[0], { root, searchInterface }) as IDependsOnCompatibleFacet;
       component.queryStateModel = queryStateModel;
       component.options = {
         id,
@@ -60,16 +62,11 @@ export function DependsOnManagerTest() {
     }
 
     beforeEach(() => {
+      searchInterface = mockSearchInterface();
       root = document.createElement('div');
       queryStateModel = new QueryStateModel(root);
       parentMock = createMock('@parent');
       dependentMock = createMock('@dependent', '@parent');
-
-      ComponentsTypes.getAllFacetsInstance = () => [parentMock.facet.ref, dependentMock.facet.ref];
-    });
-
-    afterAll(() => {
-      ComponentsTypes.getAllFacetsInstance = getAllFacetsInstance;
     });
 
     it('the dependent facet is hidden at startup', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2951

Follow up to https://github.com/coveo/search-ui/pull/1486
- Use new method in other relevant parts of the code (duplicate facets, depends on)
- Rename older methods to something less confusing (open to other suggestions)
- Fix many UTs

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)