### PR TITLE
JSUI-3228 Call load method on values passed via dictionary

### DIFF
--- a/src/ui/Base/ComponentOptionsLoader.ts
+++ b/src/ui/Base/ComponentOptionsLoader.ts
@@ -1,6 +1,7 @@
 import { find } from 'underscore';
 import { Logger } from '../../misc/Logger';
 import { Utils } from '../../utils/Utils';
+import { ComponentOptions } from './ComponentOptions';
 import { ComponentOptionsType, IComponentLocalizedStringOptionArgs, IComponentOptionsOption } from './IComponentOptions';
 
 export class ComponentOptionLoader {
@@ -18,7 +19,7 @@ export class ComponentOptionLoader {
   public load() {
     return this.findFirstValidValue(
       this.loadFromAttribute.bind(this),
-      this.loadFromOptionsDictionnary.bind(this),
+      this.loadFromOptionsDictionary.bind(this),
       this.loadFromDefaultValue.bind(this),
       this.loadFromDefaultFunction.bind(this)
     );
@@ -28,8 +29,20 @@ export class ComponentOptionLoader {
     return this.optionDefinition.load ? this.optionDefinition.load(this.element, this.optionName, this.optionDefinition) : null;
   }
 
-  private loadFromOptionsDictionnary() {
-    return this.values[this.optionName];
+  private loadFromOptionsDictionary() {
+    const value = this.values[this.optionName];
+
+    if (!value) {
+      return undefined;
+    }
+
+    if (this.optionDefinition.load) {
+      const attrName = ComponentOptions.attrNameFromName(this.optionName, this.optionDefinition);
+      this.element.setAttribute(attrName, value);
+      return this.loadFromAttribute();
+    }
+
+    return value;
   }
 
   private loadFromDefaultValue() {
@@ -66,9 +79,7 @@ export class ComponentOptionLoader {
 
   private warnDeprecatedLocalizedStringAndReturnDefaultValue() {
     this.logger.warn(
-      `defaultValue for option ${
-        this.optionName
-      } is deprecated. You should instead use localizedString. Not doing so could cause localization bug in your interface.`
+      `defaultValue for option ${this.optionName} is deprecated. You should instead use localizedString. Not doing so could cause localization bug in your interface.`
     );
     return this.optionDefinition.defaultValue;
   }

--- a/unitTests/ui/ComponentOptionsLoaderTest.ts
+++ b/unitTests/ui/ComponentOptionsLoaderTest.ts
@@ -1,6 +1,6 @@
 import { ComponentOptionLoader } from '../../src/ui/Base/ComponentOptionsLoader';
 import { $$, ComponentOptions, ComponentOptionsType, l } from '../../src/Core';
-import { IComponentLocalizedStringOptionArgs } from '../../src/ui/Base/IComponentOptions';
+import { IComponentLocalizedStringOptionArgs, IComponentOptions } from '../../src/ui/Base/IComponentOptions';
 export function ComponentOptionLoaderTest() {
   describe('ComponentOptionLoader', () => {
     it('should be able to load from the element attribute', () => {
@@ -10,11 +10,37 @@ export function ComponentOptionLoaderTest() {
       expect(valueLoaded).toBe('bar');
     });
 
-    it('should be able to load from dictionnary value', () => {
+    it('should be able to load from dictionary value', () => {
       const elem = $$('div').el;
 
       const valueLoaded = new ComponentOptionLoader(elem, { abc: 'def' }, 'abc', {}).load();
       expect(valueLoaded).toBe('def');
+    });
+
+    it(`when the value of a custom option is specified using a dictionary,
+    the value is transformed by the option definition`, () => {
+      const elem = $$('div').el;
+      const optionName = 'a';
+      const dictionary = { [optionName]: 'b' };
+
+      const definition: IComponentOptions<string> = {};
+      ComponentOptions.buildCustomOption(() => 'c', definition);
+
+      const option = new ComponentOptionLoader(elem, dictionary, optionName, definition);
+      expect(option.load()).toBe('c');
+    });
+
+    it(`when the value of a custom option with an alias is specified using a dictionary,
+    the value is transformed by the option definition`, () => {
+      const elem = $$('div').el;
+      const optionName = 'a';
+      const dictionary = { [optionName]: 'b' };
+
+      const definition: IComponentOptions<string> = { attrName: `data-alias-${optionName}` };
+      ComponentOptions.buildCustomOption(() => 'c', definition);
+
+      const option = new ComponentOptionLoader(elem, dictionary, optionName, definition);
+      expect(option.load()).toBe('c');
     });
 
     describe('should be able to load default value from option definition', () => {


### PR DESCRIPTION
When an option is passed via dictionary, the value was not being resolved using the load method which performs a transformation on the original value. The[ issue was reported via Discuss](https://discuss.coveo.com/t/add-many-search-interfaces-in-a-single-page-and-each-of-them-should-target-a-different-endpoint/5750) regarding the `endpoint` option. The option is configured as a string, but it's value is ultimately a class instance.

https://coveord.atlassian.net/browse/JSUI-3228





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)