### PR TITLE
JSUI-3248 resolved relative URLs in smart snippet subtitle

### DIFF
--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -2,7 +2,7 @@ import { ModalBox as ModalBoxModule } from '../../ExternalModulesShim';
 import { exportGlobally } from '../../GlobalExports';
 import { Component } from '../Base/Component';
 import { IComponentBindings } from '../Base/ComponentBindings';
-import { QueryEvents, Initialization, $$, StringUtils } from '../../Core';
+import { QueryEvents, Initialization, $$ } from '../../Core';
 import { IQuerySuccessEventArgs } from '../../events/QueryEvents';
 import { IQuestionAnswerResponse } from '../../rest/QuestionAnswerResponse';
 import 'styling/_SmartSnippet';
@@ -301,22 +301,24 @@ export class SmartSnippet extends Component {
   }
 
   private renderSourceTitle() {
-    return this.buildLink(Utils.getFieldValue(this.lastRenderedResult, <string>this.options.titleField), SOURCE_TITLE_CLASSNAME);
+    const link = this.buildLink();
+    link.innerText = Utils.getFieldValue(this.lastRenderedResult, <string>this.options.titleField);
+    link.classList.add(SOURCE_TITLE_CLASSNAME);
+    return link;
   }
 
   private renderSourceUrl() {
-    const uri = this.options.hrefTemplate
-      ? StringUtils.buildStringTemplateFromResult(this.options.hrefTemplate, this.lastRenderedResult)
-      : this.lastRenderedResult.clickUri;
-    return this.buildLink(uri, SOURCE_URL_CLASSNAME);
+    const link = this.buildLink();
+    link.innerText = link.href;
+    link.classList.add(SOURCE_URL_CLASSNAME);
+    return link;
   }
 
-  private buildLink(text: string, className: string) {
-    const element = $$('a', { className: `CoveoResultLink ${className}` }).el as HTMLAnchorElement;
-    element.innerText = text;
+  private buildLink() {
+    const element = $$('a', { className: 'CoveoResultLink' }).el as HTMLAnchorElement;
     new ResultLink(
       element,
-      { hrefTemplate: this.options.hrefTemplate },
+      this.options.hrefTemplate ? { hrefTemplate: this.options.hrefTemplate } : {},
       { ...this.getBindings(), resultElement: this.element },
       this.lastRenderedResult
     );

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -318,7 +318,7 @@ export class SmartSnippet extends Component {
     const element = $$('a', { className: 'CoveoResultLink' }).el as HTMLAnchorElement;
     new ResultLink(
       element,
-      this.options.hrefTemplate ? { hrefTemplate: this.options.hrefTemplate } : {},
+      { hrefTemplate: this.options.hrefTemplate },
       { ...this.getBindings(), resultElement: this.element },
       this.lastRenderedResult
     );

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -295,29 +295,29 @@ export class SmartSnippet extends Component {
   }
 
   private renderSource() {
-    $$(this.sourceContainer).empty();
-    this.sourceContainer.appendChild(this.renderSourceUrl());
-    this.sourceContainer.appendChild(this.renderSourceTitle());
+    const container = $$(this.sourceContainer);
+    container.empty();
+    container.append(this.renderSourceUrl().el);
+    container.append(this.renderSourceTitle().el);
   }
 
   private renderSourceTitle() {
-    const link = this.buildLink();
-    link.innerText = Utils.getFieldValue(this.lastRenderedResult, <string>this.options.titleField);
-    link.classList.add(SOURCE_TITLE_CLASSNAME);
+    const link = this.buildLink(SOURCE_TITLE_CLASSNAME);
+    link.text(Utils.getFieldValue(this.lastRenderedResult, <string>this.options.titleField));
     return link;
   }
 
   private renderSourceUrl() {
-    const link = this.buildLink();
-    link.innerText = link.href;
-    link.classList.add(SOURCE_URL_CLASSNAME);
+    const link = this.buildLink(SOURCE_URL_CLASSNAME);
+    link.text((link.el as HTMLAnchorElement).href);
     return link;
   }
 
-  private buildLink() {
-    const element = $$('a', { className: 'CoveoResultLink' }).el as HTMLAnchorElement;
+  private buildLink(className: string) {
+    const element = $$('a', { className: 'CoveoResultLink' });
+    element.addClass(className);
     new ResultLink(
-      element,
+      element.el,
       { hrefTemplate: this.options.hrefTemplate },
       { ...this.getBindings(), resultElement: this.element },
       this.lastRenderedResult

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -32,6 +32,7 @@ export function SmartSnippetTest() {
   function mockResult() {
     return (<Partial<IQueryResult>>{
       title: sourceTitle,
+      titleHighlights: [],
       clickUri: sourceUrl,
       raw: {
         alt: sourceAlt,
@@ -139,6 +140,15 @@ export function SmartSnippetTest() {
       expect(getFirstChild<HTMLAnchorElement>(ClassNames.SOURCE_URL_CLASSNAME).href).toEqual(expectedHref);
       expect(getFirstChild<HTMLAnchorElement>(ClassNames.SOURCE_URL_CLASSNAME).innerText).toEqual(expectedHref);
       expect(getFirstChild<HTMLAnchorElement>(ClassNames.SOURCE_TITLE_CLASSNAME).href).toEqual(expectedHref);
+      test.env.root.remove();
+      done();
+    });
+
+    it('displays resolved relative URLs when specified in the hrefTemplate', async done => {
+      instantiateSmartSnippet(null, { hrefTemplate: '../${raw.alt}' });
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      expect(getFirstChild<HTMLAnchorElement>(ClassNames.SOURCE_URL_CLASSNAME).innerText.indexOf(window.location.protocol)).toEqual(0);
       test.env.root.remove();
       done();
     });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3248

Before:
![image](https://user-images.githubusercontent.com/54454747/123672544-0b3e4b00-d805-11eb-942e-ed550248e92c.png)

After: 
![image](https://user-images.githubusercontent.com/54454747/123672516-02e61000-d805-11eb-8e59-b295ef9447c0.png)


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)