### PR TITLE
JSUI-3028 Stop escaping strings added in the result URI that is used as href

### DIFF
--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -472,11 +472,11 @@ export class ResultLink extends Component {
   );
 
   private filterProtocol(uri: string) {
-    if (/^javascript:/i.test(uri)) {
-      return '';
+    if (/^(https?|ftp|file|mailto|tel):/i.test(uri)) {
+      return uri;
     }
 
-    return uri;
+    return '';
   }
 
   private getResultUri(): string {

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -492,7 +492,7 @@ export class ResultLink extends Component {
       return this.filterProtocol(Utils.getFieldValue(this.result, <string>this.options.field));
     }
 
-    return this.filterProtocol(this.escapedClickUri);
+    return this.filterProtocol(this.result.clickUri);
   }
 
   private elementIsAnAnchor() {

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -18,7 +18,7 @@ export function ResultLinkTest() {
       let fakeResult = FakeResults.createFakeResult();
       fakeResult.title = 'A test title';
       fakeResult.titleHighlights = [{ offset: 2, length: 4 }];
-      fakeResult.clickUri = 'uri';
+      fakeResult.clickUri = 'http://www.coveo.com';
       return fakeResult;
     }
 
@@ -373,8 +373,8 @@ export function ResultLinkTest() {
 
       describe('and the result has the outlookfield', () => {
         beforeEach(() => {
-          fakeResult.raw['outlookuri'] = 'uri.for.outlook';
-          fakeResult.raw['outlookformacuri'] = 'uri.for.outlook.for.mac';
+          fakeResult.raw['outlookuri'] = 'mailto:test@coveo.comm';
+          fakeResult.raw['outlookformacuri'] = 'mailto:test.mac@coveo.comm';
         });
 
         it('should generate the correct href if the os is windows and the option is openInOutlook', () => {

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -340,6 +340,14 @@ export function ResultLinkTest() {
         expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
       });
 
+      it(`when the href contains "&" characters,
+        should set the href the unescaped the result click uri`, () => {
+        fakeResult.clickUri =
+          'https://testing.com/supportcenter/portal?DataSource=Solutions&eventSubmit_doNavigate=&PageNumber=Prev&tab=Solutions&ts=6';
+        initHyperLink();
+        expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+      });
+
       it(`when the uri (clickUri) defined in the results contains the javascript protocol,
         it clears the value to prevent XSS`, () => {
         fakeResult.clickUri = 'JavaScript:void(0)';


### PR DESCRIPTION
The original XSS issue is here: https://coveord.atlassian.net/browse/JSUI-2962
The bug is not reproduced because the displayed resultUri is still escaped. We could be more precise and escape if there are still concerns with leaving stuff like <> unescaped in the href
https://coveord.atlassian.net/browse/JSUI-3028

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)