### PR TITLE
feat(event logging): event logging is generic like their underlying clients

### DIFF
--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -47,7 +47,7 @@ export interface IAnalyticsResultsSortMeta {
  * See also the [`Analytics`]{@link Analytics} component, and more specifically its
  * [`logClickEvent`]{@link Analytics.logClickEvent} method.
  */
-export interface IAnalyticsDocumentViewMeta {
+export type IAnalyticsDocumentViewMeta = {
   /**
    * The URL of the clicked item.
    */

--- a/src/ui/Base/RegisteredNamedMethods.ts
+++ b/src/ui/Base/RegisteredNamedMethods.ts
@@ -259,15 +259,15 @@ function getCoveoAnalytics(element: HTMLElement) {
  * ( `{}` ).
  * @param result The query result that relates to the custom event, if applicable.
  */
-export function logCustomEvent(
+export function logCustomEvent<TMeta extends IStringMap<any> = IStringMap<string>>(
   element: HTMLElement,
   customEventCause: IAnalyticsActionCause,
-  metadata: IStringMap<string>,
+  metadata: TMeta,
   result?: IQueryResult
 ) {
   var client = getCoveoAnalyticsClient(element);
   if (client) {
-    client.logCustomEvent<any>(customEventCause, metadata, element, result);
+    client.logCustomEvent<TMeta>(customEventCause, metadata, element, result);
   }
 }
 
@@ -330,14 +330,14 @@ Initialization.registerNamedMethod(
  * names. Each value must be a simple string. If you do not need to log metadata, you can simply pass an empty JSON
  * ( `{}` ).
  */
-export function logSearchAsYouTypeEvent(
+export function logSearchAsYouTypeEvent<TMeta extends IStringMap<any> = IStringMap<string>>(
   element: HTMLElement,
   searchAsYouTypeEventCause: IAnalyticsActionCause,
-  metadata: IStringMap<string>
+  metadata: TMeta
 ) {
   var client = getCoveoAnalyticsClient(element);
   if (client) {
-    client.logSearchAsYouType<any>(searchAsYouTypeEventCause, metadata);
+    client.logSearchAsYouType<TMeta>(searchAsYouTypeEventCause, metadata);
   }
 }
 
@@ -364,15 +364,15 @@ Initialization.registerNamedMethod(
  * ( `{}` ).
  * @param result The result that was clicked.
  */
-export function logClickEvent(
+export function logClickEvent<TMeta extends IStringMap<any> = IAnalyticsDocumentViewMeta>(
   element: HTMLElement,
   clickEventCause: IAnalyticsActionCause,
-  metadata: IStringMap<any>,
+  metadata: TMeta,
   result: IQueryResult
 ) {
   var client = getCoveoAnalyticsClient(element);
   if (client) {
-    client.logClickEvent(clickEventCause, <IAnalyticsDocumentViewMeta>metadata, result, element);
+    client.logClickEvent<TMeta>(clickEventCause, metadata, result, element);
   }
 }
 


### PR DESCRIPTION
This change introduces generics for event logging `meta` arguments.

A common issue encountered today is with `customData`, where the current type for `meta` expects `Record<string, string>` which won't conform when passing an object.

```ts
Coveo.logCustomEvent(
  elem,
  {
    name: "pageLoad",
    type: "interfaceLoad",
  },
  {
    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
    // @ts-ignore
    customData: {
      domain: emailDomain,
      user_type: userType,
    },
  },
);
```

With the introduction of generics this should be possible without an explicit `ts-ignore`.

An example using the extracted type:

```ts
type ICoveo = {
  logCustomEvent: <TMeta extends Record<string, any> = Record<string, string>>(
    element: HTMLElement,
    customEventCause: Record<string, string>,
    metadata: TMeta,
    result?: unknown
  ) => void
}

(Coveo as unknown as ICoveo).logCustomEvent(
  elem,
  {
    name: "pageLoad",
    type: "interfaceLoad",
  },
  {
    customData: {
      domain: emailDomain,
      user_type: userType,
    },
  },
);
```

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)