### PR TITLE
JSUI-2973 Assign objecttype/filetype field values to html safely (XSS prevention)

### DIFF
--- a/src/ui/Icon/Icon.ts
+++ b/src/ui/Icon/Icon.ts
@@ -127,11 +127,11 @@ export class Icon extends Component {
   }
 
   private initialize(element: HTMLElement, bindings: IComponentBindings) {
-    var possibleInternalQuickview = $$(this.element).find('.' + Component.computeCssClassNameForType('Quickview'));
+    const possibleInternalQuickview = $$(this.element).find('.' + Component.computeCssClassNameForType('Quickview'));
     if (!Utils.isNullOrUndefined(possibleInternalQuickview) && QueryUtils.hasHTMLVersion(this.result)) {
       $$(this.element).addClass('coveo-with-quickview');
       $$(this.element).on('click', () => {
-        var qv = <any>Component.get(possibleInternalQuickview);
+        const qv = <any>Component.get(possibleInternalQuickview);
         qv.open();
       });
     }
@@ -140,8 +140,7 @@ export class Icon extends Component {
   }
 
   static createIcon(result: IQueryResult, options: IIconOptions = {}, element: HTMLElement = $$('div').el, bindings?: IComponentBindings) {
-    var info = FileTypes.get(result);
-
+    let info = FileTypes.get(result);
     if (!bindings && result.searchInterface) {
       // try to resolve results bindings automatically
       bindings = result.searchInterface.getBindings();

--- a/src/ui/Misc/FileTypes.ts
+++ b/src/ui/Misc/FileTypes.ts
@@ -2,8 +2,7 @@ import { IQueryResult } from '../../rest/QueryResult';
 import { Utils } from '../../utils/Utils';
 import { l } from '../../strings/Strings';
 import { Assert } from '../../misc/Assert';
-import * as _ from 'underscore';
-import { StringUtils } from '../../Core';
+import { keys, escape } from 'underscore';
 
 // On-demand mapping of file types to captions. Used by facets, but I don't
 // really like this. Maybe a dedicated filetype facet would be better? Hmm...
@@ -47,13 +46,7 @@ export class FileTypes {
       localizedString = l(objecttype);
     }
 
-    const iconClass = StringUtils.htmlEncode(loweredCaseObjecttype).replace(' ', '-');
-    const caption = StringUtils.htmlEncode(localizedString);
-
-    return {
-      icon: `coveo-icon objecttype ${iconClass}`,
-      caption
-    };
+    return this.safelyBuildFileTypeInfo('filetype', loweredCaseObjecttype, localizedString);
   }
 
   static getFileType(filetype: string): IFileTypeInfo {
@@ -76,13 +69,7 @@ export class FileTypes {
       localizedString = l(filetype);
     }
 
-    const iconClass = StringUtils.htmlEncode(loweredCaseFiletype).replace(' ', '-');
-    const caption = StringUtils.htmlEncode(localizedString);
-
-    return {
-      icon: `coveo-icon filetype ${iconClass}`,
-      caption
-    };
+    return this.safelyBuildFileTypeInfo('filetype', loweredCaseFiletype, localizedString);
   }
 
   static getFileTypeCaptions() {
@@ -90,7 +77,7 @@ export class FileTypes {
       fileTypeCaptions = {};
       var strings = String['locales'][String['locale'].toLowerCase()];
       Assert.isNotUndefined(strings);
-      _.each(_.keys(strings), function(key) {
+      keys(strings).forEach(key => {
         if (key.indexOf('filetype_') == 0) {
           fileTypeCaptions[key.substr('filetype_'.length)] = key.toLocaleString();
         } else if (key.indexOf('objecttype_') == 0) {
@@ -100,5 +87,12 @@ export class FileTypes {
     }
 
     return fileTypeCaptions;
+  }
+
+  static safelyBuildFileTypeInfo(fieldname: string, iconClass: string, caption: string): IFileTypeInfo {
+    return {
+      icon: `coveo-icon ${fieldname} ${escape(iconClass.replace(' ', '-'))}`,
+      caption: escape(caption)
+    };
   }
 }

--- a/src/ui/Misc/FileTypes.ts
+++ b/src/ui/Misc/FileTypes.ts
@@ -3,6 +3,7 @@ import { Utils } from '../../utils/Utils';
 import { l } from '../../strings/Strings';
 import { Assert } from '../../misc/Assert';
 import * as _ from 'underscore';
+import { StringUtils } from '../../Core';
 
 // On-demand mapping of file types to captions. Used by facets, but I don't
 // really like this. Maybe a dedicated filetype facet would be better? Hmm...
@@ -15,8 +16,8 @@ export interface IFileTypeInfo {
 
 export class FileTypes {
   static get(result: IQueryResult): IFileTypeInfo {
-    var objecttype = <string>Utils.getFieldValue(result, 'objecttype');
-    var filetype = <string>Utils.getFieldValue(result, 'filetype');
+    const objecttype = <string>Utils.getFieldValue(result, 'objecttype');
+    const filetype = <string>Utils.getFieldValue(result, 'filetype');
 
     // When @objecttype is File, Item, Document, or ContentVersion we fallback on @filetype for icons and such
     if (Utils.isNonEmptyString(objecttype) && !objecttype.match(/^(file|document|contentversion|item)$/i)) {
@@ -45,9 +46,13 @@ export class FileTypes {
     if (localizedString.toLowerCase() == variableValue.toLowerCase()) {
       localizedString = l(objecttype);
     }
+
+    const iconClass = StringUtils.htmlEncode(loweredCaseObjecttype).replace(' ', '-');
+    const caption = StringUtils.htmlEncode(localizedString);
+
     return {
-      icon: 'coveo-icon objecttype ' + loweredCaseObjecttype.replace(' ', '-'),
-      caption: localizedString
+      icon: `coveo-icon objecttype ${iconClass}`,
+      caption
     };
   }
 
@@ -70,9 +75,13 @@ export class FileTypes {
       // The main dictionary by using the original value.
       localizedString = l(filetype);
     }
+
+    const iconClass = StringUtils.htmlEncode(loweredCaseFiletype).replace(' ', '-');
+    const caption = StringUtils.htmlEncode(localizedString);
+
     return {
-      icon: 'coveo-icon filetype ' + loweredCaseFiletype.replace(' ', '-'),
-      caption: localizedString
+      icon: `coveo-icon filetype ${iconClass}`,
+      caption
     };
   }
 

--- a/src/ui/Misc/FileTypes.ts
+++ b/src/ui/Misc/FileTypes.ts
@@ -46,7 +46,7 @@ export class FileTypes {
       localizedString = l(objecttype);
     }
 
-    return this.safelyBuildFileTypeInfo('filetype', loweredCaseObjecttype, localizedString);
+    return this.safelyBuildFileTypeInfo('objecttype', loweredCaseObjecttype, localizedString);
   }
 
   static getFileType(filetype: string): IFileTypeInfo {

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -836,3 +836,6 @@ ResponsiveFacetColumnTest();
 
 import { ResponsiveDropdownModalContentTest } from './ui/ResponsiveComponents/ResponsiveDropdownModalContentTest';
 ResponsiveDropdownModalContentTest();
+
+import { FileTypesTest } from './ui/FileTypesTest';
+FileTypesTest();

--- a/unitTests/ui/FileTypesTest.ts
+++ b/unitTests/ui/FileTypesTest.ts
@@ -1,4 +1,5 @@
 import { FileTypes } from '../../src/ui/Misc/FileTypes';
+import { escape } from 'underscore';
 
 export function FileTypesTest() {
   describe('FileTypes', () => {
@@ -6,8 +7,8 @@ export function FileTypesTest() {
       const unsafeInput = 'Foo><img src=y onerror=alert(document.cookie)>';
       const info = FileTypes.safelyBuildFileTypeInfo('objecttype', unsafeInput, unsafeInput);
 
-      expect(info.icon).toBe('coveo-icon objecttype Foo&gt;&lt;img-src=y onerror=alert(document.cookie)&gt;');
-      expect(info.caption).toBe('Foo&gt;&lt;img src=y onerror=alert(document.cookie)&gt;');
+      expect(info.icon).toEqual(`coveo-icon objecttype ${escape(unsafeInput.replace(' ', '-'))}`);
+      expect(info.caption).toBe(escape(unsafeInput));
     });
   });
 }

--- a/unitTests/ui/FileTypesTest.ts
+++ b/unitTests/ui/FileTypesTest.ts
@@ -1,0 +1,13 @@
+import { FileTypes } from '../../src/ui/Misc/FileTypes';
+
+export function FileTypesTest() {
+  describe('FileTypes', () => {
+    it('safelyBuildFileTypeInfo should prevent XSS attacks by espacing inputs', () => {
+      const unsafeInput = 'Foo><img src=y onerror=alert(document.cookie)>';
+      const info = FileTypes.safelyBuildFileTypeInfo('objecttype', unsafeInput, unsafeInput);
+
+      expect(info.icon).toBe('coveo-icon objecttype Foo&gt;&lt;img-src=y onerror=alert(document.cookie)&gt;');
+      expect(info.caption).toBe('Foo&gt;&lt;img src=y onerror=alert(document.cookie)&gt;');
+    });
+  });
+}


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2973

If the objecttype or fieldtype was something like `Foo><img src=y onerror=alert(document.cookie)>` it would be executed



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)