### PR TITLE
JSUI-3219 Made `Pager`'s `NumberOfPages` consistent near last page

### DIFF
--- a/src/ui/Pager/Pager.ts
+++ b/src/ui/Pager/Pager.ts
@@ -349,7 +349,7 @@ export class Pager extends Component {
     lastPageNumber = Math.max(lastPageNumber, 1);
     const halfLength = Math.floor(this.options.numberOfPages / 2);
     let firstPageNumber = currentPage - halfLength;
-    firstPageNumber = Math.max(firstPageNumber, 1);
+    firstPageNumber = Math.max(Math.min(firstPageNumber, lastPageNumber - this.options.numberOfPages + 1), 1);
     let endPageNumber = firstPageNumber + this.options.numberOfPages - 1;
     endPageNumber = Math.min(endPageNumber, lastPageNumber);
     return {

--- a/src/ui/Pager/Pager.ts
+++ b/src/ui/Pager/Pager.ts
@@ -345,13 +345,12 @@ export class Pager extends Component {
   private computePagerBoundary(firstResult: number, totalCount: number) {
     const resultPerPage = this.searchInterface.resultsPerPage;
     const currentPage = Math.floor(firstResult / resultPerPage) + 1;
-    let lastPageNumber = Math.min(Math.ceil(totalCount / resultPerPage), this.getMaxNumberOfPagesForCurrentResultsPerPage());
-    lastPageNumber = Math.max(lastPageNumber, 1);
+    const lastPageNumber = Math.max(Math.min(Math.ceil(totalCount / resultPerPage), this.getMaxNumberOfPagesForCurrentResultsPerPage()), 1);
+
     const halfLength = Math.floor(this.options.numberOfPages / 2);
-    let firstPageNumber = currentPage - halfLength;
-    firstPageNumber = Math.max(Math.min(firstPageNumber, lastPageNumber - this.options.numberOfPages + 1), 1);
-    let endPageNumber = firstPageNumber + this.options.numberOfPages - 1;
-    endPageNumber = Math.min(endPageNumber, lastPageNumber);
+    const firstPageNumber = Math.max(Math.min(currentPage - halfLength, lastPageNumber - this.options.numberOfPages + 1), 1);
+    const endPageNumber = Math.min(firstPageNumber + this.options.numberOfPages - 1, lastPageNumber);
+
     return {
       start: firstPageNumber,
       end: endPageNumber,


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3219

Near the last pages, the `numberOfPages` option wasn't respected anymore. For instance, if `numberOfPages` was 5 and we were on the last page, only 3 buttons would show up.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)