### PR TITLE
[DOC-7768] Remove 'required' from 'ranges' DynamicFacetRange option

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacetRange.ts
+++ b/src/ui/DynamicFacet/DynamicFacetRange.ts
@@ -92,7 +92,6 @@ export class DynamicFacetRange extends DynamicFacet implements IComponentBinding
      * If this option is not defined, the index will try to generate automatic ranges.
      */
     ranges: ComponentOptions.buildJsonOption<IRangeValue[]>({
-      required: false,
       section: 'CommonOptions',
       postProcessing: ranges => (Utils.isNonEmptyArray(ranges) ? ranges : [])
     }),


### PR DESCRIPTION
I'm removing this completely rather than leaving it to 'false', because otherwise the generated documentation still indicates that the option is required (see https://coveo.github.io/search-ui/components/dynamicfacetrange.html#options.ranges)


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)