### PR TITLE
JSUI-3119 Introduced an option to limit the height of `SmartSnippet`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coveo-search-ui",
-  "version": "2.0.822",
+  "version": "2.0.823",
   "description": "Coveo JavaScript Search Framework",
   "main": "./bin/js/CoveoJsSearch.js",
   "types": "./bin/ts/CoveoJsSearch.d.ts",

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -88,9 +88,9 @@ export class SmartSnippet extends Component {
    */
   static options: ISmartSnippetOptions = {
     /**
-     * The maximum height a question answer can have in pixels.
-     * Any part of a question answering exceeding this height will be hidden.
-     * A "show more" button is added underneath an answer when some part of it is hidden.
+     * The maximum height an answer can have in pixels.
+     * Any part of an answer exceeding this height will be hidden by default and expendable via a "show more" button.
+     * Default value is `250`.
      */
     maximumSnippetHeight: ComponentOptions.buildNumberOption({ defaultValue: 250, min: 0 })
   };

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -20,6 +20,7 @@ import { ExplanationModal, IReason } from './ExplanationModal';
 import { l } from '../../strings/Strings';
 import { attachShadow } from '../../misc/AttachShadowPolyfill';
 import { Utils } from '../../utils/Utils';
+import { ComponentOptions } from '../Base/ComponentOptions';
 
 interface ISmartSnippetReason {
   analytics: AnalyticsSmartSnippetFeedbackReason;
@@ -68,6 +69,10 @@ export const SmartSnippetClassNames = {
   SOURCE_URL_CLASSNAME
 };
 
+export interface ISmartSnippetOptions {
+  maximumSnippetHeight: number;
+}
+
 export class SmartSnippet extends Component {
   static ID = 'SmartSnippet';
 
@@ -75,6 +80,19 @@ export class SmartSnippet extends Component {
     exportGlobally({
       SmartSnippet
     });
+  };
+
+  /**
+   * The options for the SmartSnippet
+   * @componentOptions
+   */
+  static options: ISmartSnippetOptions = {
+    /**
+     * The maximum height a question answer can have in pixels.
+     * Any part of a question answering exceeding this height will be hidden.
+     * A "show more" button is added underneath an answer when some part of it is hidden.
+     */
+    maximumSnippetHeight: ComponentOptions.buildNumberOption({ defaultValue: 250, min: 0 })
   };
 
   private lastRenderedResult: IQueryResult;
@@ -87,8 +105,14 @@ export class SmartSnippet extends Component {
   private feedbackBanner: UserFeedbackBanner;
   private shadowLoading: Promise<HTMLElement>;
 
-  constructor(public element: HTMLElement, public options?: {}, bindings?: IComponentBindings, private ModalBox = ModalBoxModule) {
+  constructor(
+    public element: HTMLElement,
+    public options?: ISmartSnippetOptions,
+    bindings?: IComponentBindings,
+    private ModalBox = ModalBoxModule
+  ) {
     super(element, SmartSnippet.ID, bindings);
+    this.options = ComponentOptions.initComponentOptions(element, SmartSnippet, options);
     this.bind.onRootElement(QueryEvents.deferredQuerySuccess, (data: IQuerySuccessEventArgs) => this.handleQuerySuccess(data));
   }
 
@@ -159,8 +183,11 @@ export class SmartSnippet extends Component {
   }
 
   private buildHeightLimiter() {
-    return (this.heightLimiter = new HeightLimiter(this.shadowContainer, this.snippetContainer, 400, isExpanded =>
-      isExpanded ? this.sendExpandSmartSnippetAnalytics() : this.sendCollapseSmartSnippetAnalytics()
+    return (this.heightLimiter = new HeightLimiter(
+      this.shadowContainer,
+      this.snippetContainer,
+      this.options.maximumSnippetHeight,
+      isExpanded => (isExpanded ? this.sendExpandSmartSnippetAnalytics() : this.sendCollapseSmartSnippetAnalytics())
     )).toggleButton;
   }
 

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -3,10 +3,7 @@ import { IQueryResult } from '../../src/rest/QueryResult';
 import { IQuestionAnswerResponse, IRelatedQuestionAnswerResponse } from '../../src/rest/QuestionAnswerResponse';
 import { SmartSnippetSuggestions, SmartSnippetSuggestionsClassNames } from '../../src/ui/SmartSnippet/SmartSnippetSuggestions';
 import { advancedComponentSetup, AdvancedComponentSetupOptions, IBasicComponentSetup } from '../MockEnvironment';
-import {
-  SmartSnippetCollapsibleSuggestion,
-  SmartSnippetCollapsibleSuggestionClassNames
-} from '../../src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion';
+import { SmartSnippetCollapsibleSuggestionClassNames } from '../../src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion';
 import { $$ } from '../../src/utils/Dom';
 import { expectChildren } from '../TestUtils';
 import { analyticsActionCauseList } from '../../src/ui/Analytics/AnalyticsActionListMeta';
@@ -118,7 +115,6 @@ export function SmartSnippetSuggestionsTest() {
 
   describe('SmartSnippetSuggestions', () => {
     let test: IBasicComponentSetup<SmartSnippetSuggestions>;
-    let collapsibleSuggestions: SmartSnippetCollapsibleSuggestion[];
 
     function instantiateSmartSnippetSuggestions(styling: string) {
       test = advancedComponentSetup<SmartSnippetSuggestions>(
@@ -128,7 +124,7 @@ export function SmartSnippetSuggestionsTest() {
     }
 
     async function waitForCollapsibleSuggestions() {
-      collapsibleSuggestions = await test.cmp['contentLoaded'];
+      await test.cmp['contentLoaded'];
     }
 
     async function triggerQuerySuccess(args: Partial<IQuerySuccessEventArgs>) {

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -129,12 +129,6 @@ export function SmartSnippetSuggestionsTest() {
 
     async function waitForCollapsibleSuggestions() {
       collapsibleSuggestions = await test.cmp['contentLoaded'];
-      collapsibleSuggestions.forEach(
-        suggestion =>
-          (suggestion['openLink'] = jasmine
-            .createSpy('openLink')
-            .and.callFake((href: string, newTab: boolean, sendAnalytics: () => void) => sendAnalytics()))
-      );
     }
 
     async function triggerQuerySuccess(args: Partial<IQuerySuccessEventArgs>) {

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -2,7 +2,7 @@ import { IQuestionAnswerResponse, IRelatedQuestionAnswerResponse } from '../../s
 import { IQueryResult } from '../../src/rest/QueryResult';
 import { $$ } from '../../src/utils/Dom';
 import { QueryEvents, IQuerySuccessEventArgs } from '../../src/events/QueryEvents';
-import { SmartSnippet, SmartSnippetClassNames as ClassNames } from '../../src/ui/SmartSnippet/SmartSnippet';
+import { ISmartSnippetOptions, SmartSnippet, SmartSnippetClassNames as ClassNames } from '../../src/ui/SmartSnippet/SmartSnippet';
 import { expectChildren } from '../TestUtils';
 import { UserFeedbackBannerClassNames } from '../../src/ui/SmartSnippet/UserFeedbackBanner';
 import { IBasicComponentSetup, advancedComponentSetup, AdvancedComponentSetupOptions } from '../MockEnvironment';
@@ -77,14 +77,11 @@ export function SmartSnippetTest() {
   describe('SmartSnippet', () => {
     let test: IBasicComponentSetup<SmartSnippet>;
 
-    function instantiateSmartSnippet(styling: string | null) {
+    function instantiateSmartSnippet(styling: string | null, options: Partial<ISmartSnippetOptions> = {}) {
       test = advancedComponentSetup<SmartSnippet>(
         SmartSnippet,
-        new AdvancedComponentSetupOptions($$('div', {}, ...(Utils.isNullOrUndefined(styling) ? [] : [mockStyling(styling)])).el)
+        new AdvancedComponentSetupOptions($$('div', {}, ...(Utils.isNullOrUndefined(styling) ? [] : [mockStyling(styling)])).el, options)
       );
-      test.cmp['openLink'] = jasmine
-        .createSpy('openLink')
-        .and.callFake((href: string, newTab: boolean, sendAnalytics: () => void) => sendAnalytics());
     }
 
     async function triggerQuerySuccess(args: Partial<IQuerySuccessEventArgs>) {
@@ -110,6 +107,17 @@ export function SmartSnippetTest() {
     function getShadowRoot() {
       return getFirstChild(ClassNames.SHADOW_CLASSNAME).shadowRoot;
     }
+
+    it('instantiates the heightLimiter using the maximumSnippetHeight option', () => {
+      let maximumSnippetHeight = 123;
+      instantiateSmartSnippet(null, { maximumSnippetHeight });
+      test.cmp.ensureDom();
+      expect(test.cmp['heightLimiter']['heightLimit']).toEqual(maximumSnippetHeight);
+      maximumSnippetHeight = 321;
+      instantiateSmartSnippet(null, { maximumSnippetHeight });
+      test.cmp.ensureDom();
+      expect(test.cmp['heightLimiter']['heightLimit']).toEqual(maximumSnippetHeight);
+    });
 
     describe('with styling without a source', () => {
       beforeEach(async done => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3119

# Old default (400px)
![image](https://user-images.githubusercontent.com/54454747/104604884-d457ec80-564b-11eb-9237-1d74a4478057.png)

# New default (250px)
![image](https://user-images.githubusercontent.com/54454747/104604777-b7bbb480-564b-11eb-93e8-df2e765f1466.png)

# Minimum value (0px)
![image](https://user-images.githubusercontent.com/54454747/104605004-f6516f00-564b-11eb-9e9f-6a874cbcaf6b.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)