### PR TITLE
JSUI-2958 Add codeowners individually

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # the repo.
 # see https://help.github.com/articles/about-codeowners/ for more details
 
-* @coveo/search
+* @samisayegh @btaillon @olamothe @ThibodeauJF @dsing-coveo @kshimCoveo
 
 # Prevent PRs that only modify dependencies from notifying everyone
 package.json @ghost


### PR DESCRIPTION
With Codeowners, when adding a team ( @coveo/search) as soon as one member of the team approves it, it put’s him as reviewer and removes the rest of the team. Bummer, it’s not really what we want. Related ticket: https://github.community/t/codeowners-and-teams/2895
I’ll switch the CODEOWNER file to use our github handles directly, just sucks a bit to make a PR everytime a member is added/removed from the team. Seems dedicated reviewers, like Bitbucket, are a Github Pro feature: https://help.github.com/en/github/getting-started-with-github/githubs-products#github-pro

https://coveord.atlassian.net/browse/JSUI-2958





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)