### PR TITLE
JSUI-2971 Ensure manually specified analytics endpoints end with /rest

### DIFF
--- a/src/ui/Analytics/Analytics.ts
+++ b/src/ui/Analytics/Analytics.ts
@@ -104,8 +104,13 @@ export class Analytics extends Component {
      * Default value is `https://platform.cloud.coveo.com/rest/ua`.
      */
     endpoint: ComponentOptions.buildStringOption({
-      defaultFunction: () => {
-        return AnalyticsEndpoint.getURLFromSearchEndpoint(SearchEndpoint.defaultEndpoint);
+      postProcessing: value => {
+        if (!value) {
+          return AnalyticsEndpoint.getURLFromSearchEndpoint(SearchEndpoint.defaultEndpoint);
+        }
+
+        const [basePlatform] = value.split('/rest');
+        return basePlatform + '/rest';
       }
     }),
 

--- a/unitTests/ui/AnalyticsTest.ts
+++ b/unitTests/ui/AnalyticsTest.ts
@@ -180,7 +180,6 @@ export function AnalyticsTest() {
       });
 
       describe('with data layer in page', () => {
-        let test: Mock.IBasicComponentSetup<Analytics>;
         let defaultDataLayerName = 'dataLayer';
         let customDataLayerName = 'myDataLayer';
         let data = {
@@ -292,65 +291,57 @@ export function AnalyticsTest() {
       });
 
       describe('exposes options', () => {
-        let test: Mock.IBasicComponentSetup<Analytics>;
-
-        afterEach(() => {
-          test = null;
-        });
+        function analyticsClient() {
+          return <LiveAnalyticsClient>test.cmp.client;
+        }
 
         it('user can be specified', () => {
           options = { user: 'foobar' };
           initAnalytics();
 
-          let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
-          expect(client.userId).toBe('foobar');
+          expect(analyticsClient().userId).toBe('foobar');
         });
 
         it('userdisplayname can be specified', () => {
           options = { userDisplayName: 'foobar' };
           initAnalytics();
 
-          let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
-          expect(client.userDisplayName).toBe('foobar');
+          expect(analyticsClient().userDisplayName).toBe('foobar');
         });
 
         it('token can be specified', () => {
           options = { token: 'qwerty123' };
           initAnalytics();
 
-          let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
-          expect(client.endpoint.endpointCaller.options.accessToken).toBe('qwerty123');
+          expect(analyticsClient().endpoint.endpointCaller.options.accessToken).toBe('qwerty123');
         });
 
         it('endpoint can be specified', () => {
           options = { endpoint: 'somewhere.com' };
           initAnalytics();
 
-          let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
-          expect(client.endpoint.options.serviceUrl).toBe('somewhere.com');
+          expect(analyticsClient().endpoint.options.serviceUrl).toBe('somewhere.com');
         });
 
         // it('if the endpoint is set to url not ending with /rest, it appends /rest', () => {
-        //   test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-        //     endpoint: 'https://usageanalyticshipaa.cloud.coveo.com'
-        //   });
+        //   options = { endpoint: 'https://usageanalyticshipaa.cloud.coveo.com' }
+        //   initAnalytics();
 
+        //   expect(analyticsClient().endpoint.options.serviceUrl).toBe(`${options.endpoint}/rest`);
         // })
 
         it('anonymous can be specified', () => {
           options = { anonymous: true };
           initAnalytics();
 
-          let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
-          expect(client.anonymous).toBe(true);
+          expect(analyticsClient().anonymous).toBe(true);
         });
 
         it('searchHub can be specified', () => {
           options = { searchHub: 'foobar' };
           initAnalytics();
 
-          let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
-          expect(client.originLevel1).toBe('foobar');
+          expect(analyticsClient().originLevel1).toBe('foobar');
         });
 
         it('searchhub will be put in the query params', () => {
@@ -372,16 +363,14 @@ export function AnalyticsTest() {
           options = { splitTestRunName: 'foobar' };
           initAnalytics();
 
-          let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
-          expect(client.splitTestRunName).toBe('foobar');
+          expect(analyticsClient().splitTestRunName).toBe('foobar');
         });
 
         it('splitTestRunVersion can be specified', () => {
           options = { splitTestRunVersion: 'foobar' };
           initAnalytics();
 
-          let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
-          expect(client.splitTestRunVersion).toBe('foobar');
+          expect(analyticsClient().splitTestRunVersion).toBe('foobar');
         });
       });
     });

--- a/unitTests/ui/AnalyticsTest.ts
+++ b/unitTests/ui/AnalyticsTest.ts
@@ -11,9 +11,15 @@ import { AnalyticsEvents, $$ } from '../../src/Core';
 
 export function AnalyticsTest() {
   describe('Analytics', () => {
+    let options: IAnalyticsOptions = {};
     let test: Mock.IBasicComponentSetup<Analytics>;
 
+    function initAnalytics() {
+      test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, options);
+    }
+
     beforeEach(() => {
+      options = {};
       SearchEndpoint.endpoints['default'] = new SearchEndpoint({
         accessToken: 'some token',
         queryStringArguments: { organizationId: 'organization' },
@@ -87,9 +93,8 @@ export function AnalyticsTest() {
       });
 
       it('uses organization from options when specified', () => {
-        test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-          organization: 'orgFromOptions'
-        });
+        options.organization = 'orgFromOptions';
+        initAnalytics();
         expect(test.cmp.options.organization).toBe('orgFromOptions');
       });
 
@@ -209,66 +214,76 @@ export function AnalyticsTest() {
         });
 
         it('should not automatically attempt to push to data layer if autoPushToGtmDataLayer is true and gtmDataLayerName is the empty string', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
+          options = {
             autoPushToGtmDataLayer: true,
             gtmDataLayerName: ''
-          });
+          };
+          initAnalytics();
+
           spyOn(test.cmp, 'pushToGtmDataLayer');
           $$(test.env.root).trigger(AnalyticsEvents.analyticsEventReady, data);
           expect(test.cmp.pushToGtmDataLayer).not.toHaveBeenCalled();
         });
 
         it('should not automatically attempt to push to data layer if autoPushToGtmDataLayer is true and data layer is undefined', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
+          options = {
             autoPushToGtmDataLayer: true,
             gtmDataLayerName: 'myImaginaryDataLayer'
-          });
+          };
+          initAnalytics();
+
           spyOn(test.cmp, 'pushToGtmDataLayer');
           $$(test.env.root).trigger(AnalyticsEvents.analyticsEventReady, data);
           expect(test.cmp.pushToGtmDataLayer).not.toHaveBeenCalled();
         });
 
         it('should automatically attempt to push to data layer if autoPushToGtmDataLayer is true and gtmDataLayerName is unspecified', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            autoPushToGtmDataLayer: true
-          });
+          options = { autoPushToGtmDataLayer: true };
+          initAnalytics();
+
           spyOn(test.cmp, 'pushToGtmDataLayer');
           $$(test.env.root).trigger(AnalyticsEvents.analyticsEventReady, data);
           expect(test.cmp.pushToGtmDataLayer).toHaveBeenCalledWith(data);
         });
 
         it('should automatically attempt to push to data layer if autoPushToGtmDataLayer is true and gtmDataLayerName is specified', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
+          options = {
             autoPushToGtmDataLayer: true,
             gtmDataLayerName: customDataLayerName
-          });
+          };
+          initAnalytics();
+
           spyOn(test.cmp, 'pushToGtmDataLayer');
           $$(test.env.root).trigger(AnalyticsEvents.analyticsEventReady, data);
           expect(test.cmp.pushToGtmDataLayer).toHaveBeenCalledWith(data);
         });
 
         it('can push to valid default gtmDataLayerName, even if autoPushToGtmDataLayer is false', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            autoPushToGtmDataLayer: false
-          });
+          options = { autoPushToGtmDataLayer: false };
+          initAnalytics();
+
           test.cmp.pushToGtmDataLayer.call(test.cmp, data);
           expect((<any>window)[defaultDataLayerName][0]).toBe(data);
         });
 
         it('can push to valid specified gtmDataLayerName, even if autoPushToGtmDataLayer is false', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
+          options = {
             autoPushToGtmDataLayer: false,
             gtmDataLayerName: customDataLayerName
-          });
+          };
+          initAnalytics();
+
           test.cmp.pushToGtmDataLayer.call(test.cmp, data);
           expect((<any>window)[customDataLayerName][0]).toBe(data);
         });
 
         it('should catch error when pushing to invalid data layer', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
+          options = {
             autoPushToGtmDataLayer: false,
             gtmDataLayerName: 'myImaginaryDataLayer'
-          });
+          };
+          initAnalytics();
+
           test.cmp.pushToGtmDataLayer.call(test.cmp, data);
           expect(() => {
             test.cmp.pushToGtmDataLayer.call(test.cmp, data);
@@ -284,81 +299,87 @@ export function AnalyticsTest() {
         });
 
         it('user can be specified', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            user: 'foobar'
-          });
+          options = { user: 'foobar' };
+          initAnalytics();
+
           let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
           expect(client.userId).toBe('foobar');
         });
 
         it('userdisplayname can be specified', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            userDisplayName: 'foobar'
-          });
+          options = { userDisplayName: 'foobar' };
+          initAnalytics();
+
           let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
           expect(client.userDisplayName).toBe('foobar');
         });
 
         it('token can be specified', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            token: 'qwerty123'
-          });
+          options = { token: 'qwerty123' };
+          initAnalytics();
+
           let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
           expect(client.endpoint.endpointCaller.options.accessToken).toBe('qwerty123');
         });
 
         it('endpoint can be specified', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            endpoint: 'somewhere.com'
-          });
+          options = { endpoint: 'somewhere.com' };
+          initAnalytics();
+
           let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
           expect(client.endpoint.options.serviceUrl).toBe('somewhere.com');
         });
 
+        // it('if the endpoint is set to url not ending with /rest, it appends /rest', () => {
+        //   test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
+        //     endpoint: 'https://usageanalyticshipaa.cloud.coveo.com'
+        //   });
+
+        // })
+
         it('anonymous can be specified', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            anonymous: true
-          });
+          options = { anonymous: true };
+          initAnalytics();
+
           let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
           expect(client.anonymous).toBe(true);
         });
 
         it('searchHub can be specified', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            searchHub: 'foobar'
-          });
+          options = { searchHub: 'foobar' };
+          initAnalytics();
+
           let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
           expect(client.originLevel1).toBe('foobar');
         });
 
         it('searchhub will be put in the query params', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            searchHub: 'yoo'
-          });
+          options = { searchHub: 'yoo' };
+          initAnalytics();
+
           let simulation = Simulate.query(test.env);
           expect(simulation.queryBuilder.build().searchHub).toBe('yoo');
         });
 
         it("searchhub should be put in the component options model for other component to see it's value", () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            searchHub: 'mama mia'
-          });
+          options = { searchHub: 'mama mia' };
+          initAnalytics();
 
           expect(test.env.componentOptionsModel.set).toHaveBeenCalledWith('searchHub', 'mama mia');
         });
 
         it('splitTestRunName can be specified', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            splitTestRunName: 'foobar'
-          });
+          options = { splitTestRunName: 'foobar' };
+          initAnalytics();
+
           let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
           expect(client.splitTestRunName).toBe('foobar');
         });
 
         it('splitTestRunVersion can be specified', () => {
-          test = Mock.optionsComponentSetup<Analytics, IAnalyticsOptions>(Analytics, {
-            splitTestRunVersion: 'foobar'
-          });
+          options = { splitTestRunVersion: 'foobar' };
+          initAnalytics();
+
           let client: LiveAnalyticsClient = <LiveAnalyticsClient>test.cmp.client;
           expect(client.splitTestRunVersion).toBe('foobar');
         });

--- a/unitTests/ui/AnalyticsTest.ts
+++ b/unitTests/ui/AnalyticsTest.ts
@@ -316,19 +316,23 @@ export function AnalyticsTest() {
           expect(analyticsClient().endpoint.endpointCaller.options.accessToken).toBe('qwerty123');
         });
 
-        it('endpoint can be specified', () => {
-          options = { endpoint: 'somewhere.com' };
+        it(`when an endpoint is defined that does not end with /rest,
+        it ensures the endpoint ends with /rest`, () => {
+          const endpoint = 'https://usageanalyticshipaa.cloud.coveo.com';
+          options = { endpoint };
           initAnalytics();
 
-          expect(analyticsClient().endpoint.options.serviceUrl).toBe('somewhere.com');
+          expect(test.cmp.options.endpoint).toBe(`${endpoint}/rest`);
         });
 
-        // it('if the endpoint is set to url not ending with /rest, it appends /rest', () => {
-        //   options = { endpoint: 'https://usageanalyticshipaa.cloud.coveo.com' }
-        //   initAnalytics();
+        it(`when an endpoint is defined that ends with /rest,
+        it does not append a second /rest`, () => {
+          const endpoint = 'somewhere.com/rest';
+          options = { endpoint };
+          initAnalytics();
 
-        //   expect(analyticsClient().endpoint.options.serviceUrl).toBe(`${options.endpoint}/rest`);
-        // })
+          expect(test.cmp.options.endpoint).toBe(endpoint);
+        });
 
         it('anonymous can be specified', () => {
           options = { anonymous: true };


### PR DESCRIPTION
**Description**

Before the [recent change](https://github.com/coveo/search-ui/commit/fc7e31e3fd3594763a3338e2d0664f01cd5099e0#diff-d29441841a806633e79db771ddd85d5eL217) to the analytics url, we used to append `/rest` to all specified endpoint urls.
With the new endpoint though, it is not possible to append /rest, because the base url contains it in the middle of the path and ends with `/ua`.

```
// old
'https://usageanalytics.coveo.com' + '/rest' (it's possible to always append /rest)

//new
'https://platform.cloud.coveo.com/rest/ua' (cannot append /rest or shorten the url)
```

This PR brings back the old behaviour for manually specified urls to avoid breaking clients who are updating versions.

**Question**

Should we use this opportunity to deprecate the `endpoint` option on the Analytics component? Or are there use-cases where manually specifying the url is a must?


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)