### PR TITLE
JSUI-2952 Fixed spacebar detection and `aria-expanded` attribute for `CategoryFacet`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run accessibilityTests
+- yarn run unitTests
+- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,7 @@ script:
 - yarn run injectTag
 - yarn run build
 - if [ "x$TRAVIS_TAG" != "x" ]; then yarn run minimize ; fi
-- yarn run unitTests
-- if [ "x$TRAVIS_TAG" != "x" ]; then yarn run accessibilityTests ; fi
+- yarn run accessibilityTests
 - set +e
 - yarn run uploadCoverage
 - set -e

--- a/src/ui/CategoryFacet/CategoryFacetSearch.ts
+++ b/src/ui/CategoryFacet/CategoryFacetSearch.ts
@@ -35,9 +35,13 @@ export class CategoryFacetSearch implements IFacetSearch {
     return CategoryFacet.ID;
   }
 
-  public setExpandedFacetSearchAccessibilityAttributes(searchResultsElements: HTMLElement) {}
+  public setExpandedFacetSearchAccessibilityAttributes(searchResultsElements: HTMLElement) {
+    this.container.setAttribute('aria-expanded', 'true');
+  }
 
-  public setCollapsedFacetSearchAccessibilityAttributes() {}
+  public setCollapsedFacetSearchAccessibilityAttributes() {
+    this.container.setAttribute('aria-expanded', 'false');
+  }
 
   public build() {
     this.container = $$('div', {

--- a/src/utils/AccessibleButton.ts
+++ b/src/utils/AccessibleButton.ts
@@ -151,12 +151,18 @@ export class AccessibleButton {
       this.bindEvent(
         'keydown',
         KeyboardUtils.keypressAction(KEYBOARD.SPACEBAR, (e: Event) => {
+          if (e.target instanceof HTMLInputElement) {
+            return;
+          }
           e.preventDefault();
         })
       );
       this.bindEvent(
         'keyup',
         KeyboardUtils.keypressAction(KEYBOARD.SPACEBAR, (e: Event) => {
+          if (e.target instanceof HTMLInputElement) {
+            return;
+          }
           this.enterKeyboardAction(e);
         })
       );

--- a/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
@@ -194,6 +194,27 @@ export function CategoryFacetSearchTest() {
       });
     });
 
+    describe('when expanding', () => {
+      beforeEach(done => {
+        categoryFacetSearch.displayNewValues();
+        setTimeout(done);
+      });
+
+      it('sets aria-expanded to true', () => {
+        expect(categoryFacetSearch.container.getAttribute('aria-expanded')).toEqual('true');
+      });
+
+      it('sets aria-expanded to false after collapsing', done => {
+        searchWithNoValues();
+        categoryFacetSearch.displayNewValues();
+
+        setTimeout(() => {
+          expect(categoryFacetSearch.container.getAttribute('aria-expanded')).toEqual('false');
+          done();
+        });
+      });
+    });
+
     describe('when selecting with the keyboard (using ENTER)', () => {
       let keyboardEvent: KeyboardEvent;
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2952

This PR aims to fix two issues:
1. The aria-expanded attribute should also be represented in `CategoryFacet`'s container, according to Deque
2. `CategoryFacetSearch` wouldn't allow spaces. This was found in a [Discuss post](https://discuss.coveo.com/t/dell-request-facetsearch-missing-in-dynamichierarchicalfacet/3655).

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)