### PR TITLE
JSUI-3165 Restore layout prior to forced responsive layout change

### DIFF
--- a/unitTests/ui/ResultLayoutSelectorTest.ts
+++ b/unitTests/ui/ResultLayoutSelectorTest.ts
@@ -44,5 +44,25 @@ export function ResultLayoutSelectorTest() {
       buildResultLayoutSelector('card');
       expect(getLayoutButton('list').getAttribute('aria-pressed')).toEqual('false');
     });
+
+    it(`when the current layout is disabled and then renabled (e.g. due to resizing the screen smaller then larger),
+    the original layout is restored`, () => {
+      buildResultLayoutSelector('list');
+
+      test.cmp.disableLayouts(['list']);
+      test.cmp.enableLayouts(['list']);
+
+      expect(test.cmp.currentLayout).toBe('list');
+    });
+
+    it(`when the current layout is disabled, changed, and then renabled, the original layout is not restored`, () => {
+      buildResultLayoutSelector('list');
+
+      test.cmp.disableLayouts(['list']);
+      test.cmp.changeLayout('card');
+      test.cmp.enableLayouts(['list']);
+
+      expect(test.cmp.currentLayout).toBe('card');
+    });
   });
 }


### PR DESCRIPTION
Resizing a screen smaller disables the `list` layout by default, and activates either `card` or `table`. When resizing larger though, the original layout is not restored. An experience that starts in `list`, will change to `card` on a smaller screen, and remain there.

This PR keeps the user's preferred layout in memory, and restores it when it becomes available again. However if the user changes the layout in between, the preferred layout is reset and no longer restored.

https://coveord.atlassian.net/browse/JSUI-3165


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)