### PR TITLE
Changed in what element the quickview creates the modalbox

### DIFF
--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -293,7 +293,7 @@ export class Quickview extends Component {
       });
     }
 
-    this.modalbox = new AccessibleModal('coveo-quick-view', element.ownerDocument.body as HTMLBodyElement, ModalBox);
+    this.modalbox = new AccessibleModal('coveo-quick-view', this.searchInterface.element, ModalBox);
   }
 
   private buildContent() {

--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -54,6 +54,7 @@ export interface IQuickviewOptions {
   loadingAnimation?: HTMLElement | Promise<HTMLElement>;
   alwaysShow?: boolean;
   tooltipPlacement?: ValidTooltipPlacement;
+  modalContainer?: HTMLElement;
 }
 
 interface IQuickviewOpenerObject {
@@ -249,7 +250,30 @@ export class Quickview extends Component {
      */
     tooltipPlacement: ComponentOptions.buildCustomOption<ValidTooltipPlacement>((value: ValidTooltipPlacement) => value, {
       defaultValue: 'bottom'
-    })
+    }),
+
+    /**
+     * Specifies the HTMLElement where the Modal Box will be created when opening a QuickView. You can
+     * either specify a CSS selector or pass an HTMLElement in the options when calling Coveo.init.
+     *
+     * Default value is `element.ownerDocument.body`.
+     *
+     * **Example in attribute:**
+     * ```html
+     * <div class="CoveoQuickview" data-modal-container="#my-modal-container"></div>
+     * ```
+     *
+     * **Example in init options:**
+     * ```javascript
+     * var myContainer = document.getElementById('my-modal-container');
+     * Coveo.init(root, {
+     *   Quickview: {
+     *     modalContainer: myContainer
+     *   }
+     * });
+     * ```
+     */
+    modalContainer: ComponentOptions.buildSelectorOption({ defaultFunction: element => element.ownerDocument.body })
   };
 
   public static resultCurrentlyBeingRendered: IQueryResult = null;
@@ -293,7 +317,7 @@ export class Quickview extends Component {
       });
     }
 
-    this.modalbox = new AccessibleModal('coveo-quick-view', this.searchInterface.element, ModalBox);
+    this.modalbox = new AccessibleModal('coveo-quick-view', this.options.modalContainer, ModalBox);
   }
 
   private buildContent() {

--- a/src/utils/AccessibleModal.ts
+++ b/src/utils/AccessibleModal.ts
@@ -57,7 +57,7 @@ export class AccessibleModal {
 
   constructor(
     private className: string,
-    private ownerBody: HTMLBodyElement,
+    private ownerElement: HTMLElement,
     private modalboxModule: Coveo.ModalBox.ModalBox = ModalBoxModule,
     options: Partial<IAccessibleModalOptions> = {}
   ) {
@@ -99,7 +99,7 @@ export class AccessibleModal {
         this.onModalClose();
         return parameters.validation();
       },
-      body: this.ownerBody,
+      body: this.ownerElement,
       sizeMod: this.options.sizeMod,
       overlayClose: this.options.overlayClose
     });


### PR DESCRIPTION
Changed in what element the QuickView component creates the modal box to use the search interface instead of the document body.
Using the document body causes problems when the search interface is initialized inside a shadow root and the styles are only applied within the shadow dom tree.
Reproduced and tested locally then ran unit tests!
JSUI-2942

PS: Do you think it would be useful to have an additional option to set a specific owner element instead of using the search interface?


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)