### PR TITLE
JSUI-2995 Removed padding inside `FacetsMobileMode`'s modal's button

### DIFF
--- a/sass/_ResponsiveFacets.scss
+++ b/sass/_ResponsiveFacets.scss
@@ -37,6 +37,7 @@
       .coveo-facet-modal-close-button {
         $close-button-size: 32px;
 
+        padding: 0;
         width: $close-button-size;
         height: $close-button-size;
         border-radius: 50%;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2995

Safari on iOS appears to add a `1em` padding on both sides of `button` elements, causing the icon inside `FacetsMobileMode`'s close button to collapse into 1px when font size is too large:
![image](https://user-images.githubusercontent.com/54454747/84300329-2538bd00-ab20-11ea-8d52-47180aca5161.png)

This PR resolves the issue by explicitly giving the close button a padding of `0`.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)