### PR TITLE
JSUI-3209 Remove coveo.analytics module declaration

### DIFF
--- a/gulpTasks/definition.js
+++ b/gulpTasks/definition.js
@@ -66,7 +66,7 @@ function externalDefs() {
       './node_modules/@types/d3/index.d.ts',
       './lib/globalize/index.d.ts',
       './lib/jstimezonedetect/index.d.ts',
-      // './lib/coveoanalytics/index.d.ts',
+      './lib/coveoanalytics/index.d.ts',
       './lib/map/index.d.ts'
     ])
     .pipe(concat('Externals.d.ts'))

--- a/gulpTasks/definition.js
+++ b/gulpTasks/definition.js
@@ -66,7 +66,7 @@ function externalDefs() {
       './node_modules/@types/d3/index.d.ts',
       './lib/globalize/index.d.ts',
       './lib/jstimezonedetect/index.d.ts',
-      './lib/coveoanalytics/index.d.ts',
+      // './lib/coveoanalytics/index.d.ts',
       './lib/map/index.d.ts'
     ])
     .pipe(concat('Externals.d.ts'))

--- a/lib/coveoanalytics/index.d.ts
+++ b/lib/coveoanalytics/index.d.ts
@@ -1,6 +1,5 @@
 declare namespace CoveoAnalytics {
-  interface Response {
-  }
+  interface Response {}
 
   interface SearchDocument {
     documentUri: string;
@@ -72,17 +71,13 @@ declare namespace CoveoAnalytics {
     visitorId: string;
   }
 
-  interface SearchEventResponse extends DefaultEventResponse {
-  }
+  interface SearchEventResponse extends DefaultEventResponse {}
 
-  interface ClickEventResponse extends DefaultEventResponse {
-  }
+  interface ClickEventResponse extends DefaultEventResponse {}
 
-  interface CustomEventResponse extends DefaultEventResponse {
-  }
+  interface CustomEventResponse extends DefaultEventResponse {}
 
-  interface ViewEventResponse extends DefaultEventResponse {
-  }
+  interface ViewEventResponse extends DefaultEventResponse {}
 
   interface VisitResponse {
     raw: Response;
@@ -120,7 +115,7 @@ declare namespace CoveoAnalytics {
 
   interface History {
     HistoryStore: {
-      new(storage?: WebStorage): HistoryStore;
+      new (storage?: WebStorage): HistoryStore;
     };
   }
 
@@ -151,7 +146,6 @@ declare namespace CoveoAnalytics {
     onLoad(callback: Function): void;
   }
 
-
   interface WebStorage {
     getItem(key: string): string;
     removeItem(key: string): void;
@@ -160,7 +154,6 @@ declare namespace CoveoAnalytics {
   let preferredStorage: WebStorage;
 
   function getAvailableStorage(): WebStorage;
-
 
   class NullStorage implements WebStorage {
     getItem(key: string): string;
@@ -179,16 +172,4 @@ declare namespace CoveoAnalytics {
   }
 
   type EventType = 'pageview';
-}
-
-declare module 'coveo.analytics' {
-  export const analytics: CoveoAnalytics.AnalyticsClient;
-  export const history: CoveoAnalytics.History;
-  export const storage: {
-    CookieStorage: new ()=> CoveoAnalytics.CookieStorage
-  }
-  export const SimpleAnalytics: {
-    SimpleAPI: CoveoAnalytics.SimpleAPI,
-    SimpleAnalytics: (action: string, ...params: any[]) => any;
-  };
 }


### PR DESCRIPTION
**Context**

This change is to solve a bundling issue with upstream projects, in this case IPX. The simplest way to describe the problem:

When a package has both `coveo-search-ui` and `coveo.analytics` as dependencies,
when the ts-loader webpack resolver sees an import from `coveo.analytics`,
it incorrectly assumes that the import's definitions are those in the coveo-search-ui `.d.ts` file.

Since these definitions are out-of-sync with what is actually exported by `coveo.analytics`, ts throws an error saying that an imported function is missing.

**Solution**

Remove the module declaration from the definitions exported by coveo-search-ui so that webpack ts-loader can correctly resolve the import's definitions. I think this is safe and not a breaking change


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)