### PR TITLE
JSUI-3086 Added an underline to focused search suggestions

### DIFF
--- a/sass/MagicBox/MagicBox.scss
+++ b/sass/MagicBox/MagicBox.scss
@@ -18,7 +18,7 @@
     > input {
       color: $grey-900;
       text-align: left;
-      padding: $padding $height+1 $padding $padding;
+      padding: $padding $height + 1 $padding $padding;
       text-indent: 0;
       font-family: arial, sans-serif;
       font-size: $fontSize;
@@ -209,6 +209,10 @@
       }
       &:hover {
         background: $grey-100;
+      }
+      &.magic-box-selected,
+      &:hover {
+        text-decoration: underline;
       }
     }
   }

--- a/sass/_Omnibox.scss
+++ b/sass/_Omnibox.scss
@@ -63,6 +63,7 @@
 
   .coveo-omnibox-selectable.coveo-omnibox-selected {
     background-color: $color-blueish-white-grey;
+    text-decoration: underline;
   }
 
   .coveo-omnibox-facet-value {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3086

In Windows' high contrast mode, nothing distinguishes focused/selected suggestions from other suggestions.
Additionally, the current suggestions suffer from the same problem as other search engines' suggestions: the focused suggestion doesn't have nearly enough contrast.

Since that would solve both problems at once, I tried adding an underline, and it didn't look as bad as I expected. What do you think about it? Would an underline be the way to go, or something else?

![Screen Recording 2020-09-03 at 2 12 11 PM](https://user-images.githubusercontent.com/54454747/92152239-590a4280-edf0-11ea-9d78-0cf95e38e326.gif)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)