### PR TITLE
JSUI-3007 Improve PipelineContext documentation

### DIFF
--- a/src/ui/PipelineContext/PipelineContext.ts
+++ b/src/ui/PipelineContext/PipelineContext.ts
@@ -14,11 +14,12 @@ declare const Coveo;
 export interface IPipelineContextOptions {}
 
 /**
- * The `PipelineContext` component injects custom contextual information into the search requests and usage analytics events sent from a search interface.
+ * The `PipelineContext` component injects custom contextual information into the search requests and usage analytics search events sent from a search interface.
  *
  * This component is meant to be initialized on a `script` HTML tag whose `type` attribute is set to `text/context` and whose optional JSON content defines the custom information to send (each value can be set to a string or array of strings).
  *
  * See [Sending Custom Context Information](https://docs.coveo.com/en/399/).
+ * Note: To customize the context sent on all usage analytics events, see [Sending Custom Metadata with Search, Click, or Custom Events](https://docs.coveo.com/en/2004/javascript-search-framework/sending-custom-metadata-with-search-click-or-custom-events).
  */
 export class PipelineContext extends Component implements IPipelineContextProvider {
   static ID = 'PipelineContext';


### PR DESCRIPTION
The change clarifies a misunderstanding around using the PipelineContext component to customize non-search UA events.
The discuss thread is available [here](https://discuss.coveo.com/t/00061577-context-is-not-passing-for-click-events-in-analytics/3924/16?u=sami_sayegh).

https://coveord.atlassian.net/browse/JSUI-3007





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)