### PR TITLE
JSUI-3051 Prevent selectAll from changing the page, adjust showMore logic

### DIFF
--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1158,10 +1158,6 @@ export class Facet extends Component implements IFieldValueCompatibleFacet {
     const valuesThatStays = this.values.getSelected().concat(this.values.getExcluded());
     this.numberOfValues = valuesThatStays.length + _.difference(valuesThatStays, facetValues).length;
     this.numberOfValues = Math.max(this.numberOfValues, this.options.numberOfValues);
-    // Then, we set current page as the last "full" page (math.floor)
-    // This is so there is no additional values displayed requested to fill the current page
-    // Also, when the user hit more, it will request the current page and fill it with more values
-    this.currentPage = Math.floor((this.numberOfValues - this.options.numberOfValues) / this.options.pageSize);
 
     this.updateQueryStateModel();
     this.triggerNewQuery(() =>
@@ -1221,7 +1217,7 @@ export class Facet extends Component implements IFieldValueCompatibleFacet {
    * Triggers a query if needed, or displays the already available values.
    */
   public showMore() {
-    this.currentPage++;
+    this.currentPage = Math.floor((this.numberOfValues - this.options.numberOfValues) / this.options.pageSize) + 1;
     this.updateNumberOfValues();
     if (this.nbAvailableValues >= this.numberOfValues || !this.canFetchMore) {
       this.rebuildValueElements();

--- a/unitTests/ui/FacetTest.ts
+++ b/unitTests/ui/FacetTest.ts
@@ -312,6 +312,38 @@ export function FacetTest() {
       expect(spy).toHaveBeenCalledWith(facetValue);
     });
 
+    it('calling #showMore increases the currentPage by 1', () => {
+      expect(test.cmp.currentPage).toBe(0);
+      test.cmp.showMore();
+      expect(test.cmp.currentPage).toBe(1);
+    });
+
+    describe('calling #processFacetSearchAllResultsSelected', () => {
+      beforeEach(() => {
+        test.cmp.options.numberOfValues = 1;
+        test.cmp.options.pageSize = 1;
+
+        expect(test.cmp.currentPage).toBe(0);
+
+        const values = ['a', 'b'].map(v => {
+          const value = FacetValue.createFromValue(v);
+          value.selected = true;
+          return value;
+        });
+
+        test.cmp.processFacetSearchAllResultsSelected(values);
+      });
+
+      it('does not change the current page', () => {
+        expect(test.cmp.currentPage).toBe(0);
+      });
+
+      it(`calling #showMore increases the page enough to show the next results`, () => {
+        test.cmp.showMore();
+        expect(test.cmp.currentPage).toBe(2);
+      });
+    });
+
     describe('with a live query state model', () => {
       beforeEach(() => {
         initializeComponentWithQSM();


### PR DESCRIPTION
This PR prevents the "select all" button in the facet search from increasing the facet page number.
Also, the showMore function is now smarter, taking into account the number of values in the facet rather than just increasing by 1. See [this Discuss post](https://discuss.coveo.com/t/support-00062406-facet-doesnt-collapse-after-clearing-all-filters/4251/3) for additional info.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)