### PR TITLE
Added exports to Eager.ts file so components are correctly exported t…

### DIFF
--- a/src/Eager.ts
+++ b/src/Eager.ts
@@ -26,7 +26,6 @@ export { Aggregate };
 
 import { Analytics } from './ui/Analytics/Analytics';
 Analytics.doExport();
-export { Analytics };
 
 import { AnalyticsSuggestions } from './ui/AnalyticsSuggestions/AnalyticsSuggestions';
 AnalyticsSuggestions.doExport();
@@ -410,3 +409,5 @@ export { SortDropdown };
 import { FacetsMobileMode } from './ui/FacetsMobileMode/FacetsMobileMode';
 FacetsMobileMode.doExport();
 export { FacetsMobileMode };
+
+export { Analytics } from './ui/Analytics/Analytics';

--- a/src/Eager.ts
+++ b/src/Eager.ts
@@ -4,245 +4,317 @@ export { CoreHelpers } from './ui/Templates/CoreHelpers';
 export { SearchInterface, StandaloneSearchInterface } from './ui/SearchInterface/SearchInterface';
 export { jQueryInstance as $ } from './ui/Base/CoveoJQuery';
 export { underscoreInstance as _ } from './ui/Base/CoveoUnderscore';
+export { AnalyticsUtils } from './utils/AnalyticsUtils';
 export { HashUtils } from './utils/HashUtils';
 export { DeviceUtils } from './utils/DeviceUtils';
 export { ColorUtils } from './utils/ColorUtils';
 export { Cookie } from './utils/CookieUtils';
 export { CurrencyUtils } from './utils/CurrencyUtils';
 export { DateUtils } from './utils/DateUtils';
+export { analyticsActionCauseList } from './ui/Analytics/AnalyticsActionListMeta';
 
 import { Initialization, EagerInitialization } from './ui/Base/Initialization';
 Initialization.componentsFactory = EagerInitialization.componentsFactory;
 
 import { AdvancedSearch } from './ui/AdvancedSearch/AdvancedSearch';
 AdvancedSearch.doExport();
+export { AdvancedSearch };
 
 import { Aggregate } from './ui/Aggregate/Aggregate';
 Aggregate.doExport();
+export { Aggregate };
 
 import { Analytics } from './ui/Analytics/Analytics';
 Analytics.doExport();
+export { Analytics };
 
 import { AnalyticsSuggestions } from './ui/AnalyticsSuggestions/AnalyticsSuggestions';
 AnalyticsSuggestions.doExport();
+export { AnalyticsSuggestions };
 
 import { ComponentEvents } from './ui/Base/Component';
 ComponentEvents.doExport();
+export { ComponentEvents };
 
 import { AuthenticationProvider } from './ui/AuthenticationProvider/AuthenticationProvider';
 AuthenticationProvider.doExport();
+export { AuthenticationProvider };
 
 import { Backdrop } from './ui/Backdrop/Backdrop';
 Backdrop.doExport();
+export { Backdrop };
 
 import { Badge } from './ui/Badge/Badge';
 Badge.doExport();
+export { Badge };
 
 import { Breadcrumb } from './ui/Breadcrumb/Breadcrumb';
 Breadcrumb.doExport();
+export { Breadcrumb };
 
 import { CardActionBar } from './ui/CardActionBar/CardActionBar';
 CardActionBar.doExport();
+export { CardActionBar };
 
 import { CardOverlay } from './ui/CardOverlay/CardOverlay';
 CardOverlay.doExport();
+export { CardOverlay };
 
 import { ChatterLikedBy } from './ui/ChatterLikedBy/ChatterLikedBy';
 ChatterLikedBy.doExport();
+export { ChatterLikedBy };
 import { registerFields as chatterLikedByRegisterFields } from './ui/ChatterLikedBy/ChatterLikedByFields';
 chatterLikedByRegisterFields();
 
 import { ChatterPostAttachment } from './ui/ChatterPostAttachment/ChatterPostAttachment';
 ChatterPostAttachment.doExport();
+export { ChatterPostAttachment };
 import { registerFields as chatterPostAttachmentRegisterFields } from './ui/ChatterPostAttachment/ChatterPostAttachmentFields';
 chatterPostAttachmentRegisterFields();
 
 import { ChatterPostedBy } from './ui/ChatterPostedBy/ChatterPostedBy';
 ChatterPostedBy.doExport();
+export { ChatterPostedBy };
 import { registerFields as chatterPostedByRegisterFields } from './ui/ChatterPostedBy/ChatterPostedByFields';
 chatterPostedByRegisterFields();
 
 import { ChatterTopic } from './ui/ChatterTopic/ChatterTopic';
 ChatterTopic.doExport();
+export { ChatterTopic };
 import { registerFields as chatterTopicRegisterFields } from './ui/ChatterTopic/ChatterTopicFields';
 chatterTopicRegisterFields();
 
 import { DidYouMean } from './ui/DidYouMean/DidYouMean';
 DidYouMean.doExport();
+export { DidYouMean };
 
 import { DistanceResources } from './ui/Distance/DistanceResources';
 DistanceResources.doExport();
+export { DistanceResources };
 
 import { ErrorReport } from './ui/ErrorReport/ErrorReport';
 ErrorReport.doExport();
+export { ErrorReport };
 
 import { Excerpt } from './ui/Excerpt/Excerpt';
 Excerpt.doExport();
+export { Excerpt };
 
 import { ExportToExcel } from './ui/ExportToExcel/ExportToExcel';
 ExportToExcel.doExport();
+export { ExportToExcel };
 
 import { Facet } from './ui/Facet/Facet';
 Facet.doExport();
+export { Facet };
 
 import { FacetRange } from './ui/FacetRange/FacetRange';
 FacetRange.doExport();
+export { FacetRange };
 
 import { FacetSlider } from './ui/FacetSlider/FacetSlider';
 FacetSlider.doExport();
+export { FacetSlider };
 
 import { FieldSuggestions } from './ui/FieldSuggestions/FieldSuggestions';
 FieldSuggestions.doExport();
+export { FieldSuggestions };
 
 import { FacetValueSuggestions } from './ui/FacetValueSuggestions/FacetValueSuggestions';
 FacetValueSuggestions.doExport();
+export { FacetValueSuggestions };
 
 import { FieldTable } from './ui/FieldTable/FieldTable';
 FieldTable.doExport();
+export { FieldTable };
 
 import { FieldValue } from './ui/FieldValue/FieldValue';
 FieldValue.doExport();
+export { FieldValue };
 
 import { Folding } from './ui/Folding/Folding';
 Folding.doExport();
+export { Folding };
 
 import { FoldingForThread } from './ui/FoldingForThread/FoldingForThread';
 FoldingForThread.doExport();
+export { FoldingForThread };
 
 import { FollowItem } from './ui/FollowItem/FollowItem';
 FollowItem.doExport();
+export { FollowItem };
 import { registerFields as followItemRegisterFields } from './ui/FollowItem/FollowItemFields';
 followItemRegisterFields();
 
 import { HiddenQuery } from './ui/HiddenQuery/HiddenQuery';
 HiddenQuery.doExport();
+export { HiddenQuery };
 
 import { HierarchicalFacet } from './ui/HierarchicalFacet/HierarchicalFacet';
 HierarchicalFacet.doExport();
+export { HierarchicalFacet };
 
 import { Icon } from './ui/Icon/Icon';
 Icon.doExport();
+export { Icon };
 import { registerFields as iconRegisterFields } from './ui/Icon/IconFields';
 iconRegisterFields();
 
 import { Logo } from './ui/Logo/Logo';
 Logo.doExport();
+export { Logo };
 
 import { Matrix } from './ui/Matrix/Matrix';
 Matrix.doExport();
+export { Matrix };
 
 import { Omnibox } from './ui/Omnibox/Omnibox';
 Omnibox.doExport();
+export { Omnibox };
 
 import { OmniboxResultList } from './ui/OmniboxResultList/OmniboxResultList';
 OmniboxResultList.doExport();
+export { OmniboxResultList };
 
 import { Pager } from './ui/Pager/Pager';
 Pager.doExport();
+export { Pager };
 
 import { PipelineContext } from './ui/PipelineContext/PipelineContext';
 PipelineContext.doExport();
+export { PipelineContext };
 
 import { PreferencesPanel } from './ui/PreferencesPanel/PreferencesPanel';
 PreferencesPanel.doExport();
+export { PreferencesPanel };
 
 import { PrintableUri } from './ui/PrintableUri/PrintableUri';
 PrintableUri.doExport();
+export { PrintableUri };
 import { registerFields as registerFieldsPrintableUri } from './ui/PrintableUri/PrintableUriFields';
 registerFieldsPrintableUri();
 
 import { Querybox } from './ui/Querybox/Querybox';
 Querybox.doExport();
+export { Querybox };
 
 import { QueryDuration } from './ui/QueryDuration/QueryDuration';
 QueryDuration.doExport();
+export { QueryDuration };
 
 import { QuerySummary } from './ui/QuerySummary/QuerySummary';
 QuerySummary.doExport();
+export { QuerySummary };
 
 import { Quickview } from './ui/Quickview/Quickview';
 Quickview.doExport();
+export { Quickview };
 import { registerFields as quickviewRegisterFields } from './ui/Quickview/QuickviewFields';
 quickviewRegisterFields();
 
 import { Recommendation } from './ui/Recommendation/Recommendation';
 Recommendation.doExport();
+export { Recommendation };
 
 import { ResultAttachments } from './ui/ResultAttachments/ResultAttachments';
 ResultAttachments.doExport();
+export { ResultAttachments };
 
 import { ResultActionsMenu } from './ui/ResultActions/ResultActionsMenu';
 ResultActionsMenu.doExport();
+export { ResultActionsMenu };
 
 import { ResultFolding } from './ui/ResultFolding/ResultFolding';
 ResultFolding.doExport();
+export { ResultFolding };
 
 import { ResultLayoutSelector } from './ui/ResultLayoutSelector/ResultLayoutSelector';
 ResultLayoutSelector.doExport();
+export { ResultLayoutSelector };
 
 import { ResultLink } from './ui/ResultLink/ResultLink';
 ResultLink.doExport();
+export { ResultLink };
 import { registerFields as resultLinkRegisterFields } from './ui/ResultLink/ResultLinkFields';
 resultLinkRegisterFields();
 
 import { ResultList } from './ui/ResultList/ResultList';
 ResultList.doExport();
+export { ResultList };
 
 import { ResultRating } from './ui/ResultRating/ResultRating';
 ResultRating.doExport();
+export { ResultRating };
 
 import { ResultsFiltersPreferences } from './ui/ResultsFiltersPreferences/ResultsFiltersPreferences';
 ResultsFiltersPreferences.doExport();
+export { ResultsFiltersPreferences };
 
 import { ResultsPerPage } from './ui/ResultsPerPage/ResultsPerPage';
 ResultsPerPage.doExport();
+export { ResultsPerPage };
 
 import { ResultsPreferences } from './ui/ResultsPreferences/ResultsPreferences';
 ResultsPreferences.doExport();
+export { ResultsPreferences };
 
 import { ResultTagging } from './ui/ResultTagging/ResultTagging';
 ResultTagging.doExport();
+export { ResultTagging };
 
 import { SearchAlerts } from './ui/SearchAlerts/SearchAlerts';
 SearchAlerts.doExport();
+export { SearchAlerts };
 
 import { Searchbox } from './ui/Searchbox/Searchbox';
 Searchbox.doExport();
+export { Searchbox };
 
 import { SearchButton } from './ui/SearchButton/SearchButton';
 SearchButton.doExport();
+export { SearchButton };
 
 import { Settings } from './ui/Settings/Settings';
 Settings.doExport();
+export { Settings };
 
 import { ShareQuery } from './ui/ShareQuery/ShareQuery';
 ShareQuery.doExport();
+export { ShareQuery };
 
 import { Sort } from './ui/Sort/Sort';
 Sort.doExport();
+export { Sort };
 
 import { StarRating } from './ui/StarRating/StarRating';
 StarRating.doExport();
+export { StarRating };
 
 import { Tab } from './ui/Tab/Tab';
 Tab.doExport();
+export { Tab };
 
 import { TemplateLoader } from './ui/TemplateLoader/TemplateLoader';
 TemplateLoader.doExport();
+export { TemplateLoader };
 
 import { Text } from './ui/Text/Text';
 Text.doExport();
+export { Text };
 
 import { Thumbnail } from './ui/Thumbnail/Thumbnail';
 Thumbnail.doExport();
+export { Thumbnail };
 import { registerFields as thumbnailRegisterFields } from './ui/Thumbnail/ThumbnailFields';
 thumbnailRegisterFields();
 
 import { Triggers } from './ui/Triggers/Triggers';
 Triggers.doExport();
+export { Triggers };
 
 import { YouTubeThumbnail } from './ui/YouTube/YouTubeThumbnail';
 YouTubeThumbnail.doExport();
+export { YouTubeThumbnail };
 import { registerFields as youtubeThumbnailRegisterFields } from './ui/YouTube/YouTubeThumbnailFields';
 youtubeThumbnailRegisterFields();
 
@@ -250,69 +322,91 @@ export { Template } from './ui/Templates/Template';
 
 import { Checkbox } from './ui/FormWidgets/Checkbox';
 Checkbox.doExport();
+export { Checkbox };
 
 import { DatePicker } from './ui/FormWidgets/DatePicker';
 DatePicker.doExport();
+export { DatePicker };
 
 import { Dropdown } from './ui/FormWidgets/Dropdown';
 Dropdown.doExport();
+export { Dropdown };
 
 import { FormGroup } from './ui/FormWidgets/FormGroup';
 FormGroup.doExport();
+export { FormGroup };
 
 import { MultiSelect } from './ui/FormWidgets/MultiSelect';
 MultiSelect.doExport();
+export { MultiSelect };
 
 import { NumericSpinner } from './ui/FormWidgets/NumericSpinner';
 NumericSpinner.doExport();
+export { NumericSpinner };
 
 import { RadioButton } from './ui/FormWidgets/RadioButton';
 RadioButton.doExport();
+export { RadioButton };
 
 import { TextInput } from './ui/FormWidgets/TextInput';
 TextInput.doExport();
+export { TextInput };
 
 import { SimpleFilter } from './ui/SimpleFilter/SimpleFilter';
 SimpleFilter.doExport();
+export { SimpleFilter };
 
 import { TimespanFacet } from './ui/TimespanFacet/TimespanFacet';
 TimespanFacet.doExport();
+export { TimespanFacet };
 
 import { DynamicFacet } from './ui/DynamicFacet/DynamicFacet';
 DynamicFacet.doExport();
+export { DynamicFacet };
 
 import { DynamicFacetRange } from './ui/DynamicFacet/DynamicFacetRange';
 DynamicFacetRange.doExport();
+export { DynamicFacetRange };
 
 import { DynamicFacetManager } from './ui/DynamicFacetManager/DynamicFacetManager';
 DynamicFacetManager.doExport();
+export { DynamicFacetManager };
 
 import { PromotedResultsBadge } from './ui/PromotedResultsBadge/PromotedResultsBadge';
 PromotedResultsBadge.doExport();
+export { PromotedResultsBadge };
 
 import { CategoryFacet } from './ui/CategoryFacet/CategoryFacet';
 CategoryFacet.doExport();
+export { CategoryFacet };
 
 import { DynamicHierarchicalFacet } from './ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet';
 DynamicHierarchicalFacet.doExport();
+export { DynamicHierarchicalFacet };
 
 import { MissingTerms } from './ui/MissingTerm/MissingTerms';
 MissingTerms.doExport();
+export { MissingTerms };
 
 import { QuerySuggestPreview } from './ui/QuerySuggestPreview/QuerySuggestPreview';
 QuerySuggestPreview.doExport();
+export { QuerySuggestPreview };
 
 import { swapVar } from './SwapVar';
 swapVar(this);
 
 import { ImageFieldValue } from './ui/FieldImage/ImageFieldValue';
 ImageFieldValue.doExport();
+export { ImageFieldValue };
 
 import { CommerceQuery } from './ui/CommerceQuery/CommerceQuery';
 CommerceQuery.doExport();
+export { CommerceQuery };
 
 import { SortDropdown } from './ui/SortDropdown/SortDropdown';
 SortDropdown.doExport();
+export { SortDropdown };
 
 import { FacetsMobileMode } from './ui/FacetsMobileMode/FacetsMobileMode';
 FacetsMobileMode.doExport();
+export { FacetsMobileMode };


### PR DESCRIPTION
Added exports to Eager.ts file so components are correctly exported to webpack when building a bundle.
For ServiceNow, we need to build a component that will bundle the JSUI and the search-ui-extensions all in one file. Without the exports in Eager.ts some classes were undefined in the output webpack bundle. Example:

![image](https://user-images.githubusercontent.com/7459000/88573653-0c706200-d00f-11ea-911b-81d05d56f298.png)

After these changes the components are accessible at runtime as expected.

In the compiled CoveoJsSearch file, it looks like this:
```
    var Checkbox_1 = __webpack_require__(63);
    Checkbox_1.Checkbox.doExport();
  + exports.Checkbox = Checkbox_1.Checkbox;
```


SNOW-385





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)