### PR TITLE
JSUI-3022 Treat "[" & "]" as field value delimiter for grammar

### DIFF
--- a/src/magicbox/Grammars/Field.ts
+++ b/src/magicbox/Grammars/Field.ts
@@ -19,7 +19,7 @@ export const Field: SubGrammar = {
     FieldValueList: '([FieldValueString][FieldValueStringList*])',
     FieldValueStringList: '[FieldValueSeparator][FieldValueString]',
     FieldValueSeparator: / *, */,
-    FieldValueNotQuoted: /[^ \(\),]+/,
+    FieldValueNotQuoted: /[^ \(\)\[\],]+/,
     NumberRange: '[Number][Spaces?]..[Spaces?][Number]'
   },
   include: [Date, Basic]

--- a/unitTests/magicbox/GrammarTest.ts
+++ b/unitTests/magicbox/GrammarTest.ts
@@ -218,6 +218,11 @@ export function GrammarTest() {
       var result = coveoGrammar.parse('word @fieldName =  (value  , abc)');
       expect(result.isSuccess()).toBeTruthy();
     });
+    it('"@fieldName=value]"', () => {
+      var result = coveoGrammar.parse('@fieldName=value]');
+      expect(result.isSuccess()).toBeFalsy();
+      expect(result.getHumanReadableExpect()).toBe('Expected Spaces or end of input but "]" found.');
+    });
     it('"word (word2"', () => {
       var result = coveoGrammar.parse('word (word2');
       expect(result.isSuccess()).toBeFalsy();


### PR DESCRIPTION
This part of the query was causing a syntax error:
`[[@foldfoldingfield] @sfdcpublic=Public]` because quotes were added `[@foldfoldingfield] @sfdcpublic="Public]"`

https://coveord.atlassian.net/browse/JSUI-3022





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)