### PR TITLE
JSUI-3252 Append collapsed Facet breadcrumbs after Nmore element

### DIFF
--- a/src/ui/Facet/BreadcrumbValuesList.ts
+++ b/src/ui/Facet/BreadcrumbValuesList.ts
@@ -1,5 +1,5 @@
 import * as Globalize from 'globalize';
-import { first, rest } from 'underscore';
+import { first, rest, filter } from 'underscore';
 import { Assert } from '../../misc/Assert';
 import { l } from '../../strings/Strings';
 import { $$ } from '../../utils/Dom';
@@ -64,8 +64,8 @@ export class BreadcrumbValueList {
   }
 
   private buildCollapsed() {
-    const numberOfSelected = this.collapsed.filter((value: FacetValue) => value.selected).length;
-    const numberOfExcluded = this.collapsed.filter((value: FacetValue) => value.excluded).length;
+    const numberOfSelected = filter(this.collapsed, (value: FacetValue) => value.selected).length;
+    const numberOfExcluded = filter(this.collapsed, (value: FacetValue) => value.excluded).length;
     Assert.check(numberOfSelected + numberOfExcluded == this.collapsed.length);
 
     const nMoreElement = $$(


### PR DESCRIPTION
For the following discuss https://discuss.coveo.com/t/support-00069878-clicking-on-breadcrumb-more-button-set-focus-on-wrong-button/6084/5

Goes along the other PR as well.

The DOM changes a bit, the collapsed values were a list inside of a list, a little weird... 🤔 

https://coveord.atlassian.net/browse/JSUI-3252





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)