### PR TITLE
JSUI-3215 Changed icon for facet slider

### DIFF
--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -618,7 +618,7 @@ export class FacetSlider extends Component {
       {
         className: 'coveo-facet-slider-breadcrumb-clear'
       },
-      SVGIcons.icons.checkboxHookExclusionMore
+      SVGIcons.icons.mainClear
     );
     SVGDom.addClassToSVGInContainer(clear.el, 'coveo-facet-slider-clear-svg');
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3215

The facet slider breadcrumb now uses the same icon as every other facet breadcrumb.
![image](https://user-images.githubusercontent.com/54454747/113444126-475a3f00-93c1-11eb-8809-243cadf350ec.png)

The previous icon was mostly used for facet search and became invisible in the context of breadcrumbs but not in other contexts.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)