### PR TITLE
JSUI-2960 Change DependsOn newQuery listener to buildingQuery listener

### DIFF
--- a/src/utils/DependsOnManager.ts
+++ b/src/utils/DependsOnManager.ts
@@ -28,7 +28,7 @@ export class DependsOnManager {
   private parentFacetRef: IDependsOnCompatibleFacet;
 
   constructor(private facet: IDependentFacet) {
-    this.facet.ref.bind.onRootElement(QueryEvents.newQuery, () => this.handleNewQuery());
+    this.facet.ref.bind.onRootElement(QueryEvents.buildingQuery, () => this.handleBuildingQuery());
 
     if (this.getDependsOn(this.facet.ref)) {
       this.facet.ref.bind.onRootElement(InitializationEvents.afterComponentsInitialization, () => this.setupDependentFacet());
@@ -100,7 +100,7 @@ export class DependsOnManager {
     );
   }
 
-  private handleNewQuery() {
+  private handleBuildingQuery() {
     this.dependentFacets.forEach(dependentFacet => {
       const condition = this.getDependsOnCondition(dependentFacet);
       if (condition(this.facet.ref)) {

--- a/unitTests/utils/DependsOnManagerTest.ts
+++ b/unitTests/utils/DependsOnManagerTest.ts
@@ -78,42 +78,42 @@ export function DependsOnManagerTest() {
     });
 
     it(`when a parent facet has selected value(s) (default condition fulfilled)
-      when triggering a new query
+      when triggering "building query"
       should enable the dependent facet`, () => {
       queryStateModel.registerNewAttribute(parentStateAttribute(), ['a value']);
       spyOn(dependentMock.facet.ref, 'enable');
 
-      $$(root).trigger(QueryEvents.newQuery);
+      $$(root).trigger(QueryEvents.buildingQuery);
       expect(dependentMock.facet.ref.enable).toHaveBeenCalledTimes(1);
     });
 
     it(`when a parent facet has no selected value (default condition not fulfilled)
-      when triggering a new query
+      when triggering "building query"
       should disable the dependent facet`, () => {
       spyOn(dependentMock.facet.ref, 'disable');
 
-      $$(root).trigger(QueryEvents.newQuery);
+      $$(root).trigger(QueryEvents.buildingQuery);
       expect(dependentMock.facet.ref.disable).toHaveBeenCalledTimes(1);
     });
 
     it(`when a parent facet fulfills the custom condition
-      when triggering a new query
+      when triggering "building query"
       should enable the dependent facet`, () => {
       assignCustomCondition();
       fulfillCustomCondition();
       spyOn(dependentMock.facet.ref, 'enable');
 
-      $$(root).trigger(QueryEvents.newQuery);
+      $$(root).trigger(QueryEvents.buildingQuery);
       expect(dependentMock.facet.ref.enable).toHaveBeenCalledTimes(1);
     });
 
     it(`when a parent facet does not fulfill the custom condition
-      when triggering a new query
+      when triggering "building query"
       should disable the dependent facet`, () => {
       assignCustomCondition();
       spyOn(dependentMock.facet.ref, 'disable');
 
-      $$(root).trigger(QueryEvents.newQuery);
+      $$(root).trigger(QueryEvents.buildingQuery);
       expect(dependentMock.facet.ref.disable).toHaveBeenCalledTimes(1);
     });
 


### PR DESCRIPTION
Reason for this change in JIRA:
https://coveord.atlassian.net/browse/JSUI-2960

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)