### PR TITLE
JSUI-3251 fix breadcrumbs focus styling

### DIFF
--- a/sass/_FacetBreadcrumb.scss
+++ b/sass/_FacetBreadcrumb.scss
@@ -5,8 +5,7 @@
 }
 
 .coveo-facet-breadcrumb-value,
-.coveo-facet-slider-breadcrumb-value,
-.coveo-facet-breadcrumb-value-list-item {
+.coveo-facet-slider-breadcrumb-value {
   @include breadcrumb-value();
   display: inline-block;
   &.coveo-excluded .coveo-facet-breadcrumb-caption {
@@ -15,6 +14,7 @@
 }
 
 .coveo-facet-breadcrumb-value-list-item {
+  display: inline-block;
   margin: 0;
   padding: 0;
 }

--- a/sass/_Variables.scss
+++ b/sass/_Variables.scss
@@ -63,7 +63,9 @@ $default-medium-border: 2px solid $color-very-light-grey;
   border-radius: 4px;
 }
 @mixin highContrastModeOutline {
-  outline: 1px solid transparent;
+  &:not(:focus) {
+    outline: 1px solid transparent;
+  }
 }
 
 $standard-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
@@ -126,7 +128,9 @@ $standard-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     }
   }
   &:hover,
-  &:hover a {
+  &:hover a,
+  &:focus,
+  &:focus a {
     text-decoration: underline;
   }
   &.coveo-selected * {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3251

Previous story https://github.com/coveo/search-ui/pull/1595 added a transparent outline to the Breadcrumbs (also valid for field values).

The problem is we used the outline to show that the buttons were focused. I did two things here:
- added the underline state to the focus, like it was for the hover
- only added the transparent outline when the use is not focused

Here is an example with red instead of transparent
![Screen Shot 2021-07-02 at 3 39 27 PM](https://user-images.githubusercontent.com/4923043/124321821-55e4fd80-db4c-11eb-802d-709a076d394b.png)






[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)