### PR TITLE
JSUI-3116 Made the details section of `ExplanationModal` hide itself when disabled

### DIFF
--- a/sass/_ExplanationModal.scss
+++ b/sass/_ExplanationModal.scss
@@ -58,7 +58,7 @@
       align-items: flex-start;
       flex-grow: 1;
 
-      &.disabled {
+      &.coveo-hidden {
         visibility: hidden;
       }
 

--- a/sass/_ExplanationModal.scss
+++ b/sass/_ExplanationModal.scss
@@ -58,6 +58,10 @@
       align-items: flex-start;
       flex-grow: 1;
 
+      &.disabled {
+        visibility: hidden;
+      }
+
       &-textarea {
         @include defaultRoundedLowContrastBorder();
         min-width: 256px;
@@ -69,11 +73,6 @@
         font-family: Arial, Helvetica, sans-serif;
         color: black;
         font-size: 1em;
-
-        &[disabled] {
-          background-color: #ddd;
-          color: #616161;
-        }
 
         &:focus {
           border-color: $color-active-orange;

--- a/src/ui/SmartSnippet/ExplanationModal.ts
+++ b/src/ui/SmartSnippet/ExplanationModal.ts
@@ -129,7 +129,7 @@ export class ExplanationModal {
   private buildDetailsSection() {
     return (this.detailsSection = $$(
       'div',
-      { className: `disabled ${DETAILS_SECTION_CLASSNAME}` },
+      { className: `coveo-hidden ${DETAILS_SECTION_CLASSNAME}` },
       $$('label', { className: DETAILS_LABEL_CLASSNAME, for: DETAILS_ID }, l('Details')).el,
       (this.detailsTextArea = $$('textarea', { className: DETAILS_TEXTAREA_CLASSNAME, id: DETAILS_ID, disabled: true })
         .el as HTMLTextAreaElement)
@@ -158,7 +158,7 @@ export class ExplanationModal {
         if (!radioButton.isSelected()) {
           return;
         }
-        this.detailsSection.toggleClass('disabled', !reason.hasDetails);
+        this.detailsSection.toggleClass('coveo-hidden', !reason.hasDetails);
         this.detailsTextArea.disabled = !reason.hasDetails;
         this.selectedReason = reason;
       },

--- a/src/ui/SmartSnippet/ExplanationModal.ts
+++ b/src/ui/SmartSnippet/ExplanationModal.ts
@@ -1,6 +1,6 @@
 import { AccessibleModal } from '../../utils/AccessibleModal';
 import { l } from '../../strings/Strings';
-import { $$ } from '../../utils/Dom';
+import { $$, Dom } from '../../utils/Dom';
 import { RadioButton } from '../FormWidgets/RadioButton';
 import 'styling/_ExplanationModal';
 
@@ -49,6 +49,7 @@ export class ExplanationModal {
   private modal: AccessibleModal;
   private reasons: RadioButton[];
   private selectedReason: IReason;
+  private detailsSection: Dom;
   private detailsTextArea: HTMLTextAreaElement;
   private shouldCallCloseEvent = false;
 
@@ -126,13 +127,13 @@ export class ExplanationModal {
   }
 
   private buildDetailsSection() {
-    return $$(
+    return (this.detailsSection = $$(
       'div',
-      { className: DETAILS_SECTION_CLASSNAME },
+      { className: `disabled ${DETAILS_SECTION_CLASSNAME}` },
       $$('label', { className: DETAILS_LABEL_CLASSNAME, for: DETAILS_ID }, l('Details')).el,
       (this.detailsTextArea = $$('textarea', { className: DETAILS_TEXTAREA_CLASSNAME, id: DETAILS_ID, disabled: true })
         .el as HTMLTextAreaElement)
-    );
+    ));
   }
 
   private buildSendButton() {
@@ -157,6 +158,7 @@ export class ExplanationModal {
         if (!radioButton.isSelected()) {
           return;
         }
+        this.detailsSection.toggleClass('disabled', !reason.hasDetails);
         this.detailsTextArea.disabled = !reason.hasDetails;
         this.selectedReason = reason;
       },

--- a/unitTests/ui/ExplanationModalTest.ts
+++ b/unitTests/ui/ExplanationModalTest.ts
@@ -130,6 +130,10 @@ export function ExplanationModalTest() {
         expect((getFirstChild(ClassNames.DETAILS_TEXTAREA_CLASSNAME) as HTMLTextAreaElement).disabled).toBeFalsy();
       });
 
+      it("doesn't disable the details section", () => {
+        expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('disabled')).toBeFalsy();
+      });
+
       it('builds a send button with the right text', () => {
         expect(getFirstChild(ClassNames.SEND_BUTTON_CLASSNAME).innerText).toEqual('Send');
       });
@@ -141,6 +145,10 @@ export function ExplanationModalTest() {
 
         it('should disable the details textarea', () => {
           expect((getFirstChild(ClassNames.DETAILS_TEXTAREA_CLASSNAME) as HTMLTextAreaElement).disabled).toBeTruthy();
+        });
+
+        it('should disable the details section', () => {
+          expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('disabled')).toBeTruthy();
         });
 
         describe('then pressing the send button', () => {
@@ -166,6 +174,10 @@ export function ExplanationModalTest() {
 
         it('should disable the details textarea', () => {
           expect((getFirstChild(ClassNames.DETAILS_TEXTAREA_CLASSNAME) as HTMLTextAreaElement).disabled).toBeTruthy();
+        });
+
+        it('should disable the details section', () => {
+          expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('disabled')).toBeTruthy();
         });
 
         describe('then pressing the send button', () => {
@@ -226,6 +238,10 @@ export function ExplanationModalTest() {
 
       it('disables the textarea', () => {
         expect((getFirstChild(ClassNames.DETAILS_TEXTAREA_CLASSNAME) as HTMLTextAreaElement).disabled).toBeTruthy();
+      });
+
+      it('disables the details section', () => {
+        expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('disabled')).toBeTruthy();
       });
     });
   });

--- a/unitTests/ui/ExplanationModalTest.ts
+++ b/unitTests/ui/ExplanationModalTest.ts
@@ -131,7 +131,7 @@ export function ExplanationModalTest() {
       });
 
       it("doesn't disable the details section", () => {
-        expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('disabled')).toBeFalsy();
+        expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('coveo-hidden')).toBeFalsy();
       });
 
       it('builds a send button with the right text', () => {
@@ -148,7 +148,7 @@ export function ExplanationModalTest() {
         });
 
         it('should disable the details section', () => {
-          expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('disabled')).toBeTruthy();
+          expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('coveo-hidden')).toBeTruthy();
         });
 
         describe('then pressing the send button', () => {
@@ -177,7 +177,7 @@ export function ExplanationModalTest() {
         });
 
         it('should disable the details section', () => {
-          expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('disabled')).toBeTruthy();
+          expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('coveo-hidden')).toBeTruthy();
         });
 
         describe('then pressing the send button', () => {
@@ -241,7 +241,7 @@ export function ExplanationModalTest() {
       });
 
       it('disables the details section', () => {
-        expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('disabled')).toBeTruthy();
+        expect(getFirstChild(ClassNames.DETAILS_SECTION_CLASSNAME).classList.contains('coveo-hidden')).toBeTruthy();
       });
     });
   });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3116

`ExplanationModal` should only be visible when "Other" is checked.

# When disabled (hidden)
![image](https://user-images.githubusercontent.com/54454747/104485038-00199a80-5598-11eb-9713-15478f67282b.png)

# When enabled (displayed)
![image](https://user-images.githubusercontent.com/54454747/104485093-0f004d00-5598-11eb-89e9-30dcaa01047d.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)