### PR TITLE
Search box on https://coveo.github.io/search-ui/ should point to https://docs.coveo.com/en/search

### DIFF
--- a/docs/theme/assets/css/coveo-connect-header.css
+++ b/docs/theme/assets/css/coveo-connect-header.css
@@ -117,7 +117,7 @@ header .content .search {
 }
 
 #coveoConnectHeaderStandaloneSearchbox .magic-box .magic-box-input input {
-  padding: 0;
+  padding: 0.5rem;
   height: 33px;
 }
 

--- a/docs/theme/assets/js/coveo-connect-header.js
+++ b/docs/theme/assets/js/coveo-connect-header.js
@@ -2,7 +2,7 @@ const headerNamespace = {
   initializeStandaloneSearchbox: () => {
     Coveo.SearchEndpoint.configureCloudV2Endpoint('coveosearch', 'xxf4d1df7a-7916-481e-9917-f562dddc322d');
     const root = Coveo.$$(document).find('#coveoConnectHeaderStandaloneSearchbox');
-    Coveo.initSearchbox(root, 'https://connect.coveo.com/s/global-search/%40uri');
+    Coveo.initSearchbox(root, 'https://docs.coveo.com/en/search');
   },
 
   initializeDropdownMenus: () => {


### PR DESCRIPTION
[DOC-7591](https://coveord.atlassian.net/browse/DOC-7591)

A clone of the community search page is now hosted on docs.coveo.com; it loads much faster than its connect.coveo.com counterpart.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)