### PR TITLE
JSUI-3150 Prevent adding highlights containing no text

### DIFF
--- a/src/ui/Quickview/QuickviewDocumentWords.ts
+++ b/src/ui/Quickview/QuickviewDocumentWords.ts
@@ -17,6 +17,10 @@ export class QuickviewDocumentWords {
       const quickviewWord = new QuickviewDocumentWord(this.result);
       quickviewWord.doCompleteInitialScanForKeywordInDocument(element);
 
+      if (!quickviewWord.text) {
+        return;
+      }
+
       const alreadyScannedKeyword = this.words[quickviewWord.indexIdentifier];
 
       if (!alreadyScannedKeyword) {

--- a/unitTests/ui/QuickviewDocumentWordsTest.ts
+++ b/unitTests/ui/QuickviewDocumentWordsTest.ts
@@ -21,58 +21,45 @@ export function QuickviewDocumentWordsTest() {
     });
 
     it('should detect multiple keywords, and ignore random elements', () => {
-      fakeBody.append(
-        $$('div', {
-          id: 'CoveoHighlight:1.1.1'
-        }).el
-      );
+      fakeBody.append($$('div', { id: 'CoveoHighlight:1.1.1' }, 'A').el);
 
-      fakeBody.append(
-        $$('div', {
-          id: 'randomStuff'
-        }).el
-      );
+      fakeBody.append($$('div', { id: 'randomStuff' }).el);
 
-      fakeBody.append(
-        $$('div', {
-          id: 'CoveoHighlight:2.1.1'
-        }).el
-      );
+      fakeBody.append($$('div', { id: 'CoveoHighlight:2.1.1' }, 'B').el);
 
-      fakeBody.append(
-        $$('div', {
-          id: 'randomStuff2'
-        }).el
-      );
+      fakeBody.append($$('div', { id: 'randomStuff2' }).el);
 
       const words = new QuickviewDocumentWords(fakeIframe, fakeResult);
+
       expect(words.words['1'].indexIdentifier).toBe('1');
+      expect(words.words['1'].text).toBe('A');
+
       expect(words.words['2'].indexIdentifier).toBe('2');
+      expect(words.words['2'].text).toBe('B');
+
       expect(Object.keys(words.words).length).toBe(2);
     });
 
     it('should detect multiple keywords in the same group', () => {
-      fakeBody.append(
-        $$('div', {
-          id: 'CoveoHighlight:1.1.1'
-        }).el
-      );
+      fakeBody.append($$('div', { id: 'CoveoHighlight:1.1.1' }, 'A').el);
 
-      fakeBody.append(
-        $$('div', {
-          id: 'CoveoHighlight:1.2.1'
-        }).el
-      );
+      fakeBody.append($$('div', { id: 'CoveoHighlight:1.2.1' }, 'A').el);
 
-      fakeBody.append(
-        $$('div', {
-          id: 'CoveoHighlight:1.3.1'
-        }).el
-      );
+      fakeBody.append($$('div', { id: 'CoveoHighlight:1.3.1' }, 'A').el);
 
       const words = new QuickviewDocumentWords(fakeIframe, fakeResult);
       expect(words.words['1'].indexIdentifier).toBe('1');
       expect(words.words['1'].elements.length).toBe(3);
+    });
+
+    it('should ignore highlights whose text resolves to an empty string', () => {
+      const span = $$('span', { id: 'CoveoHighlight:1.1.1' }, $$('coveotaggedword', { id: 'CoveoHighlight:2.1.1' }, 'A'));
+
+      fakeBody.append(span.el);
+      const words = new QuickviewDocumentWords(fakeIframe, fakeResult);
+
+      expect(words.words['1'].text).toBe('A');
+      expect(words.words['2']).toBe(undefined);
     });
   });
 }


### PR DESCRIPTION
### Setup
I am not sure whether this fix should be in the JSUI or if it is caused by an issue with the index. The problem occurs when calculating Quickview highlight toggles for a document with the following structure:

```
<span id="CoveoHighlight:1.1.1" style="background-color: #e9bdff">
    <coveotaggedword id="CoveoHighlight:2.1.1">FICO Score</coveotaggedword>
</span

<span id="CoveoHighlight:2.2.1" style="background-color: #ffe6b8">FICO</span>
```

### Control flow
1. When processing the document, the first element is the `1.x.x` `span` and we add `FICO Score` as the `1` highlight.

2. The next element is the `2.x.x` `coveotaggedword`. This resolves to an empty string because in the case of `coveotaggedword` elements, the logic looks at the text of child elements of which there are none. Before this PR, this would be added as the `2` highlight.

3. The final element is the `2.x.x` `span`. The `FICO` text is resolved but not used since we already have a `2` highlight entry. Instead the span is push as another value under the entry, but the root is still an empty string.

The net result is the `2` highlight is broken, with no text, no background-color, and broken navigation when clicking the toggle (see jira for screenshots).

### Solution
This PR prevents adding highlights with empty text by returning early.

https://coveord.atlassian.net/browse/JSUI-3150


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)