### PR TITLE
JSUI-3006 Display "label" for FacetRange value when defined.

### DIFF
--- a/src/ui/FacetRange/FacetRange.ts
+++ b/src/ui/FacetRange/FacetRange.ts
@@ -14,6 +14,7 @@ import { exportGlobally } from '../../GlobalExports';
 import { ResponsiveFacetOptions } from '../ResponsiveComponents/ResponsiveFacetOptions';
 import { ResponsiveFacets } from '../ResponsiveComponents/ResponsiveFacets';
 import { FacetValue } from '../Facet/FacetValue';
+import { isUndefined } from 'underscore';
 
 export interface IFacetRangeOptions extends IFacetOptions {
   ranges?: IRangeValue[];
@@ -116,7 +117,8 @@ export class FacetRange extends Facet implements IComponentBindings {
   }
 
   public getValueCaption(facetValue: FacetValue): string {
-    if (this.options.valueCaption) {
+    const lookupValueIsDefined = !isUndefined(facetValue.lookupValue) && facetValue.lookupValue !== facetValue.value;
+    if (this.options.valueCaption || lookupValueIsDefined) {
       return super.getValueCaption(facetValue);
     }
 

--- a/src/ui/FacetRange/FacetRange.ts
+++ b/src/ui/FacetRange/FacetRange.ts
@@ -117,8 +117,8 @@ export class FacetRange extends Facet implements IComponentBindings {
   }
 
   public getValueCaption(facetValue: FacetValue): string {
-    const lookupValueIsDefined = !isUndefined(facetValue.lookupValue) && facetValue.lookupValue !== facetValue.value;
-    if (this.options.valueCaption || lookupValueIsDefined) {
+    const lookupValueIsSpecified = !isUndefined(facetValue.lookupValue) && facetValue.lookupValue !== facetValue.value;
+    if (this.options.valueCaption || lookupValueIsSpecified) {
       return super.getValueCaption(facetValue);
     }
 

--- a/unitTests/ui/FacetRangeTest.ts
+++ b/unitTests/ui/FacetRangeTest.ts
@@ -49,6 +49,26 @@ export function FacetRangeTest() {
       });
     });
 
+    it(`when the facetValue's lookupValue is defined & different than the value
+    should display the lookupValue (originally the label) instead of the formatted value`, () => {
+      const facetValue: FacetValue = FacetValue.create('1900/01/31@18:38:50..2020/06/25@18:30:00');
+      facetValue.lookupValue = 'All dates';
+      expect(test.cmp.getValueCaption(facetValue)).toEqual('All dates');
+    });
+
+    it(`when the facetValue's lookupValue is identical as the value
+    should display the formatted value`, () => {
+      const facetValue: FacetValue = FacetValue.create('1900/01/31@18:38:50..2020/06/25@18:30:00');
+      facetValue.lookupValue = '1900/01/31@18:38:50..2020/06/25@18:30:00';
+      expect(test.cmp.getValueCaption(facetValue)).toEqual('1/31/1900 - 6/25/2020');
+    });
+
+    it(`when the facetValue's lookupValue is undefined
+    should display the formatted value`, () => {
+      const facetValue: FacetValue = FacetValue.create('1900/01/31@18:38:50..2020/06/25@18:30:00');
+      expect(test.cmp.getValueCaption(facetValue)).toEqual('1/31/1900 - 6/25/2020');
+    });
+
     describe('with a value format', () => {
       it('should allow to get a formatted value with a number ', () => {
         test = Mock.optionsComponentSetup<FacetRange, IFacetRangeOptions>(FacetRange, <IFacetRangeOptions>{


### PR DESCRIPTION
The label is sent to the API and returned as the lookupValue, in those cases we should prioritize the label.
https://coveord.atlassian.net/browse/JSUI-3006

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)