### PR TITLE
JSUI-3023 Fixed subsequent resizes of `HeightLimiter`

### DIFF
--- a/src/ui/SmartSnippet/HeightLimiter.ts
+++ b/src/ui/SmartSnippet/HeightLimiter.ts
@@ -21,7 +21,6 @@ export const HeightLimiterClassNames = {
 
 export class HeightLimiter {
   private isExpanded = false;
-  private scrollHeight = 0;
   private button: HTMLElement;
   private buttonLabel: HTMLElement;
   private buttonIcon: HTMLElement;
@@ -31,16 +30,24 @@ export class HeightLimiter {
   }
 
   private set height(height: number) {
-    this.element.style.height = `${height}px`;
+    this.containerElement.style.height = `${height}px`;
   }
 
-  constructor(private element: HTMLElement, private heightLimit: number, private onToggle?: (isExpanded: boolean) => void) {
+  private get contentHeight() {
+    return this.contentElement.clientHeight;
+  }
+
+  constructor(
+    private containerElement: HTMLElement,
+    private contentElement: HTMLElement,
+    private heightLimit: number,
+    private onToggle?: (isExpanded: boolean) => void
+  ) {
     this.buildButton();
-    this.onScrollHeightChanged();
+    this.updateActiveAppearance();
   }
 
-  public onScrollHeightChanged() {
-    this.scrollHeight = this.element.scrollHeight;
+  public onContentHeightChanged() {
     this.updateActiveAppearance();
   }
 
@@ -57,15 +64,15 @@ export class HeightLimiter {
   }
 
   private updateActiveAppearance() {
-    const shouldBeActive = this.scrollHeight > this.heightLimit;
-    this.element.classList.toggle(CONTAINER_ACTIVE_CLASSNAME, shouldBeActive);
+    const shouldBeActive = this.contentHeight > this.heightLimit;
+    this.containerElement.classList.toggle(CONTAINER_ACTIVE_CLASSNAME, shouldBeActive);
     this.button.classList.toggle(BUTTON_ACTIVE_CLASSNAME, shouldBeActive);
     if (shouldBeActive) {
       this.updateExpandedAppearance();
     } else {
       this.isExpanded = false;
       this.updateExpandedAppearance();
-      this.element.style.height = '';
+      this.containerElement.style.height = '';
     }
   }
 
@@ -76,8 +83,8 @@ export class HeightLimiter {
 
   private updateExpandedAppearance() {
     this.updateButton();
-    this.element.classList.toggle(CONTAINER_EXPANDED_CLASSNAME, this.isExpanded);
-    this.height = this.isExpanded ? this.scrollHeight : this.heightLimit;
+    this.containerElement.classList.toggle(CONTAINER_EXPANDED_CLASSNAME, this.isExpanded);
+    this.height = this.isExpanded ? this.contentElement.clientHeight : this.heightLimit;
   }
 
   private toggle() {

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -92,7 +92,7 @@ export class SmartSnippet extends Component {
     private ModalBox = ModalBoxModule
   ) {
     super(element, SmartSnippet.ID, bindings);
-    this.bind.onRootElement(QueryEvents.querySuccess, (data: IQuerySuccessEventArgs) => this.handleQuerySuccess(data));
+    this.bind.onRootElement(QueryEvents.deferredQuerySuccess, (data: IQuerySuccessEventArgs) => this.handleQuerySuccess(data));
   }
 
   private get style() {
@@ -155,6 +155,7 @@ export class SmartSnippet extends Component {
   private buildHeightLimiter() {
     return (this.heightLimiter = new HeightLimiter(
       this.shadowContainer,
+      this.snippetContainer,
       400,
       isExpanded => (isExpanded ? this.sendExpandSmartSnippetAnalytics() : this.sendCollapseSmartSnippetAnalytics())
     )).toggleButton;
@@ -201,7 +202,7 @@ export class SmartSnippet extends Component {
     if (lastRenderedResult) {
       this.renderSource(lastRenderedResult);
     }
-    this.heightLimiter.onScrollHeightChanged();
+    this.heightLimiter.onContentHeightChanged();
   }
 
   private renderSnippet(content: string) {

--- a/unitTests/ui/HeightLimiterTest.ts
+++ b/unitTests/ui/HeightLimiterTest.ts
@@ -15,23 +15,33 @@ interface IElementsState {
 export function HeightLimiterTest() {
   let heightLimiter: HeightLimiter;
   let container: HTMLElement;
+  let content: HTMLElement;
   let onToggleSpy: jasmine.Spy;
-  let scrollHeight: number;
+  let contentHeight: number;
 
-  function createContainer(height: number) {
-    scrollHeight = height;
-    container = $$('div').el;
-    Object.defineProperty(container, 'scrollHeight', { get: () => scrollHeight });
-    return container;
+  function createContainer() {
+    return (container = $$('div').el);
+  }
+
+  function createContent(height: number) {
+    contentHeight = height;
+    content = $$('div').el;
+    Object.defineProperty(content, 'clientHeight', { get: () => contentHeight });
+    return content;
   }
 
   function initializeHeightLimiter(initialHeight: number) {
-    heightLimiter = new HeightLimiter(createContainer(initialHeight), heightLimit, (onToggleSpy = jasmine.createSpy('onToggle')));
+    heightLimiter = new HeightLimiter(
+      createContainer(),
+      createContent(initialHeight),
+      heightLimit,
+      (onToggleSpy = jasmine.createSpy('onToggle'))
+    );
   }
 
   function resizeContainer(newHeight: number) {
-    scrollHeight = newHeight;
-    heightLimiter.onScrollHeightChanged();
+    contentHeight = newHeight;
+    heightLimiter.onContentHeightChanged();
   }
 
   function getElementsState(): IElementsState {
@@ -152,7 +162,7 @@ export function HeightLimiterTest() {
         });
 
         it('should force the scrollHeight on the container', () => {
-          expect(container.style.height).toEqual(`${scrollHeight}px`);
+          expect(container.style.height).toEqual(`${contentHeight}px`);
         });
 
         it('should have the show less label on the toggle button', () => {

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -86,7 +86,7 @@ export function SmartSnippetTest() {
     function triggerQuerySuccess(withSource: boolean) {
       const results = withSource ? [mockResult()] : [];
       (test.env.queryController.getLastResults as jasmine.Spy).and.returnValue({ results });
-      $$(test.env.root).trigger(QueryEvents.querySuccess, <IQuerySuccessEventArgs>{
+      $$(test.env.root).trigger(QueryEvents.deferredQuerySuccess, <IQuerySuccessEventArgs>{
         results: {
           results,
           questionAnswer: mockQuestionAnswer()


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3023

Sending a query that results in a long snippet, expanding it, then sending a query that results in a small snippet caused `HeightLimiter` to stay resizable due to `scrollHeight` being the max value between the current size of a parent container and the current size of its content.

This PR replaces `scrollHeight` with the content's size.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)