### PR TITLE
* Add button type to ShowMoreLessButton

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueMoreLessButton.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueMoreLessButton.ts
@@ -15,7 +15,8 @@ export class DynamicFacetValueShowMoreLessButton {
       'button',
       {
         className: options.className,
-        ariaLabel: options.ariaLabel
+        ariaLabel: options.ariaLabel,
+        type: 'button'
       },
       options.label
     );


### PR DESCRIPTION
The default type of button if 'submit'. In the context of ServiceNow, clicking the button therefore submits the form in which the button is. Changing the type of button to 'button' prevents submitting form on click.
SNOW-349




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)