### PR TITLE
JSUI-3045 Add alias for data-results-container-selector

### DIFF
--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -115,7 +115,7 @@ export class ResultList extends Component {
      * If you specify no value for this option, a `div` element will be dynamically created and appended to the result
      * list. This element will then be used as a result container.
      */
-    resultsContainer: ComponentOptions.buildChildHtmlElementOption(),
+    resultsContainer: ComponentOptions.buildChildHtmlElementOption({ alias: 'resultContainerSelector' }),
     resultTemplate: TemplateComponentOptions.buildTemplateOption({ defaultFunction: ResultList.getDefaultTemplate }),
 
     /**

--- a/unitTests/ui/ResultListTest.ts
+++ b/unitTests/ui/ResultListTest.ts
@@ -514,6 +514,32 @@ export function ResultListTest() {
         });
       });
 
+      it(`when "data-result-container-selector" attribute is set,
+      it appends the result list to the element with the selector`, done => {
+        const selector = 'mycontainer';
+        const root = document.createElement('div');
+        const target = $$('div', { id: selector });
+
+        const resultList = $$('div', {
+          className: 'CoveoResultList',
+          'data-result-container-selector': `#${selector}`
+        });
+
+        root.appendChild(target.el);
+        root.appendChild(resultList.el);
+
+        document.body.appendChild(root);
+        test = Mock.advancedComponentSetup<ResultList>(ResultList, <Mock.AdvancedComponentSetupOptions>{ element: resultList.el });
+        document.body.removeChild(root);
+
+        Simulate.query(test.env);
+
+        setTimeout(() => {
+          expect(target.el.children.length).toBe(10);
+          done();
+        }, 0);
+      });
+
       it('should get the minimal amount of fields to include when the option is true', () => {
         test = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, {
           autoSelectFieldsToInclude: true


### PR DESCRIPTION
Starting with version `2.7023`, the `data-result-container-selector` option (`result` is singular as in our [documentation](https://coveo.github.io/search-ui/components/resultlist.html)) stopped working. This occurred due to [renaming the option](https://github.com/coveo/search-ui/pull/1167/files#diff-8fe6a6cc8cb32278669d7cb6f08f2291R113) to use the plural `results`.

This PR adds an alias to support the attribute when written with either the singular or plural form.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)