### PR TITLE
JSUI-3199 Prevent keyboard accessibility events from overriding mouse click

### DIFF
--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -69,6 +69,7 @@ export class FacetSearchElement {
     $$(this.input).on('focus', (e: Event) => {
       this.handleFacetSearchFocus();
     });
+    $$(this.input).on('blur', (e: FocusEvent) => this.onInputBlur(e));
 
     this.detectSearchBarAnimation();
     this.initSearchDropdownNavigator();
@@ -88,8 +89,17 @@ export class FacetSearchElement {
     $$(this.searchResults).hide();
   }
 
-  private onSearchResultsFocusOut(event: FocusEvent) {
-    const target = event.relatedTarget as HTMLElement;
+  private onInputBlur(e: FocusEvent) {
+    const target = e.relatedTarget as HTMLElement;
+    const focusedOnSearchResult = this.searchResults.contains(target);
+
+    if (!focusedOnSearchResult) {
+      this.facetSearch.dismissSearchResults();
+    }
+  }
+
+  private onSearchResultsFocusOut(e: FocusEvent) {
+    const target = e.relatedTarget as HTMLElement;
     const focusedOnInput = this.input.contains(target);
     const focusedOnSearchResult = this.searchResults.contains(target);
 

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -91,19 +91,21 @@ export class FacetSearchElement {
 
   private onInputBlur(e: FocusEvent) {
     const target = e.relatedTarget as HTMLElement;
+    const isUsingKeyboard = !!target;
     const focusedOnSearchResult = this.searchResults.contains(target);
 
-    if (!focusedOnSearchResult) {
+    if (isUsingKeyboard && !focusedOnSearchResult) {
       this.facetSearch.dismissSearchResults();
     }
   }
 
   private onSearchResultsFocusOut(e: FocusEvent) {
     const target = e.relatedTarget as HTMLElement;
+    const isUsingKeyboard = !!target;
     const focusedOnInput = this.input.contains(target);
     const focusedOnSearchResult = this.searchResults.contains(target);
 
-    if (!focusedOnInput && !focusedOnSearchResult) {
+    if (isUsingKeyboard && !focusedOnInput && !focusedOnSearchResult) {
       this.facetSearch.dismissSearchResults();
     }
   }

--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -84,7 +84,18 @@ export class FacetSearchElement {
         this.facetSearch.dismissSearchResults();
       }
     });
+    $$(this.searchResults).on('focusout', (event: FocusEvent) => this.onSearchResultsFocusOut(event));
     $$(this.searchResults).hide();
+  }
+
+  private onSearchResultsFocusOut(event: FocusEvent) {
+    const target = event.relatedTarget as HTMLElement;
+    const focusedOnInput = this.input.contains(target);
+    const focusedOnSearchResult = this.searchResults.contains(target);
+
+    if (!focusedOnInput && !focusedOnSearchResult) {
+      this.facetSearch.dismissSearchResults();
+    }
   }
 
   private initSearchDropdownNavigator() {


### PR DESCRIPTION
I created a regression when trying to improve keyboard accessibility https://github.com/coveo/search-ui/pull/1707.

- If someone tried to click on a facet search result, the input blur would close the dropdown before the click event could execute.
- Similarly, if someone tabbed with their keyboard to focus on a facet search result, but then decided to click on the result instead of using the Enter key, the result would not be selected.

Before closing the results, I now check first check if the event handler was actually triggered by the keyboard.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)