### PR TITLE
JSUI-3042 Disable action history tracking if analytics is disabled. 

### DIFF
--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -95,11 +95,11 @@ class DefaultQueryOptions implements IQueryOptions {
  */
 export class QueryController extends RootComponent {
   static ID = 'QueryController';
+  public historyStore: CoveoAnalytics.HistoryStore;
   public firstQuery: boolean;
   public modalBox = ModalBox;
   public closeModalBox = true;
 
-  private actionsHistory: CoveoAnalytics.HistoryStore;
   private currentPendingQuery: Promise<IQueryResults>;
   private lastQueryBuilder: QueryBuilder;
   private lastQueryHash: string;
@@ -131,10 +131,6 @@ export class QueryController extends RootComponent {
     Assert.exists(options);
     this.firstQuery = true;
     this.initializeActionsHistory();
-  }
-
-  public get historyStore() {
-    return this.actionsHistory;
   }
 
   public get usageAnalytics(): IAnalyticsClient {
@@ -505,11 +501,11 @@ export class QueryController extends RootComponent {
   }
 
   public enableHistory() {
-    this.actionsHistory = new history.HistoryStore();
+    this.historyStore = new history.HistoryStore();
   }
 
   public disableHistory() {
-    this.actionsHistory = new history.HistoryStore(new NullStorage());
+    this.historyStore = new history.HistoryStore(new NullStorage());
   }
 
   private initializeActionsHistory() {
@@ -519,7 +515,7 @@ export class QueryController extends RootComponent {
       return;
     }
 
-    this.actionsHistory.clear();
+    this.historyStore.clear();
     this.disableHistory();
   }
 

--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -95,7 +95,6 @@ class DefaultQueryOptions implements IQueryOptions {
  */
 export class QueryController extends RootComponent {
   static ID = 'QueryController';
-  public historyStore: CoveoAnalytics.HistoryStore;
   public firstQuery: boolean;
   public modalBox = ModalBox;
   public closeModalBox = true;
@@ -130,7 +129,10 @@ export class QueryController extends RootComponent {
     Assert.exists(element);
     Assert.exists(options);
     this.firstQuery = true;
-    this.enableHistory();
+  }
+
+  public get historyStore() {
+    return this.searchInterface.actionHistory;
   }
 
   public get usageAnalytics(): IAnalyticsClient {
@@ -501,11 +503,11 @@ export class QueryController extends RootComponent {
   }
 
   public enableHistory() {
-    this.historyStore = new history.HistoryStore();
+    this.searchInterface.actionHistory = new history.HistoryStore();
   }
 
   public disableHistory() {
-    this.historyStore = new history.HistoryStore(new NullStorage());
+    this.searchInterface.actionHistory = new history.HistoryStore(new NullStorage());
   }
 
   private closeModalBoxIfNeeded(needed?: boolean) {

--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -99,6 +99,7 @@ export class QueryController extends RootComponent {
   public modalBox = ModalBox;
   public closeModalBox = true;
 
+  private actionsHistory: CoveoAnalytics.HistoryStore;
   private currentPendingQuery: Promise<IQueryResults>;
   private lastQueryBuilder: QueryBuilder;
   private lastQueryHash: string;
@@ -129,10 +130,11 @@ export class QueryController extends RootComponent {
     Assert.exists(element);
     Assert.exists(options);
     this.firstQuery = true;
+    this.initializeActionsHistory();
   }
 
   public get historyStore() {
-    return this.searchInterface.actionHistory;
+    return this.actionsHistory;
   }
 
   public get usageAnalytics(): IAnalyticsClient {
@@ -503,11 +505,22 @@ export class QueryController extends RootComponent {
   }
 
   public enableHistory() {
-    this.searchInterface.actionHistory = new history.HistoryStore();
+    this.actionsHistory = new history.HistoryStore();
   }
 
   public disableHistory() {
-    this.searchInterface.actionHistory = new history.HistoryStore(new NullStorage());
+    this.actionsHistory = new history.HistoryStore(new NullStorage());
+  }
+
+  private initializeActionsHistory() {
+    this.enableHistory();
+
+    if (this.usageAnalytics.isActivated()) {
+      return;
+    }
+
+    this.actionsHistory.clear();
+    this.disableHistory();
   }
 
   private closeModalBoxIfNeeded(needed?: boolean) {

--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -17,7 +17,6 @@ import { INoResultsEventArgs } from '../../events/QueryEvents';
 import { IQueryErrorEventArgs } from '../../events/QueryEvents';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { ResponsiveRecommendation } from '../ResponsiveComponents/ResponsiveRecommendation';
-import { history } from 'coveo.analytics';
 import { get } from '../Base/RegisteredNamedMethods';
 import { InitializationEvents } from '../../events/InitializationEvents';
 import { ComponentOptionsModel } from '../../models/ComponentOptionsModel';
@@ -203,7 +202,6 @@ export class Recommendation extends SearchInterface implements IComponentBinding
   // so that clicks event inside the recommendation component can be modified and attached to the main search interface.
   public mainQuerySearchUID: string;
   public mainQueryPipeline: string;
-  public historyStore: CoveoAnalytics.HistoryStore;
 
   private mainInterfaceQuery: IQuerySuccessEventArgs;
 
@@ -236,12 +234,15 @@ export class Recommendation extends SearchInterface implements IComponentBinding
     $$(this.element).on(QueryEvents.noResults, (e: Event, args: INoResultsEventArgs) => this.handleRecommendationNoResults());
     $$(this.element).on(QueryEvents.queryError, (e: Event, args: IQueryErrorEventArgs) => this.handleRecommendationQueryError());
 
-    this.historyStore = new history.HistoryStore();
     if (!this.options.mainSearchInterface) {
       // When the recommendation component is "standalone", we add additional safeguard against bad config.
       this.ensureCurrentPageViewExistsInStore();
     }
     ResponsiveRecommendation.init(this.root, this, options);
+  }
+
+  public get historyStore() {
+    return this.actionHistory;
   }
 
   public getId(): string {

--- a/src/ui/Recommendation/Recommendation.ts
+++ b/src/ui/Recommendation/Recommendation.ts
@@ -242,7 +242,7 @@ export class Recommendation extends SearchInterface implements IComponentBinding
   }
 
   public get historyStore() {
-    return this.actionHistory;
+    return this.queryController.historyStore;
   }
 
   public getId(): string {

--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -54,8 +54,6 @@ import { FacetValueStateHandler } from './FacetValueStateHandler';
 import RelevanceInspectorModule = require('../RelevanceInspector/RelevanceInspector');
 import { ComponentsTypes } from '../../utils/ComponentsTypes';
 import { ScrollRestorer } from './ScrollRestorer';
-import { history } from 'coveo.analytics';
-import { NullStorage } from 'coveo.analytics/dist/storage';
 
 export interface ISearchInterfaceOptions {
   enableHistory?: boolean;
@@ -521,7 +519,6 @@ export class SearchInterface extends RootComponent implements IComponentBindings
   public componentOptionsModel: ComponentOptionsModel;
   public usageAnalytics: IAnalyticsClient;
   public historyManager: IHistoryManager;
-  public actionHistory: CoveoAnalytics.HistoryStore;
   public scrollRestorer: ScrollRestorer;
   /**
    * Allows to get and set the different breakpoints for mobile and tablet devices.
@@ -563,7 +560,6 @@ export class SearchInterface extends RootComponent implements IComponentBindings
     this.componentStateModel = new ComponentStateModel(element);
     this.componentOptionsModel = new ComponentOptionsModel(element);
     this.usageAnalytics = this.initializeAnalytics();
-    this.actionHistory = this.initializeActionHistory();
     this.queryController = new QueryController(element, this.options, this.usageAnalytics, this);
     this.facetValueStateHandler = new FacetValueStateHandler(this);
     new SentryLogger(this.queryController);
@@ -729,17 +725,6 @@ export class SearchInterface extends RootComponent implements IComponentBindings
       return analyticsRef.create(this.element, this.analyticsOptions, this.getBindings());
     }
     return new NoopAnalyticsClient();
-  }
-
-  private initializeActionHistory() {
-    let actionHistory = new history.HistoryStore();
-
-    if (!this.usageAnalytics.isActivated()) {
-      actionHistory.clear();
-      actionHistory = new history.HistoryStore(new NullStorage());
-    }
-
-    return actionHistory;
   }
 
   private setupHistoryManager(element: HTMLElement, _window: Window) {

--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -54,6 +54,8 @@ import { FacetValueStateHandler } from './FacetValueStateHandler';
 import RelevanceInspectorModule = require('../RelevanceInspector/RelevanceInspector');
 import { ComponentsTypes } from '../../utils/ComponentsTypes';
 import { ScrollRestorer } from './ScrollRestorer';
+import { history } from 'coveo.analytics';
+import { NullStorage } from 'coveo.analytics/dist/storage';
 
 export interface ISearchInterfaceOptions {
   enableHistory?: boolean;
@@ -519,6 +521,7 @@ export class SearchInterface extends RootComponent implements IComponentBindings
   public componentOptionsModel: ComponentOptionsModel;
   public usageAnalytics: IAnalyticsClient;
   public historyManager: IHistoryManager;
+  public actionHistory: CoveoAnalytics.HistoryStore;
   public scrollRestorer: ScrollRestorer;
   /**
    * Allows to get and set the different breakpoints for mobile and tablet devices.
@@ -560,6 +563,7 @@ export class SearchInterface extends RootComponent implements IComponentBindings
     this.componentStateModel = new ComponentStateModel(element);
     this.componentOptionsModel = new ComponentOptionsModel(element);
     this.usageAnalytics = this.initializeAnalytics();
+    this.actionHistory = this.initializeActionHistory();
     this.queryController = new QueryController(element, this.options, this.usageAnalytics, this);
     this.facetValueStateHandler = new FacetValueStateHandler(this);
     new SentryLogger(this.queryController);
@@ -725,6 +729,17 @@ export class SearchInterface extends RootComponent implements IComponentBindings
       return analyticsRef.create(this.element, this.analyticsOptions, this.getBindings());
     }
     return new NoopAnalyticsClient();
+  }
+
+  private initializeActionHistory() {
+    let actionHistory = new history.HistoryStore();
+
+    if (!this.usageAnalytics.isActivated()) {
+      actionHistory.clear();
+      actionHistory = new history.HistoryStore(new NullStorage());
+    }
+
+    return actionHistory;
   }
 
   private setupHistoryManager(element: HTMLElement, _window: Window) {

--- a/unitTests/controllers/QueryControllerTest.ts
+++ b/unitTests/controllers/QueryControllerTest.ts
@@ -6,17 +6,26 @@ import { FakeResults } from '../Fake';
 import * as Mock from '../MockEnvironment';
 import { Simulate } from '../Simulate';
 import { ExecutionPlan } from '../../src/rest/Plan';
+import { SearchInterface } from '../../src/ui/SearchInterface/SearchInterface';
 
 export function QueryControllerTest() {
   describe('QueryController', () => {
     let test: Mock.IBasicComponentSetup<QueryController>;
+    let searchInterface: SearchInterface;
 
-    beforeEach(() => {
+    function initQueryController() {
       test = <Mock.IBasicComponentSetup<QueryController>>{};
       test.env = new Mock.MockEnvironmentBuilder().build();
-      test.cmp = new QueryController(test.env.root, {}, test.env.usageAnalytics, test.env.searchInterface);
+      test.cmp = new QueryController(test.env.root, {}, test.env.usageAnalytics, searchInterface);
       test.cmp.setEndpoint(test.env.searchEndpoint);
       test.cmp.element = test.env.root;
+    }
+
+    beforeEach(() => {
+      const env = new Mock.MockEnvironmentBuilder().build();
+      searchInterface = env.searchInterface;
+
+      initQueryController();
     });
 
     afterEach(() => {
@@ -399,8 +408,10 @@ export function QueryControllerTest() {
 
       beforeEach(() => {
         store = Simulate.analyticsStoreModule();
-        test.cmp.historyStore = store;
         spyOn(store, 'addElement');
+
+        searchInterface.actionHistory = store;
+        initQueryController();
       });
 
       afterEach(() => {

--- a/unitTests/controllers/QueryControllerTest.ts
+++ b/unitTests/controllers/QueryControllerTest.ts
@@ -4,7 +4,6 @@ import { QueryBuilder } from '../../src/ui/Base/QueryBuilder';
 import { $$ } from '../../src/utils/Dom';
 import { FakeResults } from '../Fake';
 import * as Mock from '../MockEnvironment';
-import { Simulate } from '../Simulate';
 import { ExecutionPlan } from '../../src/rest/Plan';
 import { SearchInterface } from '../../src/ui/SearchInterface/SearchInterface';
 
@@ -404,29 +403,47 @@ export function QueryControllerTest() {
     });
 
     describe('coveoanalytics', () => {
-      let store: CoveoAnalytics.HistoryStore;
+      const key = '__coveo.analytics.history';
 
-      beforeEach(() => {
-        store = Simulate.analyticsStoreModule();
-        spyOn(store, 'addElement');
+      describe('when enabled', () => {
+        beforeEach(() => {
+          localStorage.clear();
+          searchInterface.usageAnalytics.isActivated = () => true;
 
-        searchInterface.actionHistory = store;
-        initQueryController();
+          initQueryController();
+        });
+
+        it(`setting action history stores the value in localStorage`, () => {
+          test.cmp.historyStore.setHistory(['a']);
+          expect(localStorage.getItem(key)).toBeTruthy();
+        });
+
+        it('should not log the query in history if not specified', () => {
+          test.cmp.executeQuery({ logInActionsHistory: false });
+          expect(localStorage.getItem(key)).toBeFalsy();
+        });
+
+        it('should log the query in history if specified', () => {
+          test.cmp.executeQuery({ logInActionsHistory: true });
+          expect(localStorage.getItem(key)).toBeTruthy();
+        });
       });
 
-      afterEach(() => {
-        store = undefined;
-        window['coveoanalytics'] = undefined;
-      });
+      describe('when disabled', () => {
+        it(`it clears the action history`, () => {
+          localStorage.setItem(key, 'a');
+          initQueryController();
 
-      it('should not log the query in the user history if not specified', () => {
-        test.cmp.executeQuery({ logInActionsHistory: false });
-        expect(store.addElement).not.toHaveBeenCalled();
-      });
+          expect(localStorage.getItem(key)).toBeFalsy();
+        });
 
-      it('should log the query in the user history if specified', () => {
-        test.cmp.executeQuery({ logInActionsHistory: true });
-        expect(store.addElement).toHaveBeenCalled();
+        it(`setting action history does not store anything in localStorage`, () => {
+          localStorage.clear();
+          initQueryController();
+
+          test.cmp.historyStore.setHistory(['a']);
+          expect(localStorage.getItem(key)).toBeFalsy();
+        });
       });
     });
   });

--- a/unitTests/ui/InitializationTest.ts
+++ b/unitTests/ui/InitializationTest.ts
@@ -585,7 +585,7 @@ export function InitializationTest() {
       });
     });
 
-    it('when analytics is active, it will send action history on automatic query', done => {
+    it('when analytics is active, it will send action history on automatic query', async () => {
       const key = '__coveo.analytics.history';
 
       localStorage.removeItem(key);
@@ -594,14 +594,13 @@ export function InitializationTest() {
       const analyticsElement = $$('div', { className: 'CoveoAnalytics', 'data-token': 'el-tokeno' }).el;
       root.appendChild(analyticsElement);
 
-      Initialization.initializeFramework(root, searchInterfaceOptions, () => {
+      await Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
-      }).then(() => {
-        const actionHistory = localStorage.getItem(key);
-        expect(actionHistory).not.toBeNull();
-        expect(JSON.parse(actionHistory)[0].name).toEqual('Query');
-        done();
       });
+
+      const actionHistory = localStorage.getItem(key);
+      expect(actionHistory).not.toBeNull();
+      expect(JSON.parse(actionHistory)[0].name).toEqual('Query');
     });
 
     describe('when initializing recommendation interface', () => {

--- a/unitTests/ui/InitializationTest.ts
+++ b/unitTests/ui/InitializationTest.ts
@@ -585,13 +585,19 @@ export function InitializationTest() {
       });
     });
 
-    it('will send action history on automatic query', done => {
-      localStorage.removeItem('__coveo.analytics.history');
-      expect(localStorage.getItem('__coveo.analytics.history')).toBeNull();
+    it('when analytics is active, it will send action history on automatic query', done => {
+      const key = '__coveo.analytics.history';
+
+      localStorage.removeItem(key);
+      expect(localStorage.getItem(key)).toBeNull();
+
+      const analyticsElement = $$('div', { className: 'CoveoAnalytics', 'data-token': 'el-tokeno' }).el;
+      root.appendChild(analyticsElement);
+
       Initialization.initializeFramework(root, searchInterfaceOptions, () => {
         return Initialization.initSearchInterface(root, searchInterfaceOptions);
       }).then(() => {
-        const actionHistory = localStorage.getItem('__coveo.analytics.history');
+        const actionHistory = localStorage.getItem(key);
         expect(actionHistory).not.toBeNull();
         expect(JSON.parse(actionHistory)[0].name).toEqual('Query');
         done();

--- a/unitTests/ui/RecommendationTest.ts
+++ b/unitTests/ui/RecommendationTest.ts
@@ -16,9 +16,7 @@ export function RecommendationTest() {
     let mainSearchInterface: Mock.IBasicComponentSetup<SearchInterface>;
     let test: Mock.IBasicComponentSetup<Recommendation>;
     let options: IRecommendationOptions;
-    let actionsHistory = [1, 2, 3];
     let userId = '123';
-    let store: CoveoAnalytics.HistoryStore;
 
     const isHidden = (test: Mock.IBasicComponentSetup<Recommendation>): boolean => {
       return $$(test.cmp.element).hasClass('coveo-hidden');
@@ -32,9 +30,8 @@ export function RecommendationTest() {
           user_id: userId
         }
       };
-      store = Simulate.analyticsStoreModule(actionsHistory);
+
       test = Mock.optionsSearchInterfaceSetup<Recommendation, IRecommendationOptions>(Recommendation, options);
-      test.cmp.historyStore = store;
     });
 
     afterEach(() => {

--- a/unitTests/ui/RegisteredNamedMethodsTest.ts
+++ b/unitTests/ui/RegisteredNamedMethodsTest.ts
@@ -20,8 +20,6 @@ import { Analytics } from '../../src/ui/Analytics/Analytics';
 import * as SharedAnalyticsCalls from '../../src/ui/Analytics/SharedAnalyticsCalls';
 import { NoopAnalyticsClient } from '../../src/ui/Analytics/NoopAnalyticsClient';
 import { SearchEndpoint } from '../../src/rest/SearchEndpoint';
-import HistoryStore from 'coveo.analytics/dist/history';
-import { NullStorage } from 'coveo.analytics/dist/storage';
 
 export function RegisteredNamedMethodsTest() {
   describe('RegisteredNamedMethods', () => {
@@ -273,7 +271,7 @@ export function RegisteredNamedMethodsTest() {
               queryStringArguments: { organizationId: 'another organization' },
               restUri: 'another/uri'
             });
-            env.queryController.historyStore = new HistoryStore(new NullStorage());
+            env.queryController.disableHistory();
             return env;
           })
         );

--- a/unitTests/ui/SearchInterfaceTest.ts
+++ b/unitTests/ui/SearchInterfaceTest.ts
@@ -67,23 +67,6 @@ export function SearchInterfaceTest() {
       expect(cmp.root).toBe(cmp.element, 'Not an element');
     });
 
-    it(`when analytics is disabled, it clears the action history`, () => {
-      const key = '__coveo.analytics.history';
-      localStorage.setItem(key, 'a');
-
-      initSearchInterface();
-
-      expect(localStorage.getItem(key)).toBeFalsy();
-    });
-
-    it(`when analytics is disabled, setting action history does not store anything in localStorage`, () => {
-      localStorage.clear();
-      initSearchInterface();
-
-      cmp.actionHistory.setHistory(['a']);
-      expect(localStorage.getItem('__coveo.analytics.history')).toBeFalsy();
-    });
-
     it('should allow to attach and detach component', () => {
       const cmpToAttach = Mock.mockComponent(Querybox);
       cmp.attachComponent('Querybox', cmpToAttach);
@@ -146,14 +129,6 @@ export function SearchInterfaceTest() {
       it('should initialize if found inside the root', () => {
         const searchInterface = new SearchInterface(searchInterfaceDiv);
         expect(searchInterface.usageAnalytics instanceof Coveo['LiveAnalyticsClient']).toBe(true);
-      });
-
-      it(`setting action history stores the value in localStorage`, () => {
-        localStorage.clear();
-        const searchInterface = new SearchInterface(searchInterfaceDiv);
-        searchInterface.actionHistory.setHistory(['a']);
-
-        expect(localStorage.getItem('__coveo.analytics.history')).toBeTruthy();
       });
     });
 

--- a/unitTests/ui/SearchInterfaceTest.ts
+++ b/unitTests/ui/SearchInterfaceTest.ts
@@ -27,8 +27,12 @@ export function SearchInterfaceTest() {
   describe('SearchInterface', () => {
     let cmp: SearchInterface;
 
-    beforeEach(() => {
+    function initSearchInterface() {
       cmp = new SearchInterface(document.createElement('div'));
+    }
+
+    beforeEach(() => {
+      initSearchInterface();
     });
 
     afterEach(() => {
@@ -61,6 +65,23 @@ export function SearchInterfaceTest() {
 
     it('should set the root as itself', () => {
       expect(cmp.root).toBe(cmp.element, 'Not an element');
+    });
+
+    it(`when analytics is disabled, it clears the action history`, () => {
+      const key = '__coveo.analytics.history';
+      localStorage.setItem(key, 'a');
+
+      initSearchInterface();
+
+      expect(localStorage.getItem(key)).toBeFalsy();
+    });
+
+    it(`when analytics is disabled, setting action history does not store anything in localStorage`, () => {
+      localStorage.clear();
+      initSearchInterface();
+
+      cmp.actionHistory.setHistory(['a']);
+      expect(localStorage.getItem('__coveo.analytics.history')).toBeFalsy();
     });
 
     it('should allow to attach and detach component', () => {
@@ -113,6 +134,8 @@ export function SearchInterfaceTest() {
           className: 'CoveoAnalytics',
           'data-token': 'el-tokeno'
         }).el;
+
+        searchInterfaceDiv.appendChild(analyticsDiv);
       });
 
       afterEach(() => {
@@ -121,10 +144,16 @@ export function SearchInterfaceTest() {
       });
 
       it('should initialize if found inside the root', () => {
-        searchInterfaceDiv.appendChild(analyticsDiv);
-        analyticsDiv.setAttribute('data-token', 'el-tokeno');
         const searchInterface = new SearchInterface(searchInterfaceDiv);
         expect(searchInterface.usageAnalytics instanceof Coveo['LiveAnalyticsClient']).toBe(true);
+      });
+
+      it(`setting action history stores the value in localStorage`, () => {
+        localStorage.clear();
+        const searchInterface = new SearchInterface(searchInterfaceDiv);
+        searchInterface.actionHistory.setHistory(['a']);
+
+        expect(localStorage.getItem('__coveo.analytics.history')).toBeTruthy();
       });
     });
 

--- a/unitTests/ui/SearchInterfaceTest.ts
+++ b/unitTests/ui/SearchInterfaceTest.ts
@@ -27,12 +27,8 @@ export function SearchInterfaceTest() {
   describe('SearchInterface', () => {
     let cmp: SearchInterface;
 
-    function initSearchInterface() {
-      cmp = new SearchInterface(document.createElement('div'));
-    }
-
     beforeEach(() => {
-      initSearchInterface();
+      cmp = new SearchInterface(document.createElement('div'));
     });
 
     afterEach(() => {


### PR DESCRIPTION
Action history was always being tracked and sent by the QueryController, even when analytics are disabled.
This PR makes it so actions are only tracked when analytics is enabled.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)