### PR TITLE
JSUI-3187 Improved SmartSnippet's expanded size

### DIFF
--- a/src/misc/AttachShadowPolyfill.ts
+++ b/src/misc/AttachShadowPolyfill.ts
@@ -1,12 +1,12 @@
 import { $$ } from '../utils/Dom';
 import 'styling/_AttachShadowPolyfill';
 
-export interface IShadowOptions extends ShadowRootInit {
+export interface IShadowOptions {
   title: string;
   onSizeChanged?: Function;
 }
 
-export async function attachShadow(element: HTMLElement, options: IShadowOptions): Promise<HTMLElement> {
+export async function attachShadow(element: HTMLElement, options: IShadowOptions & ShadowRootInit): Promise<HTMLElement> {
   const iframe = $$('iframe', { className: 'coveo-shadow-iframe', scrolling: 'no', title: options.title }).el as HTMLIFrameElement;
   const onLoad = new Promise(resolve => iframe.addEventListener('load', () => resolve()));
   element.appendChild(iframe);

--- a/src/misc/AttachShadowPolyfill.ts
+++ b/src/misc/AttachShadowPolyfill.ts
@@ -32,6 +32,8 @@ function autoUpdateHeight(elementToResize: HTMLElement, content: HTMLElement, on
     if (lastWidth === content.clientWidth && lastHeight === content.clientHeight) {
       return;
     }
+    lastWidth = content.clientWidth;
+    lastHeight = content.clientHeight;
     elementToResize.style.width = `${content.clientWidth}px`;
     elementToResize.style.height = `${content.clientHeight}px`;
     if (onUpdate) {

--- a/src/misc/AttachShadowPolyfill.ts
+++ b/src/misc/AttachShadowPolyfill.ts
@@ -1,8 +1,13 @@
 import { $$ } from '../utils/Dom';
 import 'styling/_AttachShadowPolyfill';
 
-export async function attachShadow(element: HTMLElement, init: ShadowRootInit & { title: string }): Promise<HTMLElement> {
-  const iframe = $$('iframe', { className: 'coveo-shadow-iframe', scrolling: 'no', title: init.title }).el as HTMLIFrameElement;
+export interface IShadowOptions extends ShadowRootInit {
+  title: string;
+  onSizeChanged?: Function;
+}
+
+export async function attachShadow(element: HTMLElement, options: IShadowOptions): Promise<HTMLElement> {
+  const iframe = $$('iframe', { className: 'coveo-shadow-iframe', scrolling: 'no', title: options.title }).el as HTMLIFrameElement;
   const onLoad = new Promise(resolve => iframe.addEventListener('load', () => resolve()));
   element.appendChild(iframe);
   await onLoad;
@@ -11,17 +16,27 @@ export async function attachShadow(element: HTMLElement, init: ShadowRootInit & 
   iframeBody.style.margin = '0';
   const shadowRoot = $$('div', { style: 'overflow: auto;' }).el;
   iframeBody.appendChild(shadowRoot);
-  autoUpdateHeight(iframe, shadowRoot);
-  if (init.mode === 'open') {
+  autoUpdateHeight(iframe, shadowRoot, options.onSizeChanged);
+  if (options.mode === 'open') {
     Object.defineProperty(element, 'shadowRoot', { get: () => shadowRoot });
   }
 
   return shadowRoot;
 }
 
-function autoUpdateHeight(elementToResize: HTMLElement, content: HTMLElement) {
+function autoUpdateHeight(elementToResize: HTMLElement, content: HTMLElement, onUpdate?: Function) {
+  let lastWidth = content.clientWidth;
+  let lastHeight = content.clientHeight;
+
   const heightObserver = new MutationObserver(() => {
+    if (lastWidth === content.clientWidth && lastHeight === content.clientHeight) {
+      return;
+    }
+    elementToResize.style.width = `${content.clientWidth}px`;
     elementToResize.style.height = `${content.clientHeight}px`;
+    if (onUpdate) {
+      onUpdate();
+    }
   });
   heightObserver.observe(content, {
     attributes: true,

--- a/unitTests/Test.ts
+++ b/unitTests/Test.ts
@@ -872,3 +872,6 @@ HistoryStoreTest();
 
 import { AnalyticsInformationTest } from './ui/AnalyticsInformationTest';
 AnalyticsInformationTest();
+
+import { AttachShadowPolyfillTest } from './misc/AttachShadowPolyfillTest';
+AttachShadowPolyfillTest();

--- a/unitTests/misc/AttachShadowPolyfillTest.ts
+++ b/unitTests/misc/AttachShadowPolyfillTest.ts
@@ -1,0 +1,44 @@
+import { Utils } from '../../src/Core';
+import { attachShadow } from '../../src/misc/AttachShadowPolyfill';
+import { $$ } from '../../src/utils/Dom';
+
+export function AttachShadowPolyfillTest() {
+  describe('AttachShadowPolyfill', () => {
+    let element: HTMLElement;
+    let shadowRoot: HTMLElement;
+    let onSizeChangedSpy: jasmine.Spy;
+
+    function appendHeightElement() {
+      shadowRoot.appendChild($$('div', { style: 'height: 200px;' }).el);
+    }
+
+    beforeEach(async done => {
+      element = $$('div').el;
+      document.body.appendChild(element);
+      shadowRoot = await attachShadow(element, {
+        mode: 'open',
+        title: 'hello',
+        onSizeChanged: onSizeChangedSpy = jasmine.createSpy('onSizeChanged')
+      });
+      done();
+    });
+
+    afterEach(() => {
+      element.remove();
+    });
+
+    it("doesn't call onSizeChanged initially", () => {
+      expect(onSizeChangedSpy).not.toHaveBeenCalled();
+    });
+
+    it('calls onSizeChanged when content is added', async done => {
+      appendHeightElement();
+      await Utils.resolveAfter(0);
+      expect(onSizeChangedSpy).toHaveBeenCalledTimes(1);
+      appendHeightElement();
+      await Utils.resolveAfter(0);
+      expect(onSizeChangedSpy).toHaveBeenCalledTimes(2);
+      done();
+    });
+  });
+}

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -87,7 +87,7 @@ export function SmartSnippetTest() {
     async function triggerQuerySuccess(args: Partial<IQuerySuccessEventArgs>) {
       (test.env.queryController.getLastResults as jasmine.Spy).and.returnValue(args.results);
       $$(test.env.root).trigger(QueryEvents.deferredQuerySuccess, args);
-      await test.cmp['shadowLoading'];
+      await test.cmp.loading;
     }
 
     async function triggerQuestionAnswerQuery(withSource: boolean) {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3187

There was a bug on certain snippets that caused `SmartSnippet` to sometimes be slightly too small and hide part of the answer.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)