### PR TITLE
JSUI-2963 Match absent terms with query case-insensitively, and display query terms

### DIFF
--- a/src/ui/MissingTerm/MissingTerms.ts
+++ b/src/ui/MissingTerm/MissingTerms.ts
@@ -93,8 +93,8 @@ export class MissingTerms extends Component {
       const result = regex.exec(query);
 
       if (result) {
-        const termInQuery = result[4];
-        terms.push(termInQuery);
+        const originalKeywordInQuery = result[4];
+        terms.push(originalKeywordInQuery);
       }
     }
 

--- a/src/ui/MissingTerm/MissingTerms.ts
+++ b/src/ui/MissingTerm/MissingTerms.ts
@@ -85,10 +85,20 @@ export class MissingTerms extends Component {
    *Returns all original basic query expression terms that were not matched by the result item the component instance is associated with.
    */
   public get missingTerms(): string[] {
-    return this.result.absentTerms.filter(term => {
+    const terms = [];
+
+    for (const term of this.result.absentTerms) {
       const regex = this.createWordBoundaryDelimitedRegex(term);
-      return regex.test(this.queryStateModel.get('q'));
-    });
+      const query = this.queryStateModel.get('q');
+      const result = regex.exec(query);
+
+      if (result) {
+        const termInQuery = result[4];
+        terms.push(termInQuery);
+      }
+    }
+
+    return terms;
   }
 
   /**
@@ -167,7 +177,7 @@ export class MissingTerms extends Component {
   }
 
   private createWordBoundaryDelimitedRegex(term: string): RegExp {
-    return XRegExp(`${MissingTermManager.wordBoundary}(${term})${MissingTermManager.wordBoundary}`, 'g');
+    return XRegExp(`${MissingTermManager.wordBoundary}(${term})${MissingTermManager.wordBoundary}`, 'gi');
   }
 
   private containsFeaturedResults(term: string): boolean {

--- a/unitTests/ui/MissingTermsTest.ts
+++ b/unitTests/ui/MissingTermsTest.ts
@@ -28,6 +28,7 @@ export function MissingTermsTest() {
     beforeEach(() => {
       fakeResult = FakeResults.createFakeResult();
     });
+
     describe('exposes options', () => {
       describe("when the 'clickable' option is set to", () => {
         let missingTermsClickableSpy: jasmine.Spy;
@@ -132,9 +133,9 @@ export function MissingTermsTest() {
           it will not be displayed as a missing term.`, () => {
             const wordBoundarysCharacter = getWordBoudaryChars();
             wordBoundarysCharacter.forEach(character => {
-              const boundaryCharacter = `\\${character}s`;
-              const query = `efile${boundaryCharacter} `;
-              fakeResult.absentTerms = [`${boundaryCharacter}`];
+              const boundaryCharacter = `${character}s`;
+              const query = `efile\\${boundaryCharacter} `;
+              fakeResult.absentTerms = [`\\${boundaryCharacter}`];
               test = mockComponent(query);
               expect(test.cmp.element.childElementCount).toEqual(0);
               expect(test.cmp.missingTerms).toEqual([`${boundaryCharacter}`]);
@@ -162,6 +163,15 @@ export function MissingTermsTest() {
             fakeResult.absentTerms = [termNotInQuery];
             expect(test.cmp.missingTerms.toString()).toBe(expectedResult.toString());
           });
+        });
+
+        it(`when a term in the query has a different case but otherwise matches an absent term,
+        the term is displayed using the query term's case`, () => {
+          const queryTerm = 'World';
+          fakeResult.absentTerms = [queryTerm.toLowerCase()];
+          test = mockComponent(`Hello ${queryTerm}`);
+
+          expect(test.cmp.missingTerms).toEqual([queryTerm]);
         });
 
         describe('when re-injecting a term', () => {
@@ -268,9 +278,9 @@ export function MissingTermsTest() {
           it will not be displayed as a missing term.`, () => {
             const wordBoundarysCharacter = getWordBoudaryChars();
             wordBoundarysCharacter.forEach(character => {
-              const boundaryCharacter = `\\${character}이것은`;
-              const query = `쿼리가${boundaryCharacter} `;
-              fakeResult.absentTerms = [`${boundaryCharacter}`];
+              const boundaryCharacter = `${character}이것은`;
+              const query = `쿼리가\\${boundaryCharacter} `;
+              fakeResult.absentTerms = [`\\${boundaryCharacter}`];
               test = mockComponent(query);
               expect(test.cmp.element.childElementCount).toEqual(0);
               expect(test.cmp.missingTerms).toEqual([`${boundaryCharacter}`]);


### PR DESCRIPTION
The searchapi returns absent terms in lower-case, and we were matching them against the query in a case-sensitive manner. This meant that `Hello WORLD` would not match `absentTerms: ['world']`.

This PR
1. Changes the regex to match in a case-insensitive way, and
2. Returns the query term so that the displayed value has the same case, [mimicking the behaviour](https://www.google.com/search?rlz=1C1GCEU_enCA822CA822&ei=x9a5Xr2uHoGo_QaF5YyABw&q=jello+bean+RolluP&oq=jello+bean+RolluP&gs_lcp=CgZwc3ktYWIQAzIHCCEQChCgAToECAAQDToGCAAQDRAeUIIpWNI4YLk8aAFwAHgAgAFuiAHuBJIBAzIuNJgBAKABAaoBB2d3cy13aXo&sclient=psy-ab&ved=0ahUKEwj9rZbs8qzpAhUBVN8KHYUyA3AQ4dUDCAw&uact=5) on Google. 






https://coveord.atlassian.net/browse/JSUI-2963





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)