### PR TITLE
SPAAS-686 export AnalyticsInformation to help IPX set clientId

### DIFF
--- a/src/UtilsModules.ts
+++ b/src/UtilsModules.ts
@@ -19,3 +19,4 @@ export { StringUtils } from './utils/StringUtils';
 export { TimeSpan } from './utils/TimeSpanUtils';
 export { Utils } from './utils/Utils';
 export { UrlUtils } from './utils/UrlUtils';
+export { AnalyticsInformation } from './ui/Analytics/AnalyticsInformation';


### PR DESCRIPTION
**Context**

I was thinking about whether we avoid IPX losing sync with the JSUI in the future ([see this PR](https://github.com/coveo/search-pages-service/pull/159)).

The reason sync broke was because the JSUI changed the key (coveo-visitorId -> visitorId) and format (JSON -> string) to fix an analytics incompatability between the JSUI and coveo.analytics for Mondou.

**Possible solution**

If instead of setting the key/value directly IPX could use an exposed JSUI utility, then changes in the implementation of `AnalyticsInformation` could be leveraged by IPX.


This fix is not perfect since it can only be leveraged by IPX configured with a JSUI version containing this change.

Thoughts?




https://coveord.atlassian.net/browse/SPAAS-686

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)