### PR TITLE
JSUI-2815 Made `FieldValue` use the `field` option as a fallback

### DIFF
--- a/unitTests/ui/FieldValueTest.ts
+++ b/unitTests/ui/FieldValueTest.ts
@@ -54,7 +54,7 @@ export function FieldValueTest() {
     function initializeFacet<T extends Facet | DynamicFacet>(type: { new (...args: any[]): T; ID: string }, options: T['options']) {
       const newFacet = Mock.mockComponent<T>(type);
 
-      newFacet.constructor['ID'] = 'Facet';
+      newFacet.constructor['ID'] = type.ID;
 
       newFacet.values = Mock.mock<FacetValues>(FacetValues);
       newFacet.values.get = () => {

--- a/unitTests/ui/FieldValueTest.ts
+++ b/unitTests/ui/FieldValueTest.ts
@@ -12,7 +12,6 @@ import { DateUtils } from '../../src/utils/DateUtils';
 import * as _ from 'underscore';
 import { l } from '../../src/Core';
 import { DynamicFacet } from '../../src/ui/DynamicFacet/DynamicFacet';
-import { DynamicFacetTestUtils } from './DynamicFacet/DynamicFacetTestUtils';
 
 export function FieldValueTest() {
   describe('FieldValue', () => {
@@ -32,23 +31,41 @@ export function FieldValueTest() {
       initializeFieldValueComponent({ field: '@string' });
     });
 
-    function initializeFieldValueComponent(
+    function initializeFieldValueComponent<T extends Facet | DynamicFacet>(
       options: IFieldValueOptions,
       result = FakeResults.createFakeResult(),
-      facet?: Facet | DynamicFacet
+      ...facets: T[]
     ) {
       result.raw.filetype = 'unknown';
       test = Mock.advancedResultComponentSetup<FieldValue>(FieldValue, result, <Mock.AdvancedComponentSetupOptions>{
         element: $$('span').el,
         cmpOptions: options,
         modifyBuilder: (builder: Mock.MockEnvironmentBuilder) => {
-          if (facet) {
-            builder.componentStateModel.get = () => [facet];
+          if (facets.length) {
+            builder.componentStateModel.get = () => facets;
             builder.queryStateModel.get = () => [];
+            facets.forEach(facet => builder.searchInterface.attachComponent((<typeof Facet>facet.constructor).ID, facet));
           }
           return builder;
         }
       });
+    }
+
+    function initializeFacet<T extends Facet | DynamicFacet>(type: { new (...args: any[]): T; ID: string }, options: T['options']) {
+      const newFacet = Mock.mockComponent<T>(type);
+
+      newFacet.constructor['ID'] = 'Facet';
+
+      newFacet.values = Mock.mock<FacetValues>(FacetValues);
+      newFacet.values.get = () => {
+        const value = Mock.mock<FacetValue>(FacetValue);
+        value.selected = true;
+        return value;
+      };
+
+      newFacet.options = options;
+
+      return newFacet;
     }
 
     describe('exposes options', () => {
@@ -269,20 +286,15 @@ export function FieldValueTest() {
       let facet: Facet;
 
       beforeEach(() => {
-        facet = Mock.mockComponent<Facet>(Facet);
-
-        facet.values = Mock.mock<FacetValues>(FacetValues);
-        facet.values.get = () => {
-          const value = Mock.mock<FacetValue>(FacetValue);
-          value.selected = true;
-          return value;
-        };
+        facet = initializeFacet(Facet, { field: '@string' });
       });
 
       describe('when translating standard field values', () => {
         beforeEach(() => {
           const fakeResult = FakeResults.createFakeResult();
           fakeResult.raw['objecttype'] = 'opportunityproduct';
+
+          facet = initializeFacet(Facet, { field: '@objecttype' });
 
           initializeFieldValueComponent({ field: '@objecttype' }, fakeResult, facet);
         });
@@ -299,13 +311,19 @@ export function FieldValueTest() {
       it('should display the field value as clickable when its facet is enabled', () => {
         facet.disabled = false;
         initializeFieldValueComponent({ field: '@string' }, FakeResults.createFakeResult(), facet);
-        expect($$($$(test.cmp.element).find('span')).hasClass('coveo-clickable')).toBe(true);
+        expect(test.cmp.element.querySelector('.coveo-clickable')).not.toBeNull();
       });
 
       it('should not display the field value as clickable when its facet is disabled', () => {
         facet.disabled = true;
         initializeFieldValueComponent({ field: '@string' }, FakeResults.createFakeResult(), facet);
-        expect($$($$(test.cmp.element).find('span')).hasClass('coveo-clickable')).toBe(false);
+        expect(test.cmp.element.querySelector('.coveo-clickable')).toBeNull();
+      });
+
+      it('should not display the field value as clickable when its facet has a different field', () => {
+        facet.disabled = false;
+        initializeFieldValueComponent({ field: '@objecttype' }, FakeResults.createFakeResult(), facet);
+        expect(test.cmp.element.querySelector('.coveo-clickable')).toBeNull();
       });
     });
 
@@ -313,14 +331,15 @@ export function FieldValueTest() {
       let facet: DynamicFacet;
 
       beforeEach(() => {
-        facet = DynamicFacetTestUtils.createFakeFacet();
-        facet.values.hasSelectedValue = () => true;
+        facet = initializeFacet(DynamicFacet, { field: '@string' });
       });
 
       describe('when translating standard field values', () => {
         beforeEach(() => {
           const fakeResult = FakeResults.createFakeResult();
           fakeResult.raw['objecttype'] = 'opportunityproduct';
+
+          facet = initializeFacet(DynamicFacet, { field: '@objecttype' });
 
           initializeFieldValueComponent({ field: '@objecttype' }, fakeResult, facet);
         });
@@ -337,13 +356,19 @@ export function FieldValueTest() {
       it('should display the field value as clickable when its facet is enabled', () => {
         facet.disabled = false;
         initializeFieldValueComponent({ field: '@string' }, FakeResults.createFakeResult(), facet);
-        expect($$($$(test.cmp.element).find('span')).hasClass('coveo-clickable')).toBe(true);
+        expect(test.cmp.element.querySelector('.coveo-clickable')).not.toBeNull();
       });
 
       it('should not display the field value as clickable when its facet is disabled', () => {
         facet.disabled = true;
         initializeFieldValueComponent({ field: '@string' }, FakeResults.createFakeResult(), facet);
-        expect($$($$(test.cmp.element).find('span')).hasClass('coveo-clickable')).toBe(false);
+        expect(test.cmp.element.querySelector('.coveo-clickable')).toBeNull();
+      });
+
+      it('should not display the field value as clickable when its facet has a different field', () => {
+        facet.disabled = false;
+        initializeFieldValueComponent({ field: '@objecttype' }, FakeResults.createFakeResult(), facet);
+        expect(test.cmp.element.querySelector('.coveo-clickable')).toBeNull();
       });
     });
 

--- a/unitTests/ui/FieldValueTest.ts
+++ b/unitTests/ui/FieldValueTest.ts
@@ -12,6 +12,7 @@ import { DateUtils } from '../../src/utils/DateUtils';
 import * as _ from 'underscore';
 import { l } from '../../src/Core';
 import { DynamicFacet } from '../../src/ui/DynamicFacet/DynamicFacet';
+import { DynamicFacetValues } from '../../src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues';
 
 export function FieldValueTest() {
   describe('FieldValue', () => {
@@ -56,12 +57,17 @@ export function FieldValueTest() {
 
       newFacet.constructor['ID'] = type.ID;
 
-      newFacet.values = Mock.mock<FacetValues>(FacetValues);
-      newFacet.values.get = () => {
-        const value = Mock.mock<FacetValue>(FacetValue);
-        value.selected = true;
-        return value;
-      };
+      if (type.ID === 'Facet') {
+        newFacet.values = Mock.mock<FacetValues>(FacetValues);
+        newFacet.values.get = () => {
+          const value = Mock.mock<FacetValue>(FacetValue);
+          value.selected = true;
+          return value;
+        };
+      } else if (type.ID === 'DynamicFacet') {
+        newFacet.values = Mock.mock<DynamicFacetValues>(DynamicFacetValues);
+        newFacet.values.hasSelectedValue = () => false;
+      }
 
       newFacet.options = options;
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2815

This PR makes `FieldValue` use its `field` option as a fallback to find a corresponding `Facet`.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)