### PR TITLE
JSUI-2993 Made `QuerySuggestPreview` keep the last constant expression

### DIFF
--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -158,7 +158,7 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
   }
 
   private buildQuery(suggestion: Suggestion): IQuery {
-    const { searchHub, pipeline, tab, locale, timezone, context } = this.queryController.getLastQuery();
+    const { searchHub, pipeline, tab, locale, timezone, context, cq } = this.queryController.getLastQuery();
     return {
       firstResult: 0,
       searchHub,
@@ -167,6 +167,7 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
       locale,
       timezone,
       context,
+      cq,
       numberOfResults: this.options.numberOfPreviewResults,
       q: suggestion.text || suggestion.dom.innerText,
       ...(suggestion.advancedQuery && { aq: suggestion.advancedQuery })

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -106,7 +106,8 @@ export function QuerySuggestPreviewTest() {
         context: {
           'the first key': 'the first value',
           'the second key': 'the second value'
-        }
+        },
+        cq: 'some constant query'
       };
       setupQuerySuggestPreview();
       (test.cmp.queryController.getLastQuery as jasmine.Spy).and.returnValue(optionsToTest);
@@ -115,6 +116,15 @@ export function QuerySuggestPreviewTest() {
       for (let optionName of Object.keys(optionsToTest)) {
         expect(lastSearchQuery[optionName]).toEqual(optionsToTest[optionName]);
       }
+      done();
+    });
+
+    it('uses the suggestion text in its search', async done => {
+      setupQuerySuggestPreview();
+      const suggestionText = 'Hello, World!';
+      await triggerPopulateSearchResultPreviewsAndPassTime(suggestionText);
+      const lastSearchQuery = (test.cmp.queryController.getEndpoint().search as jasmine.Spy).calls.mostRecent().args[0] as IQuery;
+      expect(lastSearchQuery.q).toEqual(suggestionText);
       done();
     });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2993

Despite the `tab` parameter from the last query being re-used, the `constantExpression` (aka `cq`) generated by the `Tab` component wasn't being re-used.

Since `constantExpression` seems to hold contextual expressions, like the tab's expression, it feels appropriate to re-use it even though it can also be defined with `SearchInterface`'s `expression` and `OmniboxResultList`'s `queryOverride`.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)