### PR TITLE
JSUI-2962 Encode clickuri before displaying it

### DIFF
--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -17,7 +17,7 @@ import { Defer } from '../../misc/Defer';
 import { $$ } from '../../utils/Dom';
 import { StreamHighlightUtils } from '../../utils/StreamHighlightUtils';
 import { StringUtils } from '../../utils/StringUtils';
-import { once, debounce, extend } from 'underscore';
+import { once, debounce, extend, escape } from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 
 import 'styling/_ResultLink';
@@ -362,17 +362,17 @@ export class ResultLink extends Component {
     if (!this.options.titleTemplate) {
       return this.result.title
         ? HighlightUtils.highlightString(this.result.title, this.result.titleHighlights, null, 'coveo-highlight')
-        : this.encodedClickUri;
+        : this.escapedClickUri;
     } else {
       let newTitle = StringUtils.buildStringTemplateFromResult(this.options.titleTemplate, this.result);
       return newTitle
         ? StreamHighlightUtils.highlightStreamText(newTitle, this.result.termsToHighlight, this.result.phrasesToHighlight)
-        : this.encodedClickUri;
+        : this.escapedClickUri;
     }
   }
 
-  private get encodedClickUri() {
-    return encodeURI(this.result.clickUri);
+  private get escapedClickUri() {
+    return escape(this.result.clickUri);
   }
 
   private bindOnClickIfNotUndefined() {
@@ -453,7 +453,7 @@ export class ResultLink extends Component {
       this.queryController.saveLastQuery();
       let documentURL = $$(this.element).getAttribute('href');
       if (documentURL == undefined || documentURL == '') {
-        documentURL = this.encodedClickUri;
+        documentURL = this.escapedClickUri;
       }
       this.usageAnalytics.logClickEvent(
         analyticsActionCauseList.documentOpen,
@@ -484,7 +484,7 @@ export class ResultLink extends Component {
       return Utils.getFieldValue(this.result, <string>this.options.field);
     }
 
-    return this.encodedClickUri;
+    return this.escapedClickUri;
   }
 
   private elementIsAnAnchor() {
@@ -511,7 +511,7 @@ export class ResultLink extends Component {
   }
 
   private isUriThatMustBeOpenedInQuickview(): boolean {
-    return this.encodedClickUri.toLowerCase().indexOf('ldap://') == 0;
+    return this.escapedClickUri.toLowerCase().indexOf('ldap://') == 0;
   }
 
   private quickviewShouldBeOpened() {

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -17,7 +17,7 @@ import { Defer } from '../../misc/Defer';
 import { $$ } from '../../utils/Dom';
 import { StreamHighlightUtils } from '../../utils/StreamHighlightUtils';
 import { StringUtils } from '../../utils/StringUtils';
-import { once, debounce } from 'underscore';
+import { once, debounce, extend } from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 
 import 'styling/_ResultLink';
@@ -246,10 +246,10 @@ export class ResultLink extends Component {
     public os?: OS_NAME
   ) {
     super(element, ResultLink.ID, bindings);
-    this.options = {
-      ...ComponentOptions.initComponentOptions(element, ResultLink, options),
-      ...this.componentOptionsModel.get(ComponentOptionsModel.attributesEnum.resultLink)
-    };
+
+    const initialOptions = ComponentOptions.initComponentOptions(element, ResultLink, options);
+    const resultLinkOptions = this.componentOptionsModel.get(ComponentOptionsModel.attributesEnum.resultLink);
+    this.options = extend({}, initialOptions, resultLinkOptions);
 
     this.result = result || this.resolveResult();
 

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -17,7 +17,7 @@ import { Defer } from '../../misc/Defer';
 import { $$ } from '../../utils/Dom';
 import { StreamHighlightUtils } from '../../utils/StreamHighlightUtils';
 import { StringUtils } from '../../utils/StringUtils';
-import * as _ from 'underscore';
+import { once, debounce } from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 
 import 'styling/_ResultLink';
@@ -246,8 +246,11 @@ export class ResultLink extends Component {
     public os?: OS_NAME
   ) {
     super(element, ResultLink.ID, bindings);
-    this.options = ComponentOptions.initComponentOptions(element, ResultLink, options);
-    this.options = _.extend({}, this.options, this.componentOptionsModel.get(ComponentOptionsModel.attributesEnum.resultLink));
+    this.options = {
+      ...ComponentOptions.initComponentOptions(element, ResultLink, options),
+      ...this.componentOptionsModel.get(ComponentOptionsModel.attributesEnum.resultLink)
+    };
+
     this.result = result || this.resolveResult();
 
     if (this.options.openQuickview == null) {
@@ -266,7 +269,7 @@ export class ResultLink extends Component {
       // It's still only one "click" event as far as UA is concerned.
       // Also need to handle "longpress" on mobile (the contextual menu), which we assume to be 1 s long.
 
-      const executeOnlyOnce = _.once(() => this.logOpenDocument());
+      const executeOnlyOnce = once(() => this.logOpenDocument());
 
       $$(element).on(['contextmenu', 'click', 'mousedown', 'mouseup'], executeOnlyOnce);
       let longPressTimer: number;
@@ -359,13 +362,17 @@ export class ResultLink extends Component {
     if (!this.options.titleTemplate) {
       return this.result.title
         ? HighlightUtils.highlightString(this.result.title, this.result.titleHighlights, null, 'coveo-highlight')
-        : this.result.clickUri;
+        : this.encodedClickUri;
     } else {
       let newTitle = StringUtils.buildStringTemplateFromResult(this.options.titleTemplate, this.result);
       return newTitle
         ? StreamHighlightUtils.highlightStreamText(newTitle, this.result.termsToHighlight, this.result.phrasesToHighlight)
-        : this.result.clickUri;
+        : this.encodedClickUri;
     }
+  }
+
+  private get encodedClickUri() {
+    return encodeURI(this.result.clickUri);
   }
 
   private bindOnClickIfNotUndefined() {
@@ -441,12 +448,12 @@ export class ResultLink extends Component {
     }
   }
 
-  private logOpenDocument = _.debounce(
+  private logOpenDocument = debounce(
     () => {
       this.queryController.saveLastQuery();
       let documentURL = $$(this.element).getAttribute('href');
       if (documentURL == undefined || documentURL == '') {
-        documentURL = this.result.clickUri;
+        documentURL = this.encodedClickUri;
       }
       this.usageAnalytics.logClickEvent(
         analyticsActionCauseList.documentOpen,
@@ -468,14 +475,16 @@ export class ResultLink extends Component {
     if (this.options.hrefTemplate) {
       return StringUtils.buildStringTemplateFromResult(this.options.hrefTemplate, this.result);
     }
+
     if (this.options.field == undefined && this.options.openInOutlook) {
       this.setField();
     }
+
     if (this.options.field != undefined) {
       return Utils.getFieldValue(this.result, <string>this.options.field);
-    } else {
-      return this.result.clickUri;
     }
+
+    return this.encodedClickUri;
   }
 
   private elementIsAnAnchor() {
@@ -502,7 +511,7 @@ export class ResultLink extends Component {
   }
 
   private isUriThatMustBeOpenedInQuickview(): boolean {
-    return this.result.clickUri.toLowerCase().indexOf('ldap://') == 0;
+    return this.encodedClickUri.toLowerCase().indexOf('ldap://') == 0;
   }
 
   private quickviewShouldBeOpened() {

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -193,6 +193,15 @@ export function ResultLinkTest() {
         expect($$(test.cmp.element).text()).toEqual(fakeResult.clickUri);
       });
 
+      it(`when the field referenced in the title template contains XSS html,
+      it escapes the html to prevent XSS`, () => {
+        titleTemplate = '${clickUri}';
+        fakeResult.clickUri = htmlContainingXSS();
+        initResultLinkWithTitleTemplate();
+
+        expect(test.cmp.element.innerHTML).toEqual('&lt;IMG SRC=/ onerror="alert(String.fromCharCode(88,83,83))"&gt;&lt;/img&gt;');
+      });
+
       it('should support nested values in result', () => {
         titleTemplate = '${raw.number}';
         initResultLinkWithTitleTemplate();

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -85,12 +85,14 @@ export function ResultLinkTest() {
       expect(test.cmp.element.innerHTML).toEqual(encodedUri);
     });
 
-    it('when the title is empty and the clickuri contains a html element, it does not render the element', () => {
+    it(`when the title is empty and the clickuri contains a html element,
+    it does not render the element to prevent XSS`, () => {
       fakeResult.title = '';
       fakeResult.clickUri = '<IMG SRC=/ onerror="alert(String.fromCharCode(88,83,83))"></img>';
       initResultLink();
 
       expect(test.cmp.element.children.length).toBe(0);
+      expect(test.cmp.element.innerHTML).toBe('&lt;IMG SRC=/ onerror="alert(String.fromCharCode(88,83,83))"&gt;&lt;/img&gt;');
     });
 
     it('can receive an onClick option to execute', done => {


### PR DESCRIPTION
I opted for the bottom-up fix on the component where the XSS was found.

An alternative would have been to sanitize all the properties of a result in a top-down way, but some concerns were:
1. Impacting performance, `O(numOfResults * propertiesPerResult * lengthOfPropertyValue)`
2. Unintended consequences within JSUI and other parts of the stack (e.g. analytics, ML, SFINT)
3. No security benefit in cases where we are not rendering the string as `innerHtml`

https://coveord.atlassian.net/browse/JSUI-2962





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)