### PR TITLE
JSUI-2966 Fix scroll-to-top by removing hash from url when there is no state

### DIFF
--- a/src/controllers/HistoryController.ts
+++ b/src/controllers/HistoryController.ts
@@ -57,6 +57,7 @@ export class HistoryController extends RootComponent implements IHistoryManager 
     $$(this.element).on(InitializationEvents.restoreHistoryState, () => {
       this.logger.trace('Restore history state. Update model');
       this.updateModelFromHash();
+      this.initialHashChange = false;
       this.lastState = this.queryStateModel.getAttributes();
     });
 
@@ -100,10 +101,11 @@ export class HistoryController extends RootComponent implements IHistoryManager 
    * Set the given map of key value in the hash of the URL
    * @param values
    */
-  public setHashValues(values: {}) {
+  public setHashValues(values: Record<string, any>) {
     this.logger.trace('Update history hash');
 
-    const hash = '#' + this.hashUtils.encodeValues(values);
+    const encoded = this.hashUtils.encodeValues(values);
+    const hash = encoded ? `#${encoded}` : '';
     const hashHasChanged = this.window.location.hash != hash;
     this.ignoreNextHashChange = hashHasChanged;
 
@@ -120,7 +122,10 @@ export class HistoryController extends RootComponent implements IHistoryManager 
         this.logger.trace('History hash modified', hash);
       }
     } else if (hashHasChanged) {
-      this.window.location.hash = hash;
+      const location = this.window.location;
+      const url = `${location.pathname}${location.search}${hash}`;
+
+      this.window.history.pushState('', '', url);
       this.logger.trace('History hash created', hash);
     }
   }

--- a/src/controllers/HistoryController.ts
+++ b/src/controllers/HistoryController.ts
@@ -27,7 +27,6 @@ export class HistoryController extends RootComponent implements IHistoryManager 
 
   static attributesThatDoNotTriggerQuery = ['quickview'];
 
-  private ignoreNextHashChange = false;
   private initialHashChange = false;
   private willUpdateHash: boolean = false;
   private hashchange: (...args: any[]) => void;
@@ -92,7 +91,6 @@ export class HistoryController extends RootComponent implements IHistoryManager 
   }
 
   public replaceState(state: Record<string, any>) {
-    this.ignoreNextHashChange = true;
     const hash = '#' + this.hashUtils.encodeValues(state);
     this.window.location.replace(hash);
   }
@@ -107,9 +105,7 @@ export class HistoryController extends RootComponent implements IHistoryManager 
     const encoded = this.hashUtils.encodeValues(values);
     const hash = encoded ? `#${encoded}` : '';
     const hashHasChanged = this.window.location.hash != hash;
-    this.ignoreNextHashChange = hashHasChanged;
 
-    this.logger.trace('ignoreNextHashChange', this.ignoreNextHashChange);
     this.logger.trace('initialHashChange', this.initialHashChange);
     this.logger.trace('from', this.window.location.hash, 'to', hash);
 
@@ -138,12 +134,6 @@ export class HistoryController extends RootComponent implements IHistoryManager 
 
   public handleHashChange() {
     this.logger.trace('History hash changed');
-
-    if (this.ignoreNextHashChange) {
-      this.logger.trace('History hash change ignored');
-      this.ignoreNextHashChange = false;
-      return;
-    }
 
     const attributesThatGotApplied = this.updateModelFromHash();
     if (_.difference(attributesThatGotApplied, HistoryController.attributesThatDoNotTriggerQuery).length > 0) {

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -191,9 +191,16 @@ export function mock<T>(contructorFunc, name = 'mock'): T {
 
 export function mockWindow(): Window {
   const mockWindow = <any>mock(window);
+
+  mockWindow.history = {
+    pushState: jasmine.createSpy('pushState')
+  };
+
   mockWindow.location = <Location>{
     href: '',
-    hash: ''
+    hash: '',
+    pathname: '',
+    search: ''
   };
   mockWindow.location.assign = mockWindow.location.replace = (newHref: string) => {
     newHref = newHref || '';
@@ -217,7 +224,6 @@ export function mockWindow(): Window {
   mockWindow.removeEventListener = jasmine.createSpy('removeEventListener');
   mockWindow.dispatchEvent = jasmine.createSpy('dispatchEvent');
   mockWindow.localStorage = mock<Storage>(localStorage);
-
   return <Window>mockWindow;
 }
 

--- a/unitTests/controllers/HistoryControllerTest.ts
+++ b/unitTests/controllers/HistoryControllerTest.ts
@@ -44,11 +44,29 @@ export function HistoryControllerTest() {
 
       $$(historyController.element).trigger('state:all');
       Defer.flush();
-      expect(historyController.window.location.hash).toBe('#c=notDefault&d=[1,2,3]');
+      expect(historyController.window.history.pushState).toHaveBeenCalledWith('', '', '#c=notDefault&d=[1,2,3]');
     });
 
     it('should listen to hashchange event', () => {
       expect(historyController.window.addEventListener).toHaveBeenCalledWith('hashchange', jasmine.any(Function));
+    });
+
+    it(`given at least one value in the hash, when calling #setHashValues with an empty object,
+    it updates the url without including a hash to prevent the page from scrolling to the top`, () => {
+      historyController.window.location.hash = '#f:@author=[TED]';
+      historyController.setHashValues({});
+      expect(historyController.window.history.pushState).toHaveBeenCalledWith('', '', '');
+    });
+
+    it(`when calling #setHashValues to update the hash,
+    it includes the current location.pathname and location.search in the new url`, () => {
+      const location = historyController.window.location;
+      location.pathname = '/sports';
+      location.search = '?type=basketball';
+      historyController.setHashValues({ q: 'shoes' });
+
+      const expectedUrl = `${location.pathname}${location.search}#q=shoes`;
+      expect(historyController.window.history.pushState).toHaveBeenCalledWith('', '', expectedUrl);
     });
 
     it('should not throw when history controller does not have an analytics client and there is a hash change', () => {

--- a/unitTests/controllers/HistoryControllerTest.ts
+++ b/unitTests/controllers/HistoryControllerTest.ts
@@ -16,6 +16,10 @@ export function HistoryControllerTest() {
     let historyController: HistoryController;
     let env: Mock.IMockEnvironment;
 
+    function triggerRestoreHistoryEvent() {
+      $$(historyController.element).trigger(InitializationEvents.restoreHistoryState);
+    }
+
     beforeEach(() => {
       env = new Mock.MockEnvironmentBuilder().withLiveQueryStateModel().build();
       historyController = new HistoryController(env.root, Mock.mockWindow(), env.queryStateModel, env.queryController);
@@ -76,11 +80,19 @@ export function HistoryControllerTest() {
     });
 
     it('should not set the hash when it has not changed on the first hash change', () => {
-      $$(historyController.element).trigger(InitializationEvents.restoreHistoryState);
+      triggerRestoreHistoryEvent();
       expect(historyController.window.location.replace).not.toHaveBeenCalled();
     });
 
-    it('should not update the model hen simply replacing the state from an old value', () => {
+    it('After the first hash change, when calling #setHashUtils, it pushes a new history entry instead of replacing state', () => {
+      triggerRestoreHistoryEvent();
+      historyController.setHashValues({ q: 'hello' });
+
+      expect(historyController.window.location.replace).not.toHaveBeenCalled();
+      expect(historyController.window.history.pushState).toHaveBeenCalledWith('', '', '#q=hello');
+    });
+
+    it('should not update the model when simply replacing the state from an old value', () => {
       historyController = new HistoryController(env.root, Mock.mockWindow(), env.queryStateModel, env.queryController);
       spyOn(env.queryStateModel, 'setMultiple');
       historyController.replaceState({ q: 'bar' });
@@ -113,8 +125,7 @@ export function HistoryControllerTest() {
         };
 
         historyController.hashUtils.getValue = jasmine.createSpy('getValue').and.callFake(throwsAnError);
-
-        $$(env.root).trigger(InitializationEvents.restoreHistoryState);
+        triggerRestoreHistoryEvent();
 
         expect(historyController.hashUtils.getValue).toHaveBeenCalledTimes(_.size(env.queryStateModel.attributes));
       });
@@ -123,7 +134,7 @@ export function HistoryControllerTest() {
         beforeEach(() => {
           historyController = new HistoryController(env.root, window, env.queryStateModel, env.queryController);
           historyController.hashUtils = fakeHashUtils;
-          $$(historyController.element).trigger(InitializationEvents.restoreHistoryState);
+          triggerRestoreHistoryEvent();
         });
 
         afterEach(() => {


### PR DESCRIPTION
When a page has no components that are always stateful (e.g. no selected tab, selected sort criteria), and when a user interacts with a stateful component and then reverses the action (e.g. select facet value, followed by unselecting the value), the page scrolls to the top.

This happens because the final url contains a hash, that causes the browser to jump to the top.

Once a hash is in the url, the simplest way to remove it without reloading the page is by using the history API. I switched away from using `window.location.hash`.

The edge-case also revealed bugs with the `initialHashChange` and `ignoreNextHashChange` flags. I added a test for the first, and removed the second.

Ref: [removing a hash from url](https://stackoverflow.com/questions/4508574/remove-hash-from-url/4508751).


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)