### PR TITLE
JSUI-3094 Added the question above `SmartSnippet`

### DIFF
--- a/sass/_SmartSnippet.scss
+++ b/sass/_SmartSnippet.scss
@@ -19,6 +19,12 @@
     display: block;
   }
 
+  @at-root .coveo-smart-snippet-question {
+    font-size: 18px;
+    border-bottom: $default-medium-border;
+    padding-bottom: 10px;
+  }
+
   @at-root .coveo-smart-snippet-answer {
     display: flex;
     flex-direction: column;
@@ -35,7 +41,7 @@
 
         &::after {
           content: '';
-          @include linear-gradient(top, rgba(255,255,255,0), rgba(255, 255, 255, 1));
+          @include linear-gradient(top, rgba(255, 255, 255, 0), rgba(255, 255, 255, 1));
           pointer-events: none;
           display: inline-block;
           position: absolute;

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -48,6 +48,7 @@ const reasons: ISmartSnippetReason[] = [
 ];
 
 const BASE_CLASSNAME = 'coveo-smart-snippet';
+const QUESTION_CLASSNAME = `${BASE_CLASSNAME}-question`;
 const ANSWER_CONTAINER_CLASSNAME = `${BASE_CLASSNAME}-answer`;
 const HAS_ANSWER_CLASSNAME = `${BASE_CLASSNAME}-has-answer`;
 const SHADOW_CLASSNAME = `${BASE_CLASSNAME}-content`;
@@ -57,6 +58,7 @@ const SOURCE_TITLE_CLASSNAME = `${SOURCE_CLASSNAME}-title`;
 const SOURCE_URL_CLASSNAME = `${SOURCE_CLASSNAME}-url`;
 
 export const SmartSnippetClassNames = {
+  QUESTION_CLASSNAME,
   ANSWER_CONTAINER_CLASSNAME,
   HAS_ANSWER_CLASSNAME,
   SHADOW_CLASSNAME,
@@ -80,6 +82,7 @@ export class SmartSnippet extends Component {
   };
 
   private lastRenderedResult: IQueryResult;
+  private questionContainer: HTMLElement;
   private shadowContainer: HTMLElement;
   private sourceContainer: HTMLElement;
   private snippetContainer: HTMLElement;
@@ -139,10 +142,15 @@ export class SmartSnippet extends Component {
       {
         className: ANSWER_CONTAINER_CLASSNAME
       },
+      this.buildQuestion(),
       this.buildShadow(),
       this.buildHeightLimiter(),
       this.buildSourceContainer()
     ).el;
+  }
+
+  private buildQuestion() {
+    return (this.questionContainer = $$('div', { className: QUESTION_CLASSNAME }).el);
   }
 
   private buildShadow() {
@@ -160,11 +168,8 @@ export class SmartSnippet extends Component {
   }
 
   private buildHeightLimiter() {
-    return (this.heightLimiter = new HeightLimiter(
-      this.shadowContainer,
-      this.snippetContainer,
-      400,
-      isExpanded => (isExpanded ? this.sendExpandSmartSnippetAnalytics() : this.sendCollapseSmartSnippetAnalytics())
+    return (this.heightLimiter = new HeightLimiter(this.shadowContainer, this.snippetContainer, 400, isExpanded =>
+      isExpanded ? this.sendExpandSmartSnippetAnalytics() : this.sendCollapseSmartSnippetAnalytics()
     )).toggleButton;
   }
 
@@ -204,6 +209,7 @@ export class SmartSnippet extends Component {
 
   private async render(questionAnswer: IQuestionAnswerResponse) {
     this.ensureDom();
+    this.questionContainer.innerText = questionAnswer.question;
     this.renderSnippet(questionAnswer.answerSnippet);
     const lastRenderedResult = this.getCorrespondingResult(questionAnswer);
     if (lastRenderedResult) {

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -175,6 +175,7 @@ export function SmartSnippetTest() {
 
         it('should render the snippet followed by the source in the answer container', () => {
           expectChildren(getFirstChild(ClassNames.ANSWER_CONTAINER_CLASSNAME), [
+            ClassNames.QUESTION_CLASSNAME,
             ClassNames.SHADOW_CLASSNAME,
             HeightLimiterClassNames.BUTTON_CLASSNAME,
             ClassNames.SOURCE_CLASSNAME


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3094

![image](https://user-images.githubusercontent.com/54454747/92631063-d0cbe780-f29e-11ea-8bff-8fbbea609c04.png)

This feature isn't part of the original design, but was requested for a demo with a client. If everybody likes it, it could be merged.

Alternatively, it could also be made optional.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)