### PR TITLE
JSUI-2997 Prevented the creation of multiple close buttons with `FacetsMobileMode`

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownModalContent.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownModalContent.ts
@@ -21,6 +21,24 @@ export class ResponsiveDropdownModalContent implements IResponsiveDropdownConten
     this.element.setAttribute('role', 'group');
     this.element.setAttribute('aria-label', l('FiltersDropdown'));
     this.hidden = false;
+    this.ensureCloseButton();
+    this.ensureFocusTrap();
+  }
+
+  public hideDropdown() {
+    this.element.el.classList.remove(this.className, ResponsiveDropdownContent.DEFAULT_CSS_CLASS_NAME);
+    this.element.setAttribute('role', null);
+    this.element.setAttribute('aria-label', null);
+    this.hidden = true;
+    this.removeCloseButton();
+    this.removeFocusTrap();
+  }
+
+  public cleanUp() {
+    this.hidden = false;
+  }
+
+  private ensureCloseButton() {
     if (!this.closeButton) {
       this.closeButton = $$(
         'button',
@@ -33,27 +51,25 @@ export class ResponsiveDropdownModalContent implements IResponsiveDropdownConten
       this.closeButton.on('click', () => this.close());
       this.element.prepend(this.closeButton.el);
     }
+  }
+
+  private ensureFocusTrap() {
     if (!this.focusTrap) {
       this.focusTrap = new FocusTrap(this.element.el);
     }
   }
 
-  public hideDropdown() {
-    this.element.el.classList.remove(this.className, ResponsiveDropdownContent.DEFAULT_CSS_CLASS_NAME);
-    this.element.setAttribute('role', null);
-    this.element.setAttribute('aria-label', null);
-    this.hidden = true;
+  private removeCloseButton() {
     if (this.closeButton) {
       this.closeButton.remove();
       this.closeButton = null;
     }
+  }
+
+  private removeFocusTrap() {
     if (this.focusTrap) {
       this.focusTrap.disable();
       this.focusTrap = null;
     }
-  }
-
-  public cleanUp() {
-    this.hidden = false;
   }
 }

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownModalContent.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownModalContent.ts
@@ -21,17 +21,21 @@ export class ResponsiveDropdownModalContent implements IResponsiveDropdownConten
     this.element.setAttribute('role', 'group');
     this.element.setAttribute('aria-label', l('FiltersDropdown'));
     this.hidden = false;
-    this.closeButton = $$(
-      'button',
-      {
-        className: 'coveo-facet-modal-close-button',
-        ariaLabel: this.closeButtonLabel
-      },
-      SVGIcons.icons.mainClear
-    );
-    this.closeButton.on('click', () => this.close());
-    this.element.prepend(this.closeButton.el);
-    this.focusTrap = new FocusTrap(this.element.el);
+    if (!this.closeButton) {
+      this.closeButton = $$(
+        'button',
+        {
+          className: 'coveo-facet-modal-close-button',
+          ariaLabel: this.closeButtonLabel
+        },
+        SVGIcons.icons.mainClear
+      );
+      this.closeButton.on('click', () => this.close());
+      this.element.prepend(this.closeButton.el);
+    }
+    if (!this.focusTrap) {
+      this.focusTrap = new FocusTrap(this.element.el);
+    }
   }
 
   public hideDropdown() {

--- a/unitTests/ui/ResponsiveComponents/ResponsiveDropdownModalContentTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveDropdownModalContentTest.ts
@@ -71,6 +71,16 @@ export function ResponsiveDropdownModalContentTest() {
         it('prevents accessible focus from leaving', () => {
           expect(sibling.getAttribute('aria-hidden')).toEqual('true');
         });
+
+        describe('twice', () => {
+          beforeEach(() => {
+            modal.positionDropdown();
+          });
+
+          it("doesn't add more close buttons", () => {
+            expect(modalElement.findClass('coveo-facet-modal-close-button').length).toEqual(1);
+          });
+        });
       });
 
       describe('when cleaned up', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2997

A bug caused `FacetsMobileMode` to create multiple close buttons when the modal was already opened and resized repeatedly:
![image](https://user-images.githubusercontent.com/54454747/86049259-d778eb80-ba1f-11ea-931b-ce9c925ed999.png)


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)