### PR TITLE
JSUI-3171 Made it possible to render `SmartSnippetSuggestions` without `SmartSnippet`

### DIFF
--- a/src/rest/QuestionAnswerResponse.ts
+++ b/src/rest/QuestionAnswerResponse.ts
@@ -1,6 +1,4 @@
-export interface IPartialQuestionAnswerResponse {
-  question: string;
-  answerSnippet: string;
+export interface IQuestionAnswerMeta {
   documentId: {
     contentIdKey: string;
     contentIdValue: string;
@@ -8,6 +6,13 @@ export interface IPartialQuestionAnswerResponse {
   score: number;
 }
 
-export interface IQuestionAnswerResponse extends Partial<IPartialQuestionAnswerResponse> {
-  relatedQuestions: IPartialQuestionAnswerResponse[];
+export interface IRelatedQuestionAnswerResponse extends IQuestionAnswerMeta {
+  question: string;
+  answerSnippet: string;
+}
+
+export interface IQuestionAnswerResponse extends IQuestionAnswerMeta {
+  question?: string;
+  answerSnippet?: string;
+  relatedQuestions: IRelatedQuestionAnswerResponse[];
 }

--- a/src/rest/QuestionAnswerResponse.ts
+++ b/src/rest/QuestionAnswerResponse.ts
@@ -8,6 +8,6 @@ export interface IPartialQuestionAnswerResponse {
   score: number;
 }
 
-export interface IQuestionAnswerResponse extends IPartialQuestionAnswerResponse {
+export interface IQuestionAnswerResponse extends Partial<IPartialQuestionAnswerResponse> {
   relatedQuestions: IPartialQuestionAnswerResponse[];
 }

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -190,12 +190,16 @@ export class SmartSnippet extends Component {
 
   private async handleQuerySuccess(data: IQuerySuccessEventArgs) {
     const { questionAnswer } = data.results;
-    if (!questionAnswer) {
+    if (!this.containsQuestionAnswer(questionAnswer)) {
       this.hasAnswer = false;
       return;
     }
     this.hasAnswer = true;
     await this.render(questionAnswer);
+  }
+
+  private containsQuestionAnswer(questionAnswer: IQuestionAnswerResponse) {
+    return questionAnswer && questionAnswer.question && questionAnswer.answerSnippet;
   }
 
   private async render(questionAnswer: IQuestionAnswerResponse) {

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -1,4 +1,4 @@
-import { IPartialQuestionAnswerResponse } from '../../rest/QuestionAnswerResponse';
+import { IRelatedQuestionAnswerResponse } from '../../rest/QuestionAnswerResponse';
 import { uniqueId } from 'underscore';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import { SVGIcons } from '../../utils/SVGIcons';
@@ -43,7 +43,7 @@ export class SmartSnippetCollapsibleSuggestion {
   private expanded = false;
 
   constructor(
-    private readonly questionAnswer: IPartialQuestionAnswerResponse,
+    private readonly questionAnswer: IRelatedQuestionAnswerResponse,
     private readonly innerCSS?: string,
     private readonly source?: IQueryResult
   ) {}

--- a/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
+++ b/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
@@ -3,7 +3,7 @@ import { Component } from '../Base/Component';
 import { exportGlobally } from '../../GlobalExports';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { QueryEvents, IQuerySuccessEventArgs } from '../../events/QueryEvents';
-import { IPartialQuestionAnswerResponse, IQuestionAnswerResponse } from '../../rest/QuestionAnswerResponse';
+import { IRelatedQuestionAnswerResponse, IQuestionAnswerResponse } from '../../rest/QuestionAnswerResponse';
 import { $$, Dom } from '../../utils/Dom';
 import { uniqueId, isEqual, find } from 'underscore';
 import { SmartSnippetCollapsibleSuggestion } from './SmartSnippetCollapsibleSuggestion';
@@ -48,7 +48,7 @@ export class SmartSnippetSuggestions extends Component {
   /**
    * @warning This method only works for the demo. In practice, the source of the answer will not always be part of the results.
    */
-  private getCorrespondingResult(questionAnswer: IPartialQuestionAnswerResponse) {
+  private getCorrespondingResult(questionAnswer: IRelatedQuestionAnswerResponse) {
     return find(
       this.queryController.getLastResults().results,
       result => result.raw[questionAnswer.documentId.contentIdKey] === questionAnswer.documentId.contentIdValue
@@ -82,7 +82,7 @@ export class SmartSnippetSuggestions extends Component {
     return $$('span', { className: QUESTIONS_LIST_TITLE_CLASSNAME, id: this.titleId }, l('SuggestedQuestions'));
   }
 
-  private buildQuestionAnswers(questionAnswers: IPartialQuestionAnswerResponse[]) {
+  private buildQuestionAnswers(questionAnswers: IRelatedQuestionAnswerResponse[]) {
     const innerCSS = this.getInnerCSS();
     const answers = questionAnswers.map(
       questionAnswer => new SmartSnippetCollapsibleSuggestion(questionAnswer, innerCSS, this.getCorrespondingResult(questionAnswer))

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -1,6 +1,6 @@
 import { IQuerySuccessEventArgs, QueryEvents } from '../../src/events/QueryEvents';
 import { IQueryResult } from '../../src/rest/QueryResult';
-import { IPartialQuestionAnswerResponse, IQuestionAnswerResponse } from '../../src/rest/QuestionAnswerResponse';
+import { IQuestionAnswerResponse, IRelatedQuestionAnswerResponse } from '../../src/rest/QuestionAnswerResponse';
 import { SmartSnippetSuggestions, SmartSnippetSuggestionsClassNames } from '../../src/ui/SmartSnippet/SmartSnippetSuggestions';
 import { SmartSnippetCollapsibleSuggestionClassNames } from '../../src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion';
 import { $$, Dom } from '../../src/utils/Dom';
@@ -96,7 +96,7 @@ export function SmartSnippetSuggestionsTest() {
   function mockRelatedQuestions() {
     return sources.map(
       (source, i) =>
-        <IPartialQuestionAnswerResponse>{
+        <IRelatedQuestionAnswerResponse>{
           question: questions[i],
           answerSnippet: mockSnippet(i).innerHTML,
           documentId: source.id,

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -7,6 +7,7 @@ import { $$, Dom } from '../../src/utils/Dom';
 import { advancedComponentSetup, AdvancedComponentSetupOptions, IBasicComponentSetup } from '../MockEnvironment';
 import { expectChildren } from '../TestUtils';
 import { flatten } from 'underscore';
+import { IQueryResults } from '../../src/rest/QueryResults';
 
 const ClassNames = {
   ...SmartSnippetSuggestionsClassNames,
@@ -92,17 +93,21 @@ export function SmartSnippetSuggestionsTest() {
     return $$('script', { type: 'text/css' }, style).el;
   }
 
+  function mockRelatedQuestions() {
+    return sources.map(
+      (source, i) =>
+        <IPartialQuestionAnswerResponse>{
+          question: questions[i],
+          answerSnippet: mockSnippet(i).innerHTML,
+          documentId: source.id,
+          score: 0
+        }
+    );
+  }
+
   function mockQuestionAnswer() {
     return <IQuestionAnswerResponse>{
-      relatedQuestions: sources.map(
-        (source, i) =>
-          <IPartialQuestionAnswerResponse>{
-            question: questions[i],
-            answerSnippet: mockSnippet(i).innerHTML,
-            documentId: source.id,
-            score: 0
-          }
-      )
+      relatedQuestions: mockRelatedQuestions()
     };
   }
 
@@ -119,16 +124,20 @@ export function SmartSnippetSuggestionsTest() {
         .and.callFake((href: string, newTab: boolean, sendAnalytics: () => void) => sendAnalytics());
     }
 
-    async function triggerQuerySuccess(withSource: boolean) {
+    async function triggerQuerySuccess(args: Partial<IQuerySuccessEventArgs>) {
+      (test.env.queryController.getLastResults as jasmine.Spy).and.returnValue(args.results);
+      $$(test.env.root).trigger(QueryEvents.deferredQuerySuccess, args);
+      await test.cmp.loading;
+    }
+
+    async function triggerQuestionAnswerQuery(withSource: boolean) {
       const results = withSource ? mockResults() : [];
-      (test.env.queryController.getLastResults as jasmine.Spy).and.returnValue({ results });
-      $$(test.env.root).trigger(QueryEvents.deferredQuerySuccess, <IQuerySuccessEventArgs>{
-        results: {
+      await triggerQuerySuccess({
+        results: <IQueryResults>{
           results,
           questionAnswer: mockQuestionAnswer()
         }
       });
-      await test.cmp['shadowLoading'];
     }
 
     function findClass<T extends HTMLElement = HTMLElement>(className: string, inShadowRoot = false): T[] {
@@ -146,7 +155,7 @@ export function SmartSnippetSuggestionsTest() {
       beforeEach(async done => {
         instantiateSmartSnippetSuggestions(true);
         document.body.appendChild(test.env.root);
-        await triggerQuerySuccess(false);
+        await triggerQuestionAnswerQuery(false);
         await test.cmp['contentLoaded'];
         done();
       });
@@ -183,9 +192,33 @@ export function SmartSnippetSuggestionsTest() {
         expect(test.cmp.element.children.length).toEqual(0);
       });
 
+      it('with only a question answer, does not render', async done => {
+        await triggerQuerySuccess({
+          results: <IQueryResults>{ questionAnswer: { question: 'abc', answerSnippet: 'def', relatedQuestions: [] } }
+        });
+        expect(test.cmp.element.classList.contains(ClassNames.HAS_QUESTIONS_CLASSNAME)).toBeFalsy();
+        done();
+      });
+
+      it('with only related questions, renders', async done => {
+        await triggerQuerySuccess({
+          results: <IQueryResults>{ questionAnswer: { relatedQuestions: mockRelatedQuestions() } }
+        });
+        expect(test.cmp.element.classList.contains(ClassNames.HAS_QUESTIONS_CLASSNAME)).toBeTruthy();
+        done();
+      });
+
+      it('with both a question answer and related questions, renders', async done => {
+        await triggerQuerySuccess({
+          results: <IQueryResults>{ questionAnswer: { question: 'abc', answerSnippet: 'def', relatedQuestions: mockRelatedQuestions() } }
+        });
+        expect(test.cmp.element.classList.contains(ClassNames.HAS_QUESTIONS_CLASSNAME)).toBeTruthy();
+        done();
+      });
+
       describe('with a source', () => {
         beforeEach(async done => {
-          await triggerQuerySuccess(true);
+          await triggerQuestionAnswerQuery(true);
           await test.cmp['contentLoaded'];
           done();
         });

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -1,4 +1,4 @@
-import { IPartialQuestionAnswerResponse, IQuestionAnswerResponse } from '../../src/rest/QuestionAnswerResponse';
+import { IQuestionAnswerResponse, IRelatedQuestionAnswerResponse } from '../../src/rest/QuestionAnswerResponse';
 import { IQueryResult } from '../../src/rest/QueryResult';
 import { $$ } from '../../src/utils/Dom';
 import { QueryEvents, IQuerySuccessEventArgs } from '../../src/events/QueryEvents';
@@ -65,7 +65,7 @@ export function SmartSnippetTest() {
   }
 
   function mockQuestionAnswer() {
-    return <IPartialQuestionAnswerResponse>{
+    return <IRelatedQuestionAnswerResponse>{
       question: 'abc',
       answerSnippet: mockSnippet().innerHTML,
       documentId: sourceId


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3171

![image](https://user-images.githubusercontent.com/54454747/104462139-2cc0b880-557e-11eb-8fe0-f770aa3e735e.png)

`SmartSnippetSuggestions` was already able to render without a main question & answer. However, `SmartSnippet` would still attempt to render when there was only `relatedQuestions`.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)