### PR TITLE
JSUI-3049 Prevent coveo-facet-empty from overriding display rule

### DIFF
--- a/sass/_FacetFooter.scss
+++ b/sass/_FacetFooter.scss
@@ -1,12 +1,14 @@
-@import "Variables";
+@import 'Variables';
 
-.coveo-facet-more, .coveo-facet-less {
+.coveo-facet-more,
+.coveo-facet-less {
   width: 100%;
   height: 15px;
   background: $color-blueish-white;
   cursor: pointer;
   text-align: center;
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     background: $color-light-grey;
     outline: none;
   }
@@ -27,15 +29,17 @@
   color: $color-greyish-teal-blue;
 }
 
-.coveo-facet-more-icon-svg, .coveo-facet-less-icon-svg {
+.coveo-facet-more-icon-svg,
+.coveo-facet-less-icon-svg {
   width: 10px;
   height: 6px;
   color: $color-greyish-teal-blue;
 }
 
-.coveo-facet-more-icon, .coveo-facet-less-icon {
-    position: relative;
-    top: -4px;
+.coveo-facet-more-icon,
+.coveo-facet-less-icon {
+  position: relative;
+  top: -4px;
 }
 
 .coveo-facet-less {
@@ -46,9 +50,7 @@
 }
 
 .coveo-facet-footer.coveo-facet-empty {
-  display: block;
   visibility: hidden;
-
 }
 
 .coveo-facet-footer {


### PR DESCRIPTION
Since divs are `display: block` by default, I found an opportunity to simplify. There is no need to specify the rule in CSS, which ends up overriding a `display:none` set when the Facet is collapsed. See [this discuss post](https://discuss.coveo.com/t/coveofacet-can-get-unwanted-additional-footing-when-collapsed/4256) for additional context behind this change.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)