### PR TITLE
JSUI-3079 Added an outline to clickable field values in Windows high contrast mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coveo-search-ui",
-  "version": "2.0.688",
+  "version": "2.0.689",
   "description": "Coveo JavaScript Search Framework",
   "main": "./bin/js/CoveoJsSearch.js",
   "types": "./bin/ts/CoveoJsSearch.d.ts",

--- a/sass/_FieldTable.scss
+++ b/sass/_FieldTable.scss
@@ -89,6 +89,8 @@
 .CoveoFieldValue {
   .coveo-clickable {
     @include clickable();
+    outline: 1px solid transparent;
+    outline-offset: 3px;
     &.coveo-selected {
       font-weight: bold;
     }

--- a/sass/_FieldTable.scss
+++ b/sass/_FieldTable.scss
@@ -89,7 +89,7 @@
 .CoveoFieldValue {
   .coveo-clickable {
     @include clickable();
-    outline: 1px solid transparent;
+    @include highContrastModeOutline();
     outline-offset: 3px;
     &.coveo-selected {
       font-weight: bold;

--- a/sass/_Variables.scss
+++ b/sass/_Variables.scss
@@ -51,6 +51,9 @@ $default-low-contrast-border: thin solid $color-light-contrast-grey;
   border: $default-low-contrast-border;
   border-radius: $default-border-radius;
 }
+@mixin highContrastModeOutline {
+  outline: 1px solid transparent;
+}
 
 $standard-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 /*
@@ -60,7 +63,7 @@ $standard-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 
 @mixin align($direction: 'vertical', $position: relative) {
   position: $position;
-  @if $direction=='vertical' {
+  @if $direction== 'vertical' {
     top: 50%;
     @include transform(translateY(-50%));
   } @else {
@@ -80,7 +83,7 @@ $standard-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   }
 }
 
-@mixin iconWithHoverState($iconClass, $float:'left', $inactive: 'coveo-disabled') {
+@mixin iconWithHoverState($iconClass, $float: 'left', $inactive: 'coveo-disabled') {
   .#{$iconClass} {
     float: #{$float};
   }
@@ -128,20 +131,20 @@ $standard-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 * @param $size size of the icon to use
 */
 
-@mixin clearButton($selector, $size:'normal') {
+@mixin clearButton($selector, $size: 'normal') {
   cursor: pointer;
   color: $color-greyish-teal-blue;
   .coveo-exclusion-svg {
     fill: $color-greyish-teal-blue;
   }
   #{$selector} svg {
-    @if $size=='normal' {
+    @if $size== 'normal' {
       width: 12px;
       height: 12px;
-    } @else if $size=='small' {
+    } @else if $size== 'small' {
       width: 8px;
       height: 8px;
-    } @else if $size=='big' {
+    } @else if $size== 'big' {
       width: 15px;
       height: 15px;
     }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3079

Before (IE11):
![image](https://user-images.githubusercontent.com/54454747/92141885-0d9c6800-ede1-11ea-81ed-87d4ea1d48d3.png)

After (IE11):
![image](https://user-images.githubusercontent.com/54454747/92141377-5d2e6400-ede0-11ea-8e98-df7d0c11bc40.png)

Before (Firefox):
![image](https://user-images.githubusercontent.com/54454747/92141561-9b2b8800-ede0-11ea-8fc6-c632cc3f0e55.png)

After (Firefox):
![image](https://user-images.githubusercontent.com/54454747/92141339-4d168480-ede0-11ea-99cb-b2cef7a778d2.png)


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)