### PR TITLE
JSUI-3082 Improved border contrasts for `Pager` and `ResultsPerPage`

### DIFF
--- a/accessibilityTest/AccessibilityPager.ts
+++ b/accessibilityTest/AccessibilityPager.ts
@@ -1,15 +1,32 @@
 import * as axe from 'axe-core';
 import { $$, Component, Pager } from 'coveo-search-ui';
 import { afterQuerySuccess, getResultsColumn, getRoot } from './Testing';
+import { ContrastChecker } from './ContrastChecker';
 
 export const AccessibilityPager = () => {
   describe('Pager', () => {
-    it('should be accessible', async done => {
-      getResultsColumn().appendChild($$('div', { className: Component.computeCssClassName(Pager) }).el);
+    let pagerElement: HTMLElement;
+    beforeEach(async done => {
+      getResultsColumn().appendChild((pagerElement = $$('div', { className: Component.computeCssClassName(Pager) }).el));
       await afterQuerySuccess();
+      done();
+    });
+
+    it('should be accessible', async done => {
       const axeResults = await axe.run(getRoot());
       expect(axeResults).toBeAccessible();
       done();
+    });
+
+    it('should have a conformant contrast ratio on the border of each button', () => {
+      $$(pagerElement)
+        .findClass('coveo-pager-list-item')
+        .forEach(button => {
+          expect(ContrastChecker.getContrastWithBackground(button.parentElement, 'borderBottomColor')).not.toBeLessThan(
+            ContrastChecker.MinimumContrastRatio,
+            `Button "${button.innerText}" must have a conformant contrast ratio on the border`
+          );
+        });
     });
   });
 };

--- a/accessibilityTest/AccessibilityResultsPerPage.ts
+++ b/accessibilityTest/AccessibilityResultsPerPage.ts
@@ -1,15 +1,32 @@
 import * as axe from 'axe-core';
 import { $$, Component, ResultsPerPage } from 'coveo-search-ui';
 import { afterQuerySuccess, getResultsColumn, getRoot } from './Testing';
+import { ContrastChecker } from './ContrastChecker';
 
 export const AccessibilityResultsPerPage = () => {
   describe('ResultsPerPage', () => {
-    it('should be accessible', async done => {
-      getResultsColumn().appendChild($$('div', { className: Component.computeCssClassName(ResultsPerPage) }).el);
+    let resultsPerPageElement: HTMLElement;
+    beforeEach(async done => {
+      getResultsColumn().appendChild((resultsPerPageElement = $$('div', { className: Component.computeCssClassName(ResultsPerPage) }).el));
       await afterQuerySuccess();
+      done();
+    });
+
+    it('should be accessible', async done => {
       const axeResults = await axe.run(getRoot());
       expect(axeResults).toBeAccessible();
       done();
+    });
+
+    it('should have a conformant contrast ratio on the border of each button', () => {
+      $$(resultsPerPageElement)
+        .findClass('coveo-results-per-page-list-item')
+        .forEach(button => {
+          expect(ContrastChecker.getContrastWithBackground(button.parentElement, 'borderBottomColor')).not.toBeLessThan(
+            ContrastChecker.MinimumContrastRatio,
+            `Button "${button.innerText}" must have a conformant contrast ratio on the border`
+          );
+        });
     });
   });
 };

--- a/sass/mixins/_pagerList.scss
+++ b/sass/mixins/_pagerList.scss
@@ -6,7 +6,7 @@
 }
 
 @mixin pager-list-item {
-  @include defaultRoundedBorder();
+  @include defaultRoundedLowContrastBorder();
   margin: 5px 6px;
   padding: 4px 8px;
   list-style: none;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3082

Before:
![Screen Shot 2020-09-10 at 4 27 30 PM](https://user-images.githubusercontent.com/54454747/92801732-de0ed200-f383-11ea-83cc-8e2cd916b6a6.png)

After:
![Screen Shot 2020-09-10 at 4 29 04 PM](https://user-images.githubusercontent.com/54454747/92801740-e1a25900-f383-11ea-9095-383669373aeb.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)