### PR TITLE
Add touch-action: none; for FacetSlider

### DIFF
--- a/sass/_FacetSlider.scss
+++ b/sass/_FacetSlider.scss
@@ -1,6 +1,8 @@
 @import 'mixins/slider';
 @include coveoSlider();
 .CoveoFacetSlider {
+  -ms-touch-action: none;
+  touch-action: none;
   &.coveo-disabled {
     .coveo-slider-line {
       background-color: $color-light-grey;

--- a/sass/_FacetSlider.scss
+++ b/sass/_FacetSlider.scss
@@ -1,8 +1,6 @@
 @import 'mixins/slider';
 @include coveoSlider();
 .CoveoFacetSlider {
-  -ms-touch-action: none;
-  touch-action: none;
   &.coveo-disabled {
     .coveo-slider-line {
       background-color: $color-light-grey;

--- a/sass/mixins/_slider.scss
+++ b/sass/mixins/_slider.scss
@@ -1,6 +1,9 @@
 @import 'Variables';
 @mixin coveoSlider {
   .coveo-slider-container {
+    -ms-touch-action: none;
+    touch-action: none;
+
     width: 100%;
     height: 85px;
     position: relative;


### PR DESCRIPTION
Without this rule, you can get weird behaviour if:

* You have a facet slider with "large snapping steps"
* You have a touch screen that is large enough (tablet, for example)

The browser would misunderstand the intention to slide buttons on the slider for wanting to navigate back and forth in the history. Since the gesture requires a lot of lateral movement to happen, you need those two conditions described above.

With this rule, the touch and hold gesture becomes 100% handled by the slider JavaScript code, and behaves correctly.

https://coveord.atlassian.net/browse/JSUI-3008




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)