### PR TITLE
+ Add possibility to attach modals to search interface

### DIFF
--- a/src/ui/AdvancedSearch/AdvancedSearch.ts
+++ b/src/ui/AdvancedSearch/AdvancedSearch.ts
@@ -151,7 +151,8 @@ export class AdvancedSearch extends Component {
       this.modalbox = this.ModalBox.open(this.content.el, {
         sizeMod: 'big',
         title: l('AdvancedSearch'),
-        className: 'coveo-advanced-search-modal'
+        className: 'coveo-advanced-search-modal',
+        body: this.searchInterface.options.modalContainer
       });
     }
   }

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -208,7 +208,8 @@ export class AuthenticationProvider extends Component {
 
     ModalBox.open(popup, {
       title: l('Authenticating', this.options.caption),
-      sizeMod: 'small'
+      sizeMod: 'small',
+      body: this.searchInterface.options.modalContainer
     });
     return ModalBox;
   }
@@ -220,7 +221,8 @@ export class AuthenticationProvider extends Component {
     ModalBox.open(popup, {
       title: l('Authenticating', this.options.caption),
       className: 'coveo-authentication-popup',
-      sizeMod: 'big'
+      sizeMod: 'big',
+      body: this.searchInterface.options.modalContainer
     });
     return ModalBox;
   }

--- a/src/ui/Debug/Debug.ts
+++ b/src/ui/Debug/Debug.ts
@@ -211,7 +211,8 @@ export class Debug extends RootComponent {
         this.onCloseModalBox();
         return true;
       },
-      sizeMod: 'big'
+      sizeMod: 'big',
+      body: document.getElementsByClassName('CoveoSearchInterface')[0] // Will return undefined if no CoveoSearchInterface is present
     });
 
     const title = $$(this.modalBox.wrapper).find('.coveo-modal-header');

--- a/src/ui/PreferencesPanel/PreferencesPanel.ts
+++ b/src/ui/PreferencesPanel/PreferencesPanel.ts
@@ -84,7 +84,8 @@ export class PreferencesPanel extends Component {
         validation: () => {
           this.cleanupOnExit();
           return true;
-        }
+        },
+        body: this.searchInterface.options.modalContainer
       });
     }
   }

--- a/src/ui/Quickview/Quickview.ts
+++ b/src/ui/Quickview/Quickview.ts
@@ -54,7 +54,6 @@ export interface IQuickviewOptions {
   loadingAnimation?: HTMLElement | Promise<HTMLElement>;
   alwaysShow?: boolean;
   tooltipPlacement?: ValidTooltipPlacement;
-  modalContainer?: HTMLElement;
 }
 
 interface IQuickviewOpenerObject {
@@ -250,30 +249,7 @@ export class Quickview extends Component {
      */
     tooltipPlacement: ComponentOptions.buildCustomOption<ValidTooltipPlacement>((value: ValidTooltipPlacement) => value, {
       defaultValue: 'bottom'
-    }),
-
-    /**
-     * Specifies the HTMLElement where the Modal Box will be created when opening a QuickView. You can
-     * either specify a CSS selector or pass an HTMLElement in the options when calling Coveo.init.
-     *
-     * Default value is `element.ownerDocument.body`.
-     *
-     * **Example in attribute:**
-     * ```html
-     * <div class="CoveoQuickview" data-modal-container="#my-modal-container"></div>
-     * ```
-     *
-     * **Example in init options:**
-     * ```javascript
-     * var myContainer = document.getElementById('my-modal-container');
-     * Coveo.init(root, {
-     *   Quickview: {
-     *     modalContainer: myContainer
-     *   }
-     * });
-     * ```
-     */
-    modalContainer: ComponentOptions.buildSelectorOption({ defaultFunction: element => element.ownerDocument.body })
+    })
   };
 
   public static resultCurrentlyBeingRendered: IQueryResult = null;
@@ -317,7 +293,7 @@ export class Quickview extends Component {
       });
     }
 
-    this.modalbox = new AccessibleModal('coveo-quick-view', this.options.modalContainer, ModalBox);
+    this.modalbox = new AccessibleModal('coveo-quick-view', this.searchInterface.options.modalContainer, ModalBox);
   }
 
   private buildContent() {

--- a/src/ui/RelevanceInspector/RelevanceInspector.ts
+++ b/src/ui/RelevanceInspector/RelevanceInspector.ts
@@ -98,7 +98,8 @@ export class RelevanceInspector {
       validation: () => {
         this.opened = false;
         return true;
-      }
+      },
+      body: document.getElementsByClassName('CoveoSearchInterface')[0] // Will return undefined if no CoveoSearchInterface is present
     };
   }
 

--- a/src/ui/SearchAlerts/SearchAlerts.ts
+++ b/src/ui/SearchAlerts/SearchAlerts.ts
@@ -336,7 +336,8 @@ export class SearchAlerts extends Component {
     this.modal = this.ModalBox.open(container.el, {
       title: title.el.outerHTML,
       className: 'coveo-subscriptions-panel',
-      sizeMod: sizeModForModalBox
+      sizeMod: sizeModForModalBox,
+      body: this.searchInterface.options.modalContainer
     });
   }
 

--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -81,6 +81,7 @@ export interface ISearchInterfaceOptions {
   responsiveSmallBreakpoint?: number;
   responsiveMode?: ValidResponsiveMode;
   enableScrollRestoration?: boolean;
+  modalContainer?: HTMLElement;
 }
 
 export interface IMissingTermManagerArgs {
@@ -484,7 +485,29 @@ export class SearchInterface extends RootComponent implements IComponentBindings
      *
      * @availablesince [March 2020 Release (v2.8521)](https://docs.coveo.com/en/3203/)
      */
-    enableScrollRestoration: ComponentOptions.buildBooleanOption({ defaultValue: false })
+    enableScrollRestoration: ComponentOptions.buildBooleanOption({ defaultValue: false }),
+    /**
+     * Specifies the HTMLElement to which Modals components of the search interface will be attached to. You can
+     * either specify a CSS selector or pass an HTMLElement in the options when calling Coveo.init.
+     *
+     * Default value is `element.ownerDocument.body`.
+     *
+     * **Example in attribute:**
+     * ```html
+     * <div class="CoveoSearchInterface" data-modal-container="#my-modal-container"></div>
+     * ```
+     *
+     * **Example in init options:**
+     * ```javascript
+     * var myContainer = document.getElementById('my-modal-container');
+     * Coveo.init(root, {
+     *   SearchInterface: {
+     *     modalContainer: myContainer
+     *   }
+     * });
+     * ```
+     */
+    modalContainer: ComponentOptions.buildSelectorOption({ defaultFunction: element => element.ownerDocument.body })
   };
 
   public static SMALL_INTERFACE_CLASS_NAME = 'coveo-small-search-interface';

--- a/src/ui/ShareQuery/ShareQuery.ts
+++ b/src/ui/ShareQuery/ShareQuery.ts
@@ -69,7 +69,8 @@ export class ShareQuery extends Component {
       this.dialogBoxContent = this.buildContent();
       this.modalbox = this.ModalBox.open(this.dialogBoxContent, {
         title: l('ShareQuery'),
-        className: 'coveo-share-query-opened'
+        className: 'coveo-share-query-opened',
+        body: this.searchInterface.options.modalContainer
       });
     }
   }

--- a/src/ui/YouTube/YouTubeThumbnail.ts
+++ b/src/ui/YouTube/YouTubeThumbnail.ts
@@ -128,8 +128,7 @@ export class YouTubeThumbnail extends Component {
     Initialization.automaticallyCreateComponentsInsideResult(element, result, {
       ResultLink: this.options.embed ? { onClick: () => this.openYoutubeIframe() } : null
     });
-
-    this.modalbox = new AccessibleModal('coveo-youtube-player', element.ownerDocument.body as HTMLBodyElement, ModalBox, {
+    this.modalbox = new AccessibleModal('coveo-youtube-player', this.searchInterface.options.modalContainer, ModalBox, {
       overlayClose: true
     });
   }

--- a/unitTests/ui/ShareQueryTest.ts
+++ b/unitTests/ui/ShareQueryTest.ts
@@ -17,7 +17,8 @@ export function ShareQueryTest() {
       test.cmp.open();
       expect(test.modalBox.open).toHaveBeenCalledWith(test.cmp.dialogBoxContent, {
         title: l('Share Query'),
-        className: 'coveo-share-query-opened'
+        className: 'coveo-share-query-opened',
+        body: undefined
       });
     });
 


### PR DESCRIPTION
In Service Now' Workspace, the Search Interface is in a shadow root. When created, Modals are added to the document's body, outside of the Shadow Dom, thus not being able to share CSS and JS to the Modal Component. 

The work-around here is to be able to specify, in the Search Interface, to attach all Modals to the Search Interface Component.

2 other points to note: 

1. There was already a possibility (added on May 4th 2020, https://github.com/coveo/search-ui/pull/1489) to specify the component to which to attach the Quickview Modal. This PR would remove that possibility. 
2. Debug Panel and Relevance Inspector do not have a SearchInterface Object because they inherit from _Root Component_ instead of _Component_. I had them attached to the Search Interface, if one present, by default.  

SNOW-329
https://coveord.atlassian.net/browse/SNOW-329

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)