### PR TITLE
Fix infinite loop in highlights for special cases [JSUI-3222]

### DIFF
--- a/src/utils/StreamHighlightUtils.ts
+++ b/src/utils/StreamHighlightUtils.ts
@@ -82,11 +82,7 @@ export function getRestHighlightsForAllTerms(
   opts: IStreamHighlightOptions
 ): IHighlight[] {
   const indexes = [];
-  const termsFromPhrases = _.chain(phrasesToHighlight)
-    .values()
-    .map(_.keys)
-    .flatten()
-    .value();
+  const termsFromPhrases = _.chain(phrasesToHighlight).values().map(_.keys).flatten().value();
 
   _.each(termsToHighlight, (terms: string[], term: string) => {
     const uniqueTermsToHighlight = _.chain([term])
@@ -96,6 +92,10 @@ export function getRestHighlightsForAllTerms(
       .map(Utils.escapeRegexCharacter)
       .sortBy('length')
       .value();
+
+    if (uniqueTermsToHighlight.length === 0) {
+      return;
+    }
 
     const regex = `${regexStart}${uniqueTermsToHighlight.join('|')})(?=(?:${wordBoundary}|$)+)`;
     const indexesFound = StringUtils.getHighlights(toHighlight, new RegExp(regex, opts.regexFlags), term);

--- a/unitTests/ui/CoreHelpersTest.ts
+++ b/unitTests/ui/CoreHelpersTest.ts
@@ -96,8 +96,11 @@ export function CoreHelperTest() {
       );
     });
 
-    it('highlightStreamText should not crash in case of duplicate terms on a text that starts with a word delimiter', () => {
+    it('highlightStreamText should not hang in case of duplicate terms on a text that starts with a word delimiter', () => {
+      // A "bad text" is any text that starts with a "word delimiter".
       const toHighlight = `'This is a bad text`;
+
+      // The only "term" needs to be in both the "terms" and the "phrases".
       const terms: IHighlightTerm = { aTerm: [] };
       const phrases: IHighlightPhrase = { aTerm: terms };
 

--- a/unitTests/ui/CoreHelpersTest.ts
+++ b/unitTests/ui/CoreHelpersTest.ts
@@ -8,6 +8,7 @@ import { mockSearchEndpoint, MockEnvironmentBuilder } from '../MockEnvironment';
 import { IQueryResult } from '../../src/rest/QueryResult';
 import { IIconOptions } from '../../src/ui/Icon/Icon';
 import { Component } from '../../src/Core';
+import * as _ from 'underscore';
 
 export function CoreHelperTest() {
   describe('CoreHelpers', () => {
@@ -93,6 +94,14 @@ export function CoreHelperTest() {
       expect(TemplateHelpers.getHelper('highlightStreamText')(toHighlight, terms, {})).toEqual(
         '<span class="coveo-highlight" data-highlight-group="1" data-highlight-group-term="a">a</span> <span class="coveo-highlight" data-highlight-group="2" data-highlight-group-term="b">b</span>'
       );
+    });
+
+    it('highlightStreamText should not crash in case of duplicate terms on a text that starts with a word delimiter', () => {
+      const toHighlight = `'This is a bad text`;
+      const terms: IHighlightTerm = { aTerm: [] };
+      const phrases: IHighlightPhrase = { aTerm: terms };
+
+      expect(TemplateHelpers.getHelper('highlightStreamText')(toHighlight, terms, phrases)).toEqual(_.escape(toHighlight));
     });
 
     it('highlightStreamTextv2 should work correctly', () => {


### PR DESCRIPTION
For the cases where the termsToHighlight  are exactly the same as the phrasesToHighlight  and that the text to highlight starts with a word delimiter, an infinite loop occurs. Validating that there is a unique term to highlight prior to execute the regex fixes the issue. If there's no unique terms to highlight there's no point in running the regex anyway.

https://coveord.atlassian.net/browse/JSUI-3222
https://discuss.coveo.com/t/performance-mem-leaks-issues-with-terms-to-highlights/5604/9


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)