### PR TITLE
JSUI-3077 Facet breadcrumbs should be represented in the accessibility tree as lists

### DIFF
--- a/sass/DynamicFacet/_DynamicFacetBreadcrumbs.scss
+++ b/sass/DynamicFacet/_DynamicFacetBreadcrumbs.scss
@@ -13,3 +13,13 @@
 .coveo-dynamic-facet-breadcrumb-value-clear {
   @include breadcrumb-value-clear();
 }
+
+ul.coveo-dynamic-facet-breadcrumb.coveo-breadcrumb-item {
+  display: block;
+  list-style: none;
+  padding: 0;
+}
+
+li.coveo-dynamic-facet-breadcrumb-value-list-item {
+  display: inline-block;
+}

--- a/sass/_FacetBreadcrumb.scss
+++ b/sass/_FacetBreadcrumb.scss
@@ -5,7 +5,8 @@
 }
 
 .coveo-facet-breadcrumb-value,
-.coveo-facet-slider-breadcrumb-value {
+.coveo-facet-slider-breadcrumb-value,
+.coveo-facet-breadcrumb-value-list-item {
   @include breadcrumb-value();
   display: inline-block;
   &.coveo-excluded .coveo-facet-breadcrumb-caption {
@@ -13,7 +14,19 @@
   }
 }
 
+.coveo-facet-breadcrumb-value-list-item {
+  margin: 0;
+  padding: 0;
+}
+
 .coveo-facet-breadcrumb-clear,
 .coveo-facet-slider-breadcrumb-clear {
   @include breadcrumb-value-clear();
+}
+
+ul.coveo-facet-breadcrumb-values {
+  display: inline-block;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }

--- a/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
+++ b/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
@@ -14,7 +14,7 @@ export class DynamicFacetBreadcrumbs {
   }
 
   private create() {
-    this.element = $$('div', { className: 'coveo-dynamic-facet-breadcrumb coveo-breadcrumb-item' }).el;
+    this.element = $$('ul', { className: 'coveo-dynamic-facet-breadcrumb coveo-breadcrumb-item' }).el;
     this.createAndAppendTitle();
 
     const activeFacetValues = this.facet.values.activeValues;
@@ -38,6 +38,7 @@ export class DynamicFacetBreadcrumbs {
   }
 
   private createAndAppendBreadcrumbValue(facetValue: IDynamicFacetValue) {
+    const listContainer = $$('li', { className: 'coveo-dynamic-facet-breadcrumb-value-list-item' }).el;
     const valueElement = $$(
       'button',
       {
@@ -50,8 +51,8 @@ export class DynamicFacetBreadcrumbs {
     valueElement.appendChild(clearElement);
 
     $$(valueElement).on('click', () => this.valueSelectAction(facetValue));
-
-    this.element.appendChild(valueElement);
+    listContainer.appendChild(valueElement);
+    this.element.appendChild(listContainer);
   }
 
   private valueSelectAction(facetValue: IDynamicFacetValue) {

--- a/src/ui/Facet/BreadcrumbValueElement.ts
+++ b/src/ui/Facet/BreadcrumbValueElement.ts
@@ -21,12 +21,13 @@ export class BreadcrumbValueElement {
   public build(): Dom {
     Assert.exists(this.facetValue);
 
-    const { container, caption, clear } = this.buildElements();
+    const { container, caption, clear, listContainer } = this.buildElements();
 
     container.append(caption.el);
     container.append(clear.el);
+    listContainer.append(container.el);
 
-    return container;
+    return listContainer;
   }
 
   public getBreadcrumbTooltip(): string {
@@ -42,7 +43,8 @@ export class BreadcrumbValueElement {
     return {
       container: this.buildContainer(),
       clear: this.buildClear(),
-      caption: this.buildCaption()
+      caption: this.buildCaption(),
+      listContainer: this.buildListContainer()
     };
   }
 
@@ -64,6 +66,12 @@ export class BreadcrumbValueElement {
       .build();
 
     return container;
+  }
+
+  private buildListContainer() {
+    return $$('li', {
+      className: 'coveo-facet-breadcrumb-value-list-item'
+    });
   }
 
   private buildClear() {

--- a/src/ui/Facet/BreadcrumbValuesList.ts
+++ b/src/ui/Facet/BreadcrumbValuesList.ts
@@ -6,6 +6,7 @@ import { $$ } from '../../utils/Dom';
 import { IBreadcrumbValueElementKlass } from './BreadcrumbValueElement';
 import { Facet } from './Facet';
 import { FacetValue } from './FacetValue';
+import { AccessibleButton } from '../../utils/AccessibleButton';
 
 export class BreadcrumbValueList {
   private expanded: FacetValue[];
@@ -24,7 +25,7 @@ export class BreadcrumbValueList {
     title.text(this.facet.options.title + ':');
     this.elem.appendChild(title.el);
 
-    this.valueContainer = $$('span', {
+    this.valueContainer = $$('ul', {
       className: 'coveo-facet-breadcrumb-values'
     }).el;
 
@@ -64,6 +65,10 @@ export class BreadcrumbValueList {
     const numberOfExcluded = filter(this.collapsed, (value: FacetValue) => value.excluded).length;
     Assert.check(numberOfSelected + numberOfExcluded == this.collapsed.length);
 
+    const listContainer = $$('li', {
+      className: 'coveo-facet-breadcrumb-value-list-item'
+    });
+
     const elem = $$('div', {
       className: 'coveo-facet-breadcrumb-value'
     });
@@ -83,19 +88,23 @@ export class BreadcrumbValueList {
       return valueElement.getBreadcrumbTooltip();
     });
 
-    elem.el.setAttribute('title', toolTips.join('\n'));
-    elem.on('click', () => {
-      const elements: HTMLElement[] = [];
-      each(valueElements, valueElement => {
-        elements.push(valueElement.build().el);
-      });
-      each(elements, el => {
-        $$(el).insertBefore(elem.el);
-      });
-      elem.detach();
-    });
+    new AccessibleButton()
+      .withElement(elem)
+      .withTitle(toolTips.join('\n'))
+      .withSelectAction(() => {
+        const elements: HTMLElement[] = [];
+        each(valueElements, valueElement => {
+          elements.push(valueElement.build().el);
+        });
+        each(elements, el => {
+          $$(el).insertBefore(elem.el);
+        });
+        elem.detach();
+      })
+      .build();
 
-    this.valueContainer.appendChild(elem.el);
+    listContainer.append(elem.el);
+    this.valueContainer.appendChild(listContainer.el);
   }
 
   private setExpandedAndCollapsed() {


### PR DESCRIPTION
Display breadcrumbs as list in the DOM.

I did not modify DynamicHierarchicalFacetBreadcrumb, since these are not "groups", and do not allow you to have more than one filter/one path selected for a given facet. 

So, it's always a unique value in that case.

https://coveord.atlassian.net/browse/JSUI-3077

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)