### PR TITLE
JSUI-3240 added support for relative urls prefixed with periods in ResultLink

### DIFF
--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -479,7 +479,7 @@ export class ResultLink extends Component {
 
   private filterProtocol(uri: string) {
     const isAbsolute = /^(https?|ftp|file|mailto|tel):/i.test(uri);
-    const isRelative = /^\//.test(uri);
+    const isRelative = /^(\/|\.\/|\.\.\/)/.test(uri);
 
     return isAbsolute || isRelative ? uri : '';
   }

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -359,8 +359,20 @@ export function ResultLinkTest() {
         expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
       });
 
-      it('when the clickUri is a relative url (starts with slash), it sets the href to the uri', () => {
+      it('when the clickUri is a relative url with a slash, it sets the href to the uri', () => {
         fakeResult.clickUri = '/casemgmt/sc_KnowledgeArticle?sfdcid=ka32C0000009t9CQAQ&type=Solution';
+        initHyperLink();
+        expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+      });
+
+      it('when the uri is a relative url with a period, it sets the href to the uri', () => {
+        fakeResult.clickUri = './articles/ka32C0000009t9CQAQ';
+        initHyperLink();
+        expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+      });
+
+      it('when the uri is a relative url with two periods, it sets the href to the uri', () => {
+        fakeResult.clickUri = '../articles/ka32C0000009t9CQAQ';
         initHyperLink();
         expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
       });
@@ -382,6 +394,27 @@ export function ResultLinkTest() {
         it clears the value to prevent XSS`, () => {
         fakeResult.raw['test'] = 'javascript:void(0)';
         initHyperLink({ field: '@test' });
+        expect(test.cmp.element.getAttribute('href')).toEqual('');
+      });
+
+      it(`when the uri uses the javascript protocol and contains a relative uri with a slash,
+        it clears the value to prevent XSS`, () => {
+        fakeResult.clickUri = 'javascript:"/casemgmt/sc_KnowledgeArticle"';
+        initHyperLink();
+        expect(test.cmp.element.getAttribute('href')).toEqual('');
+      });
+
+      it(`when the uri uses the javascript protocol and contains a relative uri with a period,
+        it clears the value to prevent XSS`, () => {
+        fakeResult.clickUri = 'javascript:"./articles/ka32C0000009t9CQAQ"';
+        initHyperLink();
+        expect(test.cmp.element.getAttribute('href')).toEqual('');
+      });
+
+      it(`when the uri uses the javascript protocol and contains a relative uri with two periods,
+        it clears the value to prevent XSS`, () => {
+        fakeResult.clickUri = 'javascript:"../articles/ka32C0000009t9CQAQ"';
+        initHyperLink();
         expect(test.cmp.element.getAttribute('href')).toEqual('');
       });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3240

`ResultLink` didn't support `../` and `./` urls.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)