### PR TITLE
JSUI-2998 Added building query event for QuerySuggestPreview

### DIFF
--- a/src/events/ResultPreviewsManagerEvents.ts
+++ b/src/events/ResultPreviewsManagerEvents.ts
@@ -4,7 +4,7 @@ import { IQuery } from '../rest/Query';
 
 export interface IBuildingResultPreviewsQueryEventArgs {
   /**
-   * The to be sent to Search API.
+   * The query to be sent to Search API.
    */
   query: IQuery;
 }

--- a/src/events/ResultPreviewsManagerEvents.ts
+++ b/src/events/ResultPreviewsManagerEvents.ts
@@ -1,5 +1,13 @@
 import { ISearchResultPreview } from '../magicbox/ResultPreviewsManager';
 import { Suggestion } from '../magicbox/SuggestionsManager';
+import { IQuery } from '../rest/Query';
+
+export interface IBuildingResultPreviewsQueryEventArgs {
+  /**
+   * The to be sent to Search API.
+   */
+  query: IQuery;
+}
 
 /**
  * Executed when a {@link Suggestion} is focused before {@link PopulateSearchResultPreviews} is called to fetch more options.
@@ -34,6 +42,11 @@ export interface IPopulateSearchResultPreviewsEventArgs {
  * Those events should be bound to the element returned by `resolveRoot`.
  */
 export class ResultPreviewsManagerEvents {
+  /**
+   * Executed when building a query to fetch result previews.
+   * This always receives {@link IBuildingResultPreviewsQueryEventArgs} as arguments.
+   */
+  public static buildingResultPreviewsQuery = 'buildingResultPreviewsQuery';
   /**
    * Executed when a {@link Suggestion} is focused before {@link PopulateSearchResultPreviews} is called to fetch more options.
    * This always receives {@link IUpdateResultPreviewsManagerOptionsEventArgs} as arguments.

--- a/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
+++ b/src/ui/QuerySuggestPreview/QuerySuggestPreview.ts
@@ -18,7 +18,8 @@ import { ImageFieldValue } from '../FieldImage/ImageFieldValue';
 import {
   ResultPreviewsManagerEvents,
   IPopulateSearchResultPreviewsEventArgs,
-  IUpdateResultPreviewsManagerOptionsEventArgs
+  IUpdateResultPreviewsManagerOptionsEventArgs,
+  IBuildingResultPreviewsQueryEventArgs
 } from '../../events/ResultPreviewsManagerEvents';
 import { IQuery } from '../../rest/Query';
 import { Suggestion } from '../../magicbox/SuggestionsManager';
@@ -157,7 +158,13 @@ export class QuerySuggestPreview extends Component implements IComponentBindings
     return this.buildResultsPreview(suggestion, results);
   }
 
-  private buildQuery(suggestion: Suggestion): IQuery {
+  private buildQuery(suggestion: Suggestion) {
+    const query = this.buildDefaultQuery(suggestion);
+    $$(this.root).trigger(ResultPreviewsManagerEvents.buildingResultPreviewsQuery, <IBuildingResultPreviewsQueryEventArgs>{ query });
+    return query;
+  }
+
+  private buildDefaultQuery(suggestion: Suggestion): IQuery {
     const { searchHub, pipeline, tab, locale, timezone, context, cq } = this.queryController.getLastQuery();
     return {
       firstResult: 0,

--- a/unitTests/ui/QuerySuggestPreviewTest.ts
+++ b/unitTests/ui/QuerySuggestPreviewTest.ts
@@ -11,7 +11,11 @@ import {
 } from '../../src/ui/Analytics/AnalyticsActionListMeta';
 import { IQueryResults } from '../../src/rest/QueryResults';
 import { last } from 'underscore';
-import { IPopulateSearchResultPreviewsEventArgs, ResultPreviewsManagerEvents } from '../../src/events/ResultPreviewsManagerEvents';
+import {
+  IBuildingResultPreviewsQueryEventArgs,
+  IPopulateSearchResultPreviewsEventArgs,
+  ResultPreviewsManagerEvents
+} from '../../src/events/ResultPreviewsManagerEvents';
 import { IQuery } from '../../src/rest/Query';
 import { ResultLink } from '../../src/ui/ResultLink/ResultLink';
 
@@ -84,6 +88,10 @@ export function QuerySuggestPreviewTest() {
       return Promise.resolve(query);
     }
 
+    function getLastQuery() {
+      return (test.cmp.queryController.getEndpoint().search as jasmine.Spy).calls.mostRecent().args[0] as IQuery;
+    }
+
     beforeEach(() => {
       testEnv = new Mock.MockEnvironmentBuilder();
       omniboxAnalytics = this.initOmniboxAnalyticsMock(omniboxAnalytics);
@@ -112,7 +120,7 @@ export function QuerySuggestPreviewTest() {
       setupQuerySuggestPreview();
       (test.cmp.queryController.getLastQuery as jasmine.Spy).and.returnValue(optionsToTest);
       await triggerPopulateSearchResultPreviewsAndPassTime();
-      const lastSearchQuery = (test.cmp.queryController.getEndpoint().search as jasmine.Spy).calls.mostRecent().args[0] as IQuery;
+      const lastSearchQuery = getLastQuery();
       for (let optionName of Object.keys(optionsToTest)) {
         expect(lastSearchQuery[optionName]).toEqual(optionsToTest[optionName]);
       }
@@ -153,6 +161,37 @@ export function QuerySuggestPreviewTest() {
       const template = test.cmp['buildDefaultSearchResultPreviewTemplate']();
       // A div tag is used instead of a script tag because Firefox doesn't support appending elements to a script tag.
       expect(template.element.tagName.toLowerCase()).toEqual('div');
+    });
+
+    it('triggers a building query event immediately when populating', async done => {
+      const onBuildingQuery = jasmine.createSpy(ResultPreviewsManagerEvents.buildingResultPreviewsQuery);
+      $$(testEnv.root).on(ResultPreviewsManagerEvents.buildingResultPreviewsQuery, onBuildingQuery);
+      setupQuerySuggestPreview();
+      await triggerPopulateSearchResultPreviewsAndPassTime();
+      expect(onBuildingQuery).toHaveBeenCalledTimes(1);
+      done();
+    });
+
+    it('allows the query to be changed with the building query event', async done => {
+      const testQuery = 'abc';
+      $$(testEnv.root).on(ResultPreviewsManagerEvents.buildingResultPreviewsQuery, (_, data: IBuildingResultPreviewsQueryEventArgs) => {
+        data.query.q = testQuery;
+      });
+      setupQuerySuggestPreview();
+      await triggerPopulateSearchResultPreviewsAndPassTime();
+      expect(getLastQuery().q).toEqual(testQuery);
+      done();
+    });
+
+    it('triggers the building query event with the same query used for search', async done => {
+      let builtQuery: IQuery;
+      $$(testEnv.root).on(ResultPreviewsManagerEvents.buildingResultPreviewsQuery, (_, data: IBuildingResultPreviewsQueryEventArgs) => {
+        builtQuery = data.query;
+      });
+      setupQuerySuggestPreview();
+      await triggerPopulateSearchResultPreviewsAndPassTime();
+      expect(getLastQuery()).toEqual(builtQuery);
+      done();
     });
 
     describe('with accessibility', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-2998

Usage example:
```js
coveoRootElement.addEventListener('buildingResultPreviewsQuery', ({ detail: { query } }) => {
  query.q = query.q === 'test' ? 'blah' : query.q;
});
```

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)