### PR TITLE
JSUI-3210 add fallback for full range request when it is completely empty

### DIFF
--- a/src/controllers/FacetSliderQueryController.ts
+++ b/src/controllers/FacetSliderQueryController.ts
@@ -59,9 +59,7 @@ export class FacetSliderQueryController {
     if (!this.isAValidRangeResponse(args)) {
       const logger = new Logger(this);
       logger.error(
-        `Cannot instantiate FacetSlider for this field : ${
-          this.facet.options.field
-        }. It needs to be configured as a numerical field in the index`
+        `Cannot instantiate FacetSlider for this field : ${this.facet.options.field}. It needs to be configured as a numerical field in the index`
       );
       logger.error(`Disabling the FacetSlider`, this.facet);
       this.facet.disable();
@@ -264,10 +262,7 @@ export class FacetSliderQueryController {
 
   private getFilterDateFormat(rawValue: any) {
     if (rawValue) {
-      return this.getISOFormat(rawValue)
-        .replace('T', '@')
-        .replace('.000Z', '')
-        .replace(/-/g, '/');
+      return this.getISOFormat(rawValue).replace('T', '@').replace('.000Z', '').replace(/-/g, '/');
     } else {
       return undefined;
     }
@@ -296,6 +291,18 @@ export class FacetSliderQueryController {
     }
 
     this.addExpressionToExcludeInvalidDates(groupByRequestForFullRange);
+
+    // If, after the above treatment, * all * parts of the group by request override are still empty,
+    // we need to add at least one override for it to be able to actually "disregard" the current filters of the interface, and retrieve the full range from the index.
+    // If all query override parts stays empty, we end up with a useless query that is affected by any other filters in the interface
+    if (
+      groupByRequestForFullRange.queryOverride === undefined &&
+      groupByRequestForFullRange.advancedQueryOverride === undefined &&
+      groupByRequestForFullRange.constantQueryOverride === undefined
+    ) {
+      groupByRequestForFullRange.advancedQueryOverride = '@uri';
+    }
+
     queryBuilder.groupByRequests.push(groupByRequestForFullRange);
   }
 

--- a/unitTests/controllers/FacetSliderQueryControllerTest.ts
+++ b/unitTests/controllers/FacetSliderQueryControllerTest.ts
@@ -96,6 +96,22 @@ export function FacetSliderQueryControllerTest() {
           expect(requestForFullRange.constantQueryOverride).toBeUndefined();
         });
 
+        it('should use @uri for advanced query override', () => {
+          expect(requestForFullRange.advancedQueryOverride).toBe('@uri');
+        });
+      });
+
+      describe('with a query containing a constant expression', () => {
+        beforeEach(() => {
+          builder.constantExpression.add('foo');
+          controller.putGroupByIntoQueryBuilder(builder);
+          requestForFullRange = builder.groupByRequests[controller.lastGroupByRequestForFullRangeIndex];
+        });
+
+        it('should have a constant query override copied from the main request', () => {
+          expect(requestForFullRange.constantQueryOverride).toBe('foo');
+        });
+
         it('should not use any advanced query override', () => {
           expect(requestForFullRange.advancedQueryOverride).toBeUndefined();
         });


### PR DESCRIPTION
To retrieve the "full range" from the index, on first load, when we cannot know for sure what is the full range of the index due to other filters active in the interface, we perform an additional group by requests for the slider ( `groupByRequestForFullRange` ).

It clones the "normal" group by request from the slider facet, and tries to tweak it to remove any filter it might contain, except the `constantQueryOverride` (that one, we still want to apply, since it comes from a Tab/is not dynamic based on user input).

There was a bug when no tab were present with any filter applied, we'd get a completely empty "query override" payload for the `groupByRequestForFullRange`.

When that happens, it defats the whole purpose of that request, since now all the filters from the main query get applied to the group by request, exactly as if it was a "normal" facet request.

AKA: it was unable to retrieve the full range of results.

`@uri` in advanced query override is essentially a query for "all documents", since all documents in a Coveo index contains an `uri`.

https://coveord.atlassian.net/browse/JSUI-3210


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)