### PR TITLE
JSUI-3164 Edit attributes of single DynamicFacet toggle versus switching between two elements

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeader.ts
+++ b/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeader.ts
@@ -57,7 +57,7 @@ export class DynamicFacetHeader {
   }
 
   public toggleCollapse(isCollapsed: boolean) {
-    this.options.enableCollapse && this.collapseToggle.toggleButtons(isCollapsed);
+    this.options.enableCollapse && this.collapseToggle.toggleButton(isCollapsed);
   }
 
   private createTitle() {

--- a/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggle.ts
+++ b/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggle.ts
@@ -3,6 +3,7 @@ import { SVGIcons } from '../../../utils/SVGIcons';
 import { $$ } from '../../../utils/Dom';
 import { DynamicFacetHeaderButton } from './DynamicFacetHeaderButton';
 import { IDynamicFacetHeaderOptions } from './DynamicFacetHeader';
+import { SVGDom } from '../../../utils/SVGDom';
 
 export interface IDynamicFacetCollapseToggleOptions {
   collapsed: boolean;
@@ -10,8 +11,7 @@ export interface IDynamicFacetCollapseToggleOptions {
 
 export class DynamicFacetHeaderCollapseToggle {
   public element: HTMLElement;
-  private collapseButton: DynamicFacetHeaderButton;
-  private expandButton: DynamicFacetHeaderButton;
+  private button: DynamicFacetHeaderButton;
 
   constructor(private options: IDynamicFacetHeaderOptions) {
     this.create();
@@ -20,37 +20,31 @@ export class DynamicFacetHeaderCollapseToggle {
   private create() {
     const parent = $$('div');
 
-    this.collapseButton = new DynamicFacetHeaderButton({
+    this.button = new DynamicFacetHeaderButton({
       label: l('CollapseFacet', this.options.title),
       iconSVG: SVGIcons.icons.arrowUp,
       iconClassName: 'coveo-dynamic-facet-collapse-toggle-svg',
       className: 'coveo-dynamic-facet-header-collapse',
       shouldDisplay: true,
-      action: () => {
-        this.options.collapse();
-        this.expandButton.element.focus();
-      }
-    });
-    this.expandButton = new DynamicFacetHeaderButton({
-      label: l('ExpandFacet', this.options.title),
-      iconSVG: SVGIcons.icons.arrowDown,
-      iconClassName: 'coveo-dynamic-facet-collapse-toggle-svg',
-      className: 'coveo-dynamic-facet-header-expand',
-      shouldDisplay: false,
-      action: () => {
-        this.options.expand();
-        this.collapseButton.element.focus();
-      }
+      action: () => this.options.toggleCollapse()
     });
 
-    parent.append(this.collapseButton.element);
-    parent.append(this.expandButton.element);
-
+    parent.append(this.button.element);
     this.element = parent.el;
   }
 
   public toggleButtons(isCollapsed: boolean) {
-    this.collapseButton.toggle(!isCollapsed);
-    this.expandButton.toggle(isCollapsed);
+    const node = $$(this.button.element);
+    const label = isCollapsed ? l('ExpandFacet', this.options.title) : l('CollapseFacet', this.options.title);
+    const icon = isCollapsed ? SVGIcons.icons.arrowDown : SVGIcons.icons.arrowUp;
+
+    node.setAttribute('aria-label', label);
+    node.setAttribute('title', label);
+
+    node.toggleClass('coveo-dynamic-facet-header-expand', isCollapsed);
+    node.toggleClass('coveo-dynamic-facet-header-collapse', !isCollapsed);
+
+    node.setHtml(icon);
+    SVGDom.addClassToSVGInContainer(node.el, 'coveo-dynamic-facet-collapse-toggle-svg');
   }
 }

--- a/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggle.ts
+++ b/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggle.ts
@@ -33,7 +33,7 @@ export class DynamicFacetHeaderCollapseToggle {
     this.element = parent.el;
   }
 
-  public toggleButtons(isCollapsed: boolean) {
+  public toggleButton(isCollapsed: boolean) {
     const node = $$(this.button.element);
     const label = isCollapsed ? l('ExpandFacet', this.options.title) : l('CollapseFacet', this.options.title);
     const icon = isCollapsed ? SVGIcons.icons.arrowDown : SVGIcons.icons.arrowUp;

--- a/src/ui/SimpleFilter/SimpleFilter.ts
+++ b/src/ui/SimpleFilter/SimpleFilter.ts
@@ -402,7 +402,6 @@ export class SimpleFilter extends Component {
       this.handleValueToggle(checkbox);
     }, this.getValueCaption(label));
     checkbox.getElement().title = l(label);
-    $$(checkbox.getElement()).setAttribute('tabindex', '0');
     return { checkbox, label };
   }
 

--- a/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggleTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggleTest.ts
@@ -37,15 +37,15 @@ export function DynamicFacetHeaderCollapseToggleTest() {
 
     it(`when calling toggleButtons with isCollapsed to true
       should display the expand button and hide the collapse button`, () => {
-      collapseToggle.toggleButtons(true);
+      collapseToggle.toggleButton(true);
       expect($$(collapseBtnElement).isVisible()).toBe(false);
       expect($$(expandBtnElement).isVisible()).toBe(true);
     });
 
     it(`when calling toggleButtons with isCollapsed to false
       should display the collapse button and hide the expand button`, () => {
-      collapseToggle.toggleButtons(true);
-      collapseToggle.toggleButtons(false);
+      collapseToggle.toggleButton(true);
+      collapseToggle.toggleButton(false);
       expect($$(collapseBtnElement).isVisible()).toBe(true);
       expect($$(expandBtnElement).isVisible()).toBe(false);
     });
@@ -75,7 +75,7 @@ export function DynamicFacetHeaderCollapseToggleTest() {
 
     it(`when clicking on the expand button
     should call expand on the DynamicFacet component`, () => {
-      collapseToggle.toggleButtons(true);
+      collapseToggle.toggleButton(true);
       $$(expandBtnElement).trigger('click');
 
       expect(options.expand).toHaveBeenCalled();

--- a/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggleTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggleTest.ts
@@ -5,9 +5,6 @@ import { IDynamicFacetHeaderOptions } from '../../../../src/ui/DynamicFacet/Dyna
 export function DynamicFacetHeaderCollapseToggleTest() {
   describe('DynamicFacetHeaderCollapseToggle', () => {
     let collapseToggle: DynamicFacetHeaderCollapseToggle;
-    let collapseToggleElement: HTMLElement;
-    let collapseBtnElement: HTMLElement;
-    let expandBtnElement: HTMLElement;
     let options: IDynamicFacetHeaderOptions;
 
     beforeEach(() => {
@@ -19,66 +16,45 @@ export function DynamicFacetHeaderCollapseToggleTest() {
         collapse: jasmine.createSpy('collapse'),
         expand: jasmine.createSpy('clear')
       };
-      initializeComponent();
+
+      collapseToggle = new DynamicFacetHeaderCollapseToggle(options);
     });
 
-    function initializeComponent() {
-      collapseToggle = new DynamicFacetHeaderCollapseToggle(options);
-      collapseToggleElement = collapseToggle.element;
-      collapseBtnElement = $$(collapseToggleElement).find('.coveo-dynamic-facet-header-collapse');
-      expandBtnElement = $$(collapseToggleElement).find('.coveo-dynamic-facet-header-expand');
+    function getCollapseButton() {
+      return $$(collapseToggle.element).find('.coveo-dynamic-facet-header-collapse');
     }
 
-    it(`should create the collapse & expand buttons
-      but only display the collapse button by default`, () => {
-      expect($$(collapseBtnElement).isVisible()).toBe(true);
-      expect($$(expandBtnElement).isVisible()).toBe(false);
+    function getExpandButton() {
+      return $$(collapseToggle.element).find('.coveo-dynamic-facet-header-expand');
+    }
+
+    it(`should create a collapse button`, () => {
+      expect(getCollapseButton()).toBeTruthy();
+      expect(getExpandButton()).toBeFalsy();
     });
 
     it(`when calling toggleButtons with isCollapsed to true
       should display the expand button and hide the collapse button`, () => {
       collapseToggle.toggleButton(true);
-      expect($$(collapseBtnElement).isVisible()).toBe(false);
-      expect($$(expandBtnElement).isVisible()).toBe(true);
+
+      expect(getCollapseButton()).toBeFalsy();
+      expect(getExpandButton()).toBeTruthy();
     });
 
     it(`when calling toggleButtons with isCollapsed to false
       should display the collapse button and hide the expand button`, () => {
       collapseToggle.toggleButton(true);
       collapseToggle.toggleButton(false);
-      expect($$(collapseBtnElement).isVisible()).toBe(true);
-      expect($$(expandBtnElement).isVisible()).toBe(false);
+
+      expect(getCollapseButton()).toBeTruthy();
+      expect(getExpandButton()).toBeFalsy();
     });
 
     it(`when clicking on the collapse button
-      should focus on the expand button`, () => {
-      spyOn(expandBtnElement, 'focus');
-      $$(collapseBtnElement).trigger('click');
+      should call toggleCollapse on the DynamicFacet component`, () => {
+      $$(getCollapseButton()).trigger('click');
 
-      expect(expandBtnElement.focus).toHaveBeenCalledTimes(1);
-    });
-
-    it(`when clicking on the collapse button
-      should call collapse on the DynamicFacet component`, () => {
-      $$(collapseBtnElement).trigger('click');
-
-      expect(options.collapse).toHaveBeenCalled();
-    });
-
-    it(`when clicking on the expand button
-    should focus on the collapse button`, () => {
-      spyOn(collapseBtnElement, 'focus');
-      $$(expandBtnElement).trigger('click');
-
-      expect(collapseBtnElement.focus).toHaveBeenCalledTimes(1);
-    });
-
-    it(`when clicking on the expand button
-    should call expand on the DynamicFacet component`, () => {
-      collapseToggle.toggleButton(true);
-      $$(expandBtnElement).trigger('click');
-
-      expect(options.expand).toHaveBeenCalled();
+      expect(options.toggleCollapse).toHaveBeenCalled();
     });
   });
 }

--- a/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderTest.ts
@@ -101,9 +101,8 @@ export function DynamicFacetHeaderTest() {
         initializeComponent();
       });
 
-      it('should create collapse & expand buttons', () => {
+      it('should create a collapse button', () => {
         expect(collapseElement()).toBeTruthy();
-        expect(expandElement()).toBeTruthy();
       });
 
       it('should add the coveo-clickable class to the title', () => {


### PR DESCRIPTION
There are two fixes in this PR:
1. Dynamic Facet collapse/expand toggle now uses a single element instead of switching focus between two elements. This change causes NVDA to read the aria-label/aria-title after toggling a change.
2. Removed a tabindex so allow navigating between SimpleFilter options with one `tab` instead of two.


https://coveord.atlassian.net/browse/JSUI-3164

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)