### PR TITLE
JSUI-3166 Allowed multiple levels of dependent DynamicFacets to hide

### DIFF
--- a/src/utils/DependsOnManager.ts
+++ b/src/utils/DependsOnManager.ts
@@ -28,7 +28,7 @@ export class DependsOnManager {
   private parentFacetRef: IDependsOnCompatibleFacet;
 
   constructor(private facet: IDependentFacet) {
-    this.facet.ref.bind.onRootElement(QueryEvents.buildingQuery, () => this.handleBuildingQuery());
+    $$(this.facet.ref.searchInterface.element).on(QueryEvents.buildingQuery, () => this.handleBuildingQuery());
 
     if (this.getDependsOn(this.facet.ref)) {
       this.facet.ref.bind.onRootElement(InitializationEvents.afterComponentsInitialization, () => this.setupDependentFacet());

--- a/unitTests/utils/DependsOnManagerTest.ts
+++ b/unitTests/utils/DependsOnManagerTest.ts
@@ -62,8 +62,9 @@ export function DependsOnManagerTest() {
     }
 
     beforeEach(() => {
-      searchInterface = mockSearchInterface();
       root = document.createElement('div');
+      searchInterface = mockSearchInterface();
+      searchInterface.element = root;
       queryStateModel = new QueryStateModel(root);
       parentMock = createMock('@parent');
       dependentMock = createMock('@dependent', '@parent');
@@ -111,6 +112,124 @@ export function DependsOnManagerTest() {
 
         $$(root).trigger(QueryEvents.buildingQuery);
         expect(facet.hasClass('coveo-hidden')).toBe(true);
+      });
+    });
+
+    describe(`when two parent facets have no selected value (default conditions not fulfilled),
+    when triggering "building query"`, () => {
+      let dependent2Mock: IDependsOnManagerTestMock;
+      beforeEach(() => {
+        dependent2Mock = createMock('@dependent2', '@dependent');
+      });
+
+      it('should disable the first dependent facet', () => {
+        spyOn(dependentMock.facet.ref, 'disable');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(dependentMock.facet.ref.disable).toHaveBeenCalledTimes(1);
+      });
+
+      it('should disable the second dependent facet', () => {
+        spyOn(dependent2Mock.facet.ref, 'disable');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(dependent2Mock.facet.ref.disable).toHaveBeenCalledTimes(1);
+      });
+
+      it('should hide the first facet', () => {
+        const facet = $$(dependentMock.facet.ref.element);
+        facet.removeClass('coveo-hidden');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(facet.hasClass('coveo-hidden')).toBe(true);
+      });
+
+      it('should hide the second facet', () => {
+        const facet = $$(dependent2Mock.facet.ref.element);
+        facet.removeClass('coveo-hidden');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(facet.hasClass('coveo-hidden')).toBe(true);
+      });
+    });
+
+    describe(`when one parent facet has selected value(s) (default condition fulfilled)
+    and the second parent facet has no selected value (default conditions not fulfilled),
+    when triggering "building query"`, () => {
+      let dependent2Mock: IDependsOnManagerTestMock;
+      beforeEach(() => {
+        queryStateModel.registerNewAttribute(parentStateAttribute(), ['a value']);
+        dependent2Mock = createMock('@dependent2', '@dependent');
+      });
+
+      it('should enable the first dependent facet', () => {
+        spyOn(dependentMock.facet.ref, 'enable');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(dependentMock.facet.ref.enable).toHaveBeenCalledTimes(1);
+      });
+
+      it('should disable the second dependent facet', () => {
+        spyOn(dependent2Mock.facet.ref, 'disable');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(dependent2Mock.facet.ref.disable).toHaveBeenCalledTimes(1);
+      });
+
+      it('should show the first facet', () => {
+        const facet = $$(dependentMock.facet.ref.element);
+        facet.addClass('coveo-hidden');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(facet.hasClass('coveo-hidden')).toBe(false);
+      });
+
+      it('should hide the second facet', () => {
+        const facet = $$(dependent2Mock.facet.ref.element);
+        facet.removeClass('coveo-hidden');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(facet.hasClass('coveo-hidden')).toBe(true);
+      });
+    });
+
+    describe(`when two parent facets have selected value(s) (default conditions fulfilled),
+    when triggering "building query"`, () => {
+      let dependent2Mock: IDependsOnManagerTestMock;
+      beforeEach(() => {
+        queryStateModel.registerNewAttribute(parentStateAttribute(), ['a value']);
+        queryStateModel.registerNewAttribute(dependentStateAttribute(), ['a value']);
+        dependent2Mock = createMock('@dependent2', '@dependent');
+      });
+
+      it('should enable the first dependent facet', () => {
+        spyOn(dependentMock.facet.ref, 'enable');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(dependentMock.facet.ref.enable).toHaveBeenCalledTimes(1);
+      });
+
+      it('should enable the second dependent facet', () => {
+        spyOn(dependent2Mock.facet.ref, 'enable');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(dependent2Mock.facet.ref.enable).toHaveBeenCalledTimes(1);
+      });
+
+      it('should show the first facet', () => {
+        const facet = $$(dependentMock.facet.ref.element);
+        facet.addClass('coveo-hidden');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(facet.hasClass('coveo-hidden')).toBe(false);
+      });
+
+      it('should show the second facet', () => {
+        const facet = $$(dependent2Mock.facet.ref.element);
+        facet.addClass('coveo-hidden');
+
+        $$(root).trigger(QueryEvents.buildingQuery);
+        expect(facet.hasClass('coveo-hidden')).toBe(false);
       });
     });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3166

This resolves a bug where if somebody had three facets where two depend on their parents (e.g., `facet1`, `facet2` [depends on `facet1`], `facet3` [depends on `facet2`]), only one facet would be hidden (in this case, `facet2`).

As it is, DynamicFacets are hidden at two different moment:
1. When initializing the `DependsOnManager`, regardless of whether a dependency is met or not, the facet is hidden (but not disabled).
2. When `QueryEvents.buildingQuery` is triggered, the facet is shown+enabled or hidden+disabled based on whether their dependency is met or not.

However, when `QueryEvents.buildingQuery` is triggered, each facet is responsible for hiding their children (e.g., `facet1` hides `facet2` and `facet2` hides `facet3`). The issue was that once facet2 was disabled, it could no longer detect the `QueryEvents.buildingQuery` event due to `onRootElement` skipping the event's handler and therefor not hide its child facet.

For the `Facet`, this didn't cause as much of an issue since it was already hidden from the first moment (when initializing the `DependsOnManager`). For the `DynamicFacet`, this caused an issue since its `coveo-hidden` class is toggled out at `DynamicFacet.ts:778`.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)