### PR TITLE
JSUI-2972 Added a prefix to `DynamicHierarchicalFacetSearch`'s values' paths.

### DIFF
--- a/sass/DynamicHierarchicalFacetSearch/_DynamicHierarchicalFacetSearch.scss
+++ b/sass/DynamicHierarchicalFacetSearch/_DynamicHierarchicalFacetSearch.scss
@@ -20,8 +20,13 @@
     display: flex;
 
     .coveo-dynamic-hierarchical-facet-search-value-path-ellipsis,
+    .coveo-dynamic-hierarchical-facet-search-value-path-prefix,
     .coveo-dynamic-hierarchical-facet-search-value-path-part {
       display: inline;
+    }
+
+    .coveo-dynamic-hierarchical-facet-search-value-path-prefix {
+      white-space: pre;
     }
 
     .coveo-dynamic-hierarchical-facet-search-value-path-part {

--- a/src/ui/DynamicHierarchicalFacetSearch/DynamicHierarchicalFacetSearchValueRenderer.ts
+++ b/src/ui/DynamicHierarchicalFacetSearch/DynamicHierarchicalFacetSearchValueRenderer.ts
@@ -13,6 +13,7 @@ const LABEL_CLASSNAME = `${VALUE_CLASSNAME}-label`;
 const COUNT_CLASSNAME = `${VALUE_CLASSNAME}-results-count`;
 const PATH_CLASSNAME = `${VALUE_CLASSNAME}-path`;
 const PATH_ELLIPSIS_CLASSNAME = `${PATH_CLASSNAME}-ellipsis`;
+const PATH_PREFIX_CLASSNAME = `${PATH_CLASSNAME}-prefix`;
 const PATH_PART_CLASSNAME = `${PATH_CLASSNAME}-part`;
 const PATH_SEPARATOR_CLASSNAME = `${PATH_CLASSNAME}-separator`;
 
@@ -23,6 +24,7 @@ export const DynamicHierarchicalFacetSearchValueRendererClassNames = {
   COUNT_CLASSNAME,
   PATH_CLASSNAME,
   PATH_ELLIPSIS_CLASSNAME,
+  PATH_PREFIX_CLASSNAME,
   PATH_PART_CLASSNAME,
   PATH_SEPARATOR_CLASSNAME
 };
@@ -83,7 +85,14 @@ export class DynamicHierarchicalFacetSearchValueRenderer {
   }
 
   private renderPath() {
-    const element = $$('ul', { className: PATH_CLASSNAME, ariaHidden: true });
+    const element = $$(
+      'ul',
+      {
+        className: PATH_CLASSNAME,
+        ariaHidden: true
+      },
+      this.renderPathPrefix()
+    );
     const { start, end } = this.pathToRender;
     start.forEach((part, index) => {
       if (index > 0) {
@@ -99,6 +108,12 @@ export class DynamicHierarchicalFacetSearchValueRenderer {
         element.append(this.renderPathPart(part).el);
       });
     }
+    return element;
+  }
+
+  private renderPathPrefix() {
+    const element = $$('li', { className: PATH_PREFIX_CLASSNAME });
+    element.text(`${l('HierarchicalFacetValuePathPrefix')} `);
     return element;
   }
 

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7548,5 +7548,9 @@
   "HierarchicalFacetValueIndentedUnder": {
     "en": "{0} under {1}",
     "fr": "{0} sous {1}"
+  },
+  "HierarchicalFacetValuePathPrefix": {
+    "en": "in",
+    "fr": "dans"
   }
 }

--- a/unitTests/ui/DynamicHierarchicalFacetSearchValueRendererTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacetSearchValueRendererTest.ts
@@ -134,10 +134,10 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
           expect(count.innerText).toEqual(`(${facetValue.numberOfResults})`);
         });
 
-        it('should render a path containing only the clearLabel', () => {
+        it('should render a path containing only the prefix and the clearLabel', () => {
           const [path] = $$(render).findClass(ClassNames.PATH_CLASSNAME);
           expect(path.getAttribute('aria-hidden')).toEqual('true');
-          const [part] = expectChildren(path, [ClassNames.PATH_PART_CLASSNAME]);
+          const [, part] = expectChildren(path, [ClassNames.PATH_PREFIX_CLASSNAME, ClassNames.PATH_PART_CLASSNAME]);
           expect(part.innerText).toEqual(facet.options.clearLabel);
         });
       });
@@ -165,9 +165,9 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
         expect(render.getAttribute('aria-label')).toEqual(expectedLabel);
       });
 
-      it('should render a path containing only the parent', () => {
+      it('should render a path containing only the prefix and the parent', () => {
         const [path] = $$(render).findClass(ClassNames.PATH_CLASSNAME);
-        const [part] = expectChildren(path, [ClassNames.PATH_PART_CLASSNAME]);
+        const [, part] = expectChildren(path, [ClassNames.PATH_PREFIX_CLASSNAME, ClassNames.PATH_PART_CLASSNAME]);
         expect(part.innerText).toEqual(parentValue);
       });
     });
@@ -196,7 +196,8 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
 
       it('should render a path containing three parents, two separators and no ellipse', () => {
         const [path] = $$(render).findClass(ClassNames.PATH_CLASSNAME);
-        const [parent0 /* separator */, , parent1 /* separator */, , parent2] = expectChildren(path, [
+        const [, parent0 /* separator */, , parent1 /* separator */, , parent2] = expectChildren(path, [
+          ClassNames.PATH_PREFIX_CLASSNAME,
           ClassNames.PATH_PART_CLASSNAME,
           ClassNames.PATH_SEPARATOR_CLASSNAME,
           ClassNames.PATH_PART_CLASSNAME,
@@ -211,7 +212,8 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
 
       it('should give separators the separator role', () => {
         const [path] = $$(render).findClass(ClassNames.PATH_CLASSNAME);
-        const [, /* parent */ firstSeparator] = expectChildren(path, [
+        const [, , /* parent */ firstSeparator] = expectChildren(path, [
+          ClassNames.PATH_PREFIX_CLASSNAME,
           ClassNames.PATH_PART_CLASSNAME,
           ClassNames.PATH_SEPARATOR_CLASSNAME,
           ClassNames.PATH_PART_CLASSNAME,
@@ -246,7 +248,8 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
 
       it('should render a path containing the first and the last two parents', () => {
         const [path] = $$(render).findClass(ClassNames.PATH_CLASSNAME);
-        const [parent0 /* separator */ /* ellipsis */ /* separator */, , , , parent2 /* separator */, , parent3] = expectChildren(path, [
+        const [, parent0 /* separator */ /* ellipsis */ /* separator */, , , , parent2 /* separator */, , parent3] = expectChildren(path, [
+          ClassNames.PATH_PREFIX_CLASSNAME,
           ClassNames.PATH_PART_CLASSNAME,
           ClassNames.PATH_SEPARATOR_CLASSNAME,
           ClassNames.PATH_ELLIPSIS_CLASSNAME,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2972

This PR adds the "in" prefix to `DynamicHierarchicalFacetSearch`'s paths.
![image](https://user-images.githubusercontent.com/54454747/83280761-16a7e880-a1a5-11ea-9bf7-89de382430b5.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)