### PR TITLE
JSUI-3173 Increase buffer size by 10x

### DIFF
--- a/build/npm.deploy.js
+++ b/build/npm.deploy.js
@@ -13,7 +13,9 @@ async function deployTaggedVersion() {
 
 async function publishToNpm(publishArgs = [], successMessage) {
   const args = ['publish', ...publishArgs].join(' ');
-  await exec(`npm ${args}`);
+  const defaultBufferSize = 1024 * 200;
+
+  await exec(`npm ${args}`, { maxBuffer: defaultBufferSize * 10 });
   console.log(successMessage);
 }
 


### PR DESCRIPTION
When publishing the beta package to npm via Jenkins, the process fails due to exceeding the buffer size.

```
(node:4285) UnhandledPromiseRejectionWarning: RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stderr maxBuffer length exceeded
    at Socket.onChildStderr (child_process.js:377:14)
    at Socket.emit (events.js:198:13)
    at addChunk (_stream_readable.js:288:12)
    at readableAddChunk (_stream_readable.js:265:13)
    at Socket.Readable.push (_stream_readable.js:224:10)
    at Pipe.onStreamRead (internal/stream_base_commons.js:94:17)
```

I could not reproduce the error locally, so I am bumping the buffer from the default of 200 kb to 2 MB in the hopes of resolving the issue on jenkins during the next run.

https://coveord.atlassian.net/browse/JSUI-3173


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)