### PR TITLE
JSUI-3198 Update documentation links; improve string

### DIFF
--- a/src/ui/Base/QueryBuilder.ts
+++ b/src/ui/Base/QueryBuilder.ts
@@ -113,7 +113,7 @@ export class QueryBuilder {
   /**
    * Whether to interpret special query syntax (e.g., `@objecttype=message`) in the basic
    * [`expression`]{@link QueryBuilder.expression} (see
-   * [Coveo Query Syntax Reference](https://www.coveo.com/go?dest=adminhelp70&lcid=9&context=10005)).
+   * [Coveo Query Syntax Reference](https://docs.coveo.com/en/1552/searching-with-coveo/coveo-cloud-query-syntax)).
    *
    * See also [`enableLowercaseOperators`]{@link QueryBuilder.enableLowercaseOperators}.
    *

--- a/src/ui/FieldSuggestions/FieldSuggestions.ts
+++ b/src/ui/FieldSuggestions/FieldSuggestions.ts
@@ -58,7 +58,7 @@ export class FieldSuggestions extends Component {
 
     /**
      * Specifies a query override to apply when retrieving suggestions. You can use any valid query expression (see
-     * [Coveo Query Syntax Reference](https://www.coveo.com/go?dest=adminhelp70&lcid=9&context=10005)).
+     * [Coveo Query Syntax Reference](https://docs.coveo.com/en/1552/searching-with-coveo/coveo-cloud-query-syntax)).
      *
      * Default value is the empty string, and the component applies no query override.
      */

--- a/src/ui/Omnibox/Omnibox.ts
+++ b/src/ui/Omnibox/Omnibox.ts
@@ -69,9 +69,10 @@ export interface IOmniboxOptions extends IQueryboxOptions {
   placeholder?: string;
   numberOfSuggestions?: number;
   querySuggestCharacterThreshold?: number;
-  grammar?: (
-    grammar: { start: string; expressions: { [id: string]: ExpressionDef } }
-  ) => { start: string; expressions: { [id: string]: ExpressionDef } };
+  grammar?: (grammar: {
+    start: string;
+    expressions: { [id: string]: ExpressionDef };
+  }) => { start: string; expressions: { [id: string]: ExpressionDef } };
   clearFiltersOnNewQuery?: boolean;
 }
 
@@ -228,7 +229,7 @@ export class Omnibox extends Component {
     /**
      * Specifies whether the Coveo Platform should try to interpret special query syntax such as field references in the
      * query that the user enters in the Querybox (see
-     * [Coveo Query Syntax Reference](https://www.coveo.com/go?dest=adminhelp70&lcid=9&context=10005)).
+     * [Coveo Query Syntax Reference](https://docs.coveo.com/en/1552/searching-with-coveo/coveo-cloud-query-syntax)).
      *
      * Setting this option to `true` also causes the query syntax in the Querybox to highlight.
      *

--- a/src/ui/Querybox/Querybox.ts
+++ b/src/ui/Querybox/Querybox.ts
@@ -79,7 +79,7 @@ export class Querybox extends Component {
     /**
      * Specifies whether to interpret special query syntax (e.g., `@objecttype=message`) when the end user types
      * a query in the `Querybox` (see
-     * [Coveo Query Syntax Reference](https://www.coveo.com/go?dest=adminhelp70&lcid=9&context=10005)). Setting this
+     * [Coveo Query Syntax Reference](https://docs.coveo.com/en/1552/searching-with-coveo/coveo-cloud-query-syntax)). Setting this
      * option to `true` also causes the `Querybox` to highlight any query syntax.
      *
      * Regardless of the value of this option, the Coveo Cloud REST Search API always interprets expressions surrounded
@@ -139,7 +139,7 @@ export class Querybox extends Component {
      * the end user types those keywords in lowercase.
      *
      * This option applies to all query operators (see
-     * [Coveo Query Syntax Reference](https://www.coveo.com/go?dest=adminhelp70&lcid=9&context=10005)).
+     * [Coveo Query Syntax Reference](https://docs.coveo.com/en/1552/searching-with-coveo/coveo-cloud-query-syntax)).
      *
      * **Example:**
      * > If this option and the `enableQuerySyntax` option are both `true`, the Coveo Platform interprets the `near`

--- a/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
+++ b/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
@@ -266,7 +266,7 @@ export class ResultsFiltersPreferences extends Component {
     const onlineHelp = $$(
       'a',
       {
-        href: 'https://www.coveo.com/go?dest=adminhelp70&lcid=9&context=10006',
+        href: 'https://docs.coveo.com/en/2053/index-content/inspect-items-with-the-content-browser#results-filtering-expressions',
         className: 'coveo-online-help'
       },
       '?'
@@ -461,11 +461,7 @@ export class ResultsFiltersPreferences extends Component {
       this.fromPreferencesToCheckboxInput();
     };
 
-    new AccessibleButton()
-      .withElement(elem)
-      .withLabel(l('RemoveFilterOn', filter.caption))
-      .withSelectAction(onSelectAction)
-      .build();
+    new AccessibleButton().withElement(elem).withLabel(l('RemoveFilterOn', filter.caption)).withSelectAction(onSelectAction).build();
 
     return elem.el;
   }

--- a/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
+++ b/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
@@ -46,7 +46,7 @@ export interface IResultsFiltersPreferencesOptions {
  * are saved to local storage.
  *
  * Only advanced end users who understand the Coveo query syntax should use this feature (see
- * [Coveo Query Syntax Reference](https://www.coveo.com/go?dest=adminhelp70&lcid=9&context=10005)).
+ * [Coveo Query Syntax Reference](https://docs.coveo.com/en/1552/searching-with-coveo/coveo-cloud-query-syntax)).
  *
  * This component is normally accessible through the [`Settings`]{@link Settings} menu. Its usual location in the DOM is
  * inside the [`PreferencesPanel`]{@link PreferencesPanel} element.

--- a/src/ui/ResultsPreferences/ResultsPreferences.ts
+++ b/src/ui/ResultsPreferences/ResultsPreferences.ts
@@ -70,7 +70,7 @@ export class ResultsPreferences extends Component {
      *
      * If query syntax is enabled, the Coveo Platform tries to interpret special query syntax (e.g.,
      * `@objecttype=message`) when the end user types a query in the [`Querybox`]{@link Querybox} (see
-     * [Coveo Query Syntax Reference](https://www.coveo.com/go?dest=adminhelp70&lcid=9&context=10005)). Enabling query
+     * [Coveo Query Syntax Reference](https://docs.coveo.com/en/1552/searching-with-coveo/coveo-cloud-query-syntax)). Enabling query
      * syntax also causes the `Querybox` to highlight any query syntax.
      *
      * Selecting **On** for the **Enable query syntax** setting enables query syntax, whereas selecting **Off** disables

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -555,7 +555,7 @@
   },
   "ResultsFilteringExpression": {
     "en": "Result filtering expressions",
-    "fr": "Expression de filtrage des résultats",
+    "fr": "Expressions de filtrage des résultats",
     "cs": "Výrazy pro filtrování výsledků",
     "da": "Tilkendegivelser filtrerer resultater",
     "de": "Ergebnisfilterausdruck",

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -554,7 +554,7 @@
     "zh-tw": "重新驗證 {0}"
   },
   "ResultsFilteringExpression": {
-    "en": "Results filtering expressions",
+    "en": "Result filtering expressions",
     "fr": "Expression de filtrage des résultats",
     "cs": "Výrazy pro filtrování výsledků",
     "da": "Tilkendegivelser filtrerer resultater",


### PR DESCRIPTION
This PR updates some links that were pointing to the old documentation site.

https://coveord.atlassian.net/browse/JSUI-3198

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)