### PR TITLE
JSUI-3066 Send currentValues with generateAutomaticRanges only when there is an active value

### DIFF
--- a/src/controllers/DynamicFacetRangeQueryController.ts
+++ b/src/controllers/DynamicFacetRangeQueryController.ts
@@ -12,20 +12,20 @@ export class DynamicFacetRangeQueryController extends DynamicFacetQueryControlle
       currentValues: this.currentValues,
       numberOfValues: this.numberOfValues,
       freezeCurrentValues: false,
-      generateAutomaticRanges: this.shouldGenerateAutomaticRanges
+      generateAutomaticRanges: !this.manualRangesAreDefined
     };
   }
 
   protected get numberOfValues() {
-    return this.shouldGenerateAutomaticRanges ? this.facet.options.numberOfValues : this.facet.options.ranges.length;
+    return this.manualRangesAreDefined ? this.facet.options.ranges.length : this.facet.options.numberOfValues;
   }
 
-  private get shouldGenerateAutomaticRanges() {
-    return !this.facet.options.ranges.length;
+  private get manualRangesAreDefined() {
+    return !!this.facet.options.ranges.length;
   }
 
   protected get currentValues(): IFacetRequestValue[] {
-    if (this.shouldGenerateAutomaticRanges && !this.facet.hasActiveValues) {
+    if (!this.manualRangesAreDefined && !this.facet.hasActiveValues) {
       return [];
     }
 

--- a/src/controllers/DynamicFacetRangeQueryController.ts
+++ b/src/controllers/DynamicFacetRangeQueryController.ts
@@ -12,19 +12,23 @@ export class DynamicFacetRangeQueryController extends DynamicFacetQueryControlle
       currentValues: this.currentValues,
       numberOfValues: this.numberOfValues,
       freezeCurrentValues: false,
-      generateAutomaticRanges: !this.isRangesOptionDefined
+      generateAutomaticRanges: this.shouldGenerateAutomaticRanges
     };
   }
 
   protected get numberOfValues() {
-    return this.isRangesOptionDefined ? this.facet.options.ranges.length : this.facet.options.numberOfValues;
+    return this.shouldGenerateAutomaticRanges ? this.facet.options.numberOfValues : this.facet.options.ranges.length;
   }
 
-  private get isRangesOptionDefined() {
-    return !!this.facet.options.ranges.length;
+  private get shouldGenerateAutomaticRanges() {
+    return !this.facet.options.ranges.length;
   }
 
   protected get currentValues(): IFacetRequestValue[] {
+    if (this.shouldGenerateAutomaticRanges && !this.facet.hasActiveValues) {
+      return [];
+    }
+
     return this.facet.values.allFacetValues.map(({ start, end, endInclusive, state }) => ({
       start,
       end,

--- a/unitTests/controllers/DynamicFacetRangeQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicFacetRangeQueryControllerTest.ts
@@ -81,7 +81,7 @@ export function DynamicFacetRangeQueryControllerTest() {
         });
       });
 
-      describe('when there are values in the facet', () => {
+      describe('when there are active values in the facet', () => {
         beforeEach(() => {
           facet.selectMultipleValues(['0..100inc', '100..200inc', '200..300inc']);
           facet.deselectValue('0..100inc');
@@ -93,6 +93,21 @@ export function DynamicFacetRangeQueryControllerTest() {
 
         it('should send current available values', () => {
           expect(facetRequest().currentValues.length).toEqual(3);
+        });
+      });
+
+      describe('when there are no active values in the facet', () => {
+        beforeEach(() => {
+          facet.selectMultipleValues(['0..100inc', '100..200inc', '200..300inc']);
+          facet.deselectMultipleValues(['0..100inc', '100..200inc', '200..300inc']);
+        });
+
+        it('generateAutomaticRanges should be true', () => {
+          expect(facetRequest().generateAutomaticRanges).toBe(true);
+        });
+
+        it('should send no current values', () => {
+          expect(facetRequest().currentValues).toEqual([]);
         });
       });
     });


### PR DESCRIPTION
Determined with the API that it's the best way to deal with possible overlap. When no values is selected in the facet, we let the index redefine the new ranges.
https://coveord.atlassian.net/browse/JSUI-3066





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)