### PR TITLE
JSUI-3062 Query summary, have a fallback string for when there is no query

### DIFF
--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -800,6 +800,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   private addAllCategoriesButton() {
     const allCategories = this.categoryFacetTemplates.buildAllCategoriesButton();
     new AccessibleButton()
+      .withLabel(l('AllCategories'))
       .withElement(allCategories)
       .withSelectAction(() => {
         this.reset();

--- a/src/ui/QuerySummary/QuerySummary.ts
+++ b/src/ui/QuerySummary/QuerySummary.ts
@@ -77,6 +77,9 @@ export class QuerySummary extends Component {
      *
      * Default value is `No results for ${query}`.
      *
+     * **Note**
+     * > If there is no query, the value will fallback to `No results`.
+     *
      * @availablesince [August 2018 Release (v2.4609.6)](https://docs.coveo.com/410/#august-2018-release-v246096)
      */
     noResultsFoundMessage: ComponentOptions.buildLocalizedStringOption({
@@ -187,6 +190,10 @@ export class QuerySummary extends Component {
   }
 
   private replaceQueryTagsWithHighlightedQuery(template: string) {
+    if (this.sanitizedQuery.trim() === '') {
+      return l('noResult');
+    }
+
     const highlightedQuery = `<span class="coveo-highlight">${this.sanitizedQuery}</span>`;
     return QuerySummaryUtils.replaceQueryTags(template, highlightedQuery);
   }
@@ -262,6 +269,7 @@ export class QuerySummary extends Component {
     );
 
     new AccessibleButton()
+      .withLabel(l('CancelLastAction'))
       .withElement(cancelLastAction)
       .withSelectAction(() => {
         this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.noResultsBack, {}, this.root);

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -1578,6 +1578,11 @@
     "zh-cn": "没有找到与 {0} 相关的结果",
     "zh-tw": "沒有找到與 {0} 相關的結果"
   },
+  "noResult": {
+    "en": "No results",
+    "fr": "Aucun résultat",
+    "es-es": "No hay resultados"
+  },
   "autoCorrectedQueryTo": {
     "en": "Query was automatically corrected to {0}",
     "fr": "La requête a été corrigée automatiquement à {0}",

--- a/unitTests/ui/QuerySummaryTest.ts
+++ b/unitTests/ui/QuerySummaryTest.ts
@@ -7,6 +7,7 @@ import { IQuerySummaryOptions } from '../../src/ui/QuerySummary/QuerySummary';
 import { QueryBuilder } from '../../src/ui/Base/QueryBuilder';
 import { ResultList } from '../../src/ui/ResultList/ResultList';
 import { escape } from 'underscore';
+import { l } from '../../src/Core';
 
 const queryTag = '${query}';
 
@@ -307,16 +308,16 @@ export function QuerySummaryTest() {
       });
 
       it(`when the query searched is an empty string,
-          it should replace the query tag with the query searched`, () => {
+          it should put the string NoResult instead`, () => {
         test = Mock.optionsComponentSetup<QuerySummary, IQuerySummaryOptions>(QuerySummary, {
           enableNoResultsFoundMessage: true,
-          noResultsFoundMessage: `${queryTag}`
+          noResultsFoundMessage: `customMessage ${queryTag}`
         });
 
         test.env.queryStateModel.get = () => '';
         Simulate.query(test.env, { results: FakeResults.createFakeResults(0) });
 
-        expect(getCustomMessageElement().textContent).toBe('');
+        expect(getCustomMessageElement().textContent).toBe(l('NoResult'));
       });
 
       it(`when the query searched is the same as the queryTag,

--- a/unitTests/ui/QuerySummaryTest.ts
+++ b/unitTests/ui/QuerySummaryTest.ts
@@ -7,7 +7,6 @@ import { IQuerySummaryOptions } from '../../src/ui/QuerySummary/QuerySummary';
 import { QueryBuilder } from '../../src/ui/Base/QueryBuilder';
 import { ResultList } from '../../src/ui/ResultList/ResultList';
 import { escape } from 'underscore';
-import { l } from '../../src/Core';
 
 const queryTag = '${query}';
 
@@ -317,7 +316,7 @@ export function QuerySummaryTest() {
         test.env.queryStateModel.get = () => '';
         Simulate.query(test.env, { results: FakeResults.createFakeResults(0) });
 
-        expect(getCustomMessageElement().textContent).toBe(l('NoResult'));
+        expect(getCustomMessageElement().textContent).toBe('No results');
       });
 
       it(`when the query searched is the same as the queryTag,
@@ -411,12 +410,12 @@ export function QuerySummaryTest() {
       });
 
       it(`when the query searched is an empty string,
-          it should replace the query tag with the query searched`, () => {
+        it should put the string NoResult instead`, () => {
         test.env.queryStateModel.get = () => '';
         test.cmp.element.innerHTML = `<div class="${noResultsCssClass}">${queryTag}</div>`;
         Simulate.query(test.env, { results: FakeResults.createFakeResults(0) });
 
-        expect(getcustomNoResultsPageElement().textContent).toBe('');
+        expect(getcustomNoResultsPageElement().textContent).toBe('No results');
       });
 
       it(`when the query searched is the same as the queryTag,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3062


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)