### PR TITLE
JSUI-3175 Upload files to dedicated s3 directory for patch version

### DIFF
--- a/.deployment.config
+++ b/.deployment.config
@@ -22,10 +22,13 @@
             ]
         }
     },
-    "phases": {
+    "ordered_phases": [
+    {
+        "id": "cdn",
         "s3": {
             "bucket": "coveo-nprod-binaries",
             "directory": "proda/StaticCDN/searchui/v$[MAJOR_MINOR_VERSION]",
+            "source": "bin",
             "parameters": {
                 "acl": "public-read"
             },
@@ -34,10 +37,26 @@
             },
             "qa": {
                 "disabled": true
-            },
-            "source": "bin"
+            }
         }
     },
+    {
+        "id": "cdn-sri",
+        "s3": {
+            "bucket": "coveo-nprod-binaries",
+            "directory": "proda/StaticCDN/searchui/v$[MAJOR_MINOR_VERSION]/$[PATCH_VERSION]",
+            "source": "bin",
+            "parameters": {
+                "acl": "public-read"
+            },
+            "dev": {
+                "disabled": true
+            },
+            "qa": {
+                "disabled": true
+            }
+        }
+    }],
     "certifiers": {
         "dev": [
             {

--- a/build/deployment-pipeline.deploy.js
+++ b/build/deployment-pipeline.deploy.js
@@ -1,7 +1,7 @@
 const { promisify } = require('util');
 const exec = promisify(require('child_process').exec);
 const compareVersions = require('compare-versions');
-const { getMajorMinorVersion, getVersion } = require('./tag.utilities');
+const { getMajorMinorVersion, getVersion, getPatchVersion } = require('./tag.utilities');
 const { getLatestVersionOnNpm } = require('./npm.utilities');
 
 async function installDeploymentPipeLineCli() {
@@ -20,7 +20,12 @@ async function createAndDeployPackage() {
 
 async function getResolvedParamString() {
   const npmVersion = await getLatestNpmVersion();
-  const params = [`MAJOR_MINOR_VERSION=${getMajorMinorVersion()}`, `LATEST_NPM_VERSION=${npmVersion}`];
+  const params = [
+    `MAJOR_MINOR_VERSION=${getMajorMinorVersion()}`,
+    `PATCH_VERSION=${getPatchVersion()}`,
+    `LATEST_NPM_VERSION=${npmVersion}`
+  ];
+
   return ['', ...params].join(' --resolve ').trim();
 }
 

--- a/build/tag.utilities.js
+++ b/build/tag.utilities.js
@@ -1,5 +1,8 @@
 const tag = process.env.TAG_NAME || '';
 
+const number = '[0-9]+';
+const dot = '[.]';
+
 function isTagged() {
   return tag && tag !== '';
 }
@@ -19,14 +22,10 @@ function isBetaTag() {
 }
 
 function semanticVersionForm() {
-  const number = '[0-9]+';
-  const dot = '[.]';
   return `${number}${dot}${number}${dot}${number}`;
 }
 
 function majorMinorForm() {
-  const number = '[0-9]+';
-  const dot = '[.]';
   return `${number}${dot}${number}`;
 }
 
@@ -62,6 +61,14 @@ function getMajorMinorVersion() {
   return majorMinorRegex.exec(version)[0];
 }
 
+function getPatchVersion() {
+  const version = getVersion();
+  const patchForm = `${number}$`;
+  const regex = new RegExp(patchForm);
+
+  return regex.exec(version)[0];
+}
+
 function getHerokuVersion() {
   const version = getVersion();
   return version ? version.replace(/\./g, '-') : 'unknown-version';
@@ -75,5 +82,6 @@ module.exports = {
   getAlphabeticSuffix,
   getVersion,
   getHerokuVersion,
-  getMajorMinorVersion
+  getMajorMinorVersion,
+  getPatchVersion
 };


### PR DESCRIPTION
I only migrated one s3 upload step when transitioning to the deployment pipeline. There was a second s3 upload step in the travis.yml file however, that uploaded the patch version to a dedicated directory.

Some of our cdn clients ask to reference a version that will never change for security reasons. This second upload into a dedicated directory is for them,


https://coveord.atlassian.net/browse/JSUI-3175

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)