### PR TITLE
JSUI-3137 Focus on the collapse/expand button only on selection & improve styles

### DIFF
--- a/sass/DynamicFacet/_DynamicFacetHeader.scss
+++ b/sass/DynamicFacet/_DynamicFacetHeader.scss
@@ -1,9 +1,11 @@
 @import '../Variables';
 @import '../mixins/_facetHeaderAnimation';
 
+$header-height: 35px;
+
 .coveo-dynamic-facet-header {
-  padding: 8px 0;
   border-bottom: $default-border;
+  height: $header-height;
   @include display(flex);
 }
 
@@ -16,6 +18,7 @@
   text-overflow: ellipsis;
   overflow: hidden;
   text-transform: capitalize;
+  line-height: $header-height;
 
   @include flex-grow(1);
 
@@ -42,6 +45,11 @@ $header-svg-dimensions: 15px;
 .coveo-dynamic-facet-header-wait-animation-svg {
   @include coveo-dynamic-facet-header-svg;
   @include facet-header-animation;
+}
+
+.coveo-dynamic-facet-header-collapse,
+.coveo-dynamic-facet-header-expand {
+  height: 100%;
 }
 
 .coveo-dynamic-facet-collapse-toggle-svg {

--- a/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderButton.ts
+++ b/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderButton.ts
@@ -52,8 +52,5 @@ export class DynamicFacetHeaderButton {
 
   public toggle(shouldDisplay: boolean) {
     this.button.toggle(shouldDisplay);
-    if (shouldDisplay) {
-      this.button.el.focus();
-    }
   }
 }

--- a/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggle.ts
+++ b/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggle.ts
@@ -26,7 +26,10 @@ export class DynamicFacetHeaderCollapseToggle {
       iconClassName: 'coveo-dynamic-facet-collapse-toggle-svg',
       className: 'coveo-dynamic-facet-header-collapse',
       shouldDisplay: true,
-      action: () => this.options.collapse()
+      action: () => {
+        this.options.collapse();
+        this.expandButton.element.focus();
+      }
     });
     this.expandButton = new DynamicFacetHeaderButton({
       label: l('ExpandFacet', this.options.title),
@@ -34,7 +37,10 @@ export class DynamicFacetHeaderCollapseToggle {
       iconClassName: 'coveo-dynamic-facet-collapse-toggle-svg',
       className: 'coveo-dynamic-facet-header-expand',
       shouldDisplay: false,
-      action: () => this.options.expand()
+      action: () => {
+        this.options.expand();
+        this.collapseButton.element.focus();
+      }
     });
 
     parent.append(this.collapseButton.element);

--- a/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderButtonTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderButtonTest.ts
@@ -93,18 +93,6 @@ export function DynamicFacetHeaderButtonTest() {
       expect($$(buttonElement).isVisible()).toBe(false);
     });
 
-    it('when "toggle" is called with "true", element should be focused', () => {
-      spyOn(button.element, 'focus');
-      button.toggle(true);
-      expect(button.element.focus).toHaveBeenCalledTimes(1);
-    });
-
-    it('when "toggle" is called with "false", element should not be focused', () => {
-      spyOn(button.element, 'focus');
-      button.toggle(false);
-      expect(button.element.focus).not.toHaveBeenCalled();
-    });
-
     describe('when the icon options ("iconSVG" & "iconClassName") are passed', () => {
       let svg: HTMLElement;
 

--- a/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggleTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggleTest.ts
@@ -51,10 +51,26 @@ export function DynamicFacetHeaderCollapseToggleTest() {
     });
 
     it(`when clicking on the collapse button
+      should focus on the expand button`, () => {
+      spyOn(expandBtnElement, 'focus');
+      $$(collapseBtnElement).trigger('click');
+
+      expect(expandBtnElement.focus).toHaveBeenCalledTimes(1);
+    });
+
+    it(`when clicking on the collapse button
       should call collapse on the DynamicFacet component`, () => {
       $$(collapseBtnElement).trigger('click');
 
       expect(options.collapse).toHaveBeenCalled();
+    });
+
+    it(`when clicking on the expand button
+    should focus on the collapse button`, () => {
+      spyOn(collapseBtnElement, 'focus');
+      $$(expandBtnElement).trigger('click');
+
+      expect(collapseBtnElement.focus).toHaveBeenCalledTimes(1);
     });
 
     it(`when clicking on the expand button


### PR DESCRIPTION
Header buttons were focused on facet select, facet search, omnibox search, etc. Now it's only when explicitly clicking or selecting the toggle with the keyboard.

**Also styles** 
Before:
<img width="357" alt="Screen Shot 2020-10-27 at 10 52 39 AM" src="https://user-images.githubusercontent.com/4923043/97328823-c8c70780-184c-11eb-8ae4-98a40d54f633.png">

After:
<img width="351" alt="Screen Shot 2020-10-27 at 12 05 40 PM" src="https://user-images.githubusercontent.com/4923043/97328834-cbc1f800-184c-11eb-98db-73b3fae62335.png">

https://coveord.atlassian.net/browse/JSUI-3137





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)