### PR TITLE
JSUI-3087 Changed the appearance of the "no results" facet search state

### DIFF
--- a/accessibilityTest/AccessibilityFacet.ts
+++ b/accessibilityTest/AccessibilityFacet.ts
@@ -27,6 +27,7 @@ export const AccessibilityFacet = () => {
 
     describe('with facet element', () => {
       let facetElement: Dom;
+      let facet: Facet;
 
       function getMagnifierSVG() {
         return facetElement.el.querySelector<HTMLElement>('.coveo-facet-search-magnifier-svg');
@@ -44,6 +45,7 @@ export const AccessibilityFacet = () => {
         facetElement = getFacetElement();
         getFacetColumn().appendChild(facetElement.el);
         await afterDeferredQuerySuccess();
+        facet = get(facetElement.el) as Facet;
         done();
       });
 
@@ -76,7 +78,7 @@ export const AccessibilityFacet = () => {
 
       describe('after focusing on the search button', () => {
         beforeEach(async done => {
-          (get(facetElement.el) as Facet).facetSearch.focus();
+          facet.facetSearch.focus();
           await waitUntilSelectorIsPresent(document.body, '.coveo-facet-search-results');
           done();
         });
@@ -87,8 +89,8 @@ export const AccessibilityFacet = () => {
           done();
         });
 
-        it('should still be accessible when search has been opened', async done => {
-          (get(facetElement.el) as Facet).facetSearch.dismissSearchResults();
+        it('should still be accessible when search has been dismissed', async done => {
+          facet.facetSearch.dismissSearchResults();
           const axeResults = await axe.run(getRoot());
           expect(axeResults).toBeAccessible();
           done();
@@ -98,6 +100,19 @@ export const AccessibilityFacet = () => {
           const contrast = ContrastChecker.getContrastWithBackground(getMagnifierSVG());
           expect(contrast).toBeGreaterThan(ContrastChecker.MinimumContrastRatio);
           done();
+        });
+
+        describe('after focusing on the search button with no results', () => {
+          beforeEach(async done => {
+            facet.facetSearch.facetSearchElement.emptyAndShowNoResults();
+            done();
+          });
+
+          it("should still be accessible when there's no results", async done => {
+            const axeResults = await axe.run(getRoot());
+            expect(axeResults).toBeAccessible();
+            done();
+          });
         });
       });
     });

--- a/sass/_CategoryFacetSearch.scss
+++ b/sass/_CategoryFacetSearch.scss
@@ -10,6 +10,9 @@
   .coveo-facet-search {
     margin: 0;
   }
+  .coveo-facet-search-results {
+    cursor: auto;
+  }
 }
 
 .coveo-category-facet-search-container + .coveo-category-facet-values {

--- a/sass/_FacetSearch.scss
+++ b/sass/_FacetSearch.scss
@@ -121,9 +121,15 @@
 }
 
 .coveo-facet-search-no-results {
-  background-color: #ffd0d0;
-  .coveo-facet-search-magnifier {
-    visibility: hidden;
+  + .coveo-facet-search-results {
+    padding: 0;
+    overflow-y: hidden;
+
+    @at-root .coveo-facet-value-not-found {
+      margin: 1px;
+      padding: 4px 9px;
+      font-size: 13px;
+    }
   }
 }
 

--- a/src/ui/CategoryFacet/CategoryFacetSearch.ts
+++ b/src/ui/CategoryFacet/CategoryFacetSearch.ts
@@ -249,7 +249,7 @@ export class CategoryFacetSearch implements IFacetSearch {
 
   private noFacetSearchResults() {
     this.facetSearchElement.hideFacetSearchWaitingAnimation();
-    this.facetSearchElement.hideSearchResultsElement();
+    this.facetSearchElement.emptyAndShowNoResults();
     $$(this.facetSearchElement.search).addClass('coveo-facet-search-no-results');
     $$(this.categoryFacet.element).addClass('coveo-no-results');
   }

--- a/src/ui/Facet/FacetSearch.ts
+++ b/src/ui/Facet/FacetSearch.ts
@@ -299,8 +299,9 @@ export class FacetSearch implements IFacetSearch {
       if (facetSearchParameters.fetchMore) {
         this.moreValuesToFetch = false;
       } else {
-        this.facetSearchElement.hideSearchResultsElement();
         $$(this.search).addClass('coveo-facet-search-no-results');
+        this.showSearchResultsElement();
+        this.facetSearchElement.emptyAndShowNoResults();
       }
     }
   }

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -24,6 +24,7 @@ export class FacetSearchElement {
 
   private triggeredScroll = false;
   private facetSearchId = uniqueId('coveo-facet-search-results');
+  private facetValueNotFoundId = uniqueId('coveo-facet-value-not-found');
   private searchDropdownNavigator: ISearchDropdownNavigator;
 
   constructor(private facetSearch: IFacetSearch) {
@@ -181,6 +182,18 @@ export class FacetSearchElement {
   public appendToSearchResults(el: HTMLElement) {
     this.searchResults.appendChild(el);
     this.setupFacetSearchResultsEvents(el);
+  }
+
+  public emptyAndShowNoResults() {
+    $$(this.searchResults).empty();
+    this.searchResults.appendChild(
+      $$(
+        'li',
+        { id: this.facetValueNotFoundId, className: 'coveo-facet-value-not-found', role: 'option', ariaSelected: 'true', tabindex: 0 },
+        l('NoValuesFound')
+      ).el
+    );
+    this.input.setAttribute('aria-activedescendant', this.facetValueNotFoundId);
   }
 
   public focus() {

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -845,3 +845,6 @@ ResponsiveDropdownModalContentTest();
 
 import { FileTypesTest } from './ui/FileTypesTest';
 FileTypesTest();
+
+import { FacetSearchElementTest } from './ui/FacetSearchElementTest';
+FacetSearchElementTest();

--- a/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
@@ -231,12 +231,12 @@ export function CategoryFacetSearchTest() {
         });
       });
 
-      it('sets aria-expanded to false after collapsing', done => {
+      it('keeps aria-expanded true when displaying no values', done => {
         searchWithNoValues();
         categoryFacetSearch.displayNewValues();
 
         setTimeout(() => {
-          expect(categoryFacetSearch.container.getAttribute('aria-expanded')).toEqual('false');
+          expect(categoryFacetSearch.container.getAttribute('aria-expanded')).toEqual('true');
           done();
         });
       });

--- a/unitTests/ui/FacetSearchElementTest.ts
+++ b/unitTests/ui/FacetSearchElementTest.ts
@@ -1,0 +1,45 @@
+import { FacetSearchElement } from '../../src/ui/Facet/FacetSearchElement';
+import { mock } from '../MockEnvironment';
+import { FacetSearch } from '../../src/ui/Facet/FacetSearch';
+import { $$ } from '../../src/utils/Dom';
+
+export function FacetSearchElementTest() {
+  describe('FacetSearchElement', () => {
+    let facetSearchElement: FacetSearchElement;
+    beforeEach(() => {
+      facetSearchElement = new FacetSearchElement(mock(FacetSearch));
+      facetSearchElement.build();
+    });
+
+    describe('when calling emptyAndShowNoResults', () => {
+      let noResultsElement: HTMLElement;
+      beforeEach(() => {
+        facetSearchElement.emptyAndShowNoResults();
+        [noResultsElement] = $$(facetSearchElement.searchResults).children();
+      });
+
+      it('searchResults contains a single element', () => {
+        expect($$(facetSearchElement.searchResults).children().length).toEqual(1);
+      });
+
+      it('renders a noResults element as a HTMLLIElement', () => {
+        expect(noResultsElement instanceof HTMLLIElement).toBeTruthy();
+      });
+
+      it('renders a noResults element with an id and a class', () => {
+        expect($$(noResultsElement).hasClass('coveo-facet-value-not-found'));
+        expect(noResultsElement.id.indexOf('coveo-facet-value-not-found')).toEqual(0);
+      });
+
+      it('renders an accessible noResults element', () => {
+        expect(noResultsElement.getAttribute('role')).toEqual('option');
+        expect(noResultsElement.tabIndex).toEqual(0);
+      });
+
+      it('selects the noResults element', () => {
+        expect(facetSearchElement.input.getAttribute('aria-activedescendant')).toEqual(noResultsElement.id);
+        expect(noResultsElement.getAttribute('aria-selected')).toEqual('true');
+      });
+    });
+  });
+}

--- a/unitTests/ui/FacetSearchElementTest.ts
+++ b/unitTests/ui/FacetSearchElementTest.ts
@@ -27,7 +27,7 @@ export function FacetSearchElementTest() {
       });
 
       it('renders a noResults element with an id and a class', () => {
-        expect($$(noResultsElement).hasClass('coveo-facet-value-not-found'));
+        expect($$(noResultsElement).hasClass('coveo-facet-value-not-found')).toBeTruthy();
         expect(noResultsElement.id.indexOf('coveo-facet-value-not-found')).toEqual(0);
       });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3087

Before:
![image](https://user-images.githubusercontent.com/54454747/92788958-65eedf00-f378-11ea-8f64-904aeb9bb01c.png)

After:
![image](https://user-images.githubusercontent.com/54454747/92788658-23c59d80-f378-11ea-8c08-c5607baf4cc2.png)

Inspiration (`DynamicFacet`'s search):
![image](https://user-images.githubusercontent.com/54454747/92794980-08f62780-f37e-11ea-81b4-8efadd134115.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)