### PR TITLE
JSUI-2957 Made facets open a modal on mobile

### DIFF
--- a/sass/_ResponsiveFacets.scss
+++ b/sass/_ResponsiveFacets.scss
@@ -1,5 +1,12 @@
 @import 'bourbon/bourbon';
 @import 'Variables';
+
+body.coveo-block-scrolling {
+  max-width: 100%;
+  max-height: 100%;
+  overflow: hidden;
+}
+
 .CoveoSearchInterface.coveo-small-facets {
   .coveo-facet-dropdown-content {
     z-index: 20;
@@ -19,39 +26,85 @@
     }
   }
 
-  .coveo-facet-column.coveo-facet-dropdown-content {
-    overflow-y: scroll;
-    max-height: 600px;
-    clear: both;
-    white-space: nowrap;
-    padding: 0;
-    min-width: 280px;
-    width: 35%;
-    z-index: 20;
-    box-shadow: 0 7px 15px rgba(0, 0, 0, 0.25);
-    border-radius: 0 0 0 2px;
-    #{$allFacetsType} {
-      margin: 0;
-      border: 0;
-      border-radius: 0;
-      .coveo-facet-header {
-        border: 0;
-        border-radius: 0;
-        border-top: $default-border;
-        white-space: initial;
+  .coveo-facet-column {
+    &.coveo-facet-dropdown-modal-content {
+      $padding: 20px;
+
+      z-index: 20;
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background-color: white;
+      overflow-y: scroll;
+      padding: $padding;
+
+      .coveo-facet-modal-close-button {
+        $close-button-size: 32px;
+
+        width: $close-button-size;
+        height: $close-button-size;
+        border-radius: 50%;
+        background-color: $coveo-blue;
+        font-weight: bold;
+        font-size: small;
+        color: white;
+        margin-left: auto;
+        margin-bottom: $padding;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+
+        &:hover {
+          opacity: 0.8;
+        }
+
+        &:focus {
+          opacity: 0.5;
+        }
       }
     }
-    #{$allDynamicFacetsType} {
-      margin: 0;
 
-      .coveo-dynamic-facet-header,
-      .coveo-dynamic-facet-values,
-      .coveo-dynamic-hierarchical-facet-values {
-        padding: 5px;
+    &.coveo-hidden {
+      display: none;
+    }
+
+    &.coveo-facet-dropdown-content {
+      overflow-y: scroll;
+      max-height: 600px;
+      clear: both;
+      white-space: nowrap;
+      padding: 0;
+      min-width: 280px;
+      width: 35%;
+      z-index: 20;
+      box-shadow: 0 7px 15px rgba(0, 0, 0, 0.25);
+      border-radius: 0 0 0 2px;
+      #{$allFacetsType} {
+        margin: 0;
+        border: 0;
+        border-radius: 0;
+        .coveo-facet-header {
+          border: 0;
+          border-radius: 0;
+          border-top: $default-border;
+          white-space: initial;
+        }
       }
+      #{$allDynamicFacetsType} {
+        margin: 0;
 
-      .coveo-dynamic-facet-search {
-        margin: 10px 5px 0;
+        .coveo-dynamic-facet-header,
+        .coveo-dynamic-facet-values,
+        .coveo-dynamic-hierarchical-facet-values {
+          padding: 5px;
+        }
+
+        .coveo-dynamic-facet-search {
+          margin: 10px 5px 0;
+        }
       }
     }
   }

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownModalContent.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownModalContent.ts
@@ -1,0 +1,51 @@
+import { IResponsiveDropdownContent, ResponsiveDropdownContent } from './ResponsiveDropdownContent';
+import { Dom, $$, l } from '../../../Core';
+import { AccessibleButton } from '../../../utils/AccessibleButton';
+
+export class ResponsiveDropdownModalContent implements IResponsiveDropdownContent {
+  private closeButton: Dom;
+  private className: string;
+
+  private set hidden(shouldHide: boolean) {
+    this.element.toggleClass('coveo-hidden', shouldHide);
+  }
+
+  private set allowPageScrolling(allow: boolean) {
+    document.body.classList.toggle('coveo-block-scrolling', !allow);
+  }
+
+  constructor(private componentName: string, public element: Dom, private closeButtonLabel: string, private close: () => void) {
+    this.className = `coveo-${this.componentName}-dropdown-modal-content`;
+  }
+
+  public positionDropdown(): void {
+    this.element.el.classList.add(this.className, ResponsiveDropdownContent.DEFAULT_CSS_CLASS_NAME);
+    this.element.setAttribute('role', 'group');
+    this.element.setAttribute('aria-label', l('FiltersDropdown'));
+    this.hidden = false;
+    this.allowPageScrolling = false;
+    this.closeButton = $$('div', { className: 'coveo-facet-modal-close-button' }, '✕');
+    new AccessibleButton()
+      .withElement(this.closeButton.el)
+      .withSelectAction(() => this.close())
+      .withLabel(this.closeButtonLabel)
+      .build();
+    this.element.prepend(this.closeButton.el);
+  }
+
+  public hideDropdown(): void {
+    this.element.el.classList.remove(this.className, ResponsiveDropdownContent.DEFAULT_CSS_CLASS_NAME);
+    this.element.setAttribute('role', null);
+    this.element.setAttribute('aria-label', null);
+    this.hidden = true;
+    this.allowPageScrolling = true;
+    if (this.closeButton) {
+      this.closeButton.remove();
+      this.closeButton = null;
+    }
+  }
+
+  public cleanUp(): void {
+    this.hidden = false;
+  }
+}

--- a/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
@@ -10,16 +10,15 @@ import { ResponsiveComponents } from './ResponsiveComponents';
 import { IResponsiveComponent, IResponsiveComponentOptions, ResponsiveComponentsManager } from './ResponsiveComponentsManager';
 import { ResponsiveComponentsUtils } from './ResponsiveComponentsUtils';
 import { ResponsiveDropdown } from './ResponsiveDropdown/ResponsiveDropdown';
-import { ResponsiveDropdownContent } from './ResponsiveDropdown/ResponsiveDropdownContent';
+import { IResponsiveDropdownContent } from './ResponsiveDropdown/ResponsiveDropdownContent';
 import { ResponsiveDropdownHeader } from './ResponsiveDropdown/ResponsiveDropdownHeader';
 import { each, debounce } from 'underscore';
 import { ComponentsTypes } from '../../utils/ComponentsTypes';
+import { ResponsiveDropdownModalContent } from './ResponsiveDropdown/ResponsiveDropdownModalContent';
 
 export class ResponsiveFacetColumn implements IResponsiveComponent {
   public static DEBOUNCE_SCROLL_WAIT = 250;
 
-  private static DROPDOWN_MIN_WIDTH: number = 280;
-  private static DROPDOWN_WIDTH_RATIO: number = 0.35; // Used to set the width relative to the coveo root.
   private static DROPDOWN_HEADER_LABEL_DEFAULT_VALUE = 'Filters';
 
   private searchInterface: SearchInterface;
@@ -127,22 +126,19 @@ export class ResponsiveFacetColumn implements IResponsiveComponent {
     let dropdownContent = this.buildDropdownContent();
     let dropdownHeader = this.buildDropdownHeader();
     let dropdown = responsiveDropdown ? responsiveDropdown : new ResponsiveDropdown(dropdownContent, dropdownHeader, this.coveoRoot);
+    dropdown.disablePopupBackground();
     return dropdown;
   }
 
-  private buildDropdownContent(): ResponsiveDropdownContent {
+  private buildDropdownContent(): IResponsiveDropdownContent {
     let dropdownContentElement = $$(this.coveoRoot.find('.coveo-facet-column'));
     let filterByContainer = $$('div', { className: 'coveo-facet-header-filter-by-container', style: 'display: none' });
     let filterBy = $$('div', { className: 'coveo-facet-header-filter-by' });
     filterBy.text(l('Filter by:'));
     filterByContainer.append(filterBy.el);
     dropdownContentElement.prepend(filterByContainer.el);
-    let dropdownContent = new ResponsiveDropdownContent(
-      'facet',
-      dropdownContentElement,
-      this.coveoRoot,
-      ResponsiveFacetColumn.DROPDOWN_MIN_WIDTH,
-      ResponsiveFacetColumn.DROPDOWN_WIDTH_RATIO
+    let dropdownContent = new ResponsiveDropdownModalContent('facet', dropdownContentElement, l('CloseFiltersDropdown'), () =>
+      this.dropdown.close()
     );
     return dropdownContent;
   }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2957

**This PR is not intended to be merged.**

The purpose of this PR is to compare different solutions for JSUI-2957, which asks for a way to detect when the popup opens/closes.

First of all, it appears that client want to be able to detect when the popup opens/closes to:
a. Prevent scrolling
b. Make the facet popup into a modal

To this problem, there are multiple solutions:
- Solution A: Simply exposing events to detect when the modal is opened/closed. This is a small change, but it may end up with a lot of clients having to re-implement their own modals individually. While implementing a variant of solution B, I discovered that an open and a close event already appear to exist `ResponsiveDropdownEvent.OPEN` and `ResponsiveDropdownEvent.Close` (in `ResponsiveDropdown.ts`). Those events aren't exposed, but I could expose them.
- Solution B: Giving clients a solution out of the box. This avoids the above problem, but it's a much bigger change.

If we go for solution B, there are multiple possible implementations.
- Implementation A: Adding a new responsive dropdown component. This is the least amount of change in the codebase and doesn't reinvent the wheel, but unless it's made into an option, it could cause problem for previous clients and doesn't allow customization easily. If we choose this solution, we should probably also expose the event to allow clients some extra flexibility.
- Implementation B: Creating new components. This approach would involve creating a new component that could wrap `Facet` components or be initialized by `DynamicFacetManager`. It would also involve disabling `ResponsiveFacetColumn` whenever said component is initialized. It would be the largest amount of additional code but it could allow for some extra customization and I believe it would be a more solid approach.

For this PR, I explored implementation A and got the facets to appear in the following modal:
![image](https://user-images.githubusercontent.com/54454747/80964547-15221500-8ddf-11ea-9e89-357dea8f8eef.png)

Which solution or implementation do you think I should go for? Do you have another idea?

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)