### PR TITLE
JSUI-3064 Added aria-pressed to facet value checkboxes and exclude buttons

### DIFF
--- a/image/svg/plus.svg
+++ b/image/svg/plus.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <path d="M496 208H304V16h-96v192H16v96h192v192h96V304h192"/>
+</svg>

--- a/sass/_FacetValues.scss
+++ b/sass/_FacetValues.scss
@@ -3,7 +3,7 @@
 
 @mixin facetValuesCheckboxes($size: 'normal') {
   $pixel-size: '18px';
-  @if $size=='smaller' {
+  @if $size== 'smaller' {
     $pixel-size: '13px';
   }
   input[type='checkbox'] {
@@ -60,8 +60,8 @@
       }
     }
   }
-  &.coveo-facet-value-will-exclude .coveo-facet-value-checkbox,
-  &:hover.coveo-facet-value-will-exclude .coveo-facet-value-checkbox {
+  &:not(.coveo-excluded).coveo-facet-value-will-exclude .coveo-facet-value-checkbox,
+  &:not(.coveo-excluded):hover.coveo-facet-value-will-exclude .coveo-facet-value-checkbox {
     svg {
       @include coveo-exclusion($size);
     }
@@ -72,7 +72,7 @@
       fill-opacity: 0;
     }
   }
-  &.coveo-excluded .coveo-facet-value-checkbox {
+  &.coveo-excluded:not(.coveo-facet-value-will-exclude) .coveo-facet-value-checkbox {
     svg {
       @include coveo-exclusion($size);
     }
@@ -86,7 +86,7 @@
 }
 
 @mixin coveo-hook($size: 'normal') {
-  @if $size=='smaller' {
+  @if $size== 'smaller' {
     width: 11px;
     height: 9px;
     bottom: 4px;
@@ -104,7 +104,7 @@
 }
 
 @mixin coveo-exclusion($size: 'normal') {
-  @if $size=='smaller' {
+  @if $size== 'smaller' {
     width: 7px;
     height: 7px;
     bottom: 5px;
@@ -147,17 +147,6 @@
     &:hover,
     &.coveo-focused {
       background-color: $color-blueish-white-grey;
-    }
-  }
-
-  &.coveo-excluded {
-    .coveo-facet-value-exclude {
-      visibility: hidden;
-    }
-    &.coveo-with-hover:hover {
-      .coveo-facet-value-exclude {
-        visibility: hidden;
-      }
     }
   }
 
@@ -213,7 +202,9 @@
   @include justify-content(space-between);
   .coveo-facet-value-label-wrapper {
     @include order(1);
-    @include display('flex'); // This needs to be set, otherwise min-width auto on the elment will make the element overflow it's flex container;
+    @include display(
+      'flex'
+    ); // This needs to be set, otherwise min-width auto on the elment will make the element overflow it's flex container;
     min-width: 0;
     .coveo-facet-value-checkbox {
       @include order(1);
@@ -257,13 +248,24 @@
   }
 }
 
-.coveo-facet-value-exclude-svg {
+$facet-exclude-icon-color: grey;
+
+@mixin facet-exclude-svg {
   width: 7px;
   height: 7px;
   position: absolute;
   top: 2px;
   left: 2px;
+}
+
+.coveo-facet-value-exclude-svg {
+  @include facet-exclude-svg();
   .coveo-exclusion-svg {
-    fill: grey;
+    fill: $facet-exclude-icon-color;
   }
+}
+
+.coveo-facet-value-unexclude-svg {
+  @include facet-exclude-svg();
+  fill: $facet-exclude-icon-color;
 }

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValue.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValue.ts
@@ -61,10 +61,9 @@ export class DynamicFacetValue implements IDynamicFacetValue {
   }
 
   public get selectAriaLabel() {
-    const selectOrUnselect = !this.isSelected ? 'SelectValueWithResultCount' : 'UnselectValueWithResultCount';
     const resultCount = l('ResultCount', this.formattedCount, this.numberOfResults);
 
-    return `${l(selectOrUnselect, this.displayValue, resultCount)}`;
+    return `${l('SelectValueWithResultCount', this.displayValue, resultCount)}`;
   }
 
   private get isRange() {

--- a/src/ui/Facet/ValueElement.ts
+++ b/src/ui/Facet/ValueElement.ts
@@ -120,8 +120,8 @@ export class ValueElement {
     this.toggleExcludeWithUA();
   }
 
-  protected handleEventForExcludedValueElement(eventBindings: IValueElementEventsBinding) {
-    let clickEvent = (event: Event) => {
+  protected handleSelectEventForExcludedValueElement(eventBindings: IValueElementEventsBinding) {
+    const clickEvent = () => {
       if (eventBindings.pinFacet) {
         this.facet.pinFacetPosition();
       }
@@ -134,14 +134,14 @@ export class ValueElement {
 
     $$(this.renderer.label).on('click', e => {
       e.stopPropagation();
-      clickEvent(e);
+      clickEvent();
     });
 
     $$(this.renderer.stylishCheckbox).on('keydown', KeyboardUtils.keypressAction([KEYBOARD.SPACEBAR, KEYBOARD.ENTER], clickEvent));
   }
 
-  protected handleEventForValueElement(eventBindings: IValueElementEventsBinding) {
-    let excludeAction = (event: Event) => {
+  protected handleExcludeEventForValueElement(eventBindings: IValueElementEventsBinding) {
+    const excludeAction = (event: Event) => {
       if (eventBindings.omniboxObject) {
         this.omniboxCloseEvent(eventBindings.omniboxObject);
       }
@@ -157,8 +157,10 @@ export class ValueElement {
     $$(this.renderer.excludeIcon).on('click', excludeAction);
 
     $$(this.renderer.excludeIcon).on('keydown', KeyboardUtils.keypressAction([KEYBOARD.SPACEBAR, KEYBOARD.ENTER], excludeAction));
+  }
 
-    let selectAction = (event: Event) => {
+  protected handleSelectEventForValueElement(eventBindings: IValueElementEventsBinding) {
+    const selectAction = (event: Event) => {
       if (eventBindings.pinFacet) {
         this.facet.pinFacetPosition();
       }
@@ -170,6 +172,16 @@ export class ValueElement {
     $$(this.renderer.label).on('click', selectAction);
 
     $$(this.renderer.stylishCheckbox).on('keydown', KeyboardUtils.keypressAction([KEYBOARD.SPACEBAR, KEYBOARD.ENTER], selectAction));
+  }
+
+  protected handleEventForExcludedValueElement(eventBindings: IValueElementEventsBinding) {
+    this.handleSelectEventForExcludedValueElement(eventBindings);
+    this.handleExcludeEventForValueElement(eventBindings);
+  }
+
+  protected handleEventForValueElement(eventBindings: IValueElementEventsBinding) {
+    this.handleSelectEventForValueElement(eventBindings);
+    this.handleExcludeEventForValueElement(eventBindings);
   }
 
   protected handleEventForCheckboxChange(eventBindings: IValueElementEventsBinding) {

--- a/src/ui/Facet/ValueElementRenderer.ts
+++ b/src/ui/Facet/ValueElementRenderer.ts
@@ -58,15 +58,17 @@ export class ValueElementRenderer {
   }
 
   protected buildExcludeIcon(): HTMLElement {
+    const isExcluded = this.facetValue.excluded;
     const excludeIcon = $$('div', {
-      title: l('ExcludeValueWithResultCount', this.caption, l('ResultCount', this.count, parseInt(this.count, 10))),
+      ariaLabel: l('ExcludeValueWithResultCount', this.caption, l('ResultCount', this.count, parseInt(this.count, 10))),
       className: 'coveo-facet-value-exclude',
       tabindex: 0,
-      role: 'button'
+      role: 'button',
+      ariaPressed: isExcluded.toString()
     }).el;
     this.addFocusAndBlurEventListeners(excludeIcon);
-    excludeIcon.innerHTML = SVGIcons.icons.checkboxHookExclusionMore;
-    SVGDom.addClassToSVGInContainer(excludeIcon, 'coveo-facet-value-exclude-svg');
+    excludeIcon.innerHTML = isExcluded ? SVGIcons.icons.plus : SVGIcons.icons.checkboxHookExclusionMore;
+    SVGDom.addClassToSVGInContainer(excludeIcon, isExcluded ? 'coveo-facet-value-unexclude-svg' : 'coveo-facet-value-exclude-svg');
     return excludeIcon;
   }
 
@@ -258,22 +260,15 @@ export class ValueElementRenderer {
     const el = this.accessibleElement;
     el.setAttribute('aria-label', this.ariaLabel);
     el.setAttribute('role', 'button');
-  }
-
-  private get actionLabel() {
-    if (this.facetValue.excluded) {
-      return 'UnexcludeValueWithResultCount';
-    }
-
-    if (this.facetValue.selected) {
-      return 'UnselectValueWithResultCount';
-    }
-
-    return 'SelectValueWithResultCount';
+    el.setAttribute('aria-pressed', this.ariaPressed);
   }
 
   private get ariaLabel() {
     const resultCount = l('ResultCount', this.count, parseInt(this.count, 10));
-    return `${l(this.actionLabel, this.caption, resultCount)}`;
+    return `${l('SelectValueWithResultCount', this.caption, resultCount)}`;
+  }
+
+  private get ariaPressed() {
+    return this.facetValue.selected ? 'true' : 'false';
   }
 }

--- a/src/ui/Facet/ValueElementRenderer.ts
+++ b/src/ui/Facet/ValueElementRenderer.ts
@@ -60,7 +60,7 @@ export class ValueElementRenderer {
   protected buildExcludeIcon(): HTMLElement {
     const isExcluded = this.facetValue.excluded;
     const excludeIcon = $$('div', {
-      ariaLabel: l('ExcludeValueWithResultCount', this.caption, l('ResultCount', this.count, parseInt(this.count, 10))),
+      title: l('ExcludeValueWithResultCount', this.caption, l('ResultCount', this.count, parseInt(this.count, 10))),
       className: 'coveo-facet-value-exclude',
       tabindex: 0,
       role: 'button',
@@ -88,8 +88,8 @@ export class ValueElementRenderer {
   protected buildValueCheckbox(): HTMLElement {
     const checkbox = $$('input', {
       type: 'checkbox',
-      'aria-hidden': true,
-      'aria-label': this.ariaLabel
+      ariaHidden: true,
+      ariaLabel: this.ariaLabel
     }).el;
 
     this.facetValue.selected ? checkbox.setAttribute('checked', 'checked') : checkbox.removeAttribute('checked');

--- a/src/ui/FormWidgets/Checkbox.ts
+++ b/src/ui/FormWidgets/Checkbox.ts
@@ -9,6 +9,8 @@ import { IFormWidgetSelectable, IFormWidgetWithLabel } from './FormWidgets';
 export class Checkbox implements IFormWidgetWithLabel, IFormWidgetSelectable {
   protected element: HTMLElement;
   protected checkbox: HTMLInputElement;
+  private button: HTMLElement;
+  private ignoreNextChange = false;
 
   static doExport = () => {
     exportGlobally({
@@ -81,7 +83,8 @@ export class Checkbox implements IFormWidgetWithLabel, IFormWidgetSelectable {
   public select(triggerChange = true) {
     const currentlyChecked = this.isSelected();
     this.checkbox.checked = true;
-    if (!currentlyChecked && triggerChange) {
+    if (!currentlyChecked) {
+      this.ignoreNextChange = !triggerChange;
       $$(this.checkbox).trigger('change');
     }
   }
@@ -114,7 +117,12 @@ export class Checkbox implements IFormWidgetWithLabel, IFormWidgetSelectable {
       'aria-label': this.ariaLabel || this.label,
       'aria-hidden': true
     }).el;
-    const button = $$('button', { type: 'button', className: 'coveo-checkbox-button', 'aria-label': this.ariaLabel || this.label });
+    this.button = $$('button', {
+      type: 'button',
+      className: 'coveo-checkbox-button',
+      'aria-label': this.ariaLabel || this.label,
+      ariaPressed: this.isSelected().toString()
+    }).el;
     const labelSpan = $$('span', { className: 'coveo-checkbox-span-label' });
     labelSpan.text(this.label);
 
@@ -122,16 +130,27 @@ export class Checkbox implements IFormWidgetWithLabel, IFormWidgetSelectable {
     labelSuffixSpan.text(this.labelSuffix);
 
     label.append(this.checkbox);
-    label.append(button.el);
+    label.append(this.button);
     label.append(labelSpan.el);
     this.labelSuffix && label.append(labelSuffixSpan.el);
 
-    button.on('click', (e: Event) => {
+    $$(this.button).on('click', (e: Event) => {
       e.preventDefault();
       this.toggle();
     });
 
-    $$(this.checkbox).on('change', () => this.onChange(this));
+    $$(this.checkbox).on('change', () => {
+      this.updateAccessibilityAttributes();
+      if (!this.ignoreNextChange) {
+        this.onChange(this);
+      } else {
+        this.ignoreNextChange = false;
+      }
+    });
     this.element = label.el;
+  }
+
+  private updateAccessibilityAttributes() {
+    this.button.setAttribute('aria-pressed', this.isSelected().toString());
   }
 }

--- a/src/ui/FormWidgets/Checkbox.ts
+++ b/src/ui/FormWidgets/Checkbox.ts
@@ -114,13 +114,13 @@ export class Checkbox implements IFormWidgetWithLabel, IFormWidgetSelectable {
       type: 'checkbox',
       className: 'coveo-checkbox',
       value: this.label,
-      'aria-label': this.ariaLabel || this.label,
-      'aria-hidden': true
+      ariaLabel: this.ariaLabel || this.label,
+      ariaHidden: true
     }).el;
     this.button = $$('button', {
       type: 'button',
       className: 'coveo-checkbox-button',
-      'aria-label': this.ariaLabel || this.label,
+      ariaLabel: this.ariaLabel || this.label,
       ariaPressed: this.isSelected().toString()
     }).el;
     const labelSpan = $$('span', { className: 'coveo-checkbox-span-label' });

--- a/src/utils/SVGIcons.ts
+++ b/src/utils/SVGIcons.ts
@@ -36,6 +36,7 @@ export class SVGIcons {
     star: require(`svg/star`),
     listLayout: require(`svg/list-layout`),
     cardLayout: require(`svg/card-layout`),
-    tableLayout: require(`svg/table-layout`)
+    tableLayout: require(`svg/table-layout`),
+    plus: require(`svg/plus`)
   };
 }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -3282,48 +3282,27 @@
     "zh-tw": "在從您的設備讀取資訊時出錯"
   },
   "AppIntro": {
-    "en":
-      "Speak with a product specialist who can answer your questions about Coveo and help you decide which Coveo solution is right for you. Or, try a live demo !",
-    "fr":
-      "Contactez-nous pour parler avec un spécialiste de produit qui pourra répondre à vos questions a propos de Coveo. Ou bien, essayer une demonstration !",
-    "cs":
-      "Promluvte si s produktovým specialistou, který vám pomůže vybrat nejvhodnější řešení Coveo a zodpoví vaše dotazy týkající se této platformy. Vyzkoušet můžete rovněž živou ukázku!",
-    "da":
-      "Tal med en produktspecialist, der kan besvare dine spørgsmål om Coveo og hjælpe dig med at beslutte hvilken Coveo-løsning, der passer til dig. Eller prøv en live demo!",
-    "de":
-      "Sprechen Sie mit einem Produktspezialisten, der Ihre Fragen zu Coveo beantworten und Ihnen helfen kann, die für Sie am besten geeignete Coveo-Lösung zu finden. Oder probieren Sie eine Testversion aus!",
-    "el":
-      "Επικοινωνήστε με άτομο εξειδικευμένο στο προϊόν, το οποίο μπορεί να απαντήσει στις ερωτήσεις σας σχετικά με την πλατφόρμα Coveo, το οποίο θα σας βοηθήσει να αποφασίσετε ποια λύση Coveo είναι η κατάλληλη για εσάς. Ή δοκιμάστε μία ζωντανή επίδειξη!",
-    "es-es":
-      "Hable con un especialista en el producto que pueda responder a sus preguntas sobre Coveo y le ayude a decidir qué solución Coveo se adapta a sus necesidades. O pruebe una versión de prueba.",
-    "fi":
-      "Puhu tuoteasiantuntijan kanssa, joka pystyy vastaamaan kysymyksiisi   Coveosta ja auttamaan sinua päättämään, mikä Coveo-ratkaisu on oikea sinulle. Kokeile live-demoa!",
-    "hu":
-      "Beszéljen egy termékszakértővel, aki örömmel válaszol a Coveóval kapcsolatos kérdéseire, és segít Önnek megtalálni az ideális Coveo-megoldást. Vagy próbálja ki az élő demót!",
-    "id":
-      "Bicaralah dengan spesialis produk yang dapat menjawab pertanyaan Anda tentang Coveo dan membantu Anda menentukan solusi Coveo mana yang tepat untuk Anda. Atau, coba demo langsung!",
-    "it":
-      "Rivolgersi a uno specialista del prodotto in grado di rispondere a domande relative a Coveo e di assistere nella scelta della soluzione Coveo più adatta. In alternativa, provare una demo dal vivo,",
-    "ja":
-      "Coveoに関するご質問にお答えし、お客様に合ったCoveoソリューションの選択をお手伝いする製品スペシャリストと話す。または、実践デモをお試しください！",
-    "ko":
-      "Coveo에 관한 질문에 답하고 Coveo 솔루션이 사용자에게 적합한지 알아보는 데 도움을 줄 수 있는 제품 전문가와 상담하십시오. 또는 실제 시연을 이용하십시오!",
-    "nl":
-      "Een productspecialist spreken die uw vragen over Coveo kan beantwoorden en u helpen te beslissen welke Coveo-oplossing geschikt is voor u. Of probeer een live demo!",
-    "no":
-      "Snakk med en produktspesialist som kan besvare dine spørsmål om Coveo og hjelpe deg å avgjøre hvilken Coveo-løsning som er riktig for deg. Eller prøv en live demo!",
-    "pl":
-      "Skontaktuj się ze specjalistą ds. produktów, który odpowie na pytania dotyczące Coveo i pomoże Ci w wyborze odpowiedniego rozwiązania Coveo. Możesz też wypróbować interaktywne demo!",
-    "pt-br":
-      "Fale com um especialista de produto que possa responder suas dúvidas sobre a Coveo e ajudá-lo a decidir qual solução Coveo é adequada para você. Ou experimente uma demonstração ao vivo!",
-    "ru":
-      "Пообщайтесь со специалистом по продукции, который сможет ответить на ваши вопросы о Conveo и поможет решить, какое решение Coveo вам подойдет. Или попробуйте демоверсию с автоматическим обновлением!",
-    "sv":
-      "Tala med en produktspecialist som kan svara på dina frågor om Coveo och hjälpa dig välja vilken Coveolösning som passar dig. Eller, prova en live demo",
-    "th":
-      "พูดคุยกับผู้เชี่ยวชาญด้านผลิตภัณฑ์ซึ่งสามารถตอบคำถามของคุณเกี่ยวกับ Coveo และช่วยคุณตัดสินใจว่าโซลูชัน Coveo ใดที่เหมาะสมกับคุณ หรือทดลองใช้ผลิตภัณฑ์ตัวอย่าง!",
-    "tr":
-      "Coveo hakkındaki sorularınıza cevap verebilecek ve hangi Coveo çözümünün sizin için doğru olduğu konusunda size yardımcı olabilecek bir ürün uzmanıyla konuşun. Veya bir canlı demoyu deneyin!",
+    "en": "Speak with a product specialist who can answer your questions about Coveo and help you decide which Coveo solution is right for you. Or, try a live demo !",
+    "fr": "Contactez-nous pour parler avec un spécialiste de produit qui pourra répondre à vos questions a propos de Coveo. Ou bien, essayer une demonstration !",
+    "cs": "Promluvte si s produktovým specialistou, který vám pomůže vybrat nejvhodnější řešení Coveo a zodpoví vaše dotazy týkající se této platformy. Vyzkoušet můžete rovněž živou ukázku!",
+    "da": "Tal med en produktspecialist, der kan besvare dine spørgsmål om Coveo og hjælpe dig med at beslutte hvilken Coveo-løsning, der passer til dig. Eller prøv en live demo!",
+    "de": "Sprechen Sie mit einem Produktspezialisten, der Ihre Fragen zu Coveo beantworten und Ihnen helfen kann, die für Sie am besten geeignete Coveo-Lösung zu finden. Oder probieren Sie eine Testversion aus!",
+    "el": "Επικοινωνήστε με άτομο εξειδικευμένο στο προϊόν, το οποίο μπορεί να απαντήσει στις ερωτήσεις σας σχετικά με την πλατφόρμα Coveo, το οποίο θα σας βοηθήσει να αποφασίσετε ποια λύση Coveo είναι η κατάλληλη για εσάς. Ή δοκιμάστε μία ζωντανή επίδειξη!",
+    "es-es": "Hable con un especialista en el producto que pueda responder a sus preguntas sobre Coveo y le ayude a decidir qué solución Coveo se adapta a sus necesidades. O pruebe una versión de prueba.",
+    "fi": "Puhu tuoteasiantuntijan kanssa, joka pystyy vastaamaan kysymyksiisi   Coveosta ja auttamaan sinua päättämään, mikä Coveo-ratkaisu on oikea sinulle. Kokeile live-demoa!",
+    "hu": "Beszéljen egy termékszakértővel, aki örömmel válaszol a Coveóval kapcsolatos kérdéseire, és segít Önnek megtalálni az ideális Coveo-megoldást. Vagy próbálja ki az élő demót!",
+    "id": "Bicaralah dengan spesialis produk yang dapat menjawab pertanyaan Anda tentang Coveo dan membantu Anda menentukan solusi Coveo mana yang tepat untuk Anda. Atau, coba demo langsung!",
+    "it": "Rivolgersi a uno specialista del prodotto in grado di rispondere a domande relative a Coveo e di assistere nella scelta della soluzione Coveo più adatta. In alternativa, provare una demo dal vivo,",
+    "ja": "Coveoに関するご質問にお答えし、お客様に合ったCoveoソリューションの選択をお手伝いする製品スペシャリストと話す。または、実践デモをお試しください！",
+    "ko": "Coveo에 관한 질문에 답하고 Coveo 솔루션이 사용자에게 적합한지 알아보는 데 도움을 줄 수 있는 제품 전문가와 상담하십시오. 또는 실제 시연을 이용하십시오!",
+    "nl": "Een productspecialist spreken die uw vragen over Coveo kan beantwoorden en u helpen te beslissen welke Coveo-oplossing geschikt is voor u. Of probeer een live demo!",
+    "no": "Snakk med en produktspesialist som kan besvare dine spørsmål om Coveo og hjelpe deg å avgjøre hvilken Coveo-løsning som er riktig for deg. Eller prøv en live demo!",
+    "pl": "Skontaktuj się ze specjalistą ds. produktów, który odpowie na pytania dotyczące Coveo i pomoże Ci w wyborze odpowiedniego rozwiązania Coveo. Możesz też wypróbować interaktywne demo!",
+    "pt-br": "Fale com um especialista de produto que possa responder suas dúvidas sobre a Coveo e ajudá-lo a decidir qual solução Coveo é adequada para você. Ou experimente uma demonstração ao vivo!",
+    "ru": "Пообщайтесь со специалистом по продукции, который сможет ответить на ваши вопросы о Conveo и поможет решить, какое решение Coveo вам подойдет. Или попробуйте демоверсию с автоматическим обновлением!",
+    "sv": "Tala med en produktspecialist som kan svara på dina frågor om Coveo och hjälpa dig välja vilken Coveolösning som passar dig. Eller, prova en live demo",
+    "th": "พูดคุยกับผู้เชี่ยวชาญด้านผลิตภัณฑ์ซึ่งสามารถตอบคำถามของคุณเกี่ยวกับ Coveo และช่วยคุณตัดสินใจว่าโซลูชัน Coveo ใดที่เหมาะสมกับคุณ หรือทดลองใช้ผลิตภัณฑ์ตัวอย่าง!",
+    "tr": "Coveo hakkındaki sorularınıza cevap verebilecek ve hangi Coveo çözümünün sizin için doğru olduğu konusunda size yardımcı olabilecek bir ürün uzmanıyla konuşun. Veya bir canlı demoyu deneyin!",
     "zh-cn": "咨询能够回答您有关 Coveo 的问题的产品专家，并帮助您确定哪个 Coveo 解决方案适合您。或者，尝试现场演示！",
     "zh-tw": "諮詢能夠回答您有關 Coveo 的問題的產品專家，並幫助您確定哪個 Coveo 解決方案適合您。或者，嘗試現場示範！"
   },
@@ -7458,17 +7437,9 @@
     "en": "Select {0} with {1}",
     "fr": "Sélectionner {0} avec {1}"
   },
-  "UnselectValueWithResultCount": {
-    "en": "Unselect {0} with {1}",
-    "fr": "Désélectionner {0} avec {1}"
-  },
   "ExcludeValueWithResultCount": {
     "en": "Exclude {0} with {1}",
     "fr": "Exclure {0} avec {1}"
-  },
-  "UnexcludeValueWithResultCount": {
-    "en": "Unexclude {0} with {1}",
-    "fr": "Réinclure {0} avec {1}"
   },
   "PageNumber": {
     "en": "Page {0}",
@@ -7479,10 +7450,8 @@
     "fr": "Afficher {0} résultats par page"
   },
   "GroupByAndFacetRequestsCannotCoexist": {
-    "en":
-      "The query is invalid because it contains both Group By and Facet requests. Ensure that the search interface does not initialize DynamicFacet components alongside Facet components (or alongside any component extending the Facet component, such as FacetRange or FacetSlider).",
-    "fr":
-      "La requête n'est pas valide car elle contient les requêtes Group By et Facet. Assurez-vous que l'interface de recherche n'initialise pas les composants DynamicFacet aux côtés des composants Facet (ou de tout composant d'extension du composant Facet, tel que FacetRange ou FacetSlider)."
+    "en": "The query is invalid because it contains both Group By and Facet requests. Ensure that the search interface does not initialize DynamicFacet components alongside Facet components (or alongside any component extending the Facet component, such as FacetRange or FacetSlider).",
+    "fr": "La requête n'est pas valide car elle contient les requêtes Group By et Facet. Assurez-vous que l'interface de recherche n'initialise pas les composants DynamicFacet aux côtés des composants Facet (ou de tout composant d'extension du composant Facet, tel que FacetRange ou FacetSlider)."
   },
   "MustContain": {
     "en": "Must contain:",

--- a/unitTests/MockElement.ts
+++ b/unitTests/MockElement.ts
@@ -1,8 +1,8 @@
 import { mock } from './MockEnvironment';
 
-export type EventListenersMap = { [type: string]: ((event: Event) => any)[] };
+export type EventListenersMap = Record<string, ((event: Event) => any)[]>;
 
-export type EventTriggersMap = { [type: string]: Event[] };
+export type EventTriggersMap = Record<string, Event[]>;
 
 export class MockElement<T extends Element> {
   public readonly element: T;

--- a/unitTests/MockElement.ts
+++ b/unitTests/MockElement.ts
@@ -1,0 +1,39 @@
+import { mock } from './MockEnvironment';
+
+export type EventListenersMap = { [type: string]: ((event: Event) => any)[] };
+
+export type EventTriggersMap = { [type: string]: Event[] };
+
+export class MockElement<T extends Element> {
+  public readonly element: T;
+  public eventListeners: EventListenersMap = {};
+  public manualEventTriggers: EventTriggersMap = {};
+
+  constructor(constructorFunc: { new (...args: any[]): T }) {
+    this.element = mock(constructorFunc) as T;
+    (this.element.addEventListener as jasmine.Spy).and.callFake((name: string, listener: (e: Event) => any) =>
+      this.addEventListener(name, listener)
+    );
+    (this.element.dispatchEvent as jasmine.Spy).and.callFake((event: Event) => this.dispatchEvent(event));
+  }
+
+  private addEventListener(name: string, listener: (e: Event) => any) {
+    this.eventListeners[name] = this.eventListeners[name] || [];
+    this.eventListeners[name].push(listener);
+  }
+
+  private dispatchEvent(event: Event) {
+    const name = event.type;
+    this.manualEventTriggers[name] = this.manualEventTriggers[name] || [];
+    this.manualEventTriggers[name].push(event);
+    if (this.eventListeners[name]) {
+      this.eventListeners[name].forEach(listener => listener(event));
+    }
+  }
+}
+
+export class MockHTMLElement extends MockElement<HTMLElement> {
+  constructor() {
+    super(HTMLElement);
+  }
+}

--- a/unitTests/ui/CheckboxTest.ts
+++ b/unitTests/ui/CheckboxTest.ts
@@ -5,10 +5,14 @@ export function CheckboxTest() {
   describe('Checkbox', () => {
     let spyChange: jasmine.Spy;
     let checkbox: Checkbox;
+    const label = 'hello';
+    const ariaLabel = 'goodbye';
 
+    let button: HTMLElement;
     beforeEach(() => {
       spyChange = jasmine.createSpy('change');
-      checkbox = new Checkbox(spyChange, 'hello');
+      checkbox = new Checkbox(spyChange, label, ariaLabel);
+      button = checkbox.getElement().querySelector('button');
     });
 
     afterEach(() => {
@@ -46,24 +50,65 @@ export function CheckboxTest() {
         $$(checkbox.getElement())
           .find('input')
           .getAttribute('aria-label')
-      ).toBeTruthy();
+      ).toEqual(ariaLabel);
     });
 
-    describe('select', () => {
-      it('should allow to select', () => {
+    it("the button's aria-label is its ariaLabel parameter", () => {
+      expect(button.getAttribute('aria-label')).toEqual(ariaLabel);
+    });
+
+    it("the button's aria-pressed should be false", () => {
+      expect(button.getAttribute('aria-pressed')).toEqual('false');
+    });
+
+    describe('after being selected', () => {
+      beforeEach(() => {
         checkbox.select();
+      });
+
+      it('isSelected should return true', () => {
         expect(checkbox.isSelected()).toBe(true);
       });
 
       it('should call on change', () => {
-        checkbox.select();
         expect(spyChange).toHaveBeenCalledWith(checkbox);
       });
 
       it('should call on change only once', () => {
         checkbox.select();
-        checkbox.select();
         expect(spyChange).toHaveBeenCalledTimes(1);
+      });
+
+      it("the button's aria-pressed should be true", () => {
+        expect(button.getAttribute('aria-pressed')).toEqual('true');
+      });
+
+      describe('then toggled', () => {
+        beforeEach(() => {
+          checkbox.toggle();
+        });
+
+        it('isSelected should return false', () => {
+          expect(checkbox.isSelected()).toBe(false);
+        });
+
+        it("the button's aria-pressed should be false", () => {
+          expect(button.getAttribute('aria-pressed')).toEqual('false');
+        });
+      });
+    });
+
+    describe('after being selected with triggerChange false', () => {
+      beforeEach(() => {
+        checkbox.select(false);
+      });
+
+      it('should not call on change', () => {
+        expect(spyChange).not.toHaveBeenCalled();
+      });
+
+      it("the button's aria-pressed should be true", () => {
+        expect(button.getAttribute('aria-pressed')).toEqual('true');
       });
     });
 

--- a/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueTest.ts
@@ -166,7 +166,7 @@ export function DynamicFacetValueTest() {
       });
 
       it('should return the correct aria-label', () => {
-        const expectedAriaLabel = `Unselect ${dynamicFacetValue.value} with ${dynamicFacetValue.formattedCount} results`;
+        const expectedAriaLabel = `Select ${dynamicFacetValue.value} with ${dynamicFacetValue.formattedCount} results`;
         expect(dynamicFacetValue.selectAriaLabel).toBe(expectedAriaLabel);
       });
 

--- a/unitTests/ui/ValueElementRendererTest.ts
+++ b/unitTests/ui/ValueElementRendererTest.ts
@@ -83,34 +83,73 @@ export function ValueElementRendererTest() {
       expect(valueRenderer.build().stylishCheckbox).toBeDefined();
     });
 
-    it(`when the facetValue is not selected,
-    the aria-label attribute contains the word 'Select'`, () => {
-      const facetValue = FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 123));
-      facetValue.selected = false;
-      valueRenderer = new ValueElementRenderer(facet, facetValue).build();
+    describe('when the facetValue is not selected', () => {
+      beforeEach(() => {
+        const facetValue = FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 123));
+        facetValue.selected = false;
+        valueRenderer = new ValueElementRenderer(facet, facetValue).build();
+      });
 
-      const ariaLabel = valueRenderer.accessibleElement.getAttribute('aria-label');
-      expect(ariaLabel).toContain('Select');
+      it("the aria-label attribute starts with the word 'Select'", () => {
+        const ariaLabel = valueRenderer.accessibleElement.getAttribute('aria-label');
+        expect(ariaLabel.indexOf('Select')).toEqual(0);
+      });
+
+      it('the aria-pressed attribute of the checkbox is false', () => {
+        const ariaPressed = valueRenderer.accessibleElement.getAttribute('aria-pressed');
+        expect(ariaPressed).toEqual('false');
+      });
+
+      it('the aria-pressed attribute of the exclude button is false', () => {
+        const ariaPressed = valueRenderer.excludeIcon.getAttribute('aria-pressed');
+        expect(ariaPressed).toEqual('false');
+      });
     });
 
-    it(`when the facetValue is selected,
-    the aria-label attribute contains the word 'Unselect'`, () => {
-      const facetValue = FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 123));
-      facetValue.selected = true;
-      valueRenderer = new ValueElementRenderer(facet, facetValue).build();
+    describe('when the facetValue is selected', () => {
+      beforeEach(() => {
+        const facetValue = FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 123));
+        facetValue.selected = true;
+        valueRenderer = new ValueElementRenderer(facet, facetValue).build();
+      });
 
-      const ariaLabel = valueRenderer.accessibleElement.getAttribute('aria-label');
-      expect(ariaLabel).toContain('Unselect');
+      it("the aria-label attribute starts with the word 'Select'", () => {
+        const ariaLabel = valueRenderer.accessibleElement.getAttribute('aria-label');
+        expect(ariaLabel.indexOf('Select')).toEqual(0);
+      });
+
+      it('the aria-pressed attribute of the checkbox is true', () => {
+        const ariaPressed = valueRenderer.accessibleElement.getAttribute('aria-pressed');
+        expect(ariaPressed).toEqual('true');
+      });
+
+      it('the aria-pressed attribute of the exclude button is false', () => {
+        const ariaPressed = valueRenderer.excludeIcon.getAttribute('aria-pressed');
+        expect(ariaPressed).toEqual('false');
+      });
     });
 
-    it(`when the facetValue is excluded,
-    the aria-label attribute contains the word 'Unexclude'`, () => {
-      const facetValue = FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 123));
-      facetValue.excluded = true;
-      valueRenderer = new ValueElementRenderer(facet, facetValue).build();
+    describe('when the facetValue is excluded', () => {
+      beforeEach(() => {
+        const facetValue = FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 123));
+        facetValue.excluded = true;
+        valueRenderer = new ValueElementRenderer(facet, facetValue).build();
+      });
 
-      const ariaLabel = valueRenderer.accessibleElement.getAttribute('aria-label');
-      expect(ariaLabel).toContain('Unexclude');
+      it("the aria-label attribute starts with the word 'Select'", () => {
+        const ariaLabel = valueRenderer.accessibleElement.getAttribute('aria-label');
+        expect(ariaLabel.indexOf('Select')).toEqual(0);
+      });
+
+      it('the aria-pressed attribute of the checkbox is false', () => {
+        const ariaPressed = valueRenderer.accessibleElement.getAttribute('aria-pressed');
+        expect(ariaPressed).toEqual('false');
+      });
+
+      it('the aria-pressed attribute of the exclude button is true', () => {
+        const ariaPressed = valueRenderer.excludeIcon.getAttribute('aria-pressed');
+        expect(ariaPressed).toEqual('true');
+      });
     });
 
     it('should build a caption', () => {

--- a/unitTests/ui/ValueElementTest.ts
+++ b/unitTests/ui/ValueElementTest.ts
@@ -4,6 +4,13 @@ import { FacetValue } from '../../src/ui/Facet/FacetValue';
 import { ValueElement } from '../../src/ui/Facet/ValueElement';
 import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
 import { ValueElementRenderer } from '../../src/ui/Facet/ValueElementRenderer';
+import { Dom, $$ } from '../../src/Core';
+import { mapObject, Dictionary } from 'underscore';
+import { MockHTMLElement } from '../MockElement';
+
+function countValues<T>(dictionaryToCount: Dictionary<T[]>) {
+  return mapObject(dictionaryToCount, listeners => listeners.length);
+}
 
 export function ValueElementTest() {
   describe('ValueElementTest', () => {
@@ -12,18 +19,35 @@ export function ValueElementTest() {
     let valueElementRenderer: ValueElementRenderer;
     let valueElement: ValueElement;
 
+    let mockLabel: MockHTMLElement;
+    let mockStylishCheckbox: MockHTMLElement;
+    let mockExcludeIcon: MockHTMLElement;
+    let mockCheckbox: MockHTMLElement;
+
+    function mockRenderer() {
+      const renderer = Mock.mock(ValueElementRenderer) as ValueElementRenderer;
+      renderer.label = (mockLabel = new MockHTMLElement()).element;
+      renderer.stylishCheckbox = (mockStylishCheckbox = new MockHTMLElement()).element;
+      renderer.excludeIcon = (mockExcludeIcon = new MockHTMLElement()).element;
+      renderer.checkbox = (mockCheckbox = new MockHTMLElement()).element;
+      return renderer;
+    }
+
+    function bindEvents() {
+      valueElement.bindEvent({ displayNextTime: true, pinFacet: true });
+    }
+
     beforeEach(() => {
+      Dom.useNativeJavaScriptEvents = true;
       facet = Mock.optionsComponentSetup<Facet, IFacetOptions>(Facet, {
         field: '@field'
       }).cmp;
-      facetValue = new FacetValue();
-      facetValue.value = 'value';
-
-      valueElementRenderer = new ValueElementRenderer(facet, facetValue);
-      spyOn(valueElementRenderer, 'setCssClassOnListValueElement');
+      facetValue = Mock.mock(FacetValue);
+      facetValue.excluded = false;
+      facetValue.selected = false;
 
       valueElement = new ValueElement(facet, facetValue);
-      valueElement.renderer = valueElementRenderer;
+      valueElement.renderer = valueElementRenderer = mockRenderer();
     });
 
     it('should send one exclude UA event when excluding a facet value', () => {
@@ -69,6 +93,62 @@ export function ValueElementTest() {
       expect(facetValue.selected).toBe(false);
       expect(facetValue.excluded).toBe(false);
       expect(valueElementRenderer.setCssClassOnListValueElement).toHaveBeenCalled();
+    });
+
+    describe('unselected and not excluded', () => {
+      beforeEach(() => {
+        bindEvents();
+      });
+
+      it('binds a click event to the label', () => {
+        expect(countValues(mockLabel.eventListeners)).toEqual({ click: 1 });
+      });
+
+      it('binds a keydown event to the stylishCheckbox', () => {
+        expect(countValues(mockStylishCheckbox.eventListeners)).toEqual({ keydown: 1 });
+      });
+
+      it('binds a click and a keydown event to the excludeIcon', () => {
+        expect(countValues(mockExcludeIcon.eventListeners)).toEqual({ click: 1, keydown: 1 });
+      });
+
+      it('binds a change event to the checkbox', () => {
+        expect(countValues(mockCheckbox.eventListeners)).toEqual({ change: 1 });
+      });
+
+      it('when the click event on the label is triggered, triggers the change event on the checkbox', () => {
+        expect(mockCheckbox.manualEventTriggers).toEqual({});
+        $$(mockLabel.element).trigger('click');
+        expect(countValues(mockCheckbox.manualEventTriggers)).toEqual({ change: 1 });
+      });
+    });
+
+    describe('unselected and excluded', () => {
+      beforeEach(() => {
+        valueElement.exclude();
+        bindEvents();
+      });
+
+      it('binds a click event to the label', () => {
+        expect(countValues(mockLabel.eventListeners)).toEqual({ click: 1 });
+      });
+
+      it('binds a keydown event to the stylishCheckbox', () => {
+        expect(countValues(mockStylishCheckbox.eventListeners)).toEqual({ keydown: 1 });
+      });
+
+      it('binds a click and a keydown event to the excludeIcon', () => {
+        expect(countValues(mockExcludeIcon.eventListeners)).toEqual({ click: 1, keydown: 1 });
+      });
+
+      it('binds a change event to the checkbox', () => {
+        expect(countValues(mockCheckbox.eventListeners)).toEqual({ change: 1 });
+      });
+
+      it('when the click event on the label is triggered, does not trigger the change event on the checkbox', () => {
+        $$(mockLabel.element).trigger('click');
+        expect(mockCheckbox.manualEventTriggers).toEqual({});
+      });
     });
   });
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3064

# Description

This PR improves accessibility for Facet values by making the following changes:
* Make the aria-label on the following elements static:
  * Facet's values' checkboxes
  * Facet's values' exclude button
  * DynamicFacet's values' checkboxes
* Adds aria-pressed to Facet's values' checkboxes, making them toggleable buttons
  * Facet's values' checkboxes
  * Facet's values' exclude button
  * DynamicFacet's values' checkboxes
* Makes Facet's values' exclude buttons stay visible & toggleable on excluded values
* Removed strings that are no longer used

# Screenshots
## Without anything hovered nor focused (Unchanged)
![image](https://user-images.githubusercontent.com/54454747/91332300-f8e52200-e799-11ea-8efe-81f1962e8691.png)

## With the exclude button on a selected value focused (Unchanged)
![image](https://user-images.githubusercontent.com/54454747/91332346-0b5f5b80-e79a-11ea-82b3-259cbeba1ec4.png)

## With the exclude button on an excluded value focused (Changed)
![image](https://user-images.githubusercontent.com/54454747/91332381-1619f080-e79a-11ea-81d9-eb16950f5849.png)

## With the exclude button on an unselected value focused (Unchanged)
![image](https://user-images.githubusercontent.com/54454747/91332415-25993980-e79a-11ea-8f41-ce839d8b80b0.png)


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)