### PR TITLE
JSUI-2958 Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,9 @@
 # These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
+# the repo.
 # see https://help.github.com/articles/about-codeowners/ for more details
 
 * @coveo/search
 
-# Prevent PRs that only modify package.json from notifying everyone
+# Prevent PRs that only modify dependencies from notifying everyone
 package.json @ghost
 yarn.lock @ghost

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+# see https://help.github.com/articles/about-codeowners/ for more details
+
+* @coveo/search
+
+# Prevent PRs that only modify package.json from notifying everyone
+package.json @ghost
+yarn.lock @ghost


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2958

Now that we're getting bigger, it's a bit tiresome to add everyone every time to our PRs.

This will automatically add everyone in the Github Search Team to this repo's PRs https://github.com/orgs/coveo/teams/search
Before merging, we should make the team members are all relevant. I don't seem to have rights to edit the team.

More doc on CODEOWNERS here https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)