### PR TITLE
JSUI-3141 Prevented IE11 from scrolling after removing the last breadcrumb

### DIFF
--- a/src/ui/Breadcrumb/Breadcrumb.ts
+++ b/src/ui/Breadcrumb/Breadcrumb.ts
@@ -162,10 +162,7 @@ export class Breadcrumb extends Component {
     const resultLists = this.searchInterface.getComponents<Component>('ResultList');
     const firstEnabledResultList = find(resultLists, resultList => resultList.disabled === false);
     if (firstEnabledResultList) {
-      // Problem with types definition of TypeScript 2.8
-      // default .focus() definition is incomplete.
-      // force cast to any
-      (firstEnabledResultList.element as any).focus({ preventScroll: true });
+      $$(firstEnabledResultList.element).focus(true);
     }
   }
 

--- a/src/utils/Dom.ts
+++ b/src/utils/Dom.ts
@@ -4,6 +4,7 @@ import { Logger } from '../misc/Logger';
 import { IStringMap } from '../rest/GenericParam';
 import { JQueryUtils } from '../utils/JQueryutils';
 import { Utils } from '../utils/Utils';
+import { DeviceUtils } from './DeviceUtils';
 
 export interface IOffset {
   left: number;
@@ -126,13 +127,17 @@ export class Dom {
 
   /**
    * Focuses on an element.
-   * @param preventScroll Whether or not to scroll the page to the focused element.
+   * @param preserveScroll Whether or not to scroll the page to the focused element.
    */
-  public focus(preventScroll: boolean) {
-    const { pageXOffset, pageYOffset } = window;
-    this.el.focus();
-    if (preventScroll) {
-      window.scrollTo(pageXOffset, pageYOffset);
+  public focus(preserveScroll: boolean) {
+    if (DeviceUtils.getDeviceName() === 'IE') {
+      const { pageXOffset, pageYOffset } = window;
+      this.el.focus();
+      if (preserveScroll) {
+        window.scrollTo(pageXOffset, pageYOffset);
+      }
+    } else {
+      (this.el as any).focus({ preventScroll: preserveScroll });
     }
   }
 

--- a/src/utils/Dom.ts
+++ b/src/utils/Dom.ts
@@ -125,6 +125,18 @@ export class Dom {
   }
 
   /**
+   * Focuses on an element.
+   * @param preventScroll Whether or not to scroll the page to the focused element.
+   */
+  public focus(preventScroll: boolean) {
+    const { pageXOffset, pageYOffset } = window;
+    this.el.focus();
+    if (preventScroll) {
+      window.scrollTo(pageXOffset, pageYOffset);
+    }
+  }
+
+  /**
    * Empty (remove all child) from the element;
    */
   public empty(): void {
@@ -833,13 +845,17 @@ export class Win {
   public scrollY(): number {
     return this.supportPageOffset()
       ? this.win.pageYOffset
-      : this.isCSS1Compat() ? this.win.document.documentElement.scrollTop : this.win.document.body.scrollTop;
+      : this.isCSS1Compat()
+      ? this.win.document.documentElement.scrollTop
+      : this.win.document.body.scrollTop;
   }
 
   public scrollX(): number {
     return this.supportPageOffset()
       ? window.pageXOffset
-      : this.isCSS1Compat() ? document.documentElement.scrollLeft : document.body.scrollLeft;
+      : this.isCSS1Compat()
+      ? document.documentElement.scrollLeft
+      : document.body.scrollLeft;
   }
 
   private isCSS1Compat() {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3141

The `focus` event scrolls the page by default, and `preventScroll` appears to be unsupported in IE11.

This solution, on my computer at-least, behaves the same on Vivaldi/Chromium and Firefox as using the `preventScroll` parameter. However, half the time on IE11, the page scrolls down for a very short moment, making the page feel jittery. I recommend trying this out on IE11 before approving this PR.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)