### PR TITLE
Only replace noResultsFoundMessage with "No result" when the query is empty

### DIFF
--- a/src/ui/QuerySummary/QuerySummary.ts
+++ b/src/ui/QuerySummary/QuerySummary.ts
@@ -190,10 +190,6 @@ export class QuerySummary extends Component {
   }
 
   private replaceQueryTagsWithHighlightedQuery(template: string) {
-    if (this.sanitizedQuery.trim() === '') {
-      return l('noResult');
-    }
-
     const highlightedQuery = `<span class="coveo-highlight">${this.sanitizedQuery}</span>`;
     return QuerySummaryUtils.replaceQueryTags(template, highlightedQuery);
   }
@@ -245,15 +241,21 @@ export class QuerySummary extends Component {
     return $$(this.element).findAll(`.${noResultsCssClass}`);
   }
 
-  private getNoResultsFoundMessageElement() {
-    const parsedNoResultsFoundMessage = this.replaceQueryTagsWithHighlightedQuery(this.options.noResultsFoundMessage);
+  private get parsedNoResultsFoundMessage() {
+    if (this.sanitizedQuery.trim() === '') {
+      return l('noResult');
+    }
 
+    return this.replaceQueryTagsWithHighlightedQuery(this.options.noResultsFoundMessage);
+  }
+
+  private getNoResultsFoundMessageElement() {
     const noResultsFoundMessage = $$(
       'div',
       {
         className: 'coveo-query-summary-no-results-string'
       },
-      parsedNoResultsFoundMessage
+      this.parsedNoResultsFoundMessage
     );
 
     return noResultsFoundMessage;

--- a/unitTests/ui/QuerySummaryTest.ts
+++ b/unitTests/ui/QuerySummaryTest.ts
@@ -274,7 +274,7 @@ export function QuerySummaryTest() {
         expect(getCustomMessageElement().textContent).toBe('custom querySearched Message querySearched');
       });
 
-      it(`when mutiple no results page are triggered consicutively with different querySearched,
+      it(`when mutiple no results page are triggered consecutively with different querySearched,
           it should update the query tags with the new query searched`, () => {
         test = Mock.optionsComponentSetup<QuerySummary, IQuerySummaryOptions>(QuerySummary, {
           enableNoResultsFoundMessage: true,
@@ -384,7 +384,7 @@ export function QuerySummaryTest() {
         expect(getcustomNoResultsPageElement().textContent).toBe('querySearched querySearched');
       });
 
-      it(`when mutiple no results page are triggered consicutively with different querySearched,
+      it(`when mutiple no results page are triggered consecutively with different querySearched,
           it should update the query tags with the new query searched`, () => {
         test.cmp.element.innerHTML = `<div class="${noResultsCssClass}">${queryTag}</div>`;
 
@@ -410,12 +410,12 @@ export function QuerySummaryTest() {
       });
 
       it(`when the query searched is an empty string,
-        it should put the string NoResult instead`, () => {
+        it should replace the query tag with the query searched`, () => {
         test.env.queryStateModel.get = () => '';
         test.cmp.element.innerHTML = `<div class="${noResultsCssClass}">${queryTag}</div>`;
         Simulate.query(test.env, { results: FakeResults.createFakeResults(0) });
 
-        expect(getcustomNoResultsPageElement().textContent).toBe('No results');
+        expect(getcustomNoResultsPageElement().textContent).toBe('');
       });
 
       it(`when the query searched is the same as the queryTag,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3148
Won't replace what is used as "snapshot" e.g.
```
<span class="CoveoQuerySummary" data-enable-no-results-found-message="true" data-enable-search-tips="false">
    <span class="coveo-show-if-no-results">This won't be replaced by "No result"</span>
</span>
```





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)