### PR TITLE
JSUI-3199 Hide facet search when tabbing away from input or last result.

### DIFF
--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -69,6 +69,7 @@ export class FacetSearchElement {
     $$(this.input).on('focus', (e: Event) => {
       this.handleFacetSearchFocus();
     });
+    $$(this.input).on('blur', (e: FocusEvent) => this.onInputBlur(e));
 
     this.detectSearchBarAnimation();
     this.initSearchDropdownNavigator();
@@ -88,8 +89,17 @@ export class FacetSearchElement {
     $$(this.searchResults).hide();
   }
 
-  private onSearchResultsFocusOut(event: FocusEvent) {
-    const target = event.relatedTarget as HTMLElement;
+  private onInputBlur(e: FocusEvent) {
+    const target = e.relatedTarget as HTMLElement;
+    const focusedOnSearchResult = this.searchResults.contains(target);
+
+    if (!focusedOnSearchResult) {
+      this.facetSearch.dismissSearchResults();
+    }
+  }
+
+  private onSearchResultsFocusOut(e: FocusEvent) {
+    const target = e.relatedTarget as HTMLElement;
     const focusedOnInput = this.input.contains(target);
     const focusedOnSearchResult = this.searchResults.contains(target);
 

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -84,7 +84,18 @@ export class FacetSearchElement {
         this.facetSearch.dismissSearchResults();
       }
     });
+    $$(this.searchResults).on('focusout', (event: FocusEvent) => this.onSearchResultsFocusOut(event));
     $$(this.searchResults).hide();
+  }
+
+  private onSearchResultsFocusOut(event: FocusEvent) {
+    const target = event.relatedTarget as HTMLElement;
+    const focusedOnInput = this.input.contains(target);
+    const focusedOnSearchResult = this.searchResults.contains(target);
+
+    if (!focusedOnInput && !focusedOnSearchResult) {
+      this.facetSearch.dismissSearchResults();
+    }
   }
 
   private initSearchDropdownNavigator() {


### PR DESCRIPTION
Accessibility issue opened by American Heart Association.

When the classic facet search is open, tabbing focuses the first search result. When tabbing from the last result, focus shifts to the "show more" button, but the facet search stays open. Similarly, when shift-tabbing from the facet search input, the facet search stays open. This PR closes the facet search when one of this events occur.

I did not feel it was worthwhile to include unit tests for these interactions. If you prefer to have them, I will revisit.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)