### PR TITLE
JSUI-3257 Fixed ImageFieldValue's srcTemplate resolution

### DIFF
--- a/src/ui/FieldValue/FieldValue.ts
+++ b/src/ui/FieldValue/FieldValue.ts
@@ -313,7 +313,7 @@ export class FieldValue extends Component {
       const helper = TemplateHelpers.getHelper(`${this.options.helper}v2`) || TemplateHelpers.getHelper(`${this.options.helper}`);
 
       if (Utils.exists(helper)) {
-        toRender = helper.call(this, value, this.getHelperOptions());
+        toRender = helper.call(this, value, this.getHelperOptions(), this.result);
       } else {
         this.logger.warn(
           `Helper ${this.options.helper} is not found in available helpers. The list of supported helpers is :`,

--- a/unitTests/ui/ImageFieldValueTest.ts
+++ b/unitTests/ui/ImageFieldValueTest.ts
@@ -41,6 +41,18 @@ export function FieldImageTest() {
         const img = $$(test.cmp.element).find('img');
         expect(img.getAttribute('height')).toBe(height.toString());
       });
+
+      it('srcTemplate should be resolved and applied to the img tag', () => {
+        initializeFieldValueComponent(
+          {
+            field: '@ccimage',
+            srcTemplate: 'https://somewebsite.com/${raw.image}.webp'
+          },
+          { ...FakeResults.createFakeResult(), raw: { image: 'abc' } }
+        );
+        const img = $$(test.cmp.element).find('img');
+        expect(img.getAttribute('src')).toBe('https://somewebsite.com/abc.webp');
+      });
     });
   });
 }


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3257

Before this change, `srcTemplate`'s `raw` always referred to the last result in the result list.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)