### PR TITLE
JSUI-3090 Added outline to clickable breadcrumb elements in Windows high contrast mode

### DIFF
--- a/sass/_Breadcrumb.scss
+++ b/sass/_Breadcrumb.scss
@@ -1,3 +1,4 @@
+@import 'Variables';
 @import 'mixins/breadcrumb';
 @import 'mixins/mediaQuery';
 
@@ -18,12 +19,12 @@
 .coveo-breadcrumb-clear-all {
   @include linkButton();
   @include flex-shrink(0);
+  @include highContrastModeOutline();
 
   display: inline-block;
   font-size: $font-size-smaller;
   padding: 5px;
   margin-left: 5px;
-  outline: 1px solid transparent;
   margin-right: 1px;
 }
 

--- a/sass/_Breadcrumb.scss
+++ b/sass/_Breadcrumb.scss
@@ -23,6 +23,8 @@
   font-size: $font-size-smaller;
   padding: 5px;
   margin-left: 5px;
+  outline: 1px solid transparent;
+  margin-right: 1px;
 }
 
 .coveo-breadcrumb-items {

--- a/sass/mixins/_breadcrumb.scss
+++ b/sass/mixins/_breadcrumb.scss
@@ -11,9 +11,9 @@
 
 @mixin breadcrumb-value {
   @include linkButton();
+  @include highContrastModeOutline();
   font-size: $font-size-smaller;
   margin-right: 15px;
-  outline: 1px solid transparent;
   outline-offset: 1px;
 
   &.coveo-selected * {

--- a/sass/mixins/_breadcrumb.scss
+++ b/sass/mixins/_breadcrumb.scss
@@ -13,6 +13,8 @@
   @include linkButton();
   font-size: $font-size-smaller;
   margin-right: 15px;
+  outline: 1px solid transparent;
+  outline-offset: 1px;
 
   &.coveo-selected * {
     color: $color-teal;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3090

Before (IE11):
![IE-before](https://user-images.githubusercontent.com/54454747/92144052-20fd0280-ede4-11ea-8c12-9a114b218a14.png)

After (IE11):
![IE-after](https://user-images.githubusercontent.com/54454747/92144059-25292000-ede4-11ea-8637-76b66ce4f4db.png)

Before (Firefox):
![FF-before](https://user-images.githubusercontent.com/54454747/92144067-29553d80-ede4-11ea-9609-3ebc23f80ec4.png)

After (Firefox):
![FF-after](https://user-images.githubusercontent.com/54454747/92144081-2ce8c480-ede4-11ea-82f3-ce61ecb84150.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)