### PR TITLE
JSUI-3233 Cache hash value to redirect to prior to fetching the execution plan

### DIFF
--- a/src/ui/SearchInterface/SearchInterface.ts
+++ b/src/ui/SearchInterface/SearchInterface.ts
@@ -1209,10 +1209,12 @@ export class StandaloneSearchInterface extends SearchInterface {
   }
 
   private async doRedirect(searchPage: string) {
+    const cachedHashValue = this.encodedHashValues;
     const executionPlan = await this.queryController.fetchQueryExecutionPlan();
     const redirectionURL = executionPlan && executionPlan.redirectionURL;
+
     if (!redirectionURL) {
-      return this.redirectToSearchPage(searchPage);
+      return this.redirectToSearchPage(searchPage, cachedHashValue);
     }
 
     this.redirectToURL(redirectionURL);
@@ -1231,18 +1233,19 @@ export class StandaloneSearchInterface extends SearchInterface {
     this._window.location.assign(url);
   }
 
-  public redirectToSearchPage(searchPage: string) {
+  public redirectToSearchPage(searchPage: string, hashValueToUse?: string) {
     const link = document.createElement('a');
     link.href = searchPage;
     link.href = link.href; // IE11 needs this to correctly fill the properties that are used below.
 
     const pathname = link.pathname.indexOf('/') == 0 ? link.pathname : '/' + link.pathname; // IE11 does not add a leading slash to this property.
     const hash = link.hash ? link.hash + '&' : '#';
+    const hashValue = hashValueToUse || this.encodedHashValues;
 
     // By using a setTimeout, we allow other possible code related to the search box / magic box time to complete.
     // eg: onblur of the magic box.
     setTimeout(() => {
-      this._window.location.href = `${link.protocol}//${link.host}${pathname}${link.search}${hash}${this.encodedHashValues}`;
+      this._window.location.href = `${link.protocol}//${link.host}${pathname}${link.search}${hash}${hashValue}`;
     }, 0);
   }
 

--- a/unitTests/ui/StandaloneSearchInterfaceTest.ts
+++ b/unitTests/ui/StandaloneSearchInterfaceTest.ts
@@ -124,6 +124,25 @@ export function StandaloneSearchInterfaceTest() {
           expect(cmp.redirectToSearchPage).toHaveBeenCalledWith(options.searchPageUri, '');
           done();
         });
+
+        it(`where there is an analytics event prior to performing a redirection,
+        when the execution plan does not return a url (but cancels pending search events),
+        the redirection url contains the original analytics event cause`, async done => {
+          const cause = analyticsActionCauseList.omniboxFromLink;
+          cmp.usageAnalytics.logSearchEvent(cause, {});
+
+          const promise = Promise.resolve(null);
+          spyOn(cmp.queryController, 'fetchQueryExecutionPlan').and.returnValue(promise);
+
+          handleRedirect();
+          cmp.usageAnalytics.cancelAllPendingEvents();
+          await promise;
+
+          setTimeout(() => {
+            expect(windoh.location.href).toContain('#firstQueryCause=omniboxFromLink');
+            done();
+          }, 0);
+        });
       });
     });
 

--- a/unitTests/ui/StandaloneSearchInterfaceTest.ts
+++ b/unitTests/ui/StandaloneSearchInterfaceTest.ts
@@ -108,7 +108,7 @@ export function StandaloneSearchInterfaceTest() {
           handleRedirect();
           await promise;
 
-          expect(cmp.redirectToSearchPage).toHaveBeenCalledWith(options.searchPageUri);
+          expect(cmp.redirectToSearchPage).toHaveBeenCalledWith(options.searchPageUri, '');
           done();
         });
 
@@ -121,7 +121,7 @@ export function StandaloneSearchInterfaceTest() {
           handleRedirect();
           await promise;
 
-          expect(cmp.redirectToSearchPage).toHaveBeenCalledWith(options.searchPageUri);
+          expect(cmp.redirectToSearchPage).toHaveBeenCalledWith(options.searchPageUri, '');
           done();
         });
       });


### PR DESCRIPTION
**Context**
Leveraging the `/plan` endpoint introduced a regression where an incorrect action cause started being sent when the redirection stemmed from a user selecting a query suggestion.

Changing the redirection code from sync to async caused the [pendingSearchEvent ](https://github.com/coveo/search-ui/blob/master/src/ui/Analytics/LiveAnalyticsClient.ts#L213) to be cleared, before it was read.

**Solution**
The PR caches the hash before the async plan request is performed.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)