### PR TITLE
JSUI-3067 Reordered `FacetValue`'s caption and count

### DIFF
--- a/sass/_FacetValues.scss
+++ b/sass/_FacetValues.scss
@@ -3,7 +3,7 @@
 
 @mixin facetValuesCheckboxes($size: 'normal') {
   $pixel-size: '18px';
-  @if $size=='smaller' {
+  @if $size== 'smaller' {
     $pixel-size: '13px';
   }
   input[type='checkbox'] {
@@ -19,7 +19,6 @@
     margin-right: 15px;
     background: white;
     position: relative;
-    float: left;
     top: 2px;
     > svg {
       position: relative;
@@ -86,7 +85,7 @@
 }
 
 @mixin coveo-hook($size: 'normal') {
-  @if $size=='smaller' {
+  @if $size== 'smaller' {
     width: 11px;
     height: 9px;
     bottom: 4px;
@@ -104,7 +103,7 @@
 }
 
 @mixin coveo-exclusion($size: 'normal') {
-  @if $size=='smaller' {
+  @if $size== 'smaller' {
     width: 7px;
     height: 7px;
     bottom: 5px;
@@ -166,6 +165,10 @@
   }
 }
 
+.coveo-facet-value-label-wrapper {
+  display: flex;
+}
+
 .coveo-facet-value-label {
   display: block;
   white-space: nowrap;
@@ -179,6 +182,7 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   vertical-align: middle;
+  flex-grow: 1;
 }
 
 .coveo-facet-value-icon {
@@ -192,7 +196,6 @@
   vertical-align: middle;
   margin: 0 5px;
   display: inline-block;
-  float: right;
   @include transition(opacity 1s);
   &.coveo-waitDelta {
     opacity: 0;
@@ -213,7 +216,9 @@
   @include justify-content(space-between);
   .coveo-facet-value-label-wrapper {
     @include order(1);
-    @include display('flex'); // This needs to be set, otherwise min-width auto on the elment will make the element overflow it's flex container;
+    @include display(
+      'flex'
+    ); // This needs to be set, otherwise min-width auto on the elment will make the element overflow it's flex container;
     min-width: 0;
     .coveo-facet-value-checkbox {
       @include order(1);

--- a/src/ui/Facet/ValueElementRenderer.ts
+++ b/src/ui/Facet/ValueElementRenderer.ts
@@ -223,8 +223,8 @@ export class ValueElementRenderer {
 
     this.initAndAppendCheckbox();
     this.initAndAppendStylishCheckbox();
-    this.initAndAppendValueCount();
     this.initAndAppendValueCaption();
+    this.initAndAppendValueCount();
 
     this.label.appendChild(this.facetValueLabelWrapper);
   }

--- a/unitTests/ui/ValueElementRendererTest.ts
+++ b/unitTests/ui/ValueElementRendererTest.ts
@@ -5,6 +5,7 @@ import { IFacetOptions } from '../../src/ui/Facet/Facet';
 import { FacetValue } from '../../src/ui/Facet/FacetValue';
 import { FakeResults } from '../Fake';
 import { $$ } from '../../src/utils/Dom';
+import { findLastIndex } from 'underscore';
 
 export function ValueElementRendererTest() {
   describe('ValueElementRenderer', function() {
@@ -130,6 +131,21 @@ export function ValueElementRendererTest() {
       // Should format big number
       valueRenderer.facetValue.occurrences = 31416;
       expect($$(valueRenderer.build().valueCount).text()).toBe('31,416');
+    });
+
+    it('should build either checkbox, the caption then the count in that order', () => {
+      valueRenderer = new ValueElementRenderer(facet, FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 1)));
+      const buildResult = valueRenderer.build();
+      const wrapper = buildResult['facetValueLabelWrapper'];
+      const wrapperChildren = $$(wrapper).children();
+      const lastCheckboxIndex = findLastIndex(
+        wrapperChildren,
+        child => [buildResult.stylishCheckbox, buildResult.checkbox].indexOf(child) !== -1
+      );
+      expect(wrapperChildren.slice(lastCheckboxIndex + 1, lastCheckboxIndex + 3)).toEqual([
+        buildResult.valueCaption,
+        buildResult.valueCount
+      ]);
     });
 
     it('should build an exclude icon', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3067

This PR simply exchanges the order of the `FacetValue` caption and count to be in the same order as they are displayed. This helps screen readers read facet values in the expected order.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)