### PR TITLE
JSUI-3168 Publish docs on tagged commits

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ node('linux && docker') {
       }
 
       stage('Build') {
-        sh '. ./read.version.sh'
+        sh './read.version.sh'
         sh 'echo $PACKAGE_JSON_VERSION'
         sh 'yarn run injectTag'
         sh 'yarn run build'
@@ -42,14 +42,14 @@ node('linux && docker') {
         sh 'yarn run validateTypeDefinitions'
       }
 
-      stage('Docs') {
-        // sh 'if [[ "x$GIT_TAG_NAME" != "x" && $IS_PULL_REQUEST_PUSH_BUILD = false ]]; then bash ./deploy.doc.sh ; fi'
-        sh 'yarn run docsitemap'
-        sh 'yarn run zipForGitReleases'
-      }
-
       if (!tag) {
         return
+      }
+
+      stage('Docs') {
+        sh './deploy.doc.sh'
+        sh 'yarn run docsitemap'
+        sh 'yarn run zipForGitReleases'
       }
 
       stage('Deploy') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,6 @@ node('linux && docker') {
       }
 
       stage('Build') {
-        sh './read.version.sh'
-        sh 'echo $PACKAGE_JSON_VERSION'
         sh 'yarn run injectTag'
         sh 'yarn run build'
 

--- a/read.version.sh
+++ b/read.version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 export PACKAGE_JSON_VERSION=`cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | sed -E 's/\.[0-9]+$//g' | xargs`
 export PACKAGE_PATCH_VERSION=`cat package.json | grep version | head -1 | awk -F: '{ print $2 }' | sed 's/[",]//g' | sed -E 's/[0-9]+\.[0-9]+\.//g' | xargs`


### PR DESCRIPTION
Docs should publish correctly 🤞 There is logic in the bash script to ensure we only release when the package json version is greater than the latest version on npm.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)