### PR TITLE
JSUI-3100 Added default styling to SmartSnippet and SmartSnippetSuggestion's anwers

### DIFF
--- a/sass/_SmartSnippet.scss
+++ b/sass/_SmartSnippet.scss
@@ -35,6 +35,7 @@
     @at-root .coveo-smart-snippet-content {
       transition: height ease-in-out 0.5s;
       overflow: hidden;
+      margin-top: 16px;
 
       @at-root .coveo-height-limiter-container-active {
         position: relative;

--- a/sass/_SmartSnippetSuggestions.scss
+++ b/sass/_SmartSnippetSuggestions.scss
@@ -62,7 +62,7 @@
         }
 
         &-content {
-          padding: 8px $inner-padding;
+          padding: 16px $inner-padding 24px $inner-padding;
         }
       }
 

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -20,6 +20,7 @@ import { ExplanationModal, IReason } from './ExplanationModal';
 import { l } from '../../strings/Strings';
 import { attachShadow } from '../../misc/AttachShadowPolyfill';
 import { Utils } from '../../utils/Utils';
+import { getDefaultSnippetStyle } from './SmartSnippetCommon';
 
 interface ISmartSnippetReason {
   analytics: AnalyticsSmartSnippetFeedbackReason;
@@ -93,11 +94,11 @@ export class SmartSnippet extends Component {
   }
 
   private get style() {
-    return $$(this.element)
+    const styles = $$(this.element)
       .children()
       .filter(element => element instanceof HTMLScriptElement && element.type.toLowerCase() === 'text/css')
-      .map(element => element.innerHTML)
-      .join('\n');
+      .map(element => element.innerHTML);
+    return styles.length ? styles.join('\n') : null;
   }
 
   private set hasAnswer(hasAnswer: boolean) {
@@ -150,9 +151,7 @@ export class SmartSnippet extends Component {
     this.shadowLoading = attachShadow(this.shadowContainer, { mode: 'open', title: l('AnswerSnippet') }).then(shadow => {
       shadow.appendChild(this.snippetContainer);
       const style = this.buildStyle();
-      if (style) {
-        shadow.appendChild(style);
-      }
+      shadow.appendChild(style);
       return shadow;
     });
     return this.shadowContainer;
@@ -169,10 +168,7 @@ export class SmartSnippet extends Component {
   }
 
   private buildStyle() {
-    const style = this.style;
-    if (!style) {
-      return;
-    }
+    const style = Utils.isNullOrUndefined(this.style) ? getDefaultSnippetStyle(CONTENT_CLASSNAME) : this.style;
     const styleTag = document.createElement('style');
     styleTag.innerHTML = style;
     return styleTag;

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -44,7 +44,7 @@ export class SmartSnippetCollapsibleSuggestion {
 
   constructor(
     private readonly questionAnswer: IRelatedQuestionAnswerResponse,
-    private readonly innerCSS?: string,
+    private readonly innerCSS: string,
     private readonly source?: IQueryResult
   ) {}
 
@@ -56,7 +56,7 @@ export class SmartSnippetCollapsibleSuggestion {
     const collapsibleContainer = this.buildCollapsibleContainer(
       this.questionAnswer.answerSnippet,
       this.questionAnswer.question,
-      this.innerCSS && this.buildStyle(this.innerCSS)
+      this.buildStyle(this.innerCSS)
     );
     const title = this.buildTitle(this.questionAnswer.question);
     this.updateExpanded();
@@ -102,7 +102,7 @@ export class SmartSnippetCollapsibleSuggestion {
     return this.checkbox;
   }
 
-  private buildCollapsibleContainer(innerHTML: string, title: string, style?: HTMLStyleElement) {
+  private buildCollapsibleContainer(innerHTML: string, title: string, style: HTMLStyleElement) {
     const shadowContainer = $$('div', { className: SHADOW_CLASSNAME });
     this.collapsibleContainer = $$('div', { className: QUESTION_SNIPPET_CLASSNAME, id: this.snippetId }, shadowContainer);
     this.contentLoaded = attachShadow(shadowContainer.el, { mode: 'open', title: l('AnswerSpecificSnippet', title) }).then(shadowRoot => {
@@ -115,12 +115,10 @@ export class SmartSnippetCollapsibleSuggestion {
     return this.collapsibleContainer;
   }
 
-  private buildAnswerSnippetContent(innerHTML: string, style?: HTMLStyleElement) {
+  private buildAnswerSnippetContent(innerHTML: string, style: HTMLStyleElement) {
     const snippet = $$('div', { className: RAW_CONTENT_CLASSNAME }, innerHTML);
     const container = $$('div', {}, snippet);
-    if (style) {
-      container.append(style);
-    }
+    container.append(style);
     return container;
   }
 

--- a/src/ui/SmartSnippet/SmartSnippetCommon.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCommon.ts
@@ -1,0 +1,13 @@
+export const getDefaultSnippetStyle = (contentClassName: string) => `
+  body {
+    font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif, sans-serif;
+  }
+
+  .${contentClassName} > :first-child {
+    margin-top: 0;
+  }
+
+  .${contentClassName} > :last-child {
+    margin-bottom: 0;
+  }
+`;

--- a/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
+++ b/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
@@ -6,9 +6,11 @@ import { QueryEvents, IQuerySuccessEventArgs } from '../../events/QueryEvents';
 import { IRelatedQuestionAnswerResponse, IQuestionAnswerResponse } from '../../rest/QuestionAnswerResponse';
 import { $$, Dom } from '../../utils/Dom';
 import { uniqueId, isEqual, find } from 'underscore';
-import { SmartSnippetCollapsibleSuggestion } from './SmartSnippetCollapsibleSuggestion';
+import { SmartSnippetCollapsibleSuggestion, SmartSnippetCollapsibleSuggestionClassNames } from './SmartSnippetCollapsibleSuggestion';
 import { l } from '../../strings/Strings';
 import { Initialization } from '../Base/Initialization';
+import { Utils } from '../../utils/Utils';
+import { getDefaultSnippetStyle } from './SmartSnippetCommon';
 
 const BASE_CLASSNAME = 'coveo-smart-snippet-suggestions';
 const HAS_QUESTIONS_CLASSNAME = `${BASE_CLASSNAME}-has-questions`;
@@ -85,7 +87,14 @@ export class SmartSnippetSuggestions extends Component {
   private buildQuestionAnswers(questionAnswers: IRelatedQuestionAnswerResponse[]) {
     const innerCSS = this.getInnerCSS();
     const answers = questionAnswers.map(
-      questionAnswer => new SmartSnippetCollapsibleSuggestion(questionAnswer, innerCSS, this.getCorrespondingResult(questionAnswer))
+      questionAnswer =>
+        new SmartSnippetCollapsibleSuggestion(
+          questionAnswer,
+          Utils.isNullOrUndefined(innerCSS)
+            ? getDefaultSnippetStyle(SmartSnippetCollapsibleSuggestionClassNames.RAW_CONTENT_CLASSNAME)
+            : innerCSS,
+          this.getCorrespondingResult(questionAnswer)
+        )
     );
     const container = $$(
       'ul',
@@ -97,11 +106,11 @@ export class SmartSnippetSuggestions extends Component {
   }
 
   private getInnerCSS() {
-    return $$(this.element)
+    const styles = $$(this.element)
       .children()
       .filter(element => element instanceof HTMLScriptElement && element.type.toLowerCase() === 'text/css')
-      .map(element => element.innerHTML)
-      .join('\n');
+      .map(element => element.innerHTML);
+    return styles.length ? styles.join('\n') : null;
   }
 }
 

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -304,6 +304,14 @@ export function SmartSnippetSuggestionsTest() {
               )
             ).toEqual([true, true, true]);
           });
+
+          it('renders the expected shadow content', () => {
+            getShadowRoots().forEach((shadowRoot, i) => {
+              const [shadowContainer] = expectChildren(shadowRoot, [ClassNames.RAW_CONTENT_CLASSNAME, null]);
+
+              expect(shadowContainer.innerHTML).toEqual(mockSnippet(i).innerHTML);
+            });
+          });
         });
 
         describe('when the second question is expanded', () => {

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -298,7 +298,7 @@ export function SmartSnippetSuggestionsTest() {
 
           it('should wrap the snippet in a container in a shadow DOM', () => {
             getShadowRoots().forEach((shadowRoot, i) => {
-              const [shadowContainer, _] = expectChildren(shadowRoot, [ClassNames.RAW_CONTENT_CLASSNAME, null]);
+              const [shadowContainer] = expectChildren(shadowRoot, [ClassNames.RAW_CONTENT_CLASSNAME, null]);
 
               expect(shadowContainer.innerHTML).toEqual(mockSnippet(i).innerHTML);
             });
@@ -306,7 +306,7 @@ export function SmartSnippetSuggestionsTest() {
 
           it('should render the default style', () => {
             getShadowRoots().forEach(shadowRoot => {
-              const [_, styleElement] = expectChildren(shadowRoot, [ClassNames.RAW_CONTENT_CLASSNAME, null]);
+              const [, styleElement] = expectChildren(shadowRoot, [ClassNames.RAW_CONTENT_CLASSNAME, null]);
 
               expect(styleElement.innerHTML).toEqual(getDefaultSnippetStyle(ClassNames.RAW_CONTENT_CLASSNAME));
             });
@@ -329,7 +329,7 @@ export function SmartSnippetSuggestionsTest() {
 
       it('should render the no style', () => {
         getShadowRoots().forEach(shadowRoot => {
-          const [_, styleElement] = expectChildren(shadowRoot, [ClassNames.RAW_CONTENT_CLASSNAME, null]);
+          const [, styleElement] = expectChildren(shadowRoot, [ClassNames.RAW_CONTENT_CLASSNAME, null]);
 
           expect(styleElement.innerHTML).toEqual('');
         });

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -8,6 +8,8 @@ import { UserFeedbackBannerClassNames } from '../../src/ui/SmartSnippet/UserFeed
 import { IBasicComponentSetup, advancedComponentSetup, AdvancedComponentSetupOptions } from '../MockEnvironment';
 import { HeightLimiterClassNames } from '../../src/ui/SmartSnippet/HeightLimiter';
 import { IQueryResults } from '../../src/rest/QueryResults';
+import { Utils } from '../../src/Core';
+import { getDefaultSnippetStyle } from '../../src/ui/SmartSnippet/SmartSnippetCommon';
 
 export function SmartSnippetTest() {
   const sourceTitle = 'Google!';
@@ -60,8 +62,8 @@ export function SmartSnippetTest() {
     ).el;
   }
 
-  function mockStyling() {
-    return $$('script', { type: 'text/css' }, style).el;
+  function mockStyling(content: string) {
+    return $$('script', { type: 'text/css' }, content).el;
   }
 
   function mockQuestionAnswer() {
@@ -75,10 +77,10 @@ export function SmartSnippetTest() {
   describe('SmartSnippet', () => {
     let test: IBasicComponentSetup<SmartSnippet>;
 
-    function instantiateSmartSnippet(hasStyling: boolean) {
+    function instantiateSmartSnippet(styling: string | null) {
       test = advancedComponentSetup<SmartSnippet>(
         SmartSnippet,
-        new AdvancedComponentSetupOptions($$('div', {}, ...(hasStyling ? [mockStyling()] : [])).el)
+        new AdvancedComponentSetupOptions($$('div', {}, ...(Utils.isNullOrUndefined(styling) ? [] : [mockStyling(styling)])).el)
       );
       test.cmp['openLink'] = jasmine
         .createSpy('openLink')
@@ -111,7 +113,7 @@ export function SmartSnippetTest() {
 
     describe('with styling without a source', () => {
       beforeEach(async done => {
-        instantiateSmartSnippet(true);
+        instantiateSmartSnippet(style);
         document.body.appendChild(test.env.root);
         await triggerQuestionAnswerQuery(false);
         done();
@@ -127,9 +129,9 @@ export function SmartSnippetTest() {
       });
     });
 
-    describe('without styling', () => {
+    describe('with default styling', () => {
       beforeEach(() => {
-        instantiateSmartSnippet(false);
+        instantiateSmartSnippet(null);
         document.body.appendChild(test.env.root);
       });
 
@@ -219,14 +221,39 @@ export function SmartSnippetTest() {
         });
 
         it('should wrap the snippet in a container in a shadow DOM', () => {
-          const [shadowContainer] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME]);
+          const [shadowContainer, _] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME, null]);
 
           expect(shadowContainer.innerHTML).toEqual(mockSnippet().innerHTML);
+        });
+
+        it('should render the default style', () => {
+          const [_, styleElement] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME, null]);
+
+          expect(styleElement.innerHTML).toEqual(getDefaultSnippetStyle(ClassNames.CONTENT_CLASSNAME));
         });
 
         it('should not render any source', () => {
           expect(getFirstChild(ClassNames.SOURCE_CLASSNAME).children.length).toEqual(0);
         });
+      });
+    });
+
+    describe('with no styling, without a source', () => {
+      beforeEach(async done => {
+        instantiateSmartSnippet('');
+        document.body.appendChild(test.env.root);
+        await triggerQuestionAnswerQuery(false);
+        done();
+      });
+
+      afterEach(() => {
+        test.env.root.remove();
+      });
+
+      it('should render an empty style', () => {
+        const [_, styleElement] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME, null]);
+
+        expect(styleElement.innerHTML).toEqual('');
       });
     });
   });

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -221,13 +221,13 @@ export function SmartSnippetTest() {
         });
 
         it('should wrap the snippet in a container in a shadow DOM', () => {
-          const [shadowContainer, _] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME, null]);
+          const [shadowContainer] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME, null]);
 
           expect(shadowContainer.innerHTML).toEqual(mockSnippet().innerHTML);
         });
 
         it('should render the default style', () => {
-          const [_, styleElement] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME, null]);
+          const [, styleElement] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME, null]);
 
           expect(styleElement.innerHTML).toEqual(getDefaultSnippetStyle(ClassNames.CONTENT_CLASSNAME));
         });
@@ -251,7 +251,7 @@ export function SmartSnippetTest() {
       });
 
       it('should render an empty style', () => {
-        const [_, styleElement] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME, null]);
+        const [, styleElement] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME, null]);
 
         expect(styleElement.innerHTML).toEqual('');
       });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3100

Most if not all `SmartSnippet` typically started and ended with elements that have margins such as `p` and `ul`. However, in the event that the first or last element didn't have the expected margins, the padding would look wrong.

Additionally, since the `SmartSnippet` uses an `iframe`, the font looks very wrong inside of it by default.

This PR attempts to solve that by introducing a default style that adds the appropriate font family. This PR also removes the top margin of the first element as well as the bottom margin of the last element, transferring the responsibility to the CSS outside the `iframe`.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)