### PR TITLE
JSUI-3107 Avoiding interacting with cookies when initializing HistoryStore

### DIFF
--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -1,4 +1,3 @@
-import { history } from 'coveo.analytics';
 import { buildHistoryStore, buildNullHistoryStore } from '../utils/HistoryStore';
 import * as _ from 'underscore';
 import {
@@ -95,7 +94,7 @@ class DefaultQueryOptions implements IQueryOptions {
  */
 export class QueryController extends RootComponent {
   static ID = 'QueryController';
-  public historyStore: history.HistoryStore;
+  public historyStore: CoveoAnalytics.HistoryStore;
   public firstQuery: boolean;
   public modalBox = ModalBox;
   public closeModalBox = true;
@@ -690,7 +689,7 @@ export class QueryController extends RootComponent {
   }
 
   private logQueryInActionsHistory(query: IQuery) {
-    let queryElement: history.HistoryElement = {
+    let queryElement: CoveoAnalytics.HistoryQueryElement = {
       name: 'Query',
       value: query.q,
       time: JSON.stringify(new Date())

--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -1,5 +1,5 @@
 import { history } from 'coveo.analytics';
-import { NullStorage } from 'coveo.analytics/dist/storage';
+import { buildHistoryStore, buildNullHistoryStore } from '../utils/HistoryStore';
 import * as _ from 'underscore';
 import {
   IBuildingCallOptionsEventArgs,
@@ -95,7 +95,7 @@ class DefaultQueryOptions implements IQueryOptions {
  */
 export class QueryController extends RootComponent {
   static ID = 'QueryController';
-  public historyStore: CoveoAnalytics.HistoryStore;
+  public historyStore: history.HistoryStore;
   public firstQuery: boolean;
   public modalBox = ModalBox;
   public closeModalBox = true;
@@ -238,7 +238,7 @@ export class QueryController extends RootComponent {
 
     let query = queryBuilder.build();
     if (options.logInActionsHistory) {
-      this.logQueryInActionsHistory(query, options.isFirstQuery);
+      this.logQueryInActionsHistory(query);
     }
 
     let endpointToUse = this.getEndpoint();
@@ -501,11 +501,11 @@ export class QueryController extends RootComponent {
   }
 
   public enableHistory() {
-    this.historyStore = new history.HistoryStore();
+    this.historyStore = buildHistoryStore();
   }
 
   public disableHistory() {
-    this.historyStore = new history.HistoryStore(new NullStorage());
+    this.historyStore = buildNullHistoryStore();
   }
 
   private initializeActionsHistory() {
@@ -689,8 +689,8 @@ export class QueryController extends RootComponent {
     return dom;
   }
 
-  private logQueryInActionsHistory(query: IQuery, isFirstQuery: boolean) {
-    let queryElement: CoveoAnalytics.HistoryQueryElement = {
+  private logQueryInActionsHistory(query: IQuery) {
+    let queryElement: history.HistoryElement = {
       name: 'Query',
       value: query.q,
       time: JSON.stringify(new Date())

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -31,7 +31,7 @@ import { QueryUtils } from '../utils/QueryUtils';
 import { QueryError } from '../rest/QueryError';
 import { Utils } from '../utils/Utils';
 import * as _ from 'underscore';
-import { history } from 'coveo.analytics';
+import { buildHistoryStore } from '../utils/HistoryStore';
 import { Cookie } from '../utils/CookieUtils';
 import { TimeSpan } from '../utils/TimeSpanUtils';
 import { UrlUtils } from '../utils/UrlUtils';
@@ -1372,7 +1372,7 @@ function accessTokenInUrl(tokenKey: string = 'access_token') {
   };
 }
 
-function includeActionsHistory(historyStore: CoveoAnalytics.HistoryStore = new history.HistoryStore()) {
+function includeActionsHistory(historyStore = buildHistoryStore()) {
   return function(target: Object, key: string, descriptor: TypedPropertyDescriptor<any>) {
     const { originalMethod, nbParams } = decoratorSetup(target, key, descriptor);
 

--- a/src/ui/Omnibox/QuerySuggestAddon.ts
+++ b/src/ui/Omnibox/QuerySuggestAddon.ts
@@ -12,9 +12,9 @@ import {
 import { StringUtils } from '../../utils/StringUtils';
 import { map, every, last, indexOf, find } from 'underscore';
 import { QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
-import { history } from 'coveo.analytics';
 import { Cookie } from '../../utils/CookieUtils';
 import { Utils } from '../../utils/Utils';
+import { buildHistoryStore } from '../../utils/HistoryStore';
 
 export interface IQuerySuggestAddon {
   getSuggestion(): Promise<IOmniboxSuggestion[]>;
@@ -152,7 +152,7 @@ export class QuerySuggestAddon implements IQuerySuggestAddon {
   }
 
   private get actionsHistory() {
-    const historyStore = new history.HistoryStore();
+    const historyStore = buildHistoryStore();
     const historyFromStore = historyStore.getHistory();
     if (historyFromStore == null) {
       return [];

--- a/src/utils/HistoryStore.ts
+++ b/src/utils/HistoryStore.ts
@@ -1,0 +1,20 @@
+import { history, storage } from 'coveo.analytics';
+
+export function buildHistoryStore() {
+  const historyStore = buildCookieHistoryStore();
+  (historyStore as any).store = storage.getAvailableStorage();
+
+  return historyStore;
+}
+
+export function buildNullHistoryStore() {
+  const historyStore = buildCookieHistoryStore();
+  (historyStore as any).store = new storage.NullStorage();
+
+  return historyStore;
+}
+
+function buildCookieHistoryStore() {
+  const cookieStorage = new storage.CookieStorage();
+  return new history.HistoryStore(cookieStorage);
+}

--- a/src/utils/HistoryStore.ts
+++ b/src/utils/HistoryStore.ts
@@ -1,20 +1,21 @@
-import { history, storage } from 'coveo.analytics';
+import { history } from 'coveo.analytics';
+import { CookieStorage, getAvailableStorage, NullStorage } from 'coveo.analytics/dist/storage';
 
 export function buildHistoryStore() {
   const historyStore = buildCookieHistoryStore();
-  (historyStore as any).store = storage.getAvailableStorage();
+  (historyStore as any).store = getAvailableStorage();
 
   return historyStore;
 }
 
 export function buildNullHistoryStore() {
   const historyStore = buildCookieHistoryStore();
-  (historyStore as any).store = new storage.NullStorage();
+  (historyStore as any).store = new NullStorage();
 
   return historyStore;
 }
 
 function buildCookieHistoryStore() {
-  const cookieStorage = new storage.CookieStorage();
+  const cookieStorage = new CookieStorage();
   return new history.HistoryStore(cookieStorage);
 }

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -848,3 +848,6 @@ FileTypesTest();
 
 import { FacetSearchElementTest } from './ui/FacetSearchElementTest';
 FacetSearchElementTest();
+
+import { HistoryStoreTest } from './utils/HistoryStoreTest';
+HistoryStoreTest();

--- a/unitTests/controllers/QueryControllerTest.ts
+++ b/unitTests/controllers/QueryControllerTest.ts
@@ -422,7 +422,7 @@ export function QueryControllerTest() {
         });
 
         it(`setting action history stores the value in localStorage`, () => {
-          test.cmp.historyStore.setHistory([{ name: 'a', time: '', value: '1' }]);
+          test.cmp.historyStore.setHistory(['a']);
           expect(localStorage.getItem(key)).toBeTruthy();
         });
 
@@ -456,7 +456,7 @@ export function QueryControllerTest() {
           localStorage.clear();
           initQueryController();
 
-          test.cmp.historyStore.setHistory([{ name: 'a', time: '', value: '1' }]);
+          test.cmp.historyStore.setHistory(['a']);
           expect(localStorage.getItem(key)).toBeFalsy();
         });
       });

--- a/unitTests/controllers/QueryControllerTest.ts
+++ b/unitTests/controllers/QueryControllerTest.ts
@@ -6,6 +6,7 @@ import { FakeResults } from '../Fake';
 import * as Mock from '../MockEnvironment';
 import { ExecutionPlan } from '../../src/rest/Plan';
 import { SearchInterface } from '../../src/ui/SearchInterface/SearchInterface';
+import * as HistoryStore from '../../src/utils/HistoryStore';
 
 export function QueryControllerTest() {
   describe('QueryController', () => {
@@ -413,8 +414,15 @@ export function QueryControllerTest() {
           initQueryController();
         });
 
+        it('initializes the historyStore by calling buildHistoryStore', () => {
+          const spy = spyOn(HistoryStore, 'buildHistoryStore');
+          initQueryController();
+
+          expect(spy).toHaveBeenCalledTimes(1);
+        });
+
         it(`setting action history stores the value in localStorage`, () => {
-          test.cmp.historyStore.setHistory(['a']);
+          test.cmp.historyStore.setHistory([{ name: 'a', time: '', value: '1' }]);
           expect(localStorage.getItem(key)).toBeTruthy();
         });
 
@@ -430,6 +438,13 @@ export function QueryControllerTest() {
       });
 
       describe('when disabled', () => {
+        it('initializes the historyStore by calling buildNullHistoryStore', () => {
+          const spy = spyOn(HistoryStore, 'buildNullHistoryStore');
+          initQueryController();
+
+          expect(spy).toHaveBeenCalledTimes(1);
+        });
+
         it(`it clears the action history`, () => {
           localStorage.setItem(key, 'a');
           initQueryController();
@@ -441,7 +456,7 @@ export function QueryControllerTest() {
           localStorage.clear();
           initQueryController();
 
-          test.cmp.historyStore.setHistory(['a']);
+          test.cmp.historyStore.setHistory([{ name: 'a', time: '', value: '1' }]);
           expect(localStorage.getItem(key)).toBeFalsy();
         });
       });

--- a/unitTests/ui/QuerySuggestAddonTest.ts
+++ b/unitTests/ui/QuerySuggestAddonTest.ts
@@ -3,9 +3,9 @@ import * as Mock from '../MockEnvironment';
 import { QuerySuggestAddon } from '../../src/ui/Omnibox/QuerySuggestAddon';
 import { IQuerySuggestResponse } from '../../src/rest/QuerySuggest';
 import { QUERY_STATE_ATTRIBUTES } from '../../src/models/QueryStateModel';
-import HistoryStore from 'coveo.analytics/dist/history';
 import { $$, OmniboxEvents } from '../../src/Core';
 import { IBuildingQuerySuggestArgs, IQuerySuggestSuccessArgs } from '../../src/events/OmniboxEvents';
+import { buildHistoryStore } from '../../src/utils/HistoryStore';
 
 export function QuerySuggestAddonTest() {
   describe('QuerySuggest', () => {
@@ -103,7 +103,7 @@ export function QuerySuggestAddonTest() {
 
       it('with actionsHistory', async done => {
         const fakeStoreEntry = { name: 'foo', value: 'foo', time: new Date().toString() };
-        const store = new HistoryStore();
+        const store = buildHistoryStore();
         store.addElement({ ...fakeStoreEntry });
         querySuggest = new QuerySuggestAddon(omnibox.cmp);
         await querySuggest.getSuggestion();

--- a/unitTests/utils/HistoryStoreTest.ts
+++ b/unitTests/utils/HistoryStoreTest.ts
@@ -1,0 +1,20 @@
+import { Cookie } from '../../src/Core';
+import { buildHistoryStore, buildNullHistoryStore } from '../../src/utils/HistoryStore';
+
+export function HistoryStoreTest() {
+  describe('HistoryStore', () => {
+    const key = '__coveo.analytics.history';
+
+    it('calling buildHistoryStore does not delete the actionHistory cookie', () => {
+      Cookie.set(key, 'a');
+      buildHistoryStore();
+      expect(Cookie.get(key)).toBe('a');
+    });
+
+    it('calling buildNullHistoryStore does not delete the actionHistory cookie', () => {
+      Cookie.set(key, 'a');
+      buildNullHistoryStore();
+      expect(Cookie.get(key)).toBe('a');
+    });
+  });
+}


### PR DESCRIPTION
**Problem**

Initializing the coveo.analytics `HistoryStore` with anything other than `CookieStorage` causes the class to delete the actionHistory cookie. Chrome detects this activity, and reports in the lock icon that the coveo-search-ui is using a cookie called `__coveo.analytics.history`. The client saw this and opened a case.

**Approaches that did not work**

I [opened a PR](https://github.com/coveo/coveo.analytics.js/pull/216) in the coveo.analytics repo removing the behaviour. 

However, I wasn't able to build the JSUI project correctly after updating the coveo.analytics package. The build errors stem from unrecognized syntax in the `coveo.analytics` typedefinitions.

To solve this issue, I tried upgrading typescript. However, starting with version 2.9.x, dts-generator stopped outputting the correct definitions.

I upgraded dts-generator to the latest version, but the outputted definitions were still incorrect. I also tried adjusting the typedefinitions directly, but there were no changes in the output. 

**Current approach**

Initialize the HistoryStore using CookieStorage, then overwrite the storage using the `getAvailableStorage` function exported by `coveo.analytics`. This prevents interacting with cookies, but otherwise keeps the same behaviour as the default constructor.



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)