### PR TITLE
JSUI-3025 Improved looks and accessibility of `ExplanationModal`

### DIFF
--- a/accessibilityTest/AccessibilitySmartSnippet.ts
+++ b/accessibilityTest/AccessibilitySmartSnippet.ts
@@ -63,15 +63,30 @@ export const AccessibilitySmartSnippet = () => {
       });
 
       describe('after pressing "Explain why"', () => {
-        let modalContent: HTMLElement;
+        let modalContainer: HTMLElement;
         beforeEach(async done => {
           getFirstChild('coveo-user-feedback-banner-explain-why').click();
-          modalContent = await waitUntilSelectorIsPresent<HTMLElement>(document.body, '.coveo-user-explanation-modal-content');
+          modalContainer = await waitUntilSelectorIsPresent<HTMLElement>(document.body, '.coveo-user-explanation-modal');
           done();
         });
 
         it('should be accessible', async done => {
-          const axeResults = await axe.run(modalContent);
+          const axeResults = await axe.run(modalContainer);
+          expect(axeResults).toBeAccessible();
+          done();
+        });
+
+        it('should be accessible after selecting other', async done => {
+          modalContainer.querySelector<HTMLInputElement>('#coveo-reason-other').click();
+          const axeResults = await axe.run(modalContainer);
+          expect(axeResults).toBeAccessible();
+          done();
+        });
+
+        it('should be accessible after selecting other and focusing the details', async done => {
+          modalContainer.querySelector<HTMLInputElement>('#coveo-reason-other').click();
+          modalContainer.querySelector<HTMLTextAreaElement>('#coveo-user-explanation-modal-details').focus();
+          const axeResults = await axe.run(modalContainer);
           expect(axeResults).toBeAccessible();
           done();
         });

--- a/sass/_ExplanationModal.scss
+++ b/sass/_ExplanationModal.scss
@@ -1,43 +1,150 @@
 @import 'Variables';
 
 .coveo-user-explanation-modal {
-  &-explanations {
-    border: none;
-    padding: 0;
+  $modal: &;
 
-    &-label {
-      padding: 0;
-      margin-bottom: 6px;
-    }
-  }
-
-  &-details {
+  &-explanation-section {
     display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    margin: 12px 0;
+    flex-wrap: wrap;
+    padding: 24px;
 
-    &-textarea {
-      width: 256px;
-      height: 90px;
+    #{$modal}-explanations,
+    #{$modal}-details {
+      margin: 16px;
 
-      &[disabled] {
-        background-color: $color-disabled-grey;
+      &-label {
+        padding: 0;
+        margin-bottom: 12px;
+      }
+    }
+
+    #{$modal}-explanations {
+      border: none;
+      padding: 0;
+
+      .coveo-radio {
+        $radio-size: 24px;
+
+        input[type='radio'] + .coveo-radio-input-label {
+          line-height: $radio-size;
+          height: $radio-size;
+
+          &::before,
+          &::after {
+            width: $radio-size;
+            height: $radio-size;
+          }
+
+          &::before {
+            border-color: $color-strong-contrast-grey;
+          }
+        }
+
+        input[type='radio']:checked + .coveo-radio-input-label {
+          &::before {
+            border-color: $color-orange;
+          }
+
+          &::after {
+            background-color: $color-orange;
+          }
+        }
+      }
+    }
+
+    #{$modal}-details {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      flex-grow: 1;
+
+      &-textarea {
+        @include defaultRoundedLowContrastBorder();
+        min-width: 256px;
+        min-height: 128px;
+        resize: none;
+        flex-grow: 1;
+        align-self: stretch;
+        padding: 8px;
+        font-family: Arial, Helvetica, sans-serif;
+        color: black;
+        font-size: 1em;
+
+        &[disabled] {
+          background-color: #ddd;
+          color: #616161;
+        }
+
+        &:focus {
+          border-color: $color-active-orange;
+        }
       }
     }
   }
 
-  &-send-button {
-    border: none;
-    border-radius: $default-border-radius;
-    background-color: $coveo-blue;
-    font-size: 1.1em;
-    color: white;
-    margin-bottom: 10px;
-    padding: 6px 10px;
-    cursor: pointer;
-    &:hover {
-      background-color: $color-greyish-teal-blue;
+  &-buttons-section {
+    display: flex;
+    justify-content: flex-end;
+    border-top: thin solid #d8d8d8;
+    padding: 24px 32px;
+
+    button {
+      border-radius: $default-border-radius;
+      font-size: 1em;
+      margin: 0;
+      padding: 6px 10px;
+      cursor: pointer;
     }
+
+    #{$modal}-send-button {
+      background-color: $color-orange;
+      color: white;
+      border: none;
+      &:hover,
+      &:focus {
+        background-color: $color-active-orange;
+      }
+    }
+
+    #{$modal}-cancel-button {
+      background: none;
+      color: $color-strong-contrast-grey;
+      border: thin solid $color-strong-contrast-grey;
+      margin-left: 24px;
+      &:hover,
+      &:focus {
+        background-color: #0000001a;
+      }
+    }
+  }
+
+  &.coveo-modal-container > .coveo-modal-content {
+    width: auto;
+    height: auto;
+    border-radius: 4px;
+    overflow: hidden;
+    box-shadow: #00000040 2px 2px 5px;
+  }
+
+  .coveo-modal-body {
+    padding: 0;
+    flex-basis: auto;
+  }
+
+  .coveo-modal-header {
+    height: auto;
+    padding: 0;
+    border: none;
+
+    h1 {
+      color: black;
+      margin: 40px 40px 24px 40px;
+      font-size: 1.25em;
+    }
+  }
+
+  + .coveo-modal-backdrop {
+    background-color: black;
+    opacity: 0.3;
   }
 }

--- a/sass/_SmartSnippet.scss
+++ b/sass/_SmartSnippet.scss
@@ -168,8 +168,8 @@
           }
 
           &.coveo-user-feedback-banner-yes-button {
-            color: $color-dark-green;
-            fill: $color-dark-green;
+            color: $color-green;
+            fill: $color-green;
           }
 
           &.coveo-user-feedback-banner-no-button {

--- a/sass/_Variables.scss
+++ b/sass/_Variables.scss
@@ -27,8 +27,7 @@ $color-light-greyish-blue: #9cb4cb;
 // Coveo Partners Colors
 $color-coveo-for-sitecore: #dc291e;
 $color-coveo-for-salesforce: #009ddc;
-$color-green: #4caf50;
-$color-dark-green: #3a833c;
+$color-green: #3a833c;
 $color-red: #cc0d00;
 $color-orange: #c65306;
 $color-active-orange: #943e05;

--- a/sass/_Variables.scss
+++ b/sass/_Variables.scss
@@ -24,13 +24,14 @@ $color-light-grey: #bcc3ca;
 $color-blueish-white-grey: #e6ecf0;
 $color-blueish-white: #f7f8f9;
 $color-light-greyish-blue: #9cb4cb;
-$color-disabled-grey: #ddd;
 // Coveo Partners Colors
 $color-coveo-for-sitecore: #dc291e;
 $color-coveo-for-salesforce: #009ddc;
 $color-green: #4caf50;
-$color-dark-green: hsl(122, 39%, 37%);
+$color-dark-green: #3a833c;
 $color-red: #cc0d00;
+$color-orange: #c65306;
+$color-active-orange: #943e05;
 $color-active-yellow: #ecad00;
 $color-transparent-background: rgba(255, 255, 255, 0.85);
 $color-white-transparent: rgba(255, 255, 255, 0.5);

--- a/src/ui/FormWidgets/RadioButton.ts
+++ b/src/ui/FormWidgets/RadioButton.ts
@@ -22,7 +22,12 @@ export class RadioButton implements IFormWidgetWithLabel, IFormWidgetSelectable 
    * @param label The label to display next to the radio button.
    * @param name The value to set the `input` HTMLElement `name` attribute to.
    */
-  constructor(public onChange: (radioButton: RadioButton) => void = (radioButton: RadioButton) => {}, public label: string, public name) {
+  constructor(
+    public onChange: (radioButton: RadioButton) => void = (radioButton: RadioButton) => {},
+    public label: string,
+    public name: string,
+    private id: string = label
+  ) {
     this.buildContent();
   }
 
@@ -95,8 +100,8 @@ export class RadioButton implements IFormWidgetWithLabel, IFormWidgetSelectable 
 
   private buildContent() {
     const radioOption = $$('div', { className: 'coveo-radio' });
-    const radioInput = $$('input', { type: 'radio', name: this.name, id: this.label });
-    const labelInput = $$('label', { className: 'coveo-radio-input-label', for: this.label });
+    const radioInput = $$('input', { type: 'radio', name: this.name, id: this.id });
+    const labelInput = $$('label', { className: 'coveo-radio-input-label', for: this.id });
     labelInput.text(this.label);
     radioInput.on('change', () => {
       this.onChange(this);

--- a/src/ui/SmartSnippet/ExplanationModal.ts
+++ b/src/ui/SmartSnippet/ExplanationModal.ts
@@ -6,6 +6,7 @@ import 'styling/_ExplanationModal';
 
 export interface IReason {
   label: string;
+  id: string;
   onSelect: () => void;
   hasDetails?: boolean;
 }
@@ -19,23 +20,29 @@ export interface IExplanationModalOptions {
 
 const ROOT_CLASSNAME = 'coveo-user-explanation-modal';
 const CONTENT_CLASSNAME = `${ROOT_CLASSNAME}-content`;
+const EXPLANATION_SECTION_CLASSNAME = `${ROOT_CLASSNAME}-explanation-section`;
 const REASONS_CLASSNAME = `${ROOT_CLASSNAME}-explanations`;
 const REASONS_LABEL_CLASSNAME = `${REASONS_CLASSNAME}-label`;
 const DETAILS_SECTION_CLASSNAME = `${ROOT_CLASSNAME}-details`;
 const DETAILS_TEXTAREA_CLASSNAME = `${DETAILS_SECTION_CLASSNAME}-textarea`;
 const DETAILS_LABEL_CLASSNAME = `${DETAILS_SECTION_CLASSNAME}-label`;
+const BUTTONS_SECTION_CLASSNAME = `${ROOT_CLASSNAME}-buttons-section`;
 const SEND_BUTTON_CLASSNAME = `${ROOT_CLASSNAME}-send-button`;
+const CANCEL_BUTTON_CLASSNAME = `${ROOT_CLASSNAME}-cancel-button`;
 const DETAILS_ID = DETAILS_SECTION_CLASSNAME;
 
 export const ExplanationModalClassNames = {
   ROOT_CLASSNAME,
   CONTENT_CLASSNAME,
+  EXPLANATION_SECTION_CLASSNAME,
   REASONS_CLASSNAME,
   REASONS_LABEL_CLASSNAME,
   DETAILS_SECTION_CLASSNAME,
   DETAILS_TEXTAREA_CLASSNAME,
   DETAILS_LABEL_CLASSNAME,
-  SEND_BUTTON_CLASSNAME
+  BUTTONS_SECTION_CLASSNAME,
+  SEND_BUTTON_CLASSNAME,
+  CANCEL_BUTTON_CLASSNAME
 };
 
 export class ExplanationModal {
@@ -43,7 +50,7 @@ export class ExplanationModal {
   private reasons: RadioButton[];
   private selectedReason: IReason;
   private detailsTextArea: HTMLTextAreaElement;
-  private isOpen = false;
+  private shouldCallCloseEvent = false;
 
   constructor(public options: IExplanationModalOptions) {
     this.modal = new AccessibleModal(ROOT_CLASSNAME, this.options.ownerElement, this.options.modalBoxModule);
@@ -62,27 +69,48 @@ export class ExplanationModal {
       title: l('UsefulnessFeedbackExplainWhyImperative'),
       content: this.buildContent(),
       validation: () => {
-        if (this.isOpen) {
+        if (this.shouldCallCloseEvent) {
           this.options.onClosed();
-          this.isOpen = false;
+          this.shouldCallCloseEvent = false;
         }
         return true;
       }
     });
-    this.isOpen = true;
+    this.shouldCallCloseEvent = true;
   }
 
   private buildContent() {
-    const detailsSection = this.buildDetailsSection();
     return $$(
       'div',
       {
         className: CONTENT_CLASSNAME
       },
-      this.buildReasons(),
-      detailsSection,
-      this.buildSendButton()
+      this.buildExplanationSection(),
+      this.buildButtonsSection()
     ).el;
+  }
+
+  private buildExplanationSection() {
+    const detailsSection = this.buildDetailsSection();
+    return $$(
+      'div',
+      {
+        className: EXPLANATION_SECTION_CLASSNAME
+      },
+      this.buildReasons(),
+      detailsSection
+    ).el;
+  }
+
+  private buildButtonsSection() {
+    return $$(
+      'div',
+      {
+        className: BUTTONS_SECTION_CLASSNAME
+      },
+      this.buildSendButton(),
+      this.buildCancelButton()
+    );
   }
 
   private buildReasons() {
@@ -111,9 +139,15 @@ export class ExplanationModal {
     const button = $$('button', { className: SEND_BUTTON_CLASSNAME }, l('Send'));
     button.on('click', () => {
       this.selectedReason.onSelect();
-      this.isOpen = false;
+      this.shouldCallCloseEvent = false;
       this.modal.close();
     });
+    return button.el;
+  }
+
+  private buildCancelButton() {
+    const button = $$('button', { className: CANCEL_BUTTON_CLASSNAME }, l('Cancel'));
+    button.on('click', () => this.modal.close());
     return button.el;
   }
 
@@ -127,7 +161,8 @@ export class ExplanationModal {
         this.selectedReason = reason;
       },
       reason.label,
-      'reason'
+      'reason',
+      `coveo-reason-${reason.id}`
     );
   }
 }

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -119,6 +119,7 @@ export class SmartSnippet extends Component {
         reason =>
           <IReason>{
             label: l(reason.localeKey),
+            id: reason.analytics.replace(/_/g, '-'),
             onSelect: () => this.sendExplanationAnalytics(reason.analytics, this.explanationModal.details),
             hasDetails: reason.hasDetails
           }

--- a/unitTests/ui/ExplanationModalTest.ts
+++ b/unitTests/ui/ExplanationModalTest.ts
@@ -20,15 +20,18 @@ export function ExplanationModalTest() {
     return [
       {
         label: 'Explanation selected by default',
+        id: 'selected-by-default',
         onSelect: jasmine.createSpy('onSelect1'),
         hasDetails: firstReasonHasDetails
       },
       {
         label: 'Second reason implicitly without details',
+        id: 'implicitly-has-no-details',
         onSelect: jasmine.createSpy('onSelect2')
       },
       {
         label: 'Third reason explicitly without details',
+        id: 'explicitly-without-details',
         onSelect: jasmine.createSpy('onSelect3'),
         hasDetails: false
       }
@@ -90,8 +93,22 @@ export function ExplanationModalTest() {
         expect(content.classList.contains(ClassNames.CONTENT_CLASSNAME)).toBeTruthy();
       });
 
-      it('builds the root with the reasons list, the details section and the send button', () => {
-        expectChildren(content, [ClassNames.REASONS_CLASSNAME, ClassNames.DETAILS_SECTION_CLASSNAME, ClassNames.SEND_BUTTON_CLASSNAME]);
+      it('builds the root with the explanations section and the buttons section', () => {
+        expectChildren(content, [ClassNames.EXPLANATION_SECTION_CLASSNAME, ClassNames.BUTTONS_SECTION_CLASSNAME]);
+      });
+
+      it('builds the explanations section with the reasons list and the details section', () => {
+        expectChildren(getFirstChild(ClassNames.EXPLANATION_SECTION_CLASSNAME), [
+          ClassNames.REASONS_CLASSNAME,
+          ClassNames.DETAILS_SECTION_CLASSNAME
+        ]);
+      });
+
+      it('builds the buttons section with the send button and the cancel button', () => {
+        expectChildren(getFirstChild(ClassNames.BUTTONS_SECTION_CLASSNAME), [
+          ClassNames.SEND_BUTTON_CLASSNAME,
+          ClassNames.CANCEL_BUTTON_CLASSNAME
+        ]);
       });
 
       it('builds a radio button for each reason', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3025

# Details
This PR aims to improve the looks of `ExplanationModal` and makes it slightly more accessible.

* For the purpose of accessibility, the orange used had to be darker.
* Although the original close button on the top right corner isn't visible due to being replaced with the "Cancel" button, it's still focusable with the keyboard.

# Screenshots
## With full width and details disabled
![image](https://user-images.githubusercontent.com/54454747/88560967-ca3e2500-cffc-11ea-84c1-941a3d4c78d5.png)

## With full width and details enabled
![image](https://user-images.githubusercontent.com/54454747/88561005-da560480-cffc-11ea-9413-4ac4fcf88b01.png)

## With full width and details focused
![image](https://user-images.githubusercontent.com/54454747/88561040-e5109980-cffc-11ea-85da-a2ab92d58d9a.png)

## With small screen width
![image](https://user-images.githubusercontent.com/54454747/88561127-fe194a80-cffc-11ea-8b8a-48175ae194a7.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)