### PR TITLE
JSUI-3015 Added unit tests and accessibility tests for `SmartSnippet`

### DIFF
--- a/accessibilityTest/AccessibilitySmartSnippet.ts
+++ b/accessibilityTest/AccessibilitySmartSnippet.ts
@@ -1,0 +1,93 @@
+import * as axe from 'axe-core';
+import { Dom, SmartSnippet, Component, $$, IQuerySuccessEventArgs } from 'coveo-search-ui';
+import { getRoot, afterDeferredQuerySuccess, getResultsColumn, waitUntilSelectorIsPresent } from './Testing';
+
+export const AccessibilitySmartSnippet = () => {
+  describe('SmartSnippet', () => {
+    function fakeNextQuestionAnswer() {
+      $$(getRoot()).one('querySuccess', (_, e: IQuerySuccessEventArgs) => {
+        e.results.questionAnswer = {
+          question: 'Getting Query Suggestions',
+          answerSnippet:
+            '<p>You can request basic query expression (q) completions from a Coveo Machine Learning (Coveo ML) Query Suggestions (QS) model by sending a GET or POST HTTP request to https://platform.cloud.coveo.com/rest/search/v2/querySuggest (or https://cloudplatform.coveo.com/rest/search/querySuggest on Coveo Cloud V1).</p> <p>The Search API query suggestion route supports several parameters which you can include either in the query string of a GET request, or in the JSON body of a POST request (see QS Parameters).</p> <div class="box note"> \n <p>When using an OAuth2 token to authenticate a GET or POST HTTP request to the Search API query suggestion route, you must specify the unique identifier of the target Coveo Cloud organization by including the organizationId argument in the query string of your request.</p> \n</div> <div class="box examples"> \n <ol> \n  <li> <p>Requesting query suggestions using the GET method:</p> \n   <div class="language-http highlighter-rouge"> \n    <div class="highlight">\n      GET https://platform.cloud.coveo.com/rest/search/v2/querySuggest?locale=en&amp;q=twa&amp;searchHub=BookstoreSearch HTTP/1.1 &nbsp; Accept: application/json Authorization: Bearer **********-****-****-****-************ \n    </div> \n   </div> </li> \n  <li> <p>Requesting query suggestions using the POST method:</p> \n   <div class="language-http highlighter-rouge"> \n    <div class="highlight">\n      POST https://platform.cloud.coveo.com/rest/search/v2/querySuggest HTTP/1.1 &nbsp; Content-Type: application/json Accept: application/json Authorization: Bearer **********-****-****-****-************ \n    </div> \n   </div> <p>Payload</p> \n   <div class="language-json highlighter-rouge"> \n    <div class="highlight">\n      { "locale": "en", "q": "twa", "searchHub": "BookstoreSearch" } \n    </div> \n   </div> \n   <div class="box success"> \n    <p><strong>200 OK response body (excerpt)</strong></p> \n    <div class="language-json highlighter-rouge"> \n     <div class="highlight">\n       { "completions": [ { "executableConfidence": 1, "expression": "mark twain", "highlighted": "[mark] {twa}[in]", "score": 14.525258530973204 }, { "executableConfidence": 0.6666666666666666, "expression": "[wes]{twa}[rd] [ho]", "highlighted": "", "score": 8.50548085208594 }, { "executableConfidence": 0.5, "expression": "hot water music", "highlighted": "[hot] (wat)[er] [music]", "score": 7.107770631785241 }, ... ] } \n     </div> \n    </div> \n   </div> </li> \n </ol> \n</div> <div class="box notes"> \n <ul> \n  <li> <p>If the query suggestion request is routed to a query pipeline with no associated Coveo ML QS model, the request will return an empty completions array.</p> </li> \n  <li> <p>In a completions array item:</p> \n   <ul> \n    <li> <p>The score property value only has relative significance within the same completions array.</p> <p>For instance, a suggestion with a score of 14.811407079917723 in the completions array of response <strong>A</strong> isn’t necessarily less relevant than a suggestion with a score of 24.325728875625282 in the completions array of response <strong>B</strong>.</p> </li> \n    <li> <p>The highlighted property uses the following logic:</p> \n     <ul> \n      <li> <p>Characters between curly braces (e.g., {cat}) indicate an exact match with q.</p> </li> \n      <li> <p>Characters between square braces (e.g., [cher]) indicate completions.</p> </li> \n      <li> <p>Characters between parentheses (e.g., (act)) indicate corrections to q.</p> </li> \n     </ul> </li> \n    <li> <p>The executableConfidence property contains a floating-point value between 0 and 1 indicating how “convinced” Coveo ML is that performing a query with this suggestion as a basic query expression will return relevant results. The threshold from which Coveo ML considers a query suggestion executable is 0.8.</p> </li> \n   </ul> </li> \n </ul> \n</div>',
+          documentId: {
+            contentIdKey: 'permanentid',
+            contentIdValue: e.results.results[0].raw.permanentid
+          },
+          score: 0.471416,
+          relatedQuestions: []
+        };
+      });
+    }
+
+    function getFirstChild(className: string) {
+      return smartSnippetElement.findClass(className)[0];
+    }
+
+    let smartSnippetElement: Dom;
+    beforeEach(async done => {
+      smartSnippetElement = $$('div', { className: Component.computeCssClassName(SmartSnippet) });
+      fakeNextQuestionAnswer();
+      getResultsColumn().appendChild(smartSnippetElement.el);
+      await afterDeferredQuerySuccess();
+      done();
+    });
+
+    it('should be accessible', async done => {
+      const axeResults = await axe.run(smartSnippetElement.el);
+      expect(axeResults).toBeAccessible();
+      done();
+    });
+
+    describe('after responding "Yes" to "Was this helpful?"', () => {
+      beforeEach(() => {
+        getFirstChild('coveo-user-feedback-banner-yes-button').click();
+      });
+
+      it('should be accessible', async done => {
+        const axeResults = await axe.run(smartSnippetElement.el);
+        expect(axeResults).toBeAccessible();
+        done();
+      });
+    });
+
+    describe('after responding "No" to "Was this helpful?"', () => {
+      beforeEach(() => {
+        getFirstChild('coveo-user-feedback-banner-no-button').click();
+      });
+
+      it('should be accessible', async done => {
+        const axeResults = await axe.run(smartSnippetElement.el);
+        expect(axeResults).toBeAccessible();
+        done();
+      });
+
+      describe('after pressing "Explain why"', () => {
+        let modalContent: HTMLElement;
+        beforeEach(async done => {
+          getFirstChild('coveo-user-feedback-banner-explain-why').click();
+          modalContent = await waitUntilSelectorIsPresent<HTMLElement>(document.body, '.coveo-user-explanation-modal-content');
+          done();
+        });
+
+        it('should be accessible', async done => {
+          const axeResults = await axe.run(modalContent);
+          expect(axeResults).toBeAccessible();
+          done();
+        });
+      });
+    });
+
+    describe('after pressing show more', () => {
+      beforeEach(() => {
+        getFirstChild('coveo-height-limiter-button').click();
+      });
+
+      it('should be accessible', async done => {
+        const axeResults = await axe.run(smartSnippetElement.el);
+        expect(axeResults).toBeAccessible();
+        done();
+      });
+    });
+  });
+};

--- a/accessibilityTest/Test.ts
+++ b/accessibilityTest/Test.ts
@@ -56,6 +56,7 @@ import { AccessibilityQuerySummary } from './AccessibilityQuerySummary';
 import { AccessibilityThumbnail } from './AccessibilityThumbnail';
 import { AccessibilityCategoryFacet } from './AccessibilityCategoryFacet';
 import { AccessibilityDynamicHierarchicalFacetSearch } from './AccessibilityDynamicHierarchicalFacetSearch';
+import { AccessibilitySmartSnippet } from './AccessibilitySmartSnippet';
 
 const getFilename = (path: string) => /\/([^\/]*$)/.exec(path)[1];
 
@@ -176,4 +177,5 @@ describe('Testing ...', () => {
   AccessibilityThumbnail();
   AccessibilityCategoryFacet();
   AccessibilityDynamicHierarchicalFacetSearch();
+  AccessibilitySmartSnippet();
 });

--- a/accessibilityTest/Testing.ts
+++ b/accessibilityTest/Testing.ts
@@ -158,7 +158,7 @@ export const isInit = () => {
 export const waitUntilSelectorIsPresent = <T extends Element = Element>(parentNode: HTMLElement, selector: string) => {
   const alreadyExistingElement = parentNode.querySelector<T>(selector);
   if (alreadyExistingElement) {
-    return alreadyExistingElement;
+    return Promise.resolve(alreadyExistingElement);
   }
   return observeUntil(
     parentNode,

--- a/sass/_ExplanationModal.scss
+++ b/sass/_ExplanationModal.scss
@@ -1,6 +1,16 @@
 @import 'Variables';
 
 .coveo-user-explanation-modal {
+  &-explanations {
+    border: none;
+    padding: 0;
+
+    &-label {
+      padding: 0;
+      margin-bottom: 6px;
+    }
+  }
+
   &-details {
     display: flex;
     flex-direction: column;

--- a/sass/_SmartSnippet.scss
+++ b/sass/_SmartSnippet.scss
@@ -168,8 +168,8 @@
           }
 
           &.coveo-user-feedback-banner-yes-button {
-            color: $color-strong-contrast-green;
-            fill: $color-strong-contrast-green;
+            color: $color-dark-green;
+            fill: $color-dark-green;
           }
 
           &.coveo-user-feedback-banner-no-button {

--- a/sass/_SmartSnippet.scss
+++ b/sass/_SmartSnippet.scss
@@ -168,8 +168,8 @@
           }
 
           &.coveo-user-feedback-banner-yes-button {
-            color: $color-green;
-            fill: $color-green;
+            color: $color-strong-contrast-green;
+            fill: $color-strong-contrast-green;
           }
 
           &.coveo-user-feedback-banner-no-button {

--- a/sass/_Variables.scss
+++ b/sass/_Variables.scss
@@ -29,6 +29,7 @@ $color-disabled-grey: #ddd;
 $color-coveo-for-sitecore: #dc291e;
 $color-coveo-for-salesforce: #009ddc;
 $color-green: #4caf50;
+$color-strong-contrast-green: hsl(122, 39%, 37%);
 $color-red: #cc0d00;
 $color-active-yellow: #ecad00;
 $color-transparent-background: rgba(255, 255, 255, 0.85);

--- a/sass/_Variables.scss
+++ b/sass/_Variables.scss
@@ -29,7 +29,7 @@ $color-disabled-grey: #ddd;
 $color-coveo-for-sitecore: #dc291e;
 $color-coveo-for-salesforce: #009ddc;
 $color-green: #4caf50;
-$color-strong-contrast-green: hsl(122, 39%, 37%);
+$color-dark-green: hsl(122, 39%, 37%);
 $color-red: #cc0d00;
 $color-active-yellow: #ecad00;
 $color-transparent-background: rgba(255, 255, 255, 0.85);

--- a/src/rest/QueryResults.ts
+++ b/src/rest/QueryResults.ts
@@ -152,5 +152,5 @@ export interface IQueryResults {
    * Facet results of the query
    */
   facets?: IFacetResponse[];
-  questionAnswer: IQuestionAnswerResponse;
+  questionAnswer?: IQuestionAnswerResponse;
 }

--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -225,11 +225,6 @@ export interface IAnalyticsMissingTerm {
   missingTerm: string;
 }
 
-export interface IAnalyticsSmartSnippetContentLink {
-  target: string;
-  outerHTML: string;
-}
-
 /**
  * Describes the object sent as metadata along with [`clickQuerySuggestPreview`]{@link analyticsActionCauseList.clickQuerySuggestPreview} usage analytics events.
  */
@@ -1411,22 +1406,6 @@ export var analyticsActionCauseList = {
    */
   openSmartSnippetSource: <IAnalyticsActionCause>{
     name: 'openSmartSnippetSource',
-    type: 'smartSnippet'
-  },
-  /**
-   * The custom event logged when a link inside a [SmartSnippet]{@link SmartSnippet} is opened.
-   *
-   * Implements the [IAnalyticsActionCause]{@link IAnalyticsActionCause} interface as such:
-   *
-   * ```javascript
-   * {
-   *  actionCause: "openLinkInSmartSnippetContent",
-   *  actionType: "smartSnippet"
-   * }
-   * ```
-   */
-  openLinkInSmartSnippetContent: <IAnalyticsActionCause>{
-    name: 'openLinkInSmartSnippetContent',
     type: 'smartSnippet'
   }
 };

--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -225,11 +225,6 @@ export interface IAnalyticsMissingTerm {
   missingTerm: string;
 }
 
-export interface IAnalyticsSmartSnippetContentLinkMeta {
-  target: string;
-  outerHTML: string;
-}
-
 export enum AnalyticsSmartSnippetFeedbackReason {
   DoesNotAnswer = 'does_not_answer',
   PartiallyAnswers = 'partially_answers',
@@ -1423,22 +1418,6 @@ export var analyticsActionCauseList = {
    */
   openSmartSnippetSource: <IAnalyticsActionCause>{
     name: 'openSmartSnippetSource',
-    type: 'smartSnippet'
-  },
-  /**
-   * The custom event logged when a link inside a [SmartSnippet]{@link SmartSnippet} is opened.
-   *
-   * Implements the [IAnalyticsActionCause]{@link IAnalyticsActionCause} interface as such:
-   *
-   * ```javascript
-   * {
-   *  actionCause: "openLinkInSmartSnippetContent",
-   *  actionType: "smartSnippet"
-   * }
-   * ```
-   */
-  openLinkInSmartSnippetContent: <IAnalyticsActionCause>{
-    name: 'openLinkInSmartSnippetContent',
     type: 'smartSnippet'
   },
   /**

--- a/src/ui/SmartSnippet/ExplanationModal.ts
+++ b/src/ui/SmartSnippet/ExplanationModal.ts
@@ -12,15 +12,15 @@ export interface IReason {
 
 export interface IExplanationModalOptions {
   ownerElement: HTMLElement;
-  explanations: IReason[];
+  reasons: IReason[];
   onClosed: () => void;
   modalBoxModule?: Coveo.ModalBox.ModalBox;
 }
 
 const ROOT_CLASSNAME = 'coveo-user-explanation-modal';
 const CONTENT_CLASSNAME = `${ROOT_CLASSNAME}-content`;
-const EXPLANATIONS_CLASSNAME = `${ROOT_CLASSNAME}-explanations`;
-const EXPLANATIONS_LABEL_CLASSNAME = `${EXPLANATIONS_CLASSNAME}-label`;
+const REASONS_CLASSNAME = `${ROOT_CLASSNAME}-explanations`;
+const REASONS_LABEL_CLASSNAME = `${REASONS_CLASSNAME}-label`;
 const DETAILS_SECTION_CLASSNAME = `${ROOT_CLASSNAME}-details`;
 const DETAILS_TEXTAREA_CLASSNAME = `${DETAILS_SECTION_CLASSNAME}-textarea`;
 const DETAILS_LABEL_CLASSNAME = `${DETAILS_SECTION_CLASSNAME}-label`;
@@ -30,7 +30,8 @@ const DETAILS_ID = DETAILS_SECTION_CLASSNAME;
 export const ExplanationModalClassNames = {
   ROOT_CLASSNAME,
   CONTENT_CLASSNAME,
-  EXPLANATIONS_CLASSNAME,
+  REASONS_CLASSNAME,
+  REASONS_LABEL_CLASSNAME,
   DETAILS_SECTION_CLASSNAME,
   DETAILS_TEXTAREA_CLASSNAME,
   DETAILS_LABEL_CLASSNAME,
@@ -78,22 +79,22 @@ export class ExplanationModal {
       {
         className: CONTENT_CLASSNAME
       },
-      this.buildExplanations(),
+      this.buildReasons(),
       detailsSection,
       this.buildSendButton()
     ).el;
   }
 
-  private buildExplanations() {
-    const explanationsContainer = $$('fieldset', { className: EXPLANATIONS_CLASSNAME }, this.buildExplanationsLabel()).el;
-    this.reasons = this.options.explanations.map(explanation => this.buildExplanationRadioButton(explanation));
+  private buildReasons() {
+    const reasonsContainer = $$('fieldset', { className: REASONS_CLASSNAME }, this.buildReasonsLabel()).el;
+    this.reasons = this.options.reasons.map(reason => this.buildReasonRadioButton(reason));
     this.reasons[0].select();
-    this.reasons.forEach(radioButton => explanationsContainer.appendChild(radioButton.getElement()));
-    return explanationsContainer;
+    this.reasons.forEach(radioButton => reasonsContainer.appendChild(radioButton.getElement()));
+    return reasonsContainer;
   }
 
-  private buildExplanationsLabel() {
-    return $$('legend', { className: EXPLANATIONS_LABEL_CLASSNAME }, l('UsefulnessFeedbackReason')).el;
+  private buildReasonsLabel() {
+    return $$('legend', { className: REASONS_LABEL_CLASSNAME }, l('UsefulnessFeedbackReason')).el;
   }
 
   private buildDetailsSection() {
@@ -116,17 +117,17 @@ export class ExplanationModal {
     return button.el;
   }
 
-  private buildExplanationRadioButton(explanation: IReason) {
+  private buildReasonRadioButton(reason: IReason) {
     return new RadioButton(
       radioButton => {
         if (!radioButton.isSelected()) {
           return;
         }
-        this.detailsTextArea.disabled = !explanation.hasDetails;
-        this.selectedReason = explanation;
+        this.detailsTextArea.disabled = !reason.hasDetails;
+        this.selectedReason = reason;
       },
-      explanation.label,
-      'explanation'
+      reason.label,
+      'reason'
     );
   }
 }

--- a/src/ui/SmartSnippet/ExplanationModal.ts
+++ b/src/ui/SmartSnippet/ExplanationModal.ts
@@ -25,11 +25,22 @@ const DETAILS_TEXTAREA_CLASSNAME = `${DETAILS_SECTION_CLASSNAME}-textarea`;
 const DETAILS_LABEL_CLASSNAME = `${DETAILS_SECTION_CLASSNAME}-label`;
 const SEND_BUTTON_CLASSNAME = `${ROOT_CLASSNAME}-send-button`;
 
+export const ExplanationModalClassNames = {
+  ROOT_CLASSNAME,
+  CONTENT_CLASSNAME,
+  EXPLANATIONS_CLASSNAME,
+  DETAILS_SECTION_CLASSNAME,
+  DETAILS_TEXTAREA_CLASSNAME,
+  DETAILS_LABEL_CLASSNAME,
+  SEND_BUTTON_CLASSNAME
+};
+
 export class ExplanationModal {
   private modal: AccessibleModal;
   private explanationRadioButtons: RadioButton[];
   private selectedExplanation: IExplanation;
   private detailsTextArea: HTMLTextAreaElement;
+  private isOpen = false;
 
   constructor(public options: IExplanationModalOptions) {
     this.modal = new AccessibleModal(ROOT_CLASSNAME, this.options.ownerElement, this.options.modalBoxModule);
@@ -48,10 +59,14 @@ export class ExplanationModal {
       title: l('UsefulnessFeedbackExplainWhyImperative'),
       content: this.buildContent(),
       validation: () => {
-        this.options.onClosed();
+        if (this.isOpen) {
+          this.options.onClosed();
+          this.isOpen = false;
+        }
         return true;
       }
     });
+    this.isOpen = true;
   }
 
   private buildContent() {
@@ -88,6 +103,7 @@ export class ExplanationModal {
     const button = $$('button', { className: SEND_BUTTON_CLASSNAME }, l('Send'));
     button.on('click', () => {
       this.selectedExplanation.onSelect();
+      this.isOpen = false;
       this.modal.close();
     });
     return button.el;

--- a/src/ui/SmartSnippet/ExplanationModal.ts
+++ b/src/ui/SmartSnippet/ExplanationModal.ts
@@ -20,10 +20,12 @@ export interface IExplanationModalOptions {
 const ROOT_CLASSNAME = 'coveo-user-explanation-modal';
 const CONTENT_CLASSNAME = `${ROOT_CLASSNAME}-content`;
 const EXPLANATIONS_CLASSNAME = `${ROOT_CLASSNAME}-explanations`;
+const EXPLANATIONS_LABEL_CLASSNAME = `${EXPLANATIONS_CLASSNAME}-label`;
 const DETAILS_SECTION_CLASSNAME = `${ROOT_CLASSNAME}-details`;
 const DETAILS_TEXTAREA_CLASSNAME = `${DETAILS_SECTION_CLASSNAME}-textarea`;
 const DETAILS_LABEL_CLASSNAME = `${DETAILS_SECTION_CLASSNAME}-label`;
 const SEND_BUTTON_CLASSNAME = `${ROOT_CLASSNAME}-send-button`;
+const DETAILS_ID = DETAILS_SECTION_CLASSNAME;
 
 export const ExplanationModalClassNames = {
   ROOT_CLASSNAME,
@@ -83,19 +85,24 @@ export class ExplanationModal {
   }
 
   private buildExplanations() {
-    const explanationsContainer = $$('div', { className: EXPLANATIONS_CLASSNAME }).el;
+    const explanationsContainer = $$('fieldset', { className: EXPLANATIONS_CLASSNAME }, this.buildExplanationsLabel()).el;
     this.reasons = this.options.explanations.map(explanation => this.buildExplanationRadioButton(explanation));
     this.reasons[0].select();
     this.reasons.forEach(radioButton => explanationsContainer.appendChild(radioButton.getElement()));
     return explanationsContainer;
   }
 
+  private buildExplanationsLabel() {
+    return $$('legend', { className: EXPLANATIONS_LABEL_CLASSNAME }, l('UsefulnessFeedbackReason')).el;
+  }
+
   private buildDetailsSection() {
     return $$(
       'div',
       { className: DETAILS_SECTION_CLASSNAME },
-      $$('span', { className: DETAILS_LABEL_CLASSNAME }, l('Details')).el,
-      (this.detailsTextArea = $$('textarea', { className: DETAILS_TEXTAREA_CLASSNAME, disabled: true }).el as HTMLTextAreaElement)
+      $$('label', { className: DETAILS_LABEL_CLASSNAME, for: DETAILS_ID }, l('Details')).el,
+      (this.detailsTextArea = $$('textarea', { className: DETAILS_TEXTAREA_CLASSNAME, id: DETAILS_ID, disabled: true })
+        .el as HTMLTextAreaElement)
     );
   }
 

--- a/src/ui/SmartSnippet/HeightLimiter.ts
+++ b/src/ui/SmartSnippet/HeightLimiter.ts
@@ -31,7 +31,7 @@ export class HeightLimiter {
   }
 
   private set height(height: number) {
-    this.element.style.height = `${Math.round(height)}px`;
+    this.element.style.height = `${height}px`;
   }
 
   constructor(private element: HTMLElement, private heightLimit: number, private onToggle?: (isExpanded: boolean) => void) {
@@ -64,7 +64,8 @@ export class HeightLimiter {
       this.updateExpandedAppearance();
     } else {
       this.isExpanded = false;
-      delete this.element.style.height;
+      this.updateExpandedAppearance();
+      this.element.style.height = '';
     }
   }
 

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -19,13 +19,13 @@ import { HeightLimiter } from './HeightLimiter';
 import { ExplanationModal, IReason } from './ExplanationModal';
 import { l } from '../../strings/Strings';
 
-interface ISmartSnippetExplaination {
+interface ISmartSnippetReason {
   analytics: AnalyticsSmartSnippetFeedbackReason;
   localeKey: string;
   hasDetails?: boolean;
 }
 
-const explanations: ISmartSnippetExplaination[] = [
+const reasons: ISmartSnippetReason[] = [
   {
     analytics: AnalyticsSmartSnippetFeedbackReason.DoesNotAnswer,
     localeKey: 'UsefulnessFeedbackDoesNotAnswer'
@@ -115,12 +115,12 @@ export class SmartSnippet extends Component {
     );
     this.element.appendChild(this.feedbackBanner.build());
     this.explanationModal = new ExplanationModal({
-      explanations: explanations.map(
-        explanation =>
+      reasons: reasons.map(
+        reason =>
           <IReason>{
-            label: l(explanation.localeKey),
-            onSelect: () => this.sendExplanationAnalytics(explanation.analytics, this.explanationModal.details),
-            hasDetails: explanation.hasDetails
+            label: l(reason.localeKey),
+            onSelect: () => this.sendExplanationAnalytics(reason.analytics, this.explanationModal.details),
+            hasDetails: reason.hasDetails
           }
       ),
       onClosed: () => this.sendCloseFeedbackModalAnalytics(),

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -8,7 +8,7 @@ import 'styling/_SmartSnippet';
 import { find } from 'underscore';
 import { IQueryResult } from '../../rest/QueryResult';
 import { UserFeedbackBanner } from './UserFeedbackBanner';
-import { analyticsActionCauseList, IAnalyticsNoMeta, IAnalyticsSmartSnippetContentLink } from '../Analytics/AnalyticsActionListMeta';
+import { analyticsActionCauseList, IAnalyticsNoMeta } from '../Analytics/AnalyticsActionListMeta';
 import { HeightLimiter } from './HeightLimiter';
 
 const BASE_CLASSNAME = 'coveo-smart-snippet';
@@ -152,9 +152,6 @@ export class SmartSnippet extends Component {
 
   private renderSnippet(content: string) {
     this.snippetContainer.innerHTML = content;
-    $$(this.snippetContainer)
-      .findAll('a')
-      .forEach((link: HTMLAnchorElement) => this.enableAnalyticsOnLink(link, () => this.sendOpenContentLinkAnalytics(link)));
   }
 
   private renderSource(source: IQueryResult) {
@@ -234,18 +231,6 @@ export class SmartSnippet extends Component {
     return this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(
       analyticsActionCauseList.openSmartSnippetSource,
       {},
-      this.element,
-      this.lastRenderedResult
-    );
-  }
-
-  private sendOpenContentLinkAnalytics(link: HTMLAnchorElement) {
-    return this.usageAnalytics.logCustomEvent<IAnalyticsSmartSnippetContentLink>(
-      analyticsActionCauseList.openLinkInSmartSnippetContent,
-      {
-        target: link.getAttribute('href'),
-        outerHTML: link.outerHTML
-      },
       this.element,
       this.lastRenderedResult
     );

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -12,7 +12,6 @@ import { UserFeedbackBanner } from './UserFeedbackBanner';
 import {
   analyticsActionCauseList,
   IAnalyticsNoMeta,
-  IAnalyticsSmartSnippetContentLinkMeta,
   IAnalyticsSmartSnippetFeedbackMeta,
   AnalyticsSmartSnippetFeedbackReason
 } from '../Analytics/AnalyticsActionListMeta';
@@ -291,18 +290,6 @@ export class SmartSnippet extends Component {
     return this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(
       analyticsActionCauseList.openSmartSnippetSource,
       {},
-      this.element,
-      this.lastRenderedResult
-    );
-  }
-
-  private sendOpenContentLinkAnalytics(link: HTMLAnchorElement) {
-    return this.usageAnalytics.logCustomEvent<IAnalyticsSmartSnippetContentLinkMeta>(
-      analyticsActionCauseList.openLinkInSmartSnippetContent,
-      {
-        target: link.getAttribute('href'),
-        outerHTML: link.outerHTML
-      },
       this.element,
       this.lastRenderedResult
     );

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7598,7 +7598,7 @@
     "fr": "Envoyer"
   },
   "UsefulnessFeedbackReason": {
-    "en": "What's wrong?",
-    "fr": "Qu'est-ce qui ne va pas?"
+    "en": "Reason",
+    "fr": "Raison"
   }
 }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7596,5 +7596,9 @@
   "Send": {
     "en": "Send",
     "fr": "Envoyer"
+  },
+  "UsefulnessFeedbackReason": {
+    "en": "What's wrong?",
+    "fr": "Qu'est-ce qui ne va pas?"
   }
 }

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -851,3 +851,6 @@ HeightLimiterTest();
 
 import { UserFeedbackBannerTest } from './ui/UserFeedbackBannerTest';
 UserFeedbackBannerTest();
+
+import { ExplanationModalTest } from './ui/ExplanationModalTest';
+ExplanationModalTest();

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -845,3 +845,9 @@ FileTypesTest();
 
 import { SmartSnippetTest } from './ui/SmartSnippetTest';
 SmartSnippetTest();
+
+import { HeightLimiterTest } from './ui/HeightLimiterTest';
+HeightLimiterTest();
+
+import { UserFeedbackBannerTest } from './ui/UserFeedbackBannerTest';
+UserFeedbackBannerTest();

--- a/unitTests/TestUtils.ts
+++ b/unitTests/TestUtils.ts
@@ -2,7 +2,9 @@ export function expectChildren(element: HTMLElement | DocumentFragment, classNam
   expect(element.childNodes.length).toEqual(classNames.length, `Expected only ${classNames.length} children.`);
   return classNames.map((className, index) => {
     const childAtIndex = element.childNodes.item(index) as HTMLElement;
-    expect(childAtIndex.classList).toContain(className, `Expected element at index ${index} to contain class ${className}.`);
+    if (className) {
+      expect(childAtIndex.classList).toContain(className, `Expected element at index ${index} to contain class ${className}.`);
+    }
     return childAtIndex;
   });
 }

--- a/unitTests/ui/ExplanationModalTest.ts
+++ b/unitTests/ui/ExplanationModalTest.ts
@@ -1,4 +1,4 @@
-import { IExplanation, ExplanationModal, ExplanationModalClassNames as ClassNames } from '../../src/ui/SmartSnippet/ExplanationModal';
+import { IReason, ExplanationModal, ExplanationModalClassNames as ClassNames } from '../../src/ui/SmartSnippet/ExplanationModal';
 import { $$ } from '../../src/utils/Dom';
 import { Simulate } from '../Simulate';
 import { mock } from '../MockEnvironment';
@@ -8,7 +8,7 @@ import { expectChildren } from '../TestUtils';
 
 export function ExplanationModalTest() {
   const details = 'Hello, World!';
-  let explanations: IExplanation[];
+  let explanations: IReason[];
   let onClosed: jasmine.Spy;
   let ownerElement: HTMLElement;
   let explanationModal: ExplanationModal;
@@ -16,7 +16,7 @@ export function ExplanationModalTest() {
   let origin: HTMLElement;
   let content: HTMLElement;
 
-  function createExplanations(firstExplanationHasDetails: boolean): IExplanation[] {
+  function createExplanations(firstExplanationHasDetails: boolean): IReason[] {
     return [
       {
         label: 'Explanation selected by default',
@@ -68,10 +68,7 @@ export function ExplanationModalTest() {
   }
 
   function selectExplanation(index: number) {
-    content
-      .querySelectorAll('input')
-      .item(index)
-      .click();
+    explanationModal['reasons'][index].select();
   }
 
   describe('ExplanationModal', () => {

--- a/unitTests/ui/ExplanationModalTest.ts
+++ b/unitTests/ui/ExplanationModalTest.ts
@@ -8,7 +8,7 @@ import { expectChildren } from '../TestUtils';
 
 export function ExplanationModalTest() {
   const details = 'Hello, World!';
-  let explanations: IReason[];
+  let reasons: IReason[];
   let onClosed: jasmine.Spy;
   let ownerElement: HTMLElement;
   let explanationModal: ExplanationModal;
@@ -16,28 +16,28 @@ export function ExplanationModalTest() {
   let origin: HTMLElement;
   let content: HTMLElement;
 
-  function createExplanations(firstExplanationHasDetails: boolean): IReason[] {
+  function createReason(firstReasonHasDetails: boolean): IReason[] {
     return [
       {
         label: 'Explanation selected by default',
         onSelect: jasmine.createSpy('onSelect1'),
-        hasDetails: firstExplanationHasDetails
+        hasDetails: firstReasonHasDetails
       },
       {
-        label: 'Second explanation implicitly without details',
+        label: 'Second reason implicitly without details',
         onSelect: jasmine.createSpy('onSelect2')
       },
       {
-        label: 'Third explanation explicitly without details',
+        label: 'Third reason explicitly without details',
         onSelect: jasmine.createSpy('onSelect3'),
         hasDetails: false
       }
     ];
   }
 
-  function initializeModal(firstExplanationHasDetails = true) {
+  function initializeModal(firstReasonHasDetails = true) {
     explanationModal = new ExplanationModal({
-      explanations: (explanations = createExplanations(firstExplanationHasDetails)),
+      reasons: (reasons = createReason(firstReasonHasDetails)),
       onClosed: (onClosed = jasmine.createSpy('onClosed')),
       ownerElement: (ownerElement = $$('div').el),
       modalBoxModule: Simulate.modalBoxModule()
@@ -67,12 +67,12 @@ export function ExplanationModalTest() {
     (getFirstChild(ClassNames.DETAILS_TEXTAREA_CLASSNAME) as HTMLTextAreaElement).value = details;
   }
 
-  function selectExplanation(index: number) {
+  function selectReason(index: number) {
     explanationModal['reasons'][index].select();
   }
 
   describe('ExplanationModal', () => {
-    describe('with a first explanation that has details', () => {
+    describe('with a first reason that has details', () => {
       beforeEach(() => {
         initializeModal();
         openModal();
@@ -90,20 +90,16 @@ export function ExplanationModalTest() {
         expect(content.classList.contains(ClassNames.CONTENT_CLASSNAME)).toBeTruthy();
       });
 
-      it('builds the root with the explanations list, the details section and the send button', () => {
-        expectChildren(content, [
-          ClassNames.EXPLANATIONS_CLASSNAME,
-          ClassNames.DETAILS_SECTION_CLASSNAME,
-          ClassNames.SEND_BUTTON_CLASSNAME
-        ]);
+      it('builds the root with the reasons list, the details section and the send button', () => {
+        expectChildren(content, [ClassNames.REASONS_CLASSNAME, ClassNames.DETAILS_SECTION_CLASSNAME, ClassNames.SEND_BUTTON_CLASSNAME]);
       });
 
-      it('builds a radio button for each explanation', () => {
+      it('builds a radio button for each reason', () => {
         const inputs = $$(content).findAll('input');
-        expect(inputs.length).toEqual(explanations.length, 'Expected as many inputs as explanations.');
+        expect(inputs.length).toEqual(reasons.length, 'Expected as many inputs as reasons.');
         const labels = inputs.map(input => $$(content).find(`label[for="${input.id}"]`));
-        expect(labels.length).toEqual(explanations.length, 'Expected a label for each explanation');
-        labels.forEach((label, index) => expect(label.innerText).toEqual(explanations[index].label));
+        expect(labels.length).toEqual(reasons.length, 'Expected a label for each reason');
+        labels.forEach((label, index) => expect(label.innerText).toEqual(reasons[index].label));
       });
 
       it('builds a details section with a label and a textarea', () => {
@@ -121,9 +117,9 @@ export function ExplanationModalTest() {
         expect(getFirstChild(ClassNames.SEND_BUTTON_CLASSNAME).innerText).toEqual('Send');
       });
 
-      describe('after selecting the second explanation', () => {
+      describe('after selecting the second reason', () => {
         beforeEach(() => {
-          selectExplanation(1);
+          selectReason(1);
         });
 
         it('should disable the details textarea', () => {
@@ -135,8 +131,8 @@ export function ExplanationModalTest() {
             pressSendButton();
           });
 
-          it('calls onSelect on the second explanation', () => {
-            expect(explanations[1].onSelect).toHaveBeenCalledTimes(1);
+          it('calls onSelect on the second reason', () => {
+            expect(reasons[1].onSelect).toHaveBeenCalledTimes(1);
           });
 
           it("doesn't provide details from the textarea", () => {
@@ -146,9 +142,9 @@ export function ExplanationModalTest() {
         });
       });
 
-      describe('after selecting the third explanation', () => {
+      describe('after selecting the third reason', () => {
         beforeEach(() => {
-          selectExplanation(2);
+          selectReason(2);
         });
 
         it('should disable the details textarea', () => {
@@ -160,8 +156,8 @@ export function ExplanationModalTest() {
             pressSendButton();
           });
 
-          it('calls onSelect on the third explanation', () => {
-            expect(explanations[2].onSelect).toHaveBeenCalledTimes(1);
+          it('calls onSelect on the third reason', () => {
+            expect(reasons[2].onSelect).toHaveBeenCalledTimes(1);
           });
 
           it("doesn't provide details from the textarea", () => {
@@ -176,8 +172,8 @@ export function ExplanationModalTest() {
           pressSendButton();
         });
 
-        it('calls onSelect on the first explanation', () => {
-          expect(explanations[0].onSelect).toHaveBeenCalledTimes(1);
+        it('calls onSelect on the first reason', () => {
+          expect(reasons[0].onSelect).toHaveBeenCalledTimes(1);
         });
 
         it('provides details from the textarea', () => {
@@ -205,7 +201,7 @@ export function ExplanationModalTest() {
       });
     });
 
-    describe("with a first explanation that doesn't have details", () => {
+    describe("with a first reason that doesn't have details", () => {
       beforeEach(() => {
         initializeModal(false);
         openModal();

--- a/unitTests/ui/ExplanationModalTest.ts
+++ b/unitTests/ui/ExplanationModalTest.ts
@@ -1,0 +1,222 @@
+import { IExplanation, ExplanationModal, ExplanationModalClassNames as ClassNames } from '../../src/ui/SmartSnippet/ExplanationModal';
+import { $$ } from '../../src/utils/Dom';
+import { Simulate } from '../Simulate';
+import { mock } from '../MockEnvironment';
+import { AccessibleModal, IAccessibleModalOpenNormalParameters } from '../../src/utils/AccessibleModal';
+import { l } from '../../src/strings/Strings';
+import { expectChildren } from '../TestUtils';
+
+export function ExplanationModalTest() {
+  const details = 'Hello, World!';
+  let explanations: IExplanation[];
+  let onClosed: jasmine.Spy;
+  let ownerElement: HTMLElement;
+  let explanationModal: ExplanationModal;
+  let accessibleModal: AccessibleModal;
+  let origin: HTMLElement;
+  let content: HTMLElement;
+
+  function createExplanations(firstExplanationHasDetails: boolean): IExplanation[] {
+    return [
+      {
+        label: 'Explanation selected by default',
+        onSelect: jasmine.createSpy('onSelect1'),
+        hasDetails: firstExplanationHasDetails
+      },
+      {
+        label: 'Second explanation implicitly without details',
+        onSelect: jasmine.createSpy('onSelect2')
+      },
+      {
+        label: 'Third explanation explicitly without details',
+        onSelect: jasmine.createSpy('onSelect3'),
+        hasDetails: false
+      }
+    ];
+  }
+
+  function initializeModal(firstExplanationHasDetails = true) {
+    explanationModal = new ExplanationModal({
+      explanations: (explanations = createExplanations(firstExplanationHasDetails)),
+      onClosed: (onClosed = jasmine.createSpy('onClosed')),
+      ownerElement: (ownerElement = $$('div').el),
+      modalBoxModule: Simulate.modalBoxModule()
+    });
+    explanationModal['modal'] = accessibleModal = mock(AccessibleModal);
+    (accessibleModal.close as jasmine.Spy).and.callFake(() => getAccessibleModalOpenParameters().validation());
+  }
+
+  function getAccessibleModalOpenParameters() {
+    return ((accessibleModal.open as jasmine.Spy).calls.mostRecent().args as [IAccessibleModalOpenNormalParameters])[0];
+  }
+
+  function openModal() {
+    explanationModal.open((origin = $$('div').el));
+    content = getAccessibleModalOpenParameters().content;
+  }
+
+  function getFirstChild(className: string) {
+    return content.getElementsByClassName(className)[0] as HTMLElement;
+  }
+
+  function pressSendButton() {
+    getFirstChild(ClassNames.SEND_BUTTON_CLASSNAME).click();
+  }
+
+  function writeDetails() {
+    (getFirstChild(ClassNames.DETAILS_TEXTAREA_CLASSNAME) as HTMLTextAreaElement).value = details;
+  }
+
+  function selectExplanation(index: number) {
+    content
+      .querySelectorAll('input')
+      .item(index)
+      .click();
+  }
+
+  describe('ExplanationModal', () => {
+    describe('with a first explanation that has details', () => {
+      beforeEach(() => {
+        initializeModal();
+        openModal();
+      });
+
+      it('should open the modal with the given origin', () => {
+        expect(getAccessibleModalOpenParameters().origin).toEqual(origin);
+      });
+
+      it('should give the modal the right title', () => {
+        expect(getAccessibleModalOpenParameters().title).toEqual(l('UsefulnessFeedbackExplainWhyImperative'));
+      });
+
+      it('should give the root the right class', () => {
+        expect(content.classList.contains(ClassNames.CONTENT_CLASSNAME)).toBeTruthy();
+      });
+
+      it('builds the root with the explanations list, the details section and the send button', () => {
+        expectChildren(content, [
+          ClassNames.EXPLANATIONS_CLASSNAME,
+          ClassNames.DETAILS_SECTION_CLASSNAME,
+          ClassNames.SEND_BUTTON_CLASSNAME
+        ]);
+      });
+
+      it('builds a radio button for each explanation', () => {
+        const inputs = $$(content).findAll('input');
+        expect(inputs.length).toEqual(explanations.length, 'Expected as many inputs as explanations.');
+        const labels = inputs.map(input => $$(content).find(`label[for="${input.id}"]`));
+        expect(labels.length).toEqual(explanations.length, 'Expected a label for each explanation');
+        labels.forEach((label, index) => expect(label.innerText).toEqual(explanations[index].label));
+      });
+
+      it('builds a details section with a label and a textarea', () => {
+        expectChildren(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME), [
+          ClassNames.DETAILS_LABEL_CLASSNAME,
+          ClassNames.DETAILS_TEXTAREA_CLASSNAME
+        ]);
+      });
+
+      it("doesn't disable the textarea", () => {
+        expect((getFirstChild(ClassNames.DETAILS_TEXTAREA_CLASSNAME) as HTMLTextAreaElement).disabled).toBeFalsy();
+      });
+
+      it('builds a send button with the right text', () => {
+        expect(getFirstChild(ClassNames.SEND_BUTTON_CLASSNAME).innerText).toEqual('Send');
+      });
+
+      describe('after selecting the second explanation', () => {
+        beforeEach(() => {
+          selectExplanation(1);
+        });
+
+        it('should disable the details textarea', () => {
+          expect((getFirstChild(ClassNames.DETAILS_TEXTAREA_CLASSNAME) as HTMLTextAreaElement).disabled).toBeTruthy();
+        });
+
+        describe('then pressing the send button', () => {
+          beforeEach(() => {
+            pressSendButton();
+          });
+
+          it('calls onSelect on the second explanation', () => {
+            expect(explanations[1].onSelect).toHaveBeenCalledTimes(1);
+          });
+
+          it("doesn't provide details from the textarea", () => {
+            writeDetails();
+            expect(explanationModal.details).toBeNull();
+          });
+        });
+      });
+
+      describe('after selecting the third explanation', () => {
+        beforeEach(() => {
+          selectExplanation(2);
+        });
+
+        it('should disable the details textarea', () => {
+          expect((getFirstChild(ClassNames.DETAILS_TEXTAREA_CLASSNAME) as HTMLTextAreaElement).disabled).toBeTruthy();
+        });
+
+        describe('then pressing the send button', () => {
+          beforeEach(() => {
+            pressSendButton();
+          });
+
+          it('calls onSelect on the third explanation', () => {
+            expect(explanations[2].onSelect).toHaveBeenCalledTimes(1);
+          });
+
+          it("doesn't provide details from the textarea", () => {
+            writeDetails();
+            expect(explanationModal.details).toBeNull();
+          });
+        });
+      });
+
+      describe('after pressing the send button', () => {
+        beforeEach(() => {
+          pressSendButton();
+        });
+
+        it('calls onSelect on the first explanation', () => {
+          expect(explanations[0].onSelect).toHaveBeenCalledTimes(1);
+        });
+
+        it('provides details from the textarea', () => {
+          writeDetails();
+          expect(explanationModal.details).toEqual(details);
+        });
+
+        it('closes the modal', () => {
+          expect(accessibleModal.close).toHaveBeenCalledTimes(1);
+        });
+
+        it("doesn't call onClosed", () => {
+          expect(onClosed).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('after pressing the close button', () => {
+        beforeEach(() => {
+          accessibleModal.close();
+        });
+
+        it('calls onClosed', () => {
+          expect(onClosed).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+
+    describe("with a first explanation that doesn't have details", () => {
+      beforeEach(() => {
+        initializeModal(false);
+        openModal();
+      });
+
+      it('disables the textarea', () => {
+        expect((getFirstChild(ClassNames.DETAILS_TEXTAREA_CLASSNAME) as HTMLTextAreaElement).disabled).toBeTruthy();
+      });
+    });
+  });
+}

--- a/unitTests/ui/HeightLimiterTest.ts
+++ b/unitTests/ui/HeightLimiterTest.ts
@@ -1,0 +1,206 @@
+import { $$ } from '../../src/utils/Dom';
+import { HeightLimiter, HeightLimiterClassNames as ClassNames } from '../../src/ui/SmartSnippet/HeightLimiter';
+import { SVGIcons } from '../../src/utils/SVGIcons';
+import { l } from '../../src/strings/Strings';
+import { expectChildren } from '../TestUtils';
+
+const heightLimit = 2;
+
+interface IElementsState {
+  containerActive: boolean;
+  buttonActive: boolean;
+  containerExpanded: boolean;
+}
+
+export function HeightLimiterTest() {
+  let heightLimiter: HeightLimiter;
+  let container: HTMLElement;
+  let onToggleSpy: jasmine.Spy;
+  let scrollHeight: number;
+
+  function createContainer(height: number) {
+    scrollHeight = height;
+    container = $$('div').el;
+    Object.defineProperty(container, 'scrollHeight', { get: () => scrollHeight });
+    return container;
+  }
+
+  function initializeHeightLimiter(initialHeight: number) {
+    heightLimiter = new HeightLimiter(createContainer(initialHeight), heightLimit, (onToggleSpy = jasmine.createSpy('onToggle')));
+  }
+
+  function resizeContainer(newHeight: number) {
+    scrollHeight = newHeight;
+    heightLimiter.onScrollHeightChanged();
+  }
+
+  function getElementsState(): IElementsState {
+    return {
+      containerActive: container.classList.contains(ClassNames.CONTAINER_ACTIVE_CLASSNAME),
+      buttonActive: heightLimiter.toggleButton.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME),
+      containerExpanded: container.classList.contains(ClassNames.CONTAINER_EXPANDED_CLASSNAME)
+    };
+  }
+
+  function getButtonText() {
+    return heightLimiter.toggleButton.querySelector(`.${ClassNames.BUTTON_LABEL_CLASSNAME}`).textContent;
+  }
+
+  function getButtonIcon() {
+    return heightLimiter.toggleButton.querySelector(`.${ClassNames.BUTTON_ICON_CLASSNAME}`).innerHTML;
+  }
+
+  describe('HeightLimiter', () => {
+    describe('initialized at the height limit', () => {
+      beforeEach(() => {
+        initializeHeightLimiter(heightLimit);
+      });
+
+      it('should have an inactive container, inactive button and collapsed container', () => {
+        expect(getElementsState()).toEqual({ containerActive: false, buttonActive: false, containerExpanded: false });
+      });
+
+      it('should not force a height on the container', () => {
+        expect(container.style.height).toEqual('');
+      });
+
+      it("doesn't call onToggle", () => {
+        expect(onToggleSpy).not.toHaveBeenCalled();
+      });
+
+      describe('then resized beyond the height limit', () => {
+        beforeEach(() => {
+          resizeContainer(heightLimit + 1);
+        });
+
+        it('makes the container and button active', () => {
+          expect(getElementsState()).toEqual({ containerActive: true, buttonActive: true, containerExpanded: false });
+        });
+
+        it('should force a height on the container', () => {
+          expect(container.style.height).toEqual(`${heightLimit}px`);
+        });
+
+        it('should render the toggle button with its label and icon inside', () => {
+          expectChildren(heightLimiter.toggleButton, [ClassNames.BUTTON_LABEL_CLASSNAME, ClassNames.BUTTON_ICON_CLASSNAME]);
+        });
+
+        it('should have the show more label on the toggle button', () => {
+          expect(getButtonText()).toEqual(l('ShowMore'));
+        });
+
+        it('should have a down arrow on the toggle button', () => {
+          expect(getButtonIcon()).toEqual(SVGIcons.icons.arrowDown);
+        });
+
+        it("doesn't call onToggle", () => {
+          expect(onToggleSpy).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('initialized beyond the height limit', () => {
+      beforeEach(() => {
+        initializeHeightLimiter(heightLimit + 1);
+      });
+
+      it('should have an active container, active button and collapsed container', () => {
+        expect(getElementsState()).toEqual({ containerActive: true, buttonActive: true, containerExpanded: false });
+      });
+
+      it('should force a height on the container', () => {
+        expect(container.style.height).toEqual(`${heightLimit}px`);
+      });
+
+      it('should have the show more label on the toggle button', () => {
+        expect(getButtonText()).toEqual(l('ShowMore'));
+      });
+
+      it('should have a down arrow on the toggle button', () => {
+        expect(getButtonIcon()).toEqual(SVGIcons.icons.arrowDown);
+      });
+
+      it("doesn't call onToggle", () => {
+        expect(onToggleSpy).not.toHaveBeenCalled();
+      });
+
+      describe('then resized to the height limit', () => {
+        beforeEach(() => {
+          resizeContainer(heightLimit);
+        });
+
+        it('makes the container and button inactive', () => {
+          expect(getElementsState()).toEqual({ containerActive: false, buttonActive: false, containerExpanded: false });
+        });
+
+        it('should not force a height on the container', () => {
+          expect(container.style.height).toEqual('');
+        });
+
+        it("doesn't call onToggle", () => {
+          expect(onToggleSpy).not.toHaveBeenCalled();
+        });
+      });
+
+      describe('then pressing the toggle button', () => {
+        beforeEach(() => {
+          heightLimiter.toggleButton.click();
+        });
+
+        it('should expand the container', () => {
+          expect(getElementsState()).toEqual({ containerActive: true, buttonActive: true, containerExpanded: true });
+        });
+
+        it('should force the scrollHeight on the container', () => {
+          expect(container.style.height).toEqual(`${scrollHeight}px`);
+        });
+
+        it('should have the show less label on the toggle button', () => {
+          expect(getButtonText()).toEqual(l('ShowLess'));
+        });
+
+        it('should have an up arrow on the toggle button', () => {
+          expect(getButtonIcon()).toEqual(SVGIcons.icons.arrowUp);
+        });
+
+        it('then resized to the height limit, should make the container and button inactive, then collapse the container', () => {
+          resizeContainer(heightLimit);
+          expect(getElementsState()).toEqual({ containerActive: false, buttonActive: false, containerExpanded: false });
+        });
+
+        it('calls onToggle', () => {
+          expect(onToggleSpy).toHaveBeenCalledTimes(1);
+          expect(onToggleSpy).toHaveBeenCalledWith(true);
+        });
+
+        describe('then pressing the toggle button', () => {
+          beforeEach(() => {
+            onToggleSpy.calls.reset();
+            heightLimiter.toggleButton.click();
+          });
+
+          it('should collapse the container', () => {
+            expect(getElementsState()).toEqual({ containerActive: true, buttonActive: true, containerExpanded: false });
+          });
+
+          it('should force the height limit on the container', () => {
+            expect(container.style.height).toEqual(`${heightLimit}px`);
+          });
+
+          it('should have the show more label on the toggle button', () => {
+            expect(getButtonText()).toEqual(l('ShowMore'));
+          });
+
+          it('should have a down arrow on the toggle button', () => {
+            expect(getButtonIcon()).toEqual(SVGIcons.icons.arrowDown);
+          });
+
+          it('calls onToggle', () => {
+            expect(onToggleSpy).toHaveBeenCalledTimes(1);
+            expect(onToggleSpy).toHaveBeenCalledWith(false);
+          });
+        });
+      });
+    });
+  });
+}

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -3,9 +3,25 @@ import { IQueryResult } from '../../src/rest/QueryResult';
 import { $$ } from '../../src/utils/Dom';
 import { QueryEvents, IQuerySuccessEventArgs } from '../../src/events/QueryEvents';
 import { SmartSnippet, SmartSnippetClassNames as ClassNames } from '../../src/ui/SmartSnippet/SmartSnippet';
-import { Component } from '../../src/Core';
 import { expectChildren } from '../TestUtils';
 import { UserFeedbackBannerClassNames } from '../../src/ui/SmartSnippet/UserFeedbackBanner';
+import { IBasicComponentSetup, advancedComponentSetup, AdvancedComponentSetupOptions } from '../MockEnvironment';
+import { HeightLimiterClassNames } from '../../src/ui/SmartSnippet/HeightLimiter';
+import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
+
+function simulateClick(element: HTMLElement) {
+  element.dispatchEvent(new MouseEvent('click', { ctrlKey: true }));
+}
+
+function expectCallWith(funct: jasmine.Spy, ...params: any[]) {
+  const lastCall = funct.calls.mostRecent();
+  expect(lastCall).not.toBeNull();
+  if (!lastCall) {
+    return;
+  }
+  const lastCallArguments = lastCall.args;
+  params.forEach((value, i) => expect(lastCallArguments[i]).toEqual(value));
+}
 
 export function SmartSnippetTest() {
   const sourceTitle = 'Google!';
@@ -14,6 +30,15 @@ export function SmartSnippetTest() {
     contentIdKey: 'unique-identifier',
     contentIdValue: 'identifier-of-the-first-result'
   };
+  const style = `
+    .abc {
+      color: red;
+    }
+
+    #hello-world {
+      cursor: url('some-ugly-animated-gif-cursor.gif');
+    }
+  `.replace(' ', '');
 
   function mockResult() {
     return (<Partial<IQueryResult>>{
@@ -49,6 +74,10 @@ export function SmartSnippetTest() {
     ).el;
   }
 
+  function mockStyling() {
+    return $$('script', { type: 'text/css' }, style).el;
+  }
+
   function mockQuestionAnswer() {
     return <IQuestionAnswerResponse>{
       answerSnippet: mockSnippet().innerHTML,
@@ -57,67 +86,137 @@ export function SmartSnippetTest() {
   }
 
   describe('SmartSnippet', () => {
-    let root: HTMLElement;
-    let smartSnippetElement: HTMLElement;
-    let smartSnippet: SmartSnippet;
+    let test: IBasicComponentSetup<SmartSnippet>;
 
-    function createRoot() {
-      root = $$('div').el;
-    }
-
-    function instantiateSmartSnippet() {
-      smartSnippet = new SmartSnippet(
-        (smartSnippetElement = $$('div', { className: Component.computeCssClassName(SmartSnippet) }).el),
-        {},
-        { root }
+    function instantiateSmartSnippet(hasStyling: boolean) {
+      test = advancedComponentSetup<SmartSnippet>(
+        SmartSnippet,
+        new AdvancedComponentSetupOptions($$('div', {}, ...(hasStyling ? [mockStyling()] : [])).el)
       );
     }
 
-    function triggerQuerySuccess(withSource: boolean = true) {
-      $$(root).trigger(QueryEvents.querySuccess, <IQuerySuccessEventArgs>{
+    function triggerQuerySuccess(withSource: boolean) {
+      const results = withSource ? [mockResult()] : [];
+      (test.env.queryController.getLastResults as jasmine.Spy).and.returnValue({ results });
+      $$(test.env.root).trigger(QueryEvents.querySuccess, <IQuerySuccessEventArgs>{
         results: {
-          results: withSource ? [mockResult()] : [],
+          results,
           questionAnswer: mockQuestionAnswer()
         }
       });
     }
 
-    beforeEach(() => {
-      createRoot();
-      instantiateSmartSnippet();
-      triggerQuerySuccess();
+    function getFirstChild(className: string) {
+      return test.cmp.element.getElementsByClassName(className)[0] as HTMLElement;
+    }
+
+    function getShadowRoot() {
+      return getFirstChild(ClassNames.SHADOW_CLASSNAME).shadowRoot;
+    }
+
+    describe('with styling without a source', () => {
+      beforeEach(() => {
+        instantiateSmartSnippet(true);
+        triggerQuerySuccess(false);
+      });
+
+      it('should render the style', () => {
+        const styleElement = getShadowRoot().querySelector('style') as HTMLStyleElement;
+        expect(styleElement.innerHTML).toEqual(style);
+      });
     });
 
-    it('should render the answer container followed by the feedback banner', () => {
-      expectChildren(smartSnippetElement, [ClassNames.ANSWER_CONTAINER_CLASSNAME, UserFeedbackBannerClassNames.ROOT_CLASSNAME]);
-    });
+    describe('without styling', () => {
+      beforeEach(() => {
+        instantiateSmartSnippet(false);
+      });
 
-    it('should render the snippet followed by the source in the answer container', () => {
-      expectChildren(smartSnippetElement.querySelector<HTMLElement>(`.${ClassNames.ANSWER_CONTAINER_CLASSNAME}`), [
-        ClassNames.SHADOW_CLASSNAME,
-        ClassNames.SOURCE_CLASSNAME
-      ]);
-    });
+      it("doesn't have the has-answer class", () => {
+        expect(test.cmp.element.classList.contains(ClassNames.HAS_ANSWER_CLASSNAME)).toBeFalsy();
+      });
 
-    it('should wrap the snippet in a container in a shadow DOM', () => {
-      const [shadowContainer] = expectChildren(smartSnippetElement.querySelector(`.${ClassNames.SHADOW_CLASSNAME}`).shadowRoot, [
-        ClassNames.CONTENT_CLASSNAME
-      ]);
+      it("doesn't render anything in the SmartSnippet element", () => {
+        expect(test.cmp.element.children.length).toEqual(0);
+      });
 
-      expect(shadowContainer.innerHTML).toEqual(mockSnippet().innerHTML);
-    });
+      describe('with a source', () => {
+        beforeEach(() => {
+          triggerQuerySuccess(true);
+        });
 
-    it('should render the source with its url first then its title', () => {
-      const [url, title] = expectChildren(smartSnippetElement.querySelector<HTMLElement>(`.${ClassNames.SOURCE_CLASSNAME}`), [
-        ClassNames.SOURCE_URL_CLASSNAME,
-        ClassNames.SOURCE_TITLE_CLASSNAME
-      ]) as HTMLAnchorElement[];
+        it('has the has-answer class', () => {
+          expect(test.cmp.element.classList.contains(ClassNames.HAS_ANSWER_CLASSNAME)).toBeTruthy();
+        });
 
-      expect(url.href).toEqual(sourceUrl);
-      expect(url.innerText).toEqual(sourceUrl);
+        it('should render the source with its url first then its title', () => {
+          const [url, title] = expectChildren(getFirstChild(ClassNames.SOURCE_CLASSNAME), [
+            ClassNames.SOURCE_URL_CLASSNAME,
+            ClassNames.SOURCE_TITLE_CLASSNAME
+          ]) as HTMLAnchorElement[];
 
-      expect(title.href).toEqual(sourceUrl);
-      expect(title.innerText).toEqual(sourceTitle);
+          expect(url.href).toEqual(sourceUrl);
+          expect(url.innerText).toEqual(sourceUrl);
+
+          expect(title.href).toEqual(sourceUrl);
+          expect(title.innerText).toEqual(sourceTitle);
+        });
+
+        it('should log analytics when clicking on the source URL', () => {
+          spyOn(window, 'open');
+
+          simulateClick(getFirstChild(ClassNames.SOURCE_URL_CLASSNAME));
+          expectCallWith(test.env.usageAnalytics.logCustomEvent as jasmine.Spy, analyticsActionCauseList.openSmartSnippetSource);
+        });
+
+        it('should log analytics when clicking on the title', () => {
+          spyOn(window, 'open');
+
+          simulateClick(getFirstChild(ClassNames.SOURCE_TITLE_CLASSNAME));
+          expectCallWith(test.env.usageAnalytics.logCustomEvent as jasmine.Spy, analyticsActionCauseList.openSmartSnippetSource);
+        });
+
+        it('should open a new tab when clicking on the source', () => {
+          const open = spyOn(window, 'open');
+
+          simulateClick(getFirstChild(ClassNames.SOURCE_URL_CLASSNAME));
+          expect(open).toHaveBeenCalledWith(sourceUrl);
+        });
+
+        it('should open a new tab when clicking on the title', () => {
+          const open = spyOn(window, 'open');
+
+          simulateClick(getFirstChild(ClassNames.SOURCE_TITLE_CLASSNAME));
+          expect(open).toHaveBeenCalledWith(sourceUrl);
+        });
+      });
+
+      describe('without a source', () => {
+        beforeEach(() => {
+          triggerQuerySuccess(false);
+        });
+
+        it('should render the answer container followed by the feedback banner', () => {
+          expectChildren(test.cmp.element, [ClassNames.ANSWER_CONTAINER_CLASSNAME, UserFeedbackBannerClassNames.ROOT_CLASSNAME]);
+        });
+
+        it('should render the snippet followed by the source in the answer container', () => {
+          expectChildren(getFirstChild(ClassNames.ANSWER_CONTAINER_CLASSNAME), [
+            ClassNames.SHADOW_CLASSNAME,
+            HeightLimiterClassNames.BUTTON_CLASSNAME,
+            ClassNames.SOURCE_CLASSNAME
+          ]);
+        });
+
+        it('should wrap the snippet in a container in a shadow DOM', () => {
+          const [shadowContainer] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME]);
+
+          expect(shadowContainer.innerHTML).toEqual(mockSnippet().innerHTML);
+        });
+
+        it('should not render any source', () => {
+          expect(getFirstChild(ClassNames.SOURCE_CLASSNAME).children.length).toEqual(0);
+        });
+      });
     });
   });
 }

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -7,21 +7,6 @@ import { expectChildren } from '../TestUtils';
 import { UserFeedbackBannerClassNames } from '../../src/ui/SmartSnippet/UserFeedbackBanner';
 import { IBasicComponentSetup, advancedComponentSetup, AdvancedComponentSetupOptions } from '../MockEnvironment';
 import { HeightLimiterClassNames } from '../../src/ui/SmartSnippet/HeightLimiter';
-import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
-
-function simulateClick(element: HTMLElement) {
-  element.dispatchEvent(new MouseEvent('click', { ctrlKey: true }));
-}
-
-function expectCallWith(funct: jasmine.Spy, ...params: any[]) {
-  const lastCall = funct.calls.mostRecent();
-  expect(lastCall).not.toBeNull();
-  if (!lastCall) {
-    return;
-  }
-  const lastCallArguments = lastCall.args;
-  params.forEach((value, i) => expect(lastCallArguments[i]).toEqual(value));
-}
 
 export function SmartSnippetTest() {
   const sourceTitle = 'Google!';
@@ -93,6 +78,9 @@ export function SmartSnippetTest() {
         SmartSnippet,
         new AdvancedComponentSetupOptions($$('div', {}, ...(hasStyling ? [mockStyling()] : [])).el)
       );
+      test.cmp['openLink'] = jasmine
+        .createSpy('openLink')
+        .and.callFake((href: string, newTab: boolean, sendAnalytics: () => void) => sendAnalytics());
     }
 
     function triggerQuerySuccess(withSource: boolean) {
@@ -159,34 +147,6 @@ export function SmartSnippetTest() {
 
           expect(title.href).toEqual(sourceUrl);
           expect(title.innerText).toEqual(sourceTitle);
-        });
-
-        it('should log analytics when clicking on the source URL', () => {
-          spyOn(window, 'open');
-
-          simulateClick(getFirstChild(ClassNames.SOURCE_URL_CLASSNAME));
-          expectCallWith(test.env.usageAnalytics.logCustomEvent as jasmine.Spy, analyticsActionCauseList.openSmartSnippetSource);
-        });
-
-        it('should log analytics when clicking on the title', () => {
-          spyOn(window, 'open');
-
-          simulateClick(getFirstChild(ClassNames.SOURCE_TITLE_CLASSNAME));
-          expectCallWith(test.env.usageAnalytics.logCustomEvent as jasmine.Spy, analyticsActionCauseList.openSmartSnippetSource);
-        });
-
-        it('should open a new tab when clicking on the source', () => {
-          const open = spyOn(window, 'open');
-
-          simulateClick(getFirstChild(ClassNames.SOURCE_URL_CLASSNAME));
-          expect(open).toHaveBeenCalledWith(sourceUrl);
-        });
-
-        it('should open a new tab when clicking on the title', () => {
-          const open = spyOn(window, 'open');
-
-          simulateClick(getFirstChild(ClassNames.SOURCE_TITLE_CLASSNAME));
-          expect(open).toHaveBeenCalledWith(sourceUrl);
         });
       });
 

--- a/unitTests/ui/UserFeedbackBannerTest.ts
+++ b/unitTests/ui/UserFeedbackBannerTest.ts
@@ -1,0 +1,3 @@
+export function UserFeedbackBannerTest() {
+  describe('UserFeedbackBanner', () => {});
+}

--- a/unitTests/ui/UserFeedbackBannerTest.ts
+++ b/unitTests/ui/UserFeedbackBannerTest.ts
@@ -7,13 +7,17 @@ export function UserFeedbackBannerTest() {
   describe('UserFeedbackBanner', () => {
     let rootElement: HTMLElement;
     let sendUsefulnessAnalyticsSpy: jasmine.Spy;
+    let onExplainWhyPressedSpy: jasmine.Spy;
 
     function getFirstChild(className: string) {
       return rootElement.getElementsByClassName(className)[0] as HTMLElement;
     }
 
     beforeEach(() => {
-      rootElement = new UserFeedbackBanner((sendUsefulnessAnalyticsSpy = jasmine.createSpy('sendUsefulnessAnalytics'))).build();
+      rootElement = new UserFeedbackBanner(
+        (sendUsefulnessAnalyticsSpy = jasmine.createSpy('sendUsefulnessAnalytics')),
+        (onExplainWhyPressedSpy = jasmine.createSpy('onExplainWhyPressed'))
+      ).build();
     });
 
     it('builds a root element with the root classname', () => {
@@ -175,6 +179,11 @@ export function UserFeedbackBannerTest() {
 
       it('sends analytics', () => {
         expect(sendUsefulnessAnalyticsSpy).toHaveBeenCalledWith(false);
+      });
+
+      it('then pressing on explain why, sends analytics', () => {
+        getFirstChild(ClassNames.EXPLAIN_WHY_CLASSNAME).click();
+        expect(onExplainWhyPressedSpy).toHaveBeenCalledTimes(1);
       });
 
       describe('then clicking on the yes button', () => {

--- a/unitTests/ui/UserFeedbackBannerTest.ts
+++ b/unitTests/ui/UserFeedbackBannerTest.ts
@@ -1,3 +1,237 @@
+import { UserFeedbackBanner, UserFeedbackBannerClassNames as ClassNames } from '../../src/ui/SmartSnippet/UserFeedbackBanner';
+import { expectChildren } from '../TestUtils';
+import { l } from '../../src/strings/Strings';
+import { SVGIcons } from '../../src/utils/SVGIcons';
+
 export function UserFeedbackBannerTest() {
-  describe('UserFeedbackBanner', () => {});
+  describe('UserFeedbackBanner', () => {
+    let rootElement: HTMLElement;
+    let sendUsefulnessAnalyticsSpy: jasmine.Spy;
+
+    function getFirstChild(className: string) {
+      return rootElement.getElementsByClassName(className)[0] as HTMLElement;
+    }
+
+    beforeEach(() => {
+      rootElement = new UserFeedbackBanner((sendUsefulnessAnalyticsSpy = jasmine.createSpy('sendUsefulnessAnalytics'))).build();
+    });
+
+    it('builds a root element with the root classname', () => {
+      expect(rootElement.classList.contains(ClassNames.ROOT_CLASSNAME)).toBeTruthy();
+    });
+
+    it('builds a root element with the top container and bottom thank you banner', () => {
+      const [, banner] = expectChildren(rootElement, [ClassNames.CONTAINER_CLASSNAME, ClassNames.THANK_YOU_BANNER_CLASSNAME]);
+
+      expect(banner.classList.contains(ClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)).toBeFalsy();
+    });
+
+    it('builds the top container with a label and buttons', () => {
+      const [label] = expectChildren(getFirstChild(ClassNames.CONTAINER_CLASSNAME), [
+        ClassNames.LABEL_CLASSNAME,
+        ClassNames.BUTTONS_CONTAINER_CLASSNAME
+      ]);
+
+      expect(label.innerText).toEqual(l('UsefulnessFeedbackRequest'));
+    });
+
+    it('builds the buttons container with both buttons', () => {
+      const [yesButton, noButton] = expectChildren(getFirstChild(ClassNames.BUTTONS_CONTAINER_CLASSNAME), [
+        ClassNames.YES_BUTTON_CLASSNAME,
+        ClassNames.NO_BUTTON_CLASSNAME
+      ]);
+
+      expect(yesButton.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME)).toBeFalsy();
+      expect(noButton.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME)).toBeFalsy();
+    });
+
+    it('builds the yes button with an icon and text', () => {
+      const [icon, label] = expectChildren(getFirstChild(ClassNames.YES_BUTTON_CLASSNAME), [ClassNames.ICON_CLASSNAME, null]);
+
+      expect(icon.innerHTML).toEqual(SVGIcons.icons.checkYes);
+      expect(label.innerText).toEqual(l('Yes'));
+    });
+
+    it('builds the no button with an icon and text', () => {
+      const [icon, label] = expectChildren(getFirstChild(ClassNames.NO_BUTTON_CLASSNAME), [ClassNames.ICON_CLASSNAME, null]);
+
+      expect(icon.innerHTML).toEqual(SVGIcons.icons.clearSmall);
+      expect(label.innerText).toEqual(l('No'));
+    });
+
+    it('builds the thank you banner with a label and a button', () => {
+      const [label, button] = expectChildren(getFirstChild(ClassNames.THANK_YOU_BANNER_CLASSNAME), [
+        null,
+        ClassNames.EXPLAIN_WHY_CLASSNAME
+      ]);
+
+      expect(label.innerText).toEqual(l('UsefulnessFeedbackThankYou'));
+      expect(button.innerHTML).toEqual(l('UsefulnessFeedbackExplainWhy'));
+      expect(button.classList.contains(ClassNames.EXPLAIN_WHY_ACTIVE_CLASSNAME)).toBeFalsy();
+    });
+
+    describe('after clicking on the yes button', () => {
+      let button: HTMLElement;
+      beforeEach(() => {
+        button = getFirstChild(ClassNames.YES_BUTTON_CLASSNAME);
+        button.click();
+      });
+
+      it('gives the active class to the button', () => {
+        expect(button.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME)).toBeTruthy();
+      });
+
+      it('gives the active class to the thank you banner', () => {
+        expect(
+          getFirstChild(ClassNames.THANK_YOU_BANNER_CLASSNAME).classList.contains(ClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)
+        ).toBeTruthy();
+      });
+
+      it("doesn't give the active class to the explain why button", () => {
+        expect(getFirstChild(ClassNames.EXPLAIN_WHY_CLASSNAME).classList.contains(ClassNames.EXPLAIN_WHY_ACTIVE_CLASSNAME)).toBeFalsy();
+      });
+
+      it('sends analytics', () => {
+        expect(sendUsefulnessAnalyticsSpy).toHaveBeenCalledWith(true);
+      });
+
+      describe('then clicking on the no button', () => {
+        let nextButton: HTMLElement;
+        beforeEach(() => {
+          sendUsefulnessAnalyticsSpy.calls.reset();
+          nextButton = getFirstChild(ClassNames.NO_BUTTON_CLASSNAME);
+          nextButton.click();
+        });
+
+        it('removes the active class from the yes button', () => {
+          expect(button.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME)).toBeFalsy();
+        });
+
+        it('gives the active class to the no button', () => {
+          expect(nextButton.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME)).toBeTruthy();
+        });
+
+        it('gives the active class to the thank you banner', () => {
+          expect(
+            getFirstChild(ClassNames.THANK_YOU_BANNER_CLASSNAME).classList.contains(ClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)
+          ).toBeTruthy();
+        });
+
+        it('gives the active class to the explain why button', () => {
+          expect(getFirstChild(ClassNames.EXPLAIN_WHY_CLASSNAME).classList.contains(ClassNames.EXPLAIN_WHY_ACTIVE_CLASSNAME)).toBeTruthy();
+        });
+
+        it('sends analytics', () => {
+          expect(sendUsefulnessAnalyticsSpy).toHaveBeenCalledWith(false);
+        });
+      });
+
+      describe('then clicking on the yes button again', () => {
+        beforeEach(() => {
+          sendUsefulnessAnalyticsSpy.calls.reset();
+          button.click();
+        });
+
+        it('keeps the active class on the button', () => {
+          expect(button.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME)).toBeTruthy();
+        });
+
+        it('keeps the active class on the thank you banner', () => {
+          expect(
+            getFirstChild(ClassNames.THANK_YOU_BANNER_CLASSNAME).classList.contains(ClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)
+          ).toBeTruthy();
+        });
+
+        it("doesn't give the active class to the explain why button", () => {
+          expect(getFirstChild(ClassNames.EXPLAIN_WHY_CLASSNAME).classList.contains(ClassNames.EXPLAIN_WHY_ACTIVE_CLASSNAME)).toBeFalsy();
+        });
+
+        it("doesn't send analytics", () => {
+          expect(sendUsefulnessAnalyticsSpy).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('after clicking on the no button', () => {
+      let button: HTMLElement;
+      beforeEach(() => {
+        button = getFirstChild(ClassNames.NO_BUTTON_CLASSNAME);
+        button.click();
+      });
+
+      it('gives the active class to the button', () => {
+        expect(button.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME)).toBeTruthy();
+      });
+
+      it('gives the active class to the thank you banner', () => {
+        expect(
+          getFirstChild(ClassNames.THANK_YOU_BANNER_CLASSNAME).classList.contains(ClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)
+        ).toBeTruthy();
+      });
+
+      it('gives the active class to the explain why button', () => {
+        expect(getFirstChild(ClassNames.EXPLAIN_WHY_CLASSNAME).classList.contains(ClassNames.EXPLAIN_WHY_ACTIVE_CLASSNAME)).toBeTruthy();
+      });
+
+      it('sends analytics', () => {
+        expect(sendUsefulnessAnalyticsSpy).toHaveBeenCalledWith(false);
+      });
+
+      describe('then clicking on the yes button', () => {
+        let nextButton: HTMLElement;
+        beforeEach(() => {
+          sendUsefulnessAnalyticsSpy.calls.reset();
+          nextButton = getFirstChild(ClassNames.YES_BUTTON_CLASSNAME);
+          nextButton.click();
+        });
+
+        it('removes the active class from the no button', () => {
+          expect(button.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME)).toBeFalsy();
+        });
+
+        it('gives the active class to the yes button', () => {
+          expect(nextButton.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME)).toBeTruthy();
+        });
+
+        it('gives the active class to the thank you banner', () => {
+          expect(
+            getFirstChild(ClassNames.THANK_YOU_BANNER_CLASSNAME).classList.contains(ClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)
+          ).toBeTruthy();
+        });
+
+        it("doesn't give the active class to the explain why button", () => {
+          expect(getFirstChild(ClassNames.EXPLAIN_WHY_CLASSNAME).classList.contains(ClassNames.EXPLAIN_WHY_ACTIVE_CLASSNAME)).toBeFalsy();
+        });
+
+        it('sends analytics', () => {
+          expect(sendUsefulnessAnalyticsSpy).toHaveBeenCalledWith(true);
+        });
+      });
+
+      describe('then clicking on the no button again', () => {
+        beforeEach(() => {
+          sendUsefulnessAnalyticsSpy.calls.reset();
+          button.click();
+        });
+
+        it('keeps the active class on the button', () => {
+          expect(button.classList.contains(ClassNames.BUTTON_ACTIVE_CLASSNAME)).toBeTruthy();
+        });
+
+        it('keeps the active class on the thank you banner', () => {
+          expect(
+            getFirstChild(ClassNames.THANK_YOU_BANNER_CLASSNAME).classList.contains(ClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)
+          ).toBeTruthy();
+        });
+
+        it('keeps the active class on the explain why button', () => {
+          expect(getFirstChild(ClassNames.EXPLAIN_WHY_CLASSNAME).classList.contains(ClassNames.EXPLAIN_WHY_ACTIVE_CLASSNAME)).toBeTruthy();
+        });
+
+        it("doesn't send analytics", () => {
+          expect(sendUsefulnessAnalyticsSpy).not.toHaveBeenCalled();
+        });
+      });
+    });
+  });
 }


### PR DESCRIPTION
Along with those unit tests and accessibility tests, some minor tweaks were made.

For instance, closing a modal by pressing the send button no longer sends both the "reason" analytics and the "modal closed" analytics, it only sends the "reason".

Additionally, the following accessibility changes were made:
![Screen Shot 2020-07-13 at 9 48 26 AM](https://user-images.githubusercontent.com/54454747/87312204-3cd3de80-c4ee-11ea-8318-84ee5ca9e6e1.png)

![Screen Shot 2020-07-13 at 9 50 39 AM](https://user-images.githubusercontent.com/54454747/87312355-70166d80-c4ee-11ea-93c2-f2c33d28cc69.png)


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)