### PR TITLE
JSUI-2959 Sync toggle height calculation to animation frame

### DIFF
--- a/src/ui/FieldTable/FieldTable.ts
+++ b/src/ui/FieldTable/FieldTable.ts
@@ -137,6 +137,7 @@ export class FieldTable extends Component {
       $$(this.toggleContainer).insertBefore(this.element);
       this.toggleContainer.appendChild(this.element);
       this.toggleContainer.appendChild(this.toggleButtonInsideTable);
+      requestAnimationFrame(() => this.updateToggleHeight());
     }
   }
 
@@ -232,8 +233,6 @@ export class FieldTable extends Component {
     } else {
       this.isExpanded = !QueryUtils.hasExcerpt(this.result);
     }
-
-    this.updateToggleHeight();
 
     const toggleAction = () => this.toggle(true);
 

--- a/src/ui/FieldTable/FieldTable.ts
+++ b/src/ui/FieldTable/FieldTable.ts
@@ -137,7 +137,6 @@ export class FieldTable extends Component {
       $$(this.toggleContainer).insertBefore(this.element);
       this.toggleContainer.appendChild(this.element);
       this.toggleContainer.appendChild(this.toggleButtonInsideTable);
-      requestAnimationFrame(() => this.updateToggleHeight());
     }
   }
 
@@ -233,6 +232,8 @@ export class FieldTable extends Component {
     } else {
       this.isExpanded = !QueryUtils.hasExcerpt(this.result);
     }
+
+    requestAnimationFrame(() => this.updateToggleHeight());
 
     const toggleAction = () => this.toggle(true);
 

--- a/unitTests/ui/FieldTableTest.ts
+++ b/unitTests/ui/FieldTableTest.ts
@@ -174,20 +174,6 @@ export function FieldTableTest() {
           expect(findToggleContainer().style.height).toBe(`${newScrollHeight}px`);
         });
 
-        it(`given a toggle container with a zero scrollHeight,
-        when calling #expand after the container has a non-zero scrollHeight,
-        it sets the height of the container to the new value`, () => {
-          const container = findToggleContainer();
-
-          expect(container.scrollHeight).toBe(0);
-
-          const newScrollHeight = 100;
-          setToggleContainerScrollHeight(newScrollHeight);
-          test.cmp.expand();
-
-          expect(findToggleContainer().style.height).toBe(`${newScrollHeight}px`);
-        });
-
         it(`given a toggle container with a non-zero scrollHeight,
         when the container scrollHeight changes,
         when calling #expand, it keeps the height of the container equal to the initial value`, () => {

--- a/unitTests/ui/FieldTableTest.ts
+++ b/unitTests/ui/FieldTableTest.ts
@@ -95,8 +95,11 @@ export function FieldTableTest() {
           expect(findToggleButton()).not.toBeNull();
         });
 
-        it('shows a toggle caption set to the minimizedTitle', () => {
-          expect(findToggleCaption().textContent).toBe(test.cmp.options.minimizedTitle);
+        it('shows a toggle caption set to the minimizedTitle', done => {
+          requestAnimationFrame(() => {
+            expect(findToggleCaption().textContent).toBe(test.cmp.options.minimizedTitle);
+            done();
+          });
         });
 
         it('should put the tabindex to 0 on the toggle caption', function() {
@@ -155,6 +158,20 @@ export function FieldTableTest() {
           test.cmp.minimize();
           let toggle = findToggleCaption();
           expect(toggle.textContent).toBe('Details'.toLocaleString());
+        });
+
+        it(`given a toggle container with a zero scrollHeight,
+        when calling #expand after the container has a non-zero scrollHeight,
+        it sets the height of the container to the new value`, () => {
+          const container = findToggleContainer();
+
+          expect(container.scrollHeight).toBe(0);
+
+          const newScrollHeight = 100;
+          setToggleContainerScrollHeight(newScrollHeight);
+          test.cmp.expand();
+
+          expect(findToggleContainer().style.height).toBe(`${newScrollHeight}px`);
         });
 
         it(`given a toggle container with a zero scrollHeight,


### PR DESCRIPTION
Small regression introduced on last release. If field table is expanded by default on initial paint, we need to sync toggle height calculation with browser paint/reflow.

https://coveord.atlassian.net/browse/JSUI-2959





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)