### PR TITLE
JSUI-3110 Decrement component counter even when a component is not responsive

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
@@ -62,20 +62,7 @@ export class ResponsiveComponentsManager {
     const initEventRoot = options.initializationEventRoot || root;
     initEventRoot.on(InitializationEvents.afterInitialization, () => {
       if (this.shouldEnableResponsiveMode(root)) {
-        let responsiveComponentsManager = _.find(this.componentManagers, componentManager => root.el == componentManager.coveoRoot.el);
-        if (!responsiveComponentsManager) {
-          responsiveComponentsManager = new ResponsiveComponentsManager(root);
-        }
-
-        if (!Utils.isNullOrUndefined(options.enableResponsiveMode) && !options.enableResponsiveMode) {
-          responsiveComponentsManager.disableComponent(ID);
-          return;
-        }
-
-        this.componentInitializations.push({
-          responsiveComponentsManager: responsiveComponentsManager,
-          arguments: [responsiveComponentConstructor, root, ID, component, options]
-        });
+        this.registerComponentIfResponsiveModeEnabled(responsiveComponentConstructor, root, ID, component, options);
       }
 
       this.remainingComponentInitializations--;
@@ -94,6 +81,29 @@ export class ResponsiveComponentsManager {
       }
     });
     this.remainingComponentInitializations++;
+  }
+
+  private static registerComponentIfResponsiveModeEnabled(
+    responsiveComponentConstructor: IResponsiveComponentConstructor,
+    root: Dom,
+    ID: string,
+    component: Component,
+    options: IResponsiveComponentOptions
+  ) {
+    let responsiveComponentsManager = _.find(this.componentManagers, componentManager => root.el == componentManager.coveoRoot.el);
+    if (!responsiveComponentsManager) {
+      responsiveComponentsManager = new ResponsiveComponentsManager(root);
+    }
+
+    if (!Utils.isNullOrUndefined(options.enableResponsiveMode) && !options.enableResponsiveMode) {
+      responsiveComponentsManager.disableComponent(ID);
+      return;
+    }
+
+    this.componentInitializations.push({
+      responsiveComponentsManager: responsiveComponentsManager,
+      arguments: [responsiveComponentConstructor, root, ID, component, options]
+    });
   }
 
   private static shouldEnableResponsiveMode(root: Dom): boolean {

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -48,6 +48,8 @@ export function ResponsiveComponentsManagerTest() {
     it(`when registering a tab with #enableResponsiveMode false and a responsive facet,
     when triggering the #afterInitialization event,
     it calls the #register instance method to make the facet responsive`, () => {
+      ResponsiveComponentsManager['remainingComponentInitializations'] = 0;
+
       const tabOptions: ITabOptions = { enableResponsiveMode: false };
       const tab = Mock.optionsComponentSetup<Tab, ITabOptions>(Tab, tabOptions);
 

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -4,6 +4,11 @@ import * as Mock from '../../MockEnvironment';
 import { SearchInterface, ISearchInterfaceOptions } from '../../../src/ui/SearchInterface/SearchInterface';
 import { Component } from '../../../src/ui/Base/Component';
 import { ValidResponsiveMode } from '../../../src/ui/ResponsiveComponents/ResponsiveComponents';
+import { ResponsiveTabs } from '../../../src/ui/ResponsiveComponents/ResponsiveTabs';
+import { ITabOptions, Tab } from '../../../src/ui/Tab/Tab';
+import { InitializationEvents } from '../../../src/Core';
+import { ResponsiveFacets } from '../../../src/ui/ResponsiveComponents/ResponsiveFacets';
+import { Facet, IFacetOptions } from '../../../src/ui/Facet/Facet';
 
 export function ResponsiveComponentsManagerTest() {
   const SMALL_RESPONSIVE_MODE = 'small';
@@ -38,6 +43,25 @@ export function ResponsiveComponentsManagerTest() {
 
     afterEach(() => {
       jasmine.clock().uninstall();
+    });
+
+    it(`when registering a tab with #enableResponsiveMode false and a responsive facet,
+    when triggering the #afterInitialization event,
+    it calls the #register instance method to make the facet responsive`, () => {
+      const tabOptions: ITabOptions = { enableResponsiveMode: false };
+      const tab = Mock.optionsComponentSetup<Tab, ITabOptions>(Tab, tabOptions);
+
+      ResponsiveComponentsManager.register(ResponsiveTabs, root, Tab.ID, tab.cmp, tabOptions);
+
+      const facetOptions: IFacetOptions = {};
+      const facet = Mock.optionsComponentSetup<Facet, IFacetOptions>(Facet, facetOptions);
+
+      ResponsiveComponentsManager.register(ResponsiveFacets, root, Facet.ID, facet.cmp, facetOptions);
+
+      const spy = spyOn(responsiveComponentsManager, 'register');
+      root.trigger(InitializationEvents.afterInitialization);
+
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     describe('when the search interface responsive mode is set to *auto*', () => {


### PR DESCRIPTION
When a tab has `enableResponsiveMode` set to `false`, other responsive components (e.g. facets) stop being responsive.
This PR fixes the bug by ensuring we always decrement the counter tracking components to initialize.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)