### PR TITLE
make result list respect the desktop/mobile/table layouts option of result layout selector

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveResultLayout.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveResultLayout.ts
@@ -23,6 +23,9 @@ export class ResponsiveResultLayout implements IResponsiveComponent {
 
   constructor(public coveoRoot: Dom, public ID: string, options: IResponsiveComponentOptions, responsiveDropdown?: ResponsiveDropdown) {
     this.searchInterface = <SearchInterface>Component.get(this.coveoRoot.el, SearchInterface, false);
+    coveoRoot.on('state:change:t', () => {
+      this.handleResizeEvent();
+    });
   }
 
   public registerComponent(accept: Component) {

--- a/src/ui/ResultLayoutSelector/ResultLayoutSelector.ts
+++ b/src/ui/ResultLayoutSelector/ResultLayoutSelector.ts
@@ -1,5 +1,5 @@
 import 'styling/_ResultLayoutSelector';
-import { contains, difference, each, filter, find, isEmpty, keys, uniq } from 'underscore';
+import { contains, difference, each, filter, find, isEmpty, keys, uniq, pick } from 'underscore';
 import { InitializationEvents } from '../../events/InitializationEvents';
 import { IQueryErrorEventArgs, IQuerySuccessEventArgs, QueryEvents } from '../../events/QueryEvents';
 import { IResultLayoutPopulateArgs, ResultLayoutEvents } from '../../events/ResultLayoutEvents';
@@ -146,6 +146,15 @@ export class ResultLayoutSelector extends Component {
   }
 
   public get activeLayouts(): { [key: string]: IActiveLayouts } {
+    if (this.searchInterface.responsiveComponents.isLargeScreenWidth()) {
+      return pick(this.currentActiveLayouts, this.options.desktopLayouts);
+    }
+    if (this.searchInterface.responsiveComponents.isMediumScreenWidth()) {
+      return pick(this.currentActiveLayouts, this.options.tabletLayouts);
+    }
+    if (this.searchInterface.responsiveComponents.isSmallScreenWidth()) {
+      return pick(this.currentActiveLayouts, this.options.mobileLayouts);
+    }
     return this.currentActiveLayouts;
   }
 

--- a/src/ui/ResultList/ResultList.ts
+++ b/src/ui/ResultList/ResultList.ts
@@ -1,7 +1,7 @@
 import 'styling/_Result';
 import 'styling/_ResultFrame';
 import 'styling/_ResultList';
-import { chain, compact, contains, each, flatten, map, unique, without, uniqueId } from 'underscore';
+import { chain, compact, contains, each, flatten, map, unique, without, uniqueId, find } from 'underscore';
 import {
   IBuildingQueryEventArgs,
   IDuringQueryEventArgs,
@@ -491,17 +491,17 @@ export class ResultList extends Component {
   }
 
   public enable(): void {
-    super.enable();
     this.disableLayoutChange = false;
-    each(this.resultLayoutSelectors, resultLayoutSelector => {
-      resultLayoutSelector.enableLayouts([this.options.layout] as ValidLayout[]);
-    });
-    $$(this.element).removeClass('coveo-hidden');
+    if (this.resultLayoutSelectors.length > 0) {
+      this.enableBasedOnActiveLayouts();
+    } else {
+      super.enable();
+      $$(this.element).removeClass('coveo-hidden');
+    }
   }
 
   public disable(): void {
     super.disable();
-
     const otherLayoutsStillActive = map(this.otherResultLists, otherResultList => otherResultList.options.layout);
     if (!contains(otherLayoutsStillActive, this.options.layout) && !this.disableLayoutChange) {
       each(this.resultLayoutSelectors, resultLayoutSelector => {
@@ -860,6 +860,18 @@ export class ResultList extends Component {
     if (currentId === '') {
       this.element.id = uniqueId('coveo-result-list');
     }
+  }
+
+  private enableBasedOnActiveLayouts() {
+    // We should try to enable a result list only when the result layout selector currently allow that result list layout to be displayed.
+    each(this.resultLayoutSelectors, resultLayoutSelector => {
+      const found = find(resultLayoutSelector.activeLayouts, (activeLayout, activeLayoutKey) => activeLayoutKey == this.options.layout);
+      if (found) {
+        super.enable();
+        resultLayoutSelector.enableLayouts([this.options.layout] as ValidLayout[]);
+        $$(this.element).removeClass('coveo-hidden');
+      }
+    });
   }
 }
 

--- a/unitTests/ui/ResultLayoutSelectorTest.ts
+++ b/unitTests/ui/ResultLayoutSelectorTest.ts
@@ -1,4 +1,4 @@
-import { ResultLayoutSelector } from '../../src/ui/ResultLayoutSelector/ResultLayoutSelector';
+import { ResultLayoutSelector, IResultLayoutOptions } from '../../src/ui/ResultLayoutSelector/ResultLayoutSelector';
 import { ValidLayout } from '../../src/ui/ResultLayoutSelector/ValidLayout';
 import * as Mock from '../MockEnvironment';
 import { $$ } from '../../src/utils/Dom';
@@ -19,13 +19,14 @@ export function ResultLayoutSelectorTest() {
       $$(test.env.root).trigger(event);
     }
 
-    function buildResultLayoutSelector(activeLayout: ValidLayout) {
+    function buildResultLayoutSelector(activeLayout: ValidLayout, options: Partial<IResultLayoutOptions> = {}) {
       test = Mock.advancedComponentSetup<ResultLayoutSelector>(ResultLayoutSelector, <Mock.AdvancedComponentSetupOptions>{
         modifyBuilder: builder => {
           handleLayoutsPopulation(builder.root);
           (builder.queryStateModel.get as jasmine.Spy).and.returnValue(activeLayout);
           return builder;
-        }
+        },
+        cmpOptions: options
       });
       triggerRootEvent(InitializationEvents.afterComponentsInitialization);
       triggerRootEvent(InitializationEvents.afterInitialization);
@@ -34,6 +35,36 @@ export function ResultLayoutSelectorTest() {
     function getLayoutButton(layout: ValidLayout) {
       return test.cmp['currentActiveLayouts'][layout].button.el;
     }
+
+    it('should filter activelayouts based on the desktopLayouts options', () => {
+      buildResultLayoutSelector('list', { desktopLayouts: ['table'] });
+      test.cmp.searchInterface.responsiveComponents.isSmallScreenWidth = () => false;
+      test.cmp.searchInterface.responsiveComponents.isMediumScreenWidth = () => false;
+      test.cmp.searchInterface.responsiveComponents.isLargeScreenWidth = () => true;
+      const layouts = Object.keys(test.cmp.activeLayouts);
+      expect(layouts.length).toBe(1);
+      expect(layouts[0]).toBe('table');
+    });
+
+    it('should filter activelayouts based on the tabletLayouts options', () => {
+      buildResultLayoutSelector('list', { tabletLayouts: ['table'] });
+      test.cmp.searchInterface.responsiveComponents.isSmallScreenWidth = () => false;
+      test.cmp.searchInterface.responsiveComponents.isMediumScreenWidth = () => true;
+      test.cmp.searchInterface.responsiveComponents.isLargeScreenWidth = () => false;
+      const layouts = Object.keys(test.cmp.activeLayouts);
+      expect(layouts.length).toBe(1);
+      expect(layouts[0]).toBe('table');
+    });
+
+    it('should filter activelayouts based on the mobileLayouts options', () => {
+      buildResultLayoutSelector('list', { mobileLayouts: ['table'] });
+      test.cmp.searchInterface.responsiveComponents.isSmallScreenWidth = () => true;
+      test.cmp.searchInterface.responsiveComponents.isMediumScreenWidth = () => false;
+      test.cmp.searchInterface.responsiveComponents.isLargeScreenWidth = () => false;
+      const layouts = Object.keys(test.cmp.activeLayouts);
+      expect(layouts.length).toBe(1);
+      expect(layouts[0]).toBe('table');
+    });
 
     it('if the list layout is selected, should give the pressed state to the list button', () => {
       buildResultLayoutSelector('list');

--- a/unitTests/ui/ResultListTest.ts
+++ b/unitTests/ui/ResultListTest.ts
@@ -820,17 +820,37 @@ export function ResultListTest() {
         describe('when it is enabled', () => {
           let mockResultLayoutSelector: ResultLayoutSelector;
 
+          const setCurrentActiveLayouts = (layout: Record<string, {}>) => {
+            (mockResultLayoutSelector as any).activeLayouts = layout;
+          };
+
           beforeEach(() => {
             test = Mock.optionsComponentSetup<ResultList, IResultListOptions>(ResultList, {
               layout: 'card'
             });
             mockResultLayoutSelector = Mock.mock<ResultLayoutSelector>(ResultLayoutSelector);
-            (test.env.searchInterface.getComponents as jasmine.Spy).and.returnValue([mockResultLayoutSelector]);
+            (test.env.searchInterface.getComponents as jasmine.Spy).and.callFake(requested => {
+              if (requested === ResultLayoutSelector.ID) {
+                return [mockResultLayoutSelector];
+              }
+              return [];
+            });
           });
 
           it('should enable the layout in the layout selector', () => {
+            setCurrentActiveLayouts({ card: {} });
+            test.cmp.options.layout = 'card';
             test.cmp.enable();
             expect(mockResultLayoutSelector.enableLayouts).toHaveBeenCalledWith(['card']);
+          });
+
+          it('should not be enabled when it does not fit current layout', () => {
+            setCurrentActiveLayouts({ card: {} });
+            test.cmp.options.layout = 'table';
+            test.cmp.disable();
+            expect(test.cmp.disabled).toBe(true);
+            test.cmp.enable();
+            expect(test.cmp.disabled).toBe(true);
           });
         });
 


### PR DESCRIPTION
We have the option on ResultLayoutSelector to specify which layout is valid for which screen size.

The ResultList component would not respect that option and could enable themselves, even if their layout did not respect those that should be currently allowed.

End result being that you could see 2 different result list activated for a single query even if you manually specified that you only want a given layout for a given screen size.

https://coveord.atlassian.net/browse/JSUI-3221





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)