### PR TITLE
JSUI-3213 update underscore; fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "moment": "~2.22.2",
     "pikaday": "^1.4.0",
     "popper.js": "^1.14.3",
-    "underscore": "^1.12.1",
+    "underscore": "^1.13.1",
     "xregexp": "^4.2.4"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "moment": "~2.22.2",
     "pikaday": "^1.4.0",
     "popper.js": "^1.14.3",
-    "underscore": "^1.10.2",
+    "underscore": "^1.12.1",
     "xregexp": "^4.2.4"
   },
   "resolutions": {

--- a/src/ui/CategoryFacet/CategoryFacetSearch.ts
+++ b/src/ui/CategoryFacet/CategoryFacetSearch.ts
@@ -1,6 +1,6 @@
 import { CategoryFacet } from './CategoryFacet';
 import { FacetSearchElement } from '../Facet/FacetSearchElement';
-import { pluck, debounce, last } from 'underscore';
+import { pluck, debounce as _debounce, last } from 'underscore';
 import { $$, Dom } from '../../utils/Dom';
 import { SVGDom } from '../../utils/SVGDom';
 import { SVGIcons } from '../../utils/SVGIcons';
@@ -13,6 +13,13 @@ import { IFacetSearch } from '../Facet/IFacetSearch';
 import { IIndexFieldValue } from '../../rest/FieldValue';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import * as Globalize from 'globalize';
+
+type Debounce = <T extends Function>(fn: T, wait: number, immediate?: boolean) => T;
+let debounce: Debounce = _debounce;
+
+export function setDebounceFn(fn: Debounce) {
+  debounce = fn;
+}
 
 export class CategoryFacetSearch implements IFacetSearch {
   public container: Dom | undefined;

--- a/src/ui/CategoryFacet/CategoryFacetSearch.ts
+++ b/src/ui/CategoryFacet/CategoryFacetSearch.ts
@@ -1,6 +1,6 @@
 import { CategoryFacet } from './CategoryFacet';
 import { FacetSearchElement } from '../Facet/FacetSearchElement';
-import { pluck, debounce as _debounce, last } from 'underscore';
+import { pluck, debounce, last } from 'underscore';
 import { $$, Dom } from '../../utils/Dom';
 import { SVGDom } from '../../utils/SVGDom';
 import { SVGIcons } from '../../utils/SVGIcons';
@@ -13,13 +13,6 @@ import { IFacetSearch } from '../Facet/IFacetSearch';
 import { IIndexFieldValue } from '../../rest/FieldValue';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import * as Globalize from 'globalize';
-
-type Debounce = <T extends Function>(fn: T, wait: number, immediate?: boolean) => T;
-let debounce: Debounce = _debounce;
-
-export function setDebounceFn(fn: Debounce) {
-  debounce = fn;
-}
 
 export class CategoryFacetSearch implements IFacetSearch {
   public container: Dom | undefined;

--- a/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
@@ -1,7 +1,7 @@
 import { CategoryFacet } from '../../../src/ui/CategoryFacet/CategoryFacet';
 import { mock, basicComponentSetup } from '../../MockEnvironment';
 import { FakeResults } from '../../Fake';
-import { CategoryFacetSearch, setDebounceFn } from '../../../src/ui/CategoryFacet/CategoryFacetSearch';
+import { CategoryFacetSearch } from '../../../src/ui/CategoryFacet/CategoryFacetSearch';
 import { CategoryFacetQueryController } from '../../../src/controllers/CategoryFacetQueryController';
 import _ = require('underscore');
 import { IGroupByValue } from '../../../src/rest/GroupByValue';
@@ -13,6 +13,7 @@ import { Simulate } from '../../Simulate';
 
 export function CategoryFacetSearchTest() {
   describe('CategoryFacetSearch', () => {
+    const facetSearchDelay = 5;
     const noResultsClass = 'coveo-no-results';
     const facetSearchNoResultsClass = 'coveo-facet-search-no-results';
     const categoryFacetTitle = 'abcdef';
@@ -59,8 +60,6 @@ export function CategoryFacetSearchTest() {
     }
 
     beforeEach(() => {
-      setDebounceFn(cb => cb);
-      const facetSearchDelay = 5;
       categoryFacetMock = basicComponentSetup<CategoryFacet>(CategoryFacet, {
         field: '@field',
         title: categoryFacetTitle,
@@ -101,12 +100,13 @@ export function CategoryFacetSearchTest() {
       expect(getInput().focus).toHaveBeenCalled();
     });
 
-    it('renders values on focus', done => {
+    it('renders values on focus', async done => {
       categoryFacetSearch.focus();
+
       setTimeout(() => {
         expect(getSearchResults().innerHTML).not.toEqual('');
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('should call updateAriaLiveWithResults', done => {
@@ -116,7 +116,7 @@ export function CategoryFacetSearchTest() {
       setTimeout(() => {
         expect(categoryFacetSearch.facetSearchElement.updateAriaLiveWithResults).toHaveBeenCalled();
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('renders values correctly', done => {
@@ -133,7 +133,7 @@ export function CategoryFacetSearchTest() {
           expect($$(valueCounts[i]).text()).toEqual((i + 1).toString());
         }
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('renders the path correctly', done => {
@@ -146,7 +146,7 @@ export function CategoryFacetSearchTest() {
         const pathCaption = $$(getSearchResults()).find('.coveo-category-facet-search-path');
         expect($$(pathCaption).text()).toEqual('a/b/');
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('sets the correct classes when there is no results', done => {
@@ -157,7 +157,7 @@ export function CategoryFacetSearchTest() {
       setTimeout(() => {
         expectNoResults();
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('removes no results classes when there are results', done => {
@@ -169,7 +169,7 @@ export function CategoryFacetSearchTest() {
       setTimeout(() => {
         expectResults();
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('selects the first results when displaying new values', done => {
@@ -178,7 +178,7 @@ export function CategoryFacetSearchTest() {
       setTimeout(() => {
         expect($$(getFacetSearchValues()[0]).hasClass('coveo-facet-search-current-result')).toBe(true);
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('sends an analytics event on selection', done => {
@@ -189,7 +189,7 @@ export function CategoryFacetSearchTest() {
         $$(getFacetSearchValues()[0]).trigger('click');
         expect(categoryFacetMock.logAnalyticsEvent).toHaveBeenCalledWith(analyticsActionCauseList.categoryFacetSelect, ['value0']);
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('it scrolls to top', done => {
@@ -200,13 +200,13 @@ export function CategoryFacetSearchTest() {
         $$(getFacetSearchValues()[0]).trigger('click');
         expect(categoryFacetMock.scrollToTop).toHaveBeenCalled();
         done();
-      });
+      }, facetSearchDelay);
     });
 
     describe('when expanding', () => {
       beforeEach(done => {
         categoryFacetSearch.displayNewValues();
-        setTimeout(done);
+        setTimeout(done, facetSearchDelay);
       });
 
       it('sets aria-expanded to true', () => {
@@ -252,7 +252,7 @@ export function CategoryFacetSearchTest() {
           getInputHandler().handleKeyboardEvent(keyboardEvent);
           expect(categoryFacetMock.changeActivePath).toHaveBeenCalledWith(['value0']);
           done();
-        });
+        }, facetSearchDelay);
       });
 
       it('it scrolls to top', done => {
@@ -260,7 +260,7 @@ export function CategoryFacetSearchTest() {
           getInputHandler().handleKeyboardEvent(keyboardEvent);
           expect(categoryFacetMock.scrollToTop).toHaveBeenCalled();
           done();
-        });
+        }, facetSearchDelay);
       });
 
       it('it sends an analytics event', done => {
@@ -268,7 +268,7 @@ export function CategoryFacetSearchTest() {
           getInputHandler().handleKeyboardEvent(keyboardEvent);
           expect(categoryFacetMock.logAnalyticsEvent).toHaveBeenCalledWith(analyticsActionCauseList.categoryFacetSelect, ['value0']);
           done();
-        });
+        }, facetSearchDelay);
       });
     });
 
@@ -280,7 +280,7 @@ export function CategoryFacetSearchTest() {
         getInputHandler().handleKeyboardEvent(keyboardEvent);
         expect($$(getFacetSearchValues()[1]).hasClass('coveo-facet-search-current-result')).toBe(true);
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('pressing up arrow while on the input moves current result up', done => {
@@ -291,7 +291,7 @@ export function CategoryFacetSearchTest() {
         getInputHandler().handleKeyboardEvent(keyboardEvent);
         expect($$(getFacetSearchValues().slice(-1)[0]).hasClass('coveo-facet-search-current-result')).toBe(true);
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('pressing escape while on the input closes the search input', done => {
@@ -312,7 +312,7 @@ export function CategoryFacetSearchTest() {
       setTimeout(() => {
         expect(getSearchResults().innerHTML).not.toEqual('');
         done();
-      });
+      }, facetSearchDelay);
     });
 
     it('pressing escape while on the results closes the search input', done => {

--- a/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
@@ -1,7 +1,7 @@
 import { CategoryFacet } from '../../../src/ui/CategoryFacet/CategoryFacet';
 import { mock, basicComponentSetup } from '../../MockEnvironment';
 import { FakeResults } from '../../Fake';
-import { CategoryFacetSearch } from '../../../src/ui/CategoryFacet/CategoryFacetSearch';
+import { CategoryFacetSearch, setDebounceFn } from '../../../src/ui/CategoryFacet/CategoryFacetSearch';
 import { CategoryFacetQueryController } from '../../../src/controllers/CategoryFacetQueryController';
 import _ = require('underscore');
 import { IGroupByValue } from '../../../src/rest/GroupByValue';
@@ -10,22 +10,6 @@ import { KEYBOARD } from '../../../src/utils/KeyboardUtils';
 import { analyticsActionCauseList } from '../../../src/ui/Analytics/AnalyticsActionListMeta';
 import * as Globalize from 'globalize';
 import { Simulate } from '../../Simulate';
-
-function undebounce(fn: (...args: any[]) => any, time = 0): (...args: any[]) => void {
-  return (...args) => {
-    let wasClockInstalled = false;
-    try {
-      jasmine.clock().install();
-    } catch (e) {
-      wasClockInstalled = true;
-    }
-    fn(...args);
-    jasmine.clock().tick(time);
-    if (!wasClockInstalled) {
-      jasmine.clock().uninstall();
-    }
-  };
-}
 
 export function CategoryFacetSearchTest() {
   describe('CategoryFacetSearch', () => {
@@ -75,6 +59,7 @@ export function CategoryFacetSearchTest() {
     }
 
     beforeEach(() => {
+      setDebounceFn(cb => cb);
       const facetSearchDelay = 5;
       categoryFacetMock = basicComponentSetup<CategoryFacet>(CategoryFacet, {
         field: '@field',
@@ -85,7 +70,6 @@ export function CategoryFacetSearchTest() {
       categoryFacetMock.categoryFacetQueryController = mock(CategoryFacetQueryController);
       categoryFacetMock.categoryFacetQueryController.searchFacetValues = () => new Promise(resolve => resolve(fakeGroupByValues));
       categoryFacetSearch = new CategoryFacetSearch(categoryFacetMock);
-      categoryFacetSearch.displayNewValues = undebounce(categoryFacetSearch.displayNewValues, facetSearchDelay);
       categoryFacetSearch.build();
     });
 

--- a/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryFacetSearchTest.ts
@@ -100,7 +100,7 @@ export function CategoryFacetSearchTest() {
       expect(getInput().focus).toHaveBeenCalled();
     });
 
-    it('renders values on focus', async done => {
+    it('renders values on focus', done => {
       categoryFacetSearch.focus();
 
       setTimeout(() => {

--- a/unitTests/ui/FacetSliderTest.ts
+++ b/unitTests/ui/FacetSliderTest.ts
@@ -215,44 +215,47 @@ export function FacetSliderTest() {
         env = mockEnvironmentBuilder.build();
       });
 
-      afterEach(() => {
-        jasmine.clock().uninstall();
-      });
-
       describe('on resize', () => {
         beforeEach(() => {
-          jasmine.clock().install();
           facetSlider = new FacetSlider(env.element, facetSliderOptions, mockEnvironmentBuilder.getBindings(), slider);
         });
 
-        afterEach(() => {
-          jasmine.clock().uninstall();
-        });
-
-        it('should draw the graph on resize when there are results', () => {
+        it('should draw the graph on resize when there are results', done => {
           facetSlider.onResize(new Event('resize'));
-          jasmine.clock().tick(FacetSlider.DEBOUNCED_RESIZE_DELAY + 1);
-          expect(slider.drawGraph).toHaveBeenCalled();
+
+          setTimeout(() => {
+            expect(slider.drawGraph).toHaveBeenCalled();
+            done();
+          }, FacetSlider.DEBOUNCED_RESIZE_DELAY);
         });
 
-        it('should execute the onMoving function of the slider on resize', () => {
+        it('should execute the onMoving function of the slider on resize', done => {
           facetSlider.onResize(new Event('resize'));
-          jasmine.clock().tick(FacetSlider.DEBOUNCED_RESIZE_DELAY + 1);
-          expect(slider.onMoving).toHaveBeenCalled();
+
+          setTimeout(() => {
+            expect(slider.onMoving).toHaveBeenCalled();
+            done();
+          }, FacetSlider.DEBOUNCED_RESIZE_DELAY);
         });
 
-        it('should not execute the onMoving function of the slider if it is not instantiated', () => {
+        it('should not execute the onMoving function of the slider if it is not instantiated', done => {
           facetSlider['slider'] = null;
           facetSlider.onResize(new Event('resize'));
-          jasmine.clock().tick(FacetSlider.DEBOUNCED_RESIZE_DELAY + 1);
-          expect(slider.onMoving).not.toHaveBeenCalled();
+
+          setTimeout(() => {
+            expect(slider.onMoving).not.toHaveBeenCalled();
+            done();
+          }, FacetSlider.DEBOUNCED_RESIZE_DELAY);
         });
 
-        it('should not draw the graph on resize when there are no results', () => {
+        it('should not draw the graph on resize when there are no results', done => {
           $$(env.root).trigger(QueryEvents.noResults);
           facetSlider.onResize(new Event('resize'));
-          jasmine.clock().tick(FacetSlider.DEBOUNCED_RESIZE_DELAY + 1);
-          expect(slider.drawGraph).not.toHaveBeenCalled();
+
+          setTimeout(() => {
+            expect(slider.drawGraph).not.toHaveBeenCalled();
+            done();
+          }, FacetSlider.DEBOUNCED_RESIZE_DELAY);
         });
       });
 

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -24,7 +24,6 @@ export function ResponsiveComponentsManagerTest() {
 
   describe('ResponsiveComponentsManager', () => {
     beforeEach(() => {
-      jasmine.clock().install();
       let searchInterfaceMock = Mock.optionsSearchInterfaceSetup<SearchInterface, ISearchInterfaceOptions>(SearchInterface, {
         enableAutomaticResponsiveMode: true
       });
@@ -39,10 +38,6 @@ export function ResponsiveComponentsManagerTest() {
       };
       component = {};
       responsiveComponentsManager = new ResponsiveComponentsManager(root);
-    });
-
-    afterEach(() => {
-      jasmine.clock().uninstall();
     });
 
     it(`when registering a tab with #enableResponsiveMode false and a responsive facet,
@@ -71,21 +66,26 @@ export function ResponsiveComponentsManagerTest() {
         setResponsiveMode('auto');
       });
 
-      it('should calls handle resize event when resize listener is called', () => {
+      it('should calls handle resize event when resize listener is called', done => {
         root.width = () => 400;
         responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
         responsiveComponentsManager.resizeListener();
-        jasmine.clock().tick(250);
-        expect(handleResizeEvent).toHaveBeenCalled();
+
+        setTimeout(() => {
+          expect(handleResizeEvent).toHaveBeenCalled();
+          done();
+        }, 250);
       });
 
-      it('should call resize listener of all ResponsiveComponentManager when resizeAllComponentsManager is called', () => {
+      it('should call resize listener of all ResponsiveComponentManager when resizeAllComponentsManager is called', done => {
         root.width = () => 400;
         responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
         ResponsiveComponentsManager.resizeAllComponentsManager();
 
-        jasmine.clock().tick(500);
-        expect(handleResizeEvent).toHaveBeenCalled();
+        setTimeout(() => {
+          expect(handleResizeEvent).toHaveBeenCalled();
+          done();
+        }, 250);
       });
 
       describe('and the root element width is zero', () => {
@@ -93,11 +93,14 @@ export function ResponsiveComponentsManagerTest() {
           root.width = () => 0;
         });
 
-        it('should  not calls handle resize event when resize listener is called', () => {
+        it('should  not call handle resize event when resize listener is called', done => {
           responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
           responsiveComponentsManager.resizeListener();
-          jasmine.clock().tick(250);
-          expect(handleResizeEvent).not.toHaveBeenCalled();
+
+          setTimeout(() => {
+            expect(handleResizeEvent).not.toHaveBeenCalled();
+            done();
+          }, 250);
         });
 
         it('should  not calls handle resize event when it registers component', () => {
@@ -117,11 +120,14 @@ export function ResponsiveComponentsManagerTest() {
           root.width = () => 0;
         });
 
-        it('should calls handle resize event when resize listener is called', () => {
+        it('should calls handle resize event when resize listener is called', done => {
           responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
           responsiveComponentsManager.resizeListener();
-          jasmine.clock().tick(250);
-          expect(handleResizeEvent).toHaveBeenCalled();
+
+          setTimeout(() => {
+            expect(handleResizeEvent).toHaveBeenCalled();
+            done();
+          }, 250);
         });
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -10915,10 +10915,10 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
-underscore@^1.12.1:
-  version "1.12.1"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
-  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
+underscore@^1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
+  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
 
 undertaker-registry@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10915,10 +10915,10 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
 
-underscore@^1.10.2:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.11.0.tgz#dd7c23a195db34267186044649870ff1bab5929e"
-  integrity sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==
+underscore@^1.12.1:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.12.1.tgz#7bb8cc9b3d397e201cf8553336d262544ead829e"
+  integrity sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw==
 
 undertaker-registry@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Updating underscore causes tests that are mocking underscore's `debounce` function, or using jasmine.clock to fail.

I did not find a way to make them pass using `jasmine.clock` or `Promise.resolve`. I also get blocked when trying to override the method using a jasmine spy.

```
debounce is not declared writable or has no setter
```

The simplest solution I found was to let the test run with debounce, and use setTimeout's with the correct delay before asserting.

https://coveord.atlassian.net/browse/JSUI-3213





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)