### PR TITLE
JSUI-2969 Whitelist HTTP(s) protocol for ResultLink

### DIFF
--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -471,6 +471,14 @@ export class ResultLink extends Component {
     true
   );
 
+  private filterProtocol(uri: string) {
+    if (!/^https?:\/\//.test(uri)) {
+      return '';
+    }
+
+    return uri;
+  }
+
   private getResultUri(): string {
     if (this.options.hrefTemplate) {
       return StringUtils.buildStringTemplateFromResult(this.options.hrefTemplate, this.result);
@@ -481,10 +489,10 @@ export class ResultLink extends Component {
     }
 
     if (this.options.field != undefined) {
-      return Utils.getFieldValue(this.result, <string>this.options.field);
+      return this.filterProtocol(Utils.getFieldValue(this.result, <string>this.options.field));
     }
 
-    return this.escapedClickUri;
+    return this.filterProtocol(this.escapedClickUri);
   }
 
   private elementIsAnAnchor() {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2969


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)