### PR TITLE
JSUI-2984 Fixed and improved accessibility tests for `DynamicHierarchicalFacet`

### DIFF
--- a/accessibilityTest/AccessibilityDynamicHierarchicalFacet.ts
+++ b/accessibilityTest/AccessibilityDynamicHierarchicalFacet.ts
@@ -1,20 +1,29 @@
 import * as axe from 'axe-core';
 import { $$, Component, DynamicHierarchicalFacet } from 'coveo-search-ui';
-import { afterDeferredQuerySuccess, getFacetColumn, getRoot, inDesktopMode, resetMode } from './Testing';
+import { afterDeferredQuerySuccess, getFacetColumn, getRoot, inDesktopMode, resetMode, waitUntilSelectorIsPresent } from './Testing';
 
 export const AccessibilityDynamicHierarchicalFacet = () => {
   describe('DynamicHierarchicalFacet', () => {
-    let dynamicHierarchicalFacet: HTMLElement;
+    let dynamicHierarchicalFacet: DynamicHierarchicalFacet;
 
-    beforeEach(() => {
-      dynamicHierarchicalFacet = $$('div', {
+    async function initializeHierarchicalFacet() {
+      const dynamicHierarchicalFacetElement = $$('div', {
         className: Component.computeCssClassName(DynamicHierarchicalFacet),
         dataTitle: 'My Facet',
-        dataField: '@champion_categories',
+        dataField: '@geographicalhierarchy',
         dataEnableCollapse: true
       }).el;
+      getFacetColumn().appendChild(dynamicHierarchicalFacetElement);
+      await afterDeferredQuerySuccess();
+      dynamicHierarchicalFacet = Component.get(dynamicHierarchicalFacetElement, DynamicHierarchicalFacet) as DynamicHierarchicalFacet;
+      dynamicHierarchicalFacet.ensureDom();
+    }
 
+    beforeEach(async done => {
       inDesktopMode();
+
+      await initializeHierarchicalFacet();
+      done();
     });
 
     afterEach(() => {
@@ -22,11 +31,7 @@ export const AccessibilityDynamicHierarchicalFacet = () => {
     });
 
     it('should be accessible', async done => {
-      getFacetColumn().appendChild(dynamicHierarchicalFacet);
-      await afterDeferredQuerySuccess();
-      $$(dynamicHierarchicalFacet)
-        .find('.coveo-dynamic-hierarchical-facet-value')
-        .click();
+      (await waitUntilSelectorIsPresent<HTMLElement>(dynamicHierarchicalFacet.element, '.coveo-dynamic-hierarchical-facet-value')).click();
       await afterDeferredQuerySuccess();
       const axeResults = await axe.run(getRoot());
       expect(axeResults).toBeAccessible();

--- a/accessibilityTest/Testing.ts
+++ b/accessibilityTest/Testing.ts
@@ -156,6 +156,10 @@ export const isInit = () => {
 };
 
 export const waitUntilSelectorIsPresent = <T extends Element = Element>(parentNode: HTMLElement, selector: string) => {
+  const alreadyExistingElement = parentNode.querySelector<T>(selector);
+  if (alreadyExistingElement) {
+    return alreadyExistingElement;
+  }
   return observeUntil(
     parentNode,
     {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2984

This PR fixes a build error reported by travis by running the `ensureDom` function on `DynamicHierarchicalFacet`, using a valid field and optionally waiting for values to be returned.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)