### PR TITLE
JSUI-3043 Display Facet even when number-of-values is 0

### DIFF
--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1358,7 +1358,6 @@ export class Facet extends Component implements IFieldValueCompatibleFacet {
   protected updateAppearanceDependingOnState() {
     $$(this.element).toggleClass('coveo-active', this.values.hasSelectedOrExcludedValues());
     $$(this.element).toggleClass('coveo-facet-empty', !this.isAnyValueCurrentlyDisplayed());
-    $$(this.element).toggleClass('coveo-hidden', !this.getDisplayedFacetValues().length);
     $$(this.facetHeader.eraserElement).toggleClass('coveo-facet-header-eraser-visible', this.values.hasSelectedOrExcludedValues());
   }
 

--- a/src/utils/DependsOnManager.ts
+++ b/src/utils/DependsOnManager.ts
@@ -104,6 +104,7 @@ export class DependsOnManager {
     this.dependentFacets.forEach(dependentFacet => {
       const condition = this.getDependsOnCondition(dependentFacet);
       if (condition(this.facet.ref)) {
+        $$(dependentFacet.element).removeClass('coveo-hidden');
         return dependentFacet.enable();
       }
 

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -472,6 +472,16 @@ export function FacetTest() {
         );
       });
 
+      it('when numberOfValues is 0, it does not hide the facet', () => {
+        test = Mock.optionsComponentSetup<Facet, IFacetOptions>(Facet, {
+          field: '@field',
+          numberOfValues: 0
+        });
+
+        Simulate.query(test.env);
+        expect($$(test.cmp.element).hasClass('coveo-hidden')).toBe(false);
+      });
+
       it(`when a query is successful and "keepDisplayedValuesNextTime" is false
       the number of value should update`, () => {
         test.cmp.numberOfValues = 13;

--- a/unitTests/utils/DependsOnManagerTest.ts
+++ b/unitTests/utils/DependsOnManagerTest.ts
@@ -77,23 +77,41 @@ export function DependsOnManagerTest() {
       expect($$(parentMock.facet.ref.element).isVisible()).toBe(true);
     });
 
-    it(`when a parent facet has selected value(s) (default condition fulfilled)
-      when triggering "building query"
-      should enable the dependent facet`, () => {
-      queryStateModel.registerNewAttribute(parentStateAttribute(), ['a value']);
-      spyOn(dependentMock.facet.ref, 'enable');
+    describe(`when a parent facet has selected value(s) (default condition fulfilled),
+    when triggering "building query"`, () => {
+      beforeEach(() => {
+        queryStateModel.registerNewAttribute(parentStateAttribute(), ['a value']);
+        spyOn(dependentMock.facet.ref, 'enable');
 
-      $$(root).trigger(QueryEvents.buildingQuery);
-      expect(dependentMock.facet.ref.enable).toHaveBeenCalledTimes(1);
+        $$(root).trigger(QueryEvents.buildingQuery);
+      });
+
+      it('should enable the dependent facet', () => {
+        expect(dependentMock.facet.ref.enable).toHaveBeenCalledTimes(1);
+      });
+
+      it('shows the facet', () => {
+        const facet = $$(dependentMock.facet.ref.element);
+        expect(facet.hasClass('coveo-hidden')).toBe(false);
+      });
     });
 
-    it(`when a parent facet has no selected value (default condition not fulfilled)
-      when triggering "building query"
-      should disable the dependent facet`, () => {
-      spyOn(dependentMock.facet.ref, 'disable');
+    describe(`when a parent facet has no selected value (default condition not fulfilled),
+    when triggering "building query"`, () => {
+      it('should disable the dependent facet', () => {
+        spyOn(dependentMock.facet.ref, 'disable');
 
-      $$(root).trigger(QueryEvents.buildingQuery);
-      expect(dependentMock.facet.ref.disable).toHaveBeenCalledTimes(1);
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(dependentMock.facet.ref.disable).toHaveBeenCalledTimes(1);
+      });
+
+      it('hides the facet', () => {
+        const facet = $$(dependentMock.facet.ref.element);
+        facet.removeClass('coveo-hidden');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(facet.hasClass('coveo-hidden')).toBe(true);
+      });
     });
 
     it(`when a parent facet fulfills the custom condition


### PR DESCRIPTION
Release `2.8864` onwards introduced a breaking change where Facets configured to display `0` values stopped being displayed.

A client upgrading versions reported the issue. They are using only the facet search box. Their configured field holds ids that users can search through and select from.

This PR brings back the old behavior for just the `CoveoFacet` component.
The behavior of `CategoryFacet` and `DynamicFacet` components is inconsistent with the `CoveoFacet`, but did not change. Configuring `0` values on these facets hides them.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)