### PR TITLE
JSUI-3151 Readd support for relative urls in ResultLink

### DIFF
--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -478,11 +478,10 @@ export class ResultLink extends Component {
   );
 
   private filterProtocol(uri: string) {
-    if (/^(https?|ftp|file|mailto|tel):/i.test(uri)) {
-      return uri;
-    }
+    const isAbsolute = /^(https?|ftp|file|mailto|tel):/i.test(uri);
+    const isRelative = /^\//.test(uri);
 
-    return '';
+    return isAbsolute || isRelative ? uri : '';
   }
 
   private getResultUri(): string {

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -359,6 +359,18 @@ export function ResultLinkTest() {
         expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
       });
 
+      it('when the clickUri is a relative url (starts with slash), it sets the href to the uri', () => {
+        fakeResult.clickUri = '/casemgmt/sc_KnowledgeArticle?sfdcid=ka32C0000009t9CQAQ&type=Solution';
+        initHyperLink();
+        expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+      });
+
+      it('when the clickUri is a string containing but not starting with a slash, it sets the href to an empty string', () => {
+        fakeResult.clickUri = 'casemgmt/sc_KnowledgeArticle';
+        initHyperLink();
+        expect(test.cmp.element.getAttribute('href')).toEqual('');
+      });
+
       it(`when the uri (clickUri) defined in the results contains the javascript protocol,
         it clears the value to prevent XSS`, () => {
         fakeResult.clickUri = 'JavaScript:void(0)';


### PR DESCRIPTION
A few months ago we added stricter checking on CoveoResultLink urls to prevent XSS. The changes only supported absolute urls. This PR loosens the check to support relative urls,


https://coveord.atlassian.net/browse/JSUI-3151

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)