### PR TITLE
JSUI-2991 Add precedence rules for Suggestions sorting

### DIFF
--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -186,7 +186,7 @@ export class SuggestionsManager {
       return;
     }
 
-    suggestions.sort((a, b) => b.index || 0 - a.index || 0).forEach(suggestion => {
+    suggestions.sort((a, b) => (b.index || 0) - (a.index || 0)).forEach(suggestion => {
       const dom = suggestion.dom ? this.modifyDomFromExistingSuggestion(suggestion.dom) : this.createDomFromSuggestion(suggestion);
 
       dom.setAttribute('id', `magic-box-suggestion-${indexOf(suggestions, suggestion)}`);

--- a/unitTests/magicbox/SuggestionsManagerTest.ts
+++ b/unitTests/magicbox/SuggestionsManagerTest.ts
@@ -400,6 +400,15 @@ export function SuggestionsManagerTest() {
         });
 
         it('sorts suggestions by descending index value', async done => {
+          suggestions[0].index = 100;
+          suggestions[1].index = 200;
+          await renderSuggestions();
+          expect(suggestionElements[0].innerText).toEqual(textSuggestions[1]);
+          done();
+        });
+
+        it('sorts suggestions by descending index index even with undefined values', async done => {
+          suggestions[0].index = undefined;
           suggestions[1].index = 100;
           await renderSuggestions();
           expect(suggestionElements[0].innerText).toEqual(textSuggestions[1]);


### PR DESCRIPTION
Without parentheses, "b" always won as long as is was defined 😓 

https://coveord.atlassian.net/browse/JSUI-2991





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)