### PR TITLE
JSUI-3205 Reseted thank you banner after a new question answer is rendered

### DIFF
--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -242,6 +242,7 @@ export class SmartSnippet extends Component {
 
   private async render(questionAnswer: IQuestionAnswerResponse) {
     this.ensureDom();
+    this.feedbackBanner.reset();
     this.questionContainer.innerText = questionAnswer.question;
     this.renderSnippet(questionAnswer.answerSnippet);
     this.lastRenderedResult = this.getCorrespondingResult(questionAnswer);

--- a/src/ui/SmartSnippet/UserFeedbackBanner.ts
+++ b/src/ui/SmartSnippet/UserFeedbackBanner.ts
@@ -72,6 +72,16 @@ export class UserFeedbackBanner {
     ).el;
   }
 
+  public reset() {
+    this.isUseful = UsefulState.Unknown;
+    $$(this.yesButton).removeClass(BUTTON_ACTIVE_CLASSNAME);
+    $$(this.yesButton).setAttribute('aria-pressed', 'false');
+    $$(this.noButton).removeClass(BUTTON_ACTIVE_CLASSNAME);
+    $$(this.noButton).setAttribute('aria-pressed', 'false');
+    $$(this.thankYouBanner).removeClass(THANK_YOU_BANNER_ACTIVE_CLASSNAME);
+    $$(this.explainWhy).removeClass(EXPLAIN_WHY_ACTIVE_CLASSNAME);
+  }
+
   private buildContainer() {
     return $$(
       'div',

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -101,7 +101,7 @@ export function SmartSnippetTest() {
     }
 
     function getFirstChild(className: string) {
-      return test.cmp.element.getElementsByClassName(className)[0] as HTMLElement;
+      return (test.cmp.element.getElementsByClassName(className)[0] as HTMLElement) || null;
     }
 
     function getShadowRoot() {
@@ -217,6 +217,30 @@ export function SmartSnippetTest() {
 
         it('should render the answer container followed by the feedback banner', () => {
           expectChildren(test.cmp.element, [ClassNames.ANSWER_CONTAINER_CLASSNAME, UserFeedbackBannerClassNames.ROOT_CLASSNAME]);
+        });
+
+        it('the thank you banner should not be active', () => {
+          expect(getFirstChild(UserFeedbackBannerClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)).toBeNull();
+        });
+
+        it('after clicking yes or no, the thank you banner should be active', () => {
+          getFirstChild(UserFeedbackBannerClassNames.NO_BUTTON_CLASSNAME).click();
+          expect(getFirstChild(UserFeedbackBannerClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)).not.toBeNull();
+        });
+
+        it('after clicking yes or no and receiving a new answer, the thank you banner should not be active', async done => {
+          getFirstChild(UserFeedbackBannerClassNames.NO_BUTTON_CLASSNAME).click();
+          await triggerQuestionAnswerQuery(false);
+          expect(getFirstChild(UserFeedbackBannerClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)).toBeNull();
+          done();
+        });
+
+        it('after clicking yes or no and receiving a new answer, it should still be possible to give the same answer', async done => {
+          getFirstChild(UserFeedbackBannerClassNames.NO_BUTTON_CLASSNAME).click();
+          await triggerQuestionAnswerQuery(false);
+          getFirstChild(UserFeedbackBannerClassNames.NO_BUTTON_CLASSNAME).click();
+          expect(getFirstChild(UserFeedbackBannerClassNames.THANK_YOU_BANNER_ACTIVE_CLASSNAME)).not.toBeNull();
+          done();
         });
 
         it('should render the snippet followed by the source in the answer container', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3205

The thank you banner was still being displayed after a new question answer was rendered.
![image](https://user-images.githubusercontent.com/54454747/112641410-c0352600-8e18-11eb-8860-70d6f94f4072.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)