### PR TITLE
JSUI-3113 Adapt ExportToExcel download to send a POST request with the full query

### DIFF
--- a/src/rest/Query.ts
+++ b/src/rest/Query.ts
@@ -8,7 +8,7 @@ import { IFacetRequest } from './Facet/FacetRequest';
 /**
  * The format of a successful response.
  */
-type ResponseFormat = 'json' | 'opensearch-atom' | 'opensearch-rss' | 'xlsx';
+export type ResponseFormat = 'json' | 'opensearch-atom' | 'opensearch-rss' | 'xlsx';
 
 /**
  * The available global configuration options when requesting facets through the [facets]{IQuery.facets} array.

--- a/src/rest/Query.ts
+++ b/src/rest/Query.ts
@@ -6,6 +6,11 @@ import { ICategoryFacetRequest } from './CategoryFacetRequest';
 import { IFacetRequest } from './Facet/FacetRequest';
 
 /**
+ * The format of a successful response.
+ */
+type ResponseFormat = 'json' | 'opensearch-atom' | 'opensearch-rss' | 'xlsx';
+
+/**
  * The available global configuration options when requesting facets through the [facets]{IQuery.facets} array.
  */
 export interface IFacetOptions {
@@ -299,4 +304,9 @@ export interface IQuery {
    * The commerce request to execute.
    */
   commerce?: ICommerceRequest;
+  /**
+   * The format of a successful response.
+   * If not specified, this parameter defaults to 'json'.
+   */
+  format?: ResponseFormat;
 }

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -397,6 +397,25 @@ export class SearchEndpoint implements ISearchEndpoint {
   }
 
   /**
+   * Performs a search on the index and returns a Promise of `ArrayBuffer`.
+   *
+   * @param query The query to execute. Typically, the query object is built using a
+   * [`QueryBuilder`]{@link QueryBuilder}.
+   * @param callOptions An additional set of options to use for this call.
+   * @param callParams The options injected by the applied decorators.
+   * @returns {Promise<ArrayBuffer>} A Promise of query results.
+   */
+  @path('/')
+  @method('POST')
+  @responseType('arraybuffer')
+  public async downloadBinary(query: IQuery, callOptions?: IEndpointCallOptions, callParams?: IEndpointCallParameters) {
+    const call = this.buildCompleteCall(query, callOptions, callParams);
+    this.logger.info('Performing REST query', query);
+
+    return await this.performOneCall<ArrayBuffer>(call.params, call.options);
+  }
+
+  /**
    * Gets the plan of execution of a search request, without performing it.
    *
    * @param query The query to execute. Typically, the query object is built using a

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -438,6 +438,9 @@ export class SearchEndpoint implements ISearchEndpoint {
   }
 
   /**
+   * @deprecated getExportToExcelLink does not factor in all query parameters (e.g. dynamic facets) due to GET request url length limitations.
+   * Please use `downloadBinary` instead to ensure all query parameters are used.
+   *
    * Gets a link / URI to download a query result set to the XLSX format.
    *
    * **Note:**

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -408,7 +408,7 @@ export class SearchEndpoint implements ISearchEndpoint {
   @path('/')
   @method('POST')
   @responseType('arraybuffer')
-  public async downloadBinary(query: IQuery, callOptions?: IEndpointCallOptions, callParams?: IEndpointCallParameters) {
+  public async fetchBinary(query: IQuery, callOptions?: IEndpointCallOptions, callParams?: IEndpointCallParameters) {
     const call = this.buildCompleteCall(query, callOptions, callParams);
     this.logger.info('Performing REST query', query);
 
@@ -439,7 +439,7 @@ export class SearchEndpoint implements ISearchEndpoint {
 
   /**
    * @deprecated getExportToExcelLink does not factor in all query parameters (e.g. dynamic facets) due to GET request url length limitations.
-   * Please use `downloadBinary` instead to ensure all query parameters are used.
+   * Please use `fetchBinary` instead to ensure all query parameters are used.
    *
    * Gets a link / URI to download a query result set to the XLSX format.
    *

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -412,7 +412,7 @@ export class SearchEndpoint implements ISearchEndpoint {
     const call = this.buildCompleteCall(query, callOptions, callParams);
     this.logger.info('Performing REST query', query);
 
-    return await this.performOneCall<ArrayBuffer>(call.params, call.options);
+    return this.performOneCall<ArrayBuffer>(call.params, call.options);
   }
 
   /**

--- a/src/rest/SearchEndpointInterface.ts
+++ b/src/rest/SearchEndpointInterface.ts
@@ -94,6 +94,7 @@ export interface ISearchEndpoint {
   getAuthenticationProviderUri(provider: string, returnUri: string, message: string): string;
   isJsonp(): boolean;
   search(query: IQuery, callOptions?: IEndpointCallOptions): Promise<IQueryResults>;
+  downloadBinary(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ArrayBuffer>;
   plan(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ExecutionPlan>;
   getExportToExcelLink(query: IQuery, numberOfResults: number, callOptions?: IEndpointCallOptions): string;
   getRawDataStream(documentUniqueId: string, dataStreamType: string, callOptions?: IViewAsHtmlOptions): Promise<ArrayBuffer>;

--- a/src/rest/SearchEndpointInterface.ts
+++ b/src/rest/SearchEndpointInterface.ts
@@ -96,7 +96,6 @@ export interface ISearchEndpoint {
   search(query: IQuery, callOptions?: IEndpointCallOptions): Promise<IQueryResults>;
   downloadBinary(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ArrayBuffer>;
   plan(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ExecutionPlan>;
-  getExportToExcelLink(query: IQuery, numberOfResults: number, callOptions?: IEndpointCallOptions): string;
   getRawDataStream(documentUniqueId: string, dataStreamType: string, callOptions?: IViewAsHtmlOptions): Promise<ArrayBuffer>;
   getDocument(documentUniqueID: string, callOptions?: IGetDocumentOptions): Promise<IQueryResult>;
   getDocumentText(documentUniqueID: string, callOptions?: IEndpointCallOptions): Promise<string>;

--- a/src/rest/SearchEndpointInterface.ts
+++ b/src/rest/SearchEndpointInterface.ts
@@ -94,7 +94,7 @@ export interface ISearchEndpoint {
   getAuthenticationProviderUri(provider: string, returnUri: string, message: string): string;
   isJsonp(): boolean;
   search(query: IQuery, callOptions?: IEndpointCallOptions): Promise<IQueryResults>;
-  downloadBinary(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ArrayBuffer>;
+  fetchBinary(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ArrayBuffer>;
   plan(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ExecutionPlan>;
   getRawDataStream(documentUniqueId: string, dataStreamType: string, callOptions?: IViewAsHtmlOptions): Promise<ArrayBuffer>;
   getDocument(documentUniqueID: string, callOptions?: IGetDocumentOptions): Promise<IQueryResult>;

--- a/src/rest/SearchEndpointInterface.ts
+++ b/src/rest/SearchEndpointInterface.ts
@@ -96,6 +96,10 @@ export interface ISearchEndpoint {
   search(query: IQuery, callOptions?: IEndpointCallOptions): Promise<IQueryResults>;
   fetchBinary(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ArrayBuffer>;
   plan(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ExecutionPlan>;
+  /** @deprecated getExportToExcelLink does not factor in all query parameters (e.g. dynamic facets) due to GET request url length limitations.
+   * Please use `fetchBinary` instead to ensure all query parameters are used.
+   * */
+  getExportToExcelLink(query: IQuery, numberOfResults: number, callOptions?: IEndpointCallOptions): string;
   getRawDataStream(documentUniqueId: string, dataStreamType: string, callOptions?: IViewAsHtmlOptions): Promise<ArrayBuffer>;
   getDocument(documentUniqueID: string, callOptions?: IGetDocumentOptions): Promise<IQueryResult>;
   getDocumentText(documentUniqueID: string, callOptions?: IEndpointCallOptions): Promise<string>;

--- a/src/rest/SearchEndpointWithDefaultCallOptions.ts
+++ b/src/rest/SearchEndpointWithDefaultCallOptions.ts
@@ -23,12 +23,11 @@ import * as _ from 'underscore';
 import { IFacetSearchRequest } from './Facet/FacetSearchRequest';
 import { IFacetSearchResponse } from './Facet/FacetSearchResponse';
 import { ExecutionPlan } from './Plan';
-import { SearchEndpoint } from '../Core';
 
 export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
   options: ISearchEndpointOptions;
 
-  constructor(private endpoint: SearchEndpoint, private callOptions?: IEndpointCallOptions) {
+  constructor(private endpoint: ISearchEndpoint, private callOptions?: IEndpointCallOptions) {
     this.options = endpoint.options;
   }
 

--- a/src/rest/SearchEndpointWithDefaultCallOptions.ts
+++ b/src/rest/SearchEndpointWithDefaultCallOptions.ts
@@ -23,11 +23,12 @@ import * as _ from 'underscore';
 import { IFacetSearchRequest } from './Facet/FacetSearchRequest';
 import { IFacetSearchResponse } from './Facet/FacetSearchResponse';
 import { ExecutionPlan } from './Plan';
+import { SearchEndpoint } from '../Core';
 
 export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
   options: ISearchEndpointOptions;
 
-  constructor(private endpoint: ISearchEndpoint, private callOptions?: IEndpointCallOptions) {
+  constructor(private endpoint: SearchEndpoint, private callOptions?: IEndpointCallOptions) {
     this.options = endpoint.options;
   }
 

--- a/src/rest/SearchEndpointWithDefaultCallOptions.ts
+++ b/src/rest/SearchEndpointWithDefaultCallOptions.ts
@@ -51,6 +51,10 @@ export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
     return this.endpoint.search(query, this.enrichCallOptions(callOptions));
   }
 
+  public downloadBinary(query: IQuery, callOptions?: IEndpointCallOptions) {
+    return this.endpoint.downloadBinary(query, this.enrichCallOptions(callOptions));
+  }
+
   public plan(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ExecutionPlan> {
     return this.endpoint.plan(query, this.enrichCallOptions(callOptions));
   }

--- a/src/rest/SearchEndpointWithDefaultCallOptions.ts
+++ b/src/rest/SearchEndpointWithDefaultCallOptions.ts
@@ -52,8 +52,8 @@ export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
     return this.endpoint.search(query, this.enrichCallOptions(callOptions));
   }
 
-  public downloadBinary(query: IQuery, callOptions?: IEndpointCallOptions) {
-    return this.endpoint.downloadBinary(query, this.enrichCallOptions(callOptions));
+  public fetchBinary(query: IQuery, callOptions?: IEndpointCallOptions) {
+    return this.endpoint.fetchBinary(query, this.enrichCallOptions(callOptions));
   }
 
   public plan(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ExecutionPlan> {

--- a/src/ui/ExportToExcel/ExportToExcel.ts
+++ b/src/ui/ExportToExcel/ExportToExcel.ts
@@ -16,6 +16,12 @@ import { get } from '../Base/RegisteredNamedMethods';
 import * as moment from 'moment';
 import { IQuery } from '../../rest/Query';
 
+let createAnchor = () => document.createElement('a');
+
+export function setCreateAnchor(fn: () => HTMLAnchorElement) {
+  createAnchor = fn;
+}
+
 export interface IExportToExcelOptions {
   numberOfResults?: number;
   fieldsToInclude?: IFieldOption[];
@@ -105,7 +111,7 @@ export class ExportToExcel extends Component {
     const endpoint = this.queryController.getEndpoint();
     this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.exportToExcel, {}, this.element);
 
-    endpoint.downloadBinary(query).then(this.generateExcelFile);
+    endpoint.downloadBinary(query).then(content => this.generateExcelFile(content));
   }
 
   private buildExcelQuery(): IQuery {
@@ -127,7 +133,7 @@ export class ExportToExcel extends Component {
     const blob = new Blob([content], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
     const url = URL.createObjectURL(blob);
 
-    const a = document.createElement('a');
+    const a = createAnchor();
     a.href = url;
     a.download = this.buildExcelFileName();
     a.click();

--- a/src/ui/ExportToExcel/ExportToExcel.ts
+++ b/src/ui/ExportToExcel/ExportToExcel.ts
@@ -111,7 +111,7 @@ export class ExportToExcel extends Component {
     const endpoint = this.queryController.getEndpoint();
     this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.exportToExcel, {}, this.element);
 
-    endpoint.fetchBinary(query).then(content => this.generateExcelFile(content));
+    endpoint.fetchBinary(query).then(content => this.downloadExcelFile(content));
   }
 
   private buildExcelQuery(): IQuery {
@@ -129,7 +129,7 @@ export class ExportToExcel extends Component {
     };
   }
 
-  private generateExcelFile(content: ArrayBuffer) {
+  private downloadExcelFile(content: ArrayBuffer) {
     const blob = new Blob([content], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
     const url = URL.createObjectURL(blob);
 

--- a/src/ui/ExportToExcel/ExportToExcel.ts
+++ b/src/ui/ExportToExcel/ExportToExcel.ts
@@ -111,7 +111,7 @@ export class ExportToExcel extends Component {
     const endpoint = this.queryController.getEndpoint();
     this.usageAnalytics.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.exportToExcel, {}, this.element);
 
-    endpoint.downloadBinary(query).then(content => this.generateExcelFile(content));
+    endpoint.fetchBinary(query).then(content => this.generateExcelFile(content));
   }
 
   private buildExcelQuery(): IQuery {

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -292,6 +292,7 @@ export function mockSearchEndpoint(): SearchEndpoint {
   m.getQuerySuggest.and.returnValue(new Promise((resolve, reject) => {}));
   m.extensions.and.returnValue(new Promise((resolve, reject) => {}));
   m.getViewAsDatastreamUri.and.returnValue('http://datastream.uri');
+  m.downloadBinary.and.returnValue(Promise.resolve({}));
   m.options = {
     queryStringArguments: {
       organizationId: 'foobar'

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -292,7 +292,7 @@ export function mockSearchEndpoint(): SearchEndpoint {
   m.getQuerySuggest.and.returnValue(new Promise((resolve, reject) => {}));
   m.extensions.and.returnValue(new Promise((resolve, reject) => {}));
   m.getViewAsDatastreamUri.and.returnValue('http://datastream.uri');
-  m.downloadBinary.and.returnValue(Promise.resolve({}));
+  m.fetchBinary.and.returnValue(Promise.resolve({}));
   m.options = {
     queryStringArguments: {
       organizationId: 'foobar'

--- a/unitTests/ui/ExportToExcelTest.ts
+++ b/unitTests/ui/ExportToExcelTest.ts
@@ -16,7 +16,7 @@ export function ExportToExcelTest() {
 
     function buildDownloadBinarySpy() {
       const spy = jasmine.createSpy('searchEndpoint');
-      spy.and.returnValue(Promise.resolve({}));
+      spy.and.returnValue(Promise.resolve(new ArrayBuffer(0)));
       return spy;
     }
 
@@ -84,11 +84,19 @@ export function ExportToExcelTest() {
         expect(excelSpy).toHaveBeenCalledWith(analyticsActionCauseList.exportToExcel, {}, test.env.element);
       });
 
-      it('download should redirect to the link provided by the search endpoint', function() {
-        const windowLocationReplaceSpy = jasmine.createSpy('windowLocationReplaceSpy');
-        test.cmp._window.location.replace = windowLocationReplaceSpy;
+      it('download should create an object url and revoke it', async () => {
+        const createObjectUrlSpy = jasmine.createSpy('createObjectUrl');
+        const revokeObjectUrlSpy = jasmine.createSpy('revokeObjectUrl');
+
+        window.URL.createObjectURL = createObjectUrlSpy;
+        window.URL.revokeObjectURL = revokeObjectUrlSpy;
+
         test.cmp.download();
-        expect(test.cmp._window.location.replace).toHaveBeenCalledWith('http://www.excellink.com');
+
+        await Promise.resolve({});
+
+        expect(createObjectUrlSpy).toHaveBeenCalled();
+        expect(revokeObjectUrlSpy).toHaveBeenCalled();
       });
     });
   });

--- a/unitTests/ui/ExportToExcelTest.ts
+++ b/unitTests/ui/ExportToExcelTest.ts
@@ -53,7 +53,7 @@ export function ExportToExcelTest() {
         test.cmp.download();
         await Promise.resolve({});
 
-        expect(a.href).toContain('blob:http://localhost:8081/');
+        expect(a.href).toContain('blob:http://localhost');
         done();
       });
 

--- a/unitTests/ui/ExportToExcelTest.ts
+++ b/unitTests/ui/ExportToExcelTest.ts
@@ -25,6 +25,26 @@ export function ExportToExcelTest() {
       initExportToExcel();
     });
 
+    describe('calling #download', () => {
+      it(`calls downloadBinary with format set to 'xlsx'`, () => {
+        const spy = buildDownloadBinarySpy();
+        test.env.searchEndpoint.downloadBinary = spy;
+
+        test.cmp.download();
+
+        expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ format: 'xlsx' }));
+      });
+
+      it('calls downloadBinary with the default number of results', () => {
+        const spy = buildDownloadBinarySpy();
+        test.env.searchEndpoint.downloadBinary = spy;
+
+        test.cmp.download();
+
+        expect(spy).toHaveBeenCalledWith(jasmine.objectContaining({ numberOfResults: 100 }));
+      });
+    });
+
     describe('exposes options', function() {
       it('numberOfResults calls search endpoint with appropriate number of results', function() {
         options.numberOfResults = 200;

--- a/unitTests/ui/ExportToExcelTest.ts
+++ b/unitTests/ui/ExportToExcelTest.ts
@@ -27,16 +27,16 @@ export function ExportToExcelTest() {
     });
 
     describe('calling #download', () => {
-      it(`calls downloadBinary with format set to 'xlsx'`, () => {
+      it(`calls fetchBinary with format set to 'xlsx'`, () => {
         test.cmp.download();
 
-        expect(test.env.searchEndpoint.downloadBinary).toHaveBeenCalledWith(jasmine.objectContaining({ format: 'xlsx' }));
+        expect(test.env.searchEndpoint.fetchBinary).toHaveBeenCalledWith(jasmine.objectContaining({ format: 'xlsx' }));
       });
 
-      it('calls downloadBinary with the default number of results', () => {
+      it('calls fetchBinary with the default number of results', () => {
         test.cmp.download();
 
-        expect(test.env.searchEndpoint.downloadBinary).toHaveBeenCalledWith(jasmine.objectContaining({ numberOfResults: 100 }));
+        expect(test.env.searchEndpoint.fetchBinary).toHaveBeenCalledWith(jasmine.objectContaining({ numberOfResults: 100 }));
       });
 
       it('should call exportToExcel event if query was made', () => {
@@ -99,7 +99,7 @@ export function ExportToExcelTest() {
 
         test.cmp.download();
 
-        expect(test.env.searchEndpoint.downloadBinary).toHaveBeenCalledWith(jasmine.objectContaining({ numberOfResults: 200 }));
+        expect(test.env.searchEndpoint.fetchBinary).toHaveBeenCalledWith(jasmine.objectContaining({ numberOfResults: 200 }));
       });
 
       it('fieldsToInclude allows to specify the needed fields to download', () => {
@@ -108,7 +108,7 @@ export function ExportToExcelTest() {
 
         test.cmp.download();
 
-        expect(test.env.searchEndpoint.downloadBinary).toHaveBeenCalledWith(
+        expect(test.env.searchEndpoint.fetchBinary).toHaveBeenCalledWith(
           jasmine.objectContaining({
             fieldsToInclude: jasmine.arrayContaining(['@foo', '@bar'])
           })
@@ -121,7 +121,7 @@ export function ExportToExcelTest() {
 
         test.cmp.download();
 
-        expect(test.env.searchEndpoint.downloadBinary).not.toHaveBeenCalledWith(
+        expect(test.env.searchEndpoint.fetchBinary).not.toHaveBeenCalledWith(
           jasmine.objectContaining({
             fieldsToInclude: jasmine.anything()
           })


### PR DESCRIPTION
The url of a GET request sent to the platform can have a max length of 8k characters. Due to the limitation, we used to pick-and-choose what query parameters were sent in the Excel export request. The dynamic facets were not included, causing a bug.

This PR adapts the logic to use a POST request with the full query.

https://coveord.atlassian.net/browse/JSUI-3113

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)