### PR TITLE
JSUI-3118 Added a margin above `HeightLimiter`'s "show more" button

### DIFF
--- a/sass/_SmartSnippet.scss
+++ b/sass/_SmartSnippet.scss
@@ -71,6 +71,7 @@
       }
 
       @at-root & {
+        margin-top: 5px;
         border: none;
         align-self: center;
         padding: 8px;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3118

I could not reproduce the other issue from this JIRA on Chrome, Firefox and Chromium, which is that pressing "show more" would scroll the page.

This PR adds a margin above the "show more" button to avoid breaking the default browser focus style. We could have our own focus style on it, but the browser's seems fine to me.

# Before
![image](https://user-images.githubusercontent.com/54454747/104598658-d5395000-5644-11eb-9108-3797f60b18b7.png)

# After
![image](https://user-images.githubusercontent.com/54454747/104598475-9efbd080-5644-11eb-98b9-758abbca4098.png)


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)