### PR TITLE
+ Add an utility to add/remove CustomActionCause

### DIFF
--- a/src/ui/Base/RegisteredNamedMethods.ts
+++ b/src/ui/Base/RegisteredNamedMethods.ts
@@ -17,6 +17,7 @@ import * as _ from 'underscore';
 import { PublicPathUtils } from '../../utils/PublicPathUtils';
 import { Logger } from '../../misc/Logger';
 import { Analytics } from '../Analytics/Analytics';
+import { AnalyticsUtils } from '../../utils/AnalyticsUtils';
 
 let registeredNamedMethodsLogger = new Logger('RegisteredNamedMethods');
 
@@ -532,6 +533,36 @@ export function disableAnalytics(searchRoot = document.querySelector(Component.c
 
 Initialization.registerNamedMethod('disableAnalytics', () => {
   disableAnalytics();
+});
+
+/**
+ * Adds a new analytics action cause to the ActionCauseList.
+ * Adding a new actionCause allows to specify a custom user-action when triggering a search event.
+ * @param newActionCause
+ * (e.g.,
+ * {
+ *  Name: "newActionCause",
+ *  Type: "exampleType"
+ * },
+ */
+export function addActionCauseToList(newActionCause: IAnalyticsActionCause) {
+  AnalyticsUtils.addActionCauseToList(newActionCause);
+}
+
+Initialization.registerNamedMethod('addActionCauseToList', (newActionCause: IAnalyticsActionCause) => {
+  addActionCauseToList(newActionCause);
+});
+
+/**
+ * Removes an actionCause from the ActionCauseList.
+ * @param actionCauseToRemoveName
+ */
+export function removeActionCauseFromList(actionCauseToRemoveName: string) {
+  AnalyticsUtils.removeActionCauseFromList(actionCauseToRemoveName);
+}
+
+Initialization.registerNamedMethod('removeActionCauseFromList', (actionCauseToRemoveName: string) => {
+  removeActionCauseFromList(actionCauseToRemoveName);
 });
 
 /**

--- a/src/utils/AnalyticsUtils.ts
+++ b/src/utils/AnalyticsUtils.ts
@@ -1,0 +1,13 @@
+import { IAnalyticsActionCause, analyticsActionCauseList } from '../ui/Analytics/AnalyticsActionListMeta';
+
+export class AnalyticsUtils {
+  static addActionCauseToList(newActionCause: IAnalyticsActionCause) {
+    if (newActionCause.name && newActionCause.type) {
+      analyticsActionCauseList[newActionCause.name] = newActionCause;
+    }
+  }
+
+  static removeActionCauseFromList(actionCauseToRemoveName: string) {
+    delete analyticsActionCauseList[actionCauseToRemoveName];
+  }
+}

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -27,6 +27,9 @@ CookieUtilsTest();
 import { ColorUtilsTest } from './utils/ColorUtilsTest';
 ColorUtilsTest();
 
+import { AnalyticsUtilsTest } from './utils/AnalyticsUtilsTest';
+AnalyticsUtilsTest();
+
 import { DomTests } from './utils/DomTest';
 DomTests();
 

--- a/unitTests/ui/AnalyticsTest.ts
+++ b/unitTests/ui/AnalyticsTest.ts
@@ -3,12 +3,11 @@ import { Analytics } from '../../src/ui/Analytics/Analytics';
 import { SearchEndpoint } from '../../src/rest/SearchEndpoint';
 import { IAnalyticsOptions } from '../../src/ui/Analytics/Analytics';
 import { Simulate } from '../Simulate';
-import { analyticsActionCauseList, IAnalyticsActionCause } from '../../src/ui/Analytics/AnalyticsActionListMeta';
+import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
 import { NoopAnalyticsClient } from '../../src/ui/Analytics/NoopAnalyticsClient';
 import { LiveAnalyticsClient } from '../../src/ui/Analytics/LiveAnalyticsClient';
 import { MultiAnalyticsClient } from '../../src/ui/Analytics/MultiAnalyticsClient';
 import { AnalyticsEvents, $$ } from '../../src/Core';
-import { AnalyticsUtils } from '../../src/utils/AnalyticsUtils';
 
 export function AnalyticsTest() {
   describe('Analytics', () => {
@@ -377,18 +376,6 @@ export function AnalyticsTest() {
 
           expect(analyticsClient().splitTestRunVersion).toBe('foobar');
         });
-      });
-    });
-    describe('utilities methods', () => {
-      it('can add/remove new actionCause to actionCauseList', () => {
-        const testActionCause: IAnalyticsActionCause = {
-          name: 'testActionCause',
-          type: 'test'
-        };
-        AnalyticsUtils.addActionCauseToList(testActionCause);
-        expect(analyticsActionCauseList[testActionCause.name]).toBe(testActionCause);
-        AnalyticsUtils.removeActionCauseFromList(testActionCause.name);
-        expect(analyticsActionCauseList[testActionCause.name]).toBe(undefined);
       });
     });
   });

--- a/unitTests/ui/AnalyticsTest.ts
+++ b/unitTests/ui/AnalyticsTest.ts
@@ -3,11 +3,12 @@ import { Analytics } from '../../src/ui/Analytics/Analytics';
 import { SearchEndpoint } from '../../src/rest/SearchEndpoint';
 import { IAnalyticsOptions } from '../../src/ui/Analytics/Analytics';
 import { Simulate } from '../Simulate';
-import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
+import { analyticsActionCauseList, IAnalyticsActionCause } from '../../src/ui/Analytics/AnalyticsActionListMeta';
 import { NoopAnalyticsClient } from '../../src/ui/Analytics/NoopAnalyticsClient';
 import { LiveAnalyticsClient } from '../../src/ui/Analytics/LiveAnalyticsClient';
 import { MultiAnalyticsClient } from '../../src/ui/Analytics/MultiAnalyticsClient';
 import { AnalyticsEvents, $$ } from '../../src/Core';
+import { AnalyticsUtils } from '../../src/utils/AnalyticsUtils';
 
 export function AnalyticsTest() {
   describe('Analytics', () => {
@@ -376,6 +377,18 @@ export function AnalyticsTest() {
 
           expect(analyticsClient().splitTestRunVersion).toBe('foobar');
         });
+      });
+    });
+    describe('utilities methods', () => {
+      it('can add/remove new actionCause to actionCauseList', () => {
+        const testActionCause: IAnalyticsActionCause = {
+          name: 'testActionCause',
+          type: 'test'
+        };
+        AnalyticsUtils.addActionCauseToList(testActionCause);
+        expect(analyticsActionCauseList[testActionCause.name]).toBe(testActionCause);
+        AnalyticsUtils.removeActionCauseFromList(testActionCause.name);
+        expect(analyticsActionCauseList[testActionCause.name]).toBe(undefined);
       });
     });
   });

--- a/unitTests/utils/AnalyticsUtilsTest.ts
+++ b/unitTests/utils/AnalyticsUtilsTest.ts
@@ -1,0 +1,23 @@
+import { IAnalyticsActionCause, analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
+import { AnalyticsUtils } from '../../src/utils/AnalyticsUtils';
+
+export function AnalyticsUtilsTest() {
+  describe('utilities methods', () => {
+    it('can add new actionCause to actionCauseList', () => {
+      const testActionCause: IAnalyticsActionCause = {
+        name: 'testActionCause',
+        type: 'test'
+      };
+      AnalyticsUtils.addActionCauseToList(testActionCause);
+      expect(analyticsActionCauseList[testActionCause.name]).toBe(testActionCause);
+    });
+    it('can remove actionCause from actionCauseList', () => {
+      analyticsActionCauseList['testActionCause'] = {
+        name: 'testActionCause',
+        type: 'test'
+      };
+      AnalyticsUtils.removeActionCauseFromList('testActionCause');
+      expect(analyticsActionCauseList['testActionCause']).toBe(undefined);
+    });
+  });
+}


### PR DESCRIPTION
The reason ServiceNow would like to be able to add custom actionCauses is to link the search event inside the search page to the use of our "top querry widget" which would potentially be in another page. (Users would click on a top querry on a certain page and be redirected to the search page)

There would be a way to add more actionCause to the actionCauseList on the ServiceNow integration side, but it would be a bit less stable IMO. Adding the addActionCause utility in the search-ui repo and covering it with tests makes it a bit more future proof.

link to a related discuss discussion: https://discuss.coveo.com/t/custom-actioncause/3903/2

SNOW-347

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)