### PR TITLE
JSUI-3260 Support multiple AuthenticationProvider instances configured with data-tab

### DIFF
--- a/src/rest/AccessToken.ts
+++ b/src/rest/AccessToken.ts
@@ -24,6 +24,11 @@ export class AccessToken {
     );
   }
 
+  public updateToken(token: string) {
+    this.token = token;
+    this.notifySubscribers();
+  }
+
   public async doRenew(onError?: (error: Error) => void): Promise<Boolean> {
     this.triedRenewals++;
     this.resetRenewalTriesAfterDelay();
@@ -33,7 +38,7 @@ export class AccessToken {
       this.logger.info('Renewing expired access token');
       this.token = await this.renew();
       this.logger.info('Access token renewed', this.token);
-      this.subscribers.forEach(subscriber => subscriber(this.token));
+      this.notifySubscribers();
       return true;
     } catch (err) {
       switch (err.message) {
@@ -67,5 +72,9 @@ export class AccessToken {
     if (this.triedRenewals >= 5) {
       throw new Error(ACCESS_TOKEN_ERRORS.REPEATED_FAILURES);
     }
+  }
+
+  private notifySubscribers() {
+    this.subscribers.forEach(subscriber => subscriber(this.token));
   }
 }

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -334,13 +334,14 @@ export class SearchEndpoint implements ISearchEndpoint {
   @method('POST')
   @requestDataType('application/json')
   @responseType('json')
-  public exchangeAuthenticationProviderHandshakeTokenForAccessToken(
+  public async exchangeAuthenticationProviderHandshakeTokenForAccessToken(
     token: string,
     callOptions?: IEndpointCallOptions,
     callParams?: IEndpointCallParameters
   ) {
     const call = this.buildCompleteCall({ token }, callOptions, callParams);
-    return this.performOneCall<string>(call.params, call.options);
+    const data = await this.performOneCall<{ token: string }>(call.params, call.options);
+    return data.token;
   }
 
   /**

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -324,20 +324,23 @@ export class SearchEndpoint implements ISearchEndpoint {
     });
   }
 
+  /**
+   * Exchanges a temporary authentication provider token for an access token.
+   *
+   * @param token - the temporary token.
+   * @returns {string} The access token.
+   */
   @path('/login/handshake/token')
   @method('POST')
   @requestDataType('application/json')
   @responseType('json')
-  public exchangeAuthenticationProviderTemporaryTokenForAccessToken(token: string) {
-    return this.performOneCall<string>({
-      method: 'POST',
-      requestData: { token },
-      queryString: [],
-      responseType: 'json',
-      url: '/login/handshake/token',
-      errorsAsSuccess: false,
-      requestDataType: 'application/json'
-    });
+  public exchangeAuthenticationProviderTemporaryTokenForAccessToken(
+    token: string,
+    callOptions?: IEndpointCallOptions,
+    callParams?: IEndpointCallParameters
+  ) {
+    const call = this.buildCompleteCall({ token }, callOptions, callParams);
+    return this.performOneCall<string>(call.params, call.options);
   }
 
   /**

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -1,4 +1,4 @@
-import { ISearchEndpointOptions, ISearchEndpoint, IViewAsHtmlOptions } from './SearchEndpointInterface';
+import { ISearchEndpointOptions, ISearchEndpoint, IViewAsHtmlOptions, IExchangeHandshakeTokenOptions } from './SearchEndpointInterface';
 import {
   EndpointCaller,
   IEndpointCallParameters,
@@ -325,7 +325,8 @@ export class SearchEndpoint implements ISearchEndpoint {
   }
 
   /**
-   * Exchanges a temporary authentication provider token for an access token.
+   * Exchanges a temporary handshake token to either get an initial access token
+   * or extend the privileges of an existing access token.
    *
    * @param token - the temporary token.
    * @returns {string} The access token.
@@ -334,12 +335,12 @@ export class SearchEndpoint implements ISearchEndpoint {
   @method('POST')
   @requestDataType('application/json')
   @responseType('json')
-  public async exchangeAuthenticationProviderToken(
-    token: string,
+  public async exchangeHandshakeToken(
+    options: IExchangeHandshakeTokenOptions,
     callOptions?: IEndpointCallOptions,
     callParams?: IEndpointCallParameters
   ) {
-    const call = this.buildCompleteCall({ token }, callOptions, callParams);
+    const call = this.buildCompleteCall(options, callOptions, callParams);
     const data = await this.performOneCall<{ token: string }>(call.params, call.options);
 
     if (!data.token) {

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -324,6 +324,22 @@ export class SearchEndpoint implements ISearchEndpoint {
     });
   }
 
+  @path('/login/handshake/token')
+  @method('POST')
+  @requestDataType('application/json')
+  @responseType('json')
+  public exchangeAuthenticationProviderTemporaryTokenForAccessToken(token: string) {
+    return this.performOneCall<string>({
+      method: 'POST',
+      requestData: { token },
+      queryString: [],
+      responseType: 'json',
+      url: '/login/handshake/token',
+      errorsAsSuccess: false,
+      requestDataType: 'application/json'
+    });
+  }
+
   /**
    * Indicates whether the search endpoint is using JSONP internally to communicate with the Search API.
    * @returns {boolean} `true` in the search enpoint is using JSONP; `false` otherwise.

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -334,7 +334,7 @@ export class SearchEndpoint implements ISearchEndpoint {
   @method('POST')
   @requestDataType('application/json')
   @responseType('json')
-  public exchangeAuthenticationProviderTemporaryTokenForAccessToken(
+  public exchangeAuthenticationProviderHandshakeTokenForAccessToken(
     token: string,
     callOptions?: IEndpointCallOptions,
     callParams?: IEndpointCallParameters

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -341,6 +341,11 @@ export class SearchEndpoint implements ISearchEndpoint {
   ) {
     const call = this.buildCompleteCall({ token }, callOptions, callParams);
     const data = await this.performOneCall<{ token: string }>(call.params, call.options);
+
+    if (!data.token) {
+      throw new Error('Failed to exchange handshake token.');
+    }
+
     return data.token;
   }
 

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -334,7 +334,7 @@ export class SearchEndpoint implements ISearchEndpoint {
   @method('POST')
   @requestDataType('application/json')
   @responseType('json')
-  public async exchangeAuthenticationProviderHandshakeTokenForAccessToken(
+  public async exchangeAuthenticationProviderToken(
     token: string,
     callOptions?: IEndpointCallOptions,
     callParams?: IEndpointCallParameters

--- a/src/rest/SearchEndpointInterface.ts
+++ b/src/rest/SearchEndpointInterface.ts
@@ -16,6 +16,7 @@ import { ISentryLog } from './SentryLog';
 import { IFacetSearchRequest } from './Facet/FacetSearchRequest';
 import { IFacetSearchResponse } from './Facet/FacetSearchResponse';
 import { ExecutionPlan } from './Plan';
+import { AccessToken } from './AccessToken';
 
 /**
  * The possible options when creating a {@link SearchEndpoint}
@@ -88,6 +89,7 @@ export interface IViewAsHtmlOptions extends IEndpointCallOptions {
 }
 
 export interface ISearchEndpoint {
+  accessToken: AccessToken;
   options?: ISearchEndpointOptions;
   getBaseUri(): string;
   getBaseAlertsUri(): string;

--- a/src/rest/SearchEndpointInterface.ts
+++ b/src/rest/SearchEndpointInterface.ts
@@ -92,7 +92,7 @@ export interface ISearchEndpoint {
   getBaseUri(): string;
   getBaseAlertsUri(): string;
   getAuthenticationProviderUri(provider: string, returnUri: string, message: string): string;
-  exchangeAuthenticationProviderHandshakeTokenForAccessToken(token: string): Promise<string>;
+  exchangeAuthenticationProviderToken(token: string): Promise<string>;
   isJsonp(): boolean;
   search(query: IQuery, callOptions?: IEndpointCallOptions): Promise<IQueryResults>;
   fetchBinary(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ArrayBuffer>;

--- a/src/rest/SearchEndpointInterface.ts
+++ b/src/rest/SearchEndpointInterface.ts
@@ -88,13 +88,18 @@ export interface IViewAsHtmlOptions extends IEndpointCallOptions {
   contentType?: string;
 }
 
+export interface IExchangeHandshakeTokenOptions {
+  handshakeToken: string;
+  accessToken?: string;
+}
+
 export interface ISearchEndpoint {
   accessToken: AccessToken;
   options?: ISearchEndpointOptions;
   getBaseUri(): string;
   getBaseAlertsUri(): string;
   getAuthenticationProviderUri(provider: string, returnUri: string, message: string): string;
-  exchangeAuthenticationProviderToken(token: string): Promise<string>;
+  exchangeHandshakeToken(options: IExchangeHandshakeTokenOptions): Promise<string>;
   isJsonp(): boolean;
   search(query: IQuery, callOptions?: IEndpointCallOptions): Promise<IQueryResults>;
   fetchBinary(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ArrayBuffer>;

--- a/src/rest/SearchEndpointInterface.ts
+++ b/src/rest/SearchEndpointInterface.ts
@@ -92,6 +92,7 @@ export interface ISearchEndpoint {
   getBaseUri(): string;
   getBaseAlertsUri(): string;
   getAuthenticationProviderUri(provider: string, returnUri: string, message: string): string;
+  exchangeAuthenticationProviderTemporaryTokenForAccessToken(token: string): Promise<string>;
   isJsonp(): boolean;
   search(query: IQuery, callOptions?: IEndpointCallOptions): Promise<IQueryResults>;
   fetchBinary(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ArrayBuffer>;

--- a/src/rest/SearchEndpointInterface.ts
+++ b/src/rest/SearchEndpointInterface.ts
@@ -92,7 +92,7 @@ export interface ISearchEndpoint {
   getBaseUri(): string;
   getBaseAlertsUri(): string;
   getAuthenticationProviderUri(provider: string, returnUri: string, message: string): string;
-  exchangeAuthenticationProviderTemporaryTokenForAccessToken(token: string): Promise<string>;
+  exchangeAuthenticationProviderHandshakeTokenForAccessToken(token: string): Promise<string>;
   isJsonp(): boolean;
   search(query: IQuery, callOptions?: IEndpointCallOptions): Promise<IQueryResults>;
   fetchBinary(query: IQuery, callOptions?: IEndpointCallOptions): Promise<ArrayBuffer>;

--- a/src/rest/SearchEndpointWithDefaultCallOptions.ts
+++ b/src/rest/SearchEndpointWithDefaultCallOptions.ts
@@ -139,8 +139,8 @@ export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
     return this.endpoint.logError(sentryLog);
   }
 
-  public exchangeAuthenticationProviderTemporaryTokenForAccessToken(token: string): Promise<string> {
-    return this.endpoint.exchangeAuthenticationProviderTemporaryTokenForAccessToken(token);
+  public exchangeAuthenticationProviderHandshakeTokenForAccessToken(token: string): Promise<string> {
+    return this.endpoint.exchangeAuthenticationProviderHandshakeTokenForAccessToken(token);
   }
 
   private enrichCallOptions<T extends IEndpointCallOptions>(callOptions?: T): T {

--- a/src/rest/SearchEndpointWithDefaultCallOptions.ts
+++ b/src/rest/SearchEndpointWithDefaultCallOptions.ts
@@ -23,6 +23,7 @@ import * as _ from 'underscore';
 import { IFacetSearchRequest } from './Facet/FacetSearchRequest';
 import { IFacetSearchResponse } from './Facet/FacetSearchResponse';
 import { ExecutionPlan } from './Plan';
+import { AccessToken } from './AccessToken';
 
 export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
   options: ISearchEndpointOptions;
@@ -31,7 +32,7 @@ export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
     this.options = endpoint.options;
   }
 
-  public get accessToken() {
+  public get accessToken(): AccessToken {
     return this.endpoint.accessToken;
   }
 

--- a/src/rest/SearchEndpointWithDefaultCallOptions.ts
+++ b/src/rest/SearchEndpointWithDefaultCallOptions.ts
@@ -139,8 +139,8 @@ export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
     return this.endpoint.logError(sentryLog);
   }
 
-  public exchangeAuthenticationProviderHandshakeTokenForAccessToken(token: string): Promise<string> {
-    return this.endpoint.exchangeAuthenticationProviderHandshakeTokenForAccessToken(token);
+  public exchangeAuthenticationProviderToken(token: string): Promise<string> {
+    return this.endpoint.exchangeAuthenticationProviderToken(token);
   }
 
   private enrichCallOptions<T extends IEndpointCallOptions>(callOptions?: T): T {

--- a/src/rest/SearchEndpointWithDefaultCallOptions.ts
+++ b/src/rest/SearchEndpointWithDefaultCallOptions.ts
@@ -3,7 +3,8 @@ import {
   IEndpointCallOptions,
   IGetDocumentOptions,
   ISearchEndpointOptions,
-  IViewAsHtmlOptions
+  IViewAsHtmlOptions,
+  IExchangeHandshakeTokenOptions
 } from './SearchEndpointInterface';
 import { IQuery } from './Query';
 import { ITaggingRequest } from './TaggingRequest';
@@ -144,8 +145,8 @@ export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
     return this.endpoint.logError(sentryLog);
   }
 
-  public exchangeAuthenticationProviderToken(token: string): Promise<string> {
-    return this.endpoint.exchangeAuthenticationProviderToken(token);
+  public exchangeHandshakeToken(options: IExchangeHandshakeTokenOptions): Promise<string> {
+    return this.endpoint.exchangeHandshakeToken(options);
   }
 
   private enrichCallOptions<T extends IEndpointCallOptions>(callOptions?: T): T {

--- a/src/rest/SearchEndpointWithDefaultCallOptions.ts
+++ b/src/rest/SearchEndpointWithDefaultCallOptions.ts
@@ -31,6 +31,10 @@ export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
     this.options = endpoint.options;
   }
 
+  public get accessToken() {
+    return this.endpoint.accessToken;
+  }
+
   public getBaseUri(): string {
     return this.endpoint.getBaseUri();
   }

--- a/src/rest/SearchEndpointWithDefaultCallOptions.ts
+++ b/src/rest/SearchEndpointWithDefaultCallOptions.ts
@@ -139,6 +139,10 @@ export class SearchEndpointWithDefaultCallOptions implements ISearchEndpoint {
     return this.endpoint.logError(sentryLog);
   }
 
+  public exchangeAuthenticationProviderTemporaryTokenForAccessToken(token: string): Promise<string> {
+    return this.endpoint.exchangeAuthenticationProviderTemporaryTokenForAccessToken(token);
+  }
+
   private enrichCallOptions<T extends IEndpointCallOptions>(callOptions?: T): T {
     return _.extend({}, callOptions, this.callOptions);
   }

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -16,7 +16,6 @@ import * as _ from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 import 'styling/_AuthenticationProvider';
 import { SVGIcons } from '../../utils/SVGIcons';
-import { SearchEndpoint } from '../../Core';
 
 export interface IAuthenticationProviderOptions {
   name?: string;
@@ -175,7 +174,7 @@ export class AuthenticationProvider extends Component {
   }
 
   private exchangeHandshakeToken(token: string) {
-    return SearchEndpoint.defaultEndpoint.exchangeAuthenticationProviderToken(token);
+    return this.queryController.getEndpoint().exchangeAuthenticationProviderToken(token);
   }
 
   private storeAccessToken(accessToken: string) {
@@ -184,7 +183,7 @@ export class AuthenticationProvider extends Component {
 
   private loadAccessTokenFromStorage() {
     const token = localStorage.getItem(authProviderAccessToken);
-    token && SearchEndpoint.defaultEndpoint.accessToken.updateToken(token);
+    token && this.queryController.getEndpoint().accessToken.updateToken(token);
   }
 
   private handleBuildingCallOptions(args: IBuildingCallOptionsEventArgs) {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -25,7 +25,6 @@ export interface IAuthenticationProviderOptions {
   showIFrame?: boolean;
 }
 
-export const authProviderTemporaryToken = 'coveo-auth-provider-temporary-token';
 export const authProviderAccessToken = 'coveo-auth-provider-access-token';
 
 /**
@@ -115,7 +114,6 @@ export class AuthenticationProvider extends Component {
     public _window?: Window
   ) {
     super(element, AuthenticationProvider.ID, bindings);
-    this.storeTemporaryTokenIfFoundInUrl();
 
     this.options = ComponentOptions.initComponentOptions(element, AuthenticationProvider, options);
 
@@ -144,11 +142,6 @@ export class AuthenticationProvider extends Component {
     });
   }
 
-  private storeTemporaryTokenIfFoundInUrl() {
-    const token = this.getTemporaryTokenFromUrl();
-    token && localStorage.setItem(authProviderTemporaryToken, token);
-  }
-
   private getTemporaryTokenFromUrl() {
     const fragment = window.location.hash.slice(1);
     const params = fragment.split('&');
@@ -167,14 +160,14 @@ export class AuthenticationProvider extends Component {
   }
 
   private onAfterComponentsInitialization(args: IInitializationEventArgs) {
-    const temporaryToken = localStorage.getItem(authProviderTemporaryToken);
+    const temporaryToken = this.getTemporaryTokenFromUrl();
 
     if (!temporaryToken) {
       return this.loadAccessTokenFromStorage();
     }
 
     const promise = this.exchangeTemporaryToken(temporaryToken)
-      .then(token => this.replaceTemporaryTokenWithAccessToken(token))
+      .then(token => this.storeAccessToken(token))
       .then(() => this.loadAccessTokenFromStorage());
 
     args.defer.push(promise);
@@ -184,8 +177,7 @@ export class AuthenticationProvider extends Component {
     return SearchEndpoint.defaultEndpoint.exchangeAuthenticationProviderTemporaryTokenForAccessToken(token);
   }
 
-  private replaceTemporaryTokenWithAccessToken(accessToken: string) {
-    localStorage.removeItem(authProviderTemporaryToken);
+  private storeAccessToken(accessToken: string) {
     localStorage.setItem(authProviderAccessToken, accessToken);
   }
 

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -142,13 +142,13 @@ export class AuthenticationProvider extends Component {
     });
   }
 
-  private getTemporaryTokenFromUrl() {
+  private getHandshakeTokenFromUrl() {
     const fragment = window.location.hash.slice(1);
     const params = fragment.split('&');
 
     const tokenParam = _.find(params, param => {
       const [key] = param.split('=');
-      return key === 'access_token';
+      return key === 'handshake_token';
     });
 
     if (!tokenParam) {
@@ -160,21 +160,21 @@ export class AuthenticationProvider extends Component {
   }
 
   private onAfterComponentsInitialization(args: IInitializationEventArgs) {
-    const temporaryToken = this.getTemporaryTokenFromUrl();
+    const handshakeToken = this.getHandshakeTokenFromUrl();
 
-    if (!temporaryToken) {
+    if (!handshakeToken) {
       return this.loadAccessTokenFromStorage();
     }
 
-    const promise = this.exchangeTemporaryToken(temporaryToken)
+    const promise = this.exchangeHandshakeToken(handshakeToken)
       .then(token => this.storeAccessToken(token))
       .then(() => this.loadAccessTokenFromStorage());
 
     args.defer.push(promise);
   }
 
-  private exchangeTemporaryToken(token: string) {
-    return SearchEndpoint.defaultEndpoint.exchangeAuthenticationProviderTemporaryTokenForAccessToken(token);
+  private exchangeHandshakeToken(token: string) {
+    return SearchEndpoint.defaultEndpoint.exchangeAuthenticationProviderHandshakeTokenForAccessToken(token);
   }
 
   private storeAccessToken(accessToken: string) {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -19,6 +19,8 @@ import { SVGIcons } from '../../utils/SVGIcons';
 import { HashUtils } from '../../utils/HashUtils';
 import { QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
 
+export const accessTokenStorageKey = 'coveo-auth-provider-access-token';
+
 export interface IAuthenticationProviderOptions {
   name?: string;
   caption?: string;
@@ -177,16 +179,12 @@ export class AuthenticationProvider extends Component {
     return this.queryController.getEndpoint().exchangeAuthenticationProviderToken(token);
   }
 
-  public get accessTokenStorageKey() {
-    return `coveo-${this.options.name}-provider-access-token`;
-  }
-
   private storeAccessToken(accessToken: string) {
-    localStorage.setItem(this.accessTokenStorageKey, accessToken);
+    localStorage.setItem(accessTokenStorageKey, accessToken);
   }
 
   private loadAccessTokenFromStorage() {
-    const token = localStorage.getItem(this.accessTokenStorageKey);
+    const token = localStorage.getItem(accessTokenStorageKey);
     token && this.queryController.getEndpoint().accessToken.updateToken(token);
   }
 

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -175,7 +175,7 @@ export class AuthenticationProvider extends Component {
   }
 
   private exchangeHandshakeToken(token: string) {
-    return SearchEndpoint.defaultEndpoint.exchangeAuthenticationProviderHandshakeTokenForAccessToken(token);
+    return SearchEndpoint.defaultEndpoint.exchangeAuthenticationProviderToken(token);
   }
 
   private storeAccessToken(accessToken: string) {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -168,7 +168,8 @@ export class AuthenticationProvider extends Component {
 
     const promise = this.exchangeHandshakeToken(handshakeToken)
       .then(token => this.storeAccessToken(token))
-      .then(() => this.loadAccessTokenFromStorage());
+      .then(() => this.loadAccessTokenFromStorage())
+      .catch(e => this.logger.error(e));
 
     args.defer.push(promise);
   }

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -172,8 +172,10 @@ export class AuthenticationProvider extends Component {
     return !tabId || tabId === activeTabId;
   }
 
-  private exchangeHandshakeToken(token: string) {
-    return this.queryController.getEndpoint().exchangeAuthenticationProviderToken(token);
+  private exchangeHandshakeToken(handshakeToken: string) {
+    const accessToken = localStorage.getItem(accessTokenStorageKey);
+    const options = accessToken ? { handshakeToken, accessToken } : { handshakeToken };
+    return this.queryController.getEndpoint().exchangeHandshakeToken(options);
   }
 
   private storeAccessToken(accessToken: string) {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -180,8 +180,8 @@ export class AuthenticationProvider extends Component {
     args.defer.push(promise);
   }
 
-  private async exchangeTemporaryToken(token: string) {
-    return await SearchEndpoint.defaultEndpoint.exchangeAuthenticationProviderTemporaryTokenForAccessToken(token);
+  private exchangeTemporaryToken(token: string) {
+    return SearchEndpoint.defaultEndpoint.exchangeAuthenticationProviderTemporaryTokenForAccessToken(token);
   }
 
   private replaceTemporaryTokenWithAccessToken(accessToken: string) {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -152,17 +152,20 @@ export class AuthenticationProvider extends Component {
   private onAfterComponentsInitialization(args: IInitializationEventArgs) {
     const handshakeToken = this.getHandshakeTokenFromUrl();
 
-    if (handshakeToken && this.shouldExchangeHandshakeToken) {
-      const promise = this.exchangeHandshakeToken(handshakeToken)
-        .then(token => this.storeAccessToken(token))
-        .then(() => this.loadAccessTokenFromStorage())
-        .catch(e => this.logger.error(e));
+    if (!handshakeToken) {
+      return this.loadAccessTokenFromStorage();
+    }
 
-      args.defer.push(promise);
+    if (!this.shouldExchangeHandshakeToken) {
       return;
     }
 
-    return this.loadAccessTokenFromStorage();
+    const promise = this.exchangeHandshakeToken(handshakeToken)
+      .then(token => this.storeAccessToken(token))
+      .then(() => this.loadAccessTokenFromStorage())
+      .catch(e => this.logger.error(e));
+
+    args.defer.push(promise);
   }
 
   private get shouldExchangeHandshakeToken() {

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -81,7 +81,7 @@ export function AuthenticationProviderTest() {
         window.location.hash = `handshake_token=${handshakeToken}`;
         setupDefaultEndpoint();
 
-        exchangeTokenSpy = spyOn(SearchEndpoint.endpoints['default'], 'exchangeAuthenticationProviderHandshakeTokenForAccessToken');
+        exchangeTokenSpy = spyOn(SearchEndpoint.endpoints['default'], 'exchangeAuthenticationProviderToken');
         exchangeTokenSpy.and.returnValue(Promise.resolve(accessToken));
 
         initAuthenticationProvider();

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -128,6 +128,29 @@ export function AuthenticationProviderTest() {
         expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken });
       });
 
+      describe(`url hash contains an active tab and a handshake token param,
+      auth provider data-tab does not match the active tab`, () => {
+        beforeEach(() => {
+          window.location.hash = `${QUERY_STATE_ATTRIBUTES.T}=a&handshake_token=${handshakeToken}`;
+          setDataTab(test.cmp.element, 'b');
+        });
+
+        it(`does not exchange the handshake token`, () => {
+          triggerAfterComponentsInitialization();
+          expect(exchangeTokenSpy).not.toHaveBeenCalled();
+        });
+
+        it('does not load an existing access token', () => {
+          // Ensures that the AuthenticationProvider that is performing the exchange is using the
+          // initially configured API key, not an access token loaded by a different instance.
+          localStorage.setItem(accessTokenStorageKey, 'access-token');
+          const spy = spyOn(test.cmp.queryController.getEndpoint().accessToken, 'updateToken');
+
+          triggerAfterComponentsInitialization();
+          expect(spy).not.toHaveBeenCalled();
+        });
+      });
+
       it(`url hash contains an active tab and a handshake token param,
       auth provider data-tab does not match the active tab,
       it does not exchange the token`, () => {

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -72,16 +72,16 @@ export function AuthenticationProviderTest() {
       expect(spy).toHaveBeenCalledWith(accessToken);
     });
 
-    describe(`url hash contains a temporary token, when components have initialized`, () => {
-      const temporaryToken = 'temporary-token';
+    describe(`url hash contains a handshake token, when components have initialized`, () => {
+      const handshakeToken = 'handshake-token';
       const accessToken = 'access-token';
       let exchangeTokenSpy: jasmine.Spy;
 
       beforeEach(() => {
-        window.location.hash = `access_token=${temporaryToken}`;
+        window.location.hash = `handshake_token=${handshakeToken}`;
         setupDefaultEndpoint();
 
-        exchangeTokenSpy = spyOn(SearchEndpoint.endpoints['default'], 'exchangeAuthenticationProviderTemporaryTokenForAccessToken');
+        exchangeTokenSpy = spyOn(SearchEndpoint.endpoints['default'], 'exchangeAuthenticationProviderHandshakeTokenForAccessToken');
         exchangeTokenSpy.and.returnValue(Promise.resolve(accessToken));
 
         initAuthenticationProvider();
@@ -89,18 +89,18 @@ export function AuthenticationProviderTest() {
 
       it('exchanges the token', () => {
         triggerAfterComponentsInitialization();
-        expect(exchangeTokenSpy).toHaveBeenCalledWith(temporaryToken);
+        expect(exchangeTokenSpy).toHaveBeenCalledWith(handshakeToken);
       });
 
-      it('url hash contains multiple params including an #access_token param, it exchanges the token', () => {
-        window.location.hash = `a=b&access_token=${temporaryToken}`;
+      it('url hash contains multiple params including an #handshake_token param, it exchanges the token', () => {
+        window.location.hash = `a=b&handshake_token=${handshakeToken}`;
         triggerAfterComponentsInitialization();
-        expect(exchangeTokenSpy).toHaveBeenCalledWith(temporaryToken);
+        expect(exchangeTokenSpy).toHaveBeenCalledWith(handshakeToken);
       });
 
-      it('url hash contains an #access_token param, it decodes the token before storing it', () => {
+      it('url hash contains an #handshake_token param, it decodes the token before storing it', () => {
         const token = 'test%3Etoken';
-        window.location.hash = `access_token=${token}`;
+        window.location.hash = `handshake_token=${token}`;
 
         triggerAfterComponentsInitialization();
 

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -47,7 +47,7 @@ export function AuthenticationProviderTest() {
       test = null;
     });
 
-    it('when the url hash contains an #access_token param, it stores the token in localstorage', () => {
+    it('url hash contains an #access_token param, it stores the token in localstorage', () => {
       const token = 'test-token';
       window.location.hash = `access_token=${token}`;
 
@@ -57,7 +57,7 @@ export function AuthenticationProviderTest() {
       expect(localStorage.getItem(samlTokenStorageKey)).toBe(token);
     });
 
-    it('when the url hash contains multiple params and an #access_token param, it stores the token in localstorage', () => {
+    it('url hash contains multiple params including an #access_token param, it stores the token in localstorage', () => {
       const token = 'test-token';
       window.location.hash = `a=b&access_token=${token}`;
 
@@ -67,7 +67,7 @@ export function AuthenticationProviderTest() {
       expect(localStorage.getItem(samlTokenStorageKey)).toBe(token);
     });
 
-    it('when the url hash contains an #access_token param, it decodes the token before storing it', () => {
+    it('url hash contains an #access_token param, it decodes the token before storing it', () => {
       const token = 'test%3Etoken';
       window.location.hash = `access_token=${token}`;
 
@@ -77,7 +77,7 @@ export function AuthenticationProviderTest() {
       expect(localStorage.getItem(samlTokenStorageKey)).toBe('test>token');
     });
 
-    it('when local storage contains a saml token, it updates the endpoint to use it', () => {
+    it('local storage contains a saml token, it updates the endpoint to use it', () => {
       const token = 'test-token';
       localStorage.setItem(samlTokenStorageKey, token);
 

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -1,5 +1,5 @@
 import * as Mock from '../MockEnvironment';
-import { AuthenticationProvider } from '../../src/ui/AuthenticationProvider/AuthenticationProvider';
+import { AuthenticationProvider, accessTokenStorageKey } from '../../src/ui/AuthenticationProvider/AuthenticationProvider';
 import { ModalBox } from '../../src/ExternalModulesShim';
 import { IAuthenticationProviderOptions } from '../../src/ui/AuthenticationProvider/AuthenticationProvider';
 import { IBuildingCallOptionsEventArgs } from '../../src/events/QueryEvents';
@@ -61,7 +61,7 @@ export function AuthenticationProviderTest() {
     it(`local storage contains an access token,
     when components have initialized, it updates the endpoint to use the access token`, () => {
       const accessToken = 'access-token';
-      localStorage.setItem(test.cmp.accessTokenStorageKey, accessToken);
+      localStorage.setItem(accessTokenStorageKey, accessToken);
 
       initAuthenticationProvider();
       setupEndpoint();
@@ -149,7 +149,7 @@ export function AuthenticationProviderTest() {
         triggerAfterComponentsInitialization();
         await Promise.resolve();
 
-        const token = localStorage.getItem(test.cmp.accessTokenStorageKey);
+        const token = localStorage.getItem(accessTokenStorageKey);
         expect(token).toBe(accessToken);
         done();
       });

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -104,20 +104,28 @@ export function AuthenticationProviderTest() {
         initAuthenticationProvider();
         setupEndpoint();
 
-        exchangeTokenSpy = spyOn(test.cmp.queryController.getEndpoint(), 'exchangeAuthenticationProviderToken');
+        exchangeTokenSpy = spyOn(test.cmp.queryController.getEndpoint(), 'exchangeHandshakeToken');
         exchangeTokenSpy.and.returnValue(Promise.resolve(accessToken));
       });
 
       it('exchanges the token', () => {
         triggerAfterComponentsInitialization();
-        expect(exchangeTokenSpy).toHaveBeenCalledWith(handshakeToken);
+        expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken });
+      });
+
+      it(`when an accessToken is found in localstorage,
+      it sends both the accessToken and handshake token`, () => {
+        const accessToken = 'access-token';
+        localStorage.setItem(accessTokenStorageKey, accessToken);
+        triggerAfterComponentsInitialization();
+        expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken, accessToken });
       });
 
       it(`url hash contains multiple params including an #handshake_token param,
       it exchanges the token`, () => {
         window.location.hash = `a=b&handshake_token=${handshakeToken}`;
         triggerAfterComponentsInitialization();
-        expect(exchangeTokenSpy).toHaveBeenCalledWith(handshakeToken);
+        expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken });
       });
 
       it(`url hash contains an active tab and a handshake token param,
@@ -136,7 +144,7 @@ export function AuthenticationProviderTest() {
         setDataTab(test.cmp.element, 'a');
         $$(test.cmp.element).setAttribute('data-tab', 'a');
         triggerAfterComponentsInitialization();
-        expect(exchangeTokenSpy).toHaveBeenCalledWith(handshakeToken);
+        expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken });
       });
 
       it(`url hash contains an #handshake_token with encoded characters,
@@ -146,7 +154,7 @@ export function AuthenticationProviderTest() {
 
         triggerAfterComponentsInitialization();
 
-        expect(exchangeTokenSpy).toHaveBeenCalledWith('test>token');
+        expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken: 'test>token' });
       });
 
       it(`when the exchange throws an error, it logs an error`, async done => {

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -28,10 +28,9 @@ export function AuthenticationProviderTest() {
       $$(test.env.root).trigger(InitializationEvents.afterComponentsInitialization, initializationArgs);
     }
 
-    function setupDefaultEndpoint() {
-      SearchEndpoint.endpoints['default'] = new SearchEndpoint({
-        restUri: 'https://platform.cloud.coveo.com/rest/search'
-      });
+    function setupEndpoint() {
+      const endpoint = new SearchEndpoint({ restUri: 'https://platform.cloud.coveo.com/rest/search' });
+      test.env.queryController.getEndpoint = () => endpoint;
     }
 
     beforeEach(function () {
@@ -63,10 +62,10 @@ export function AuthenticationProviderTest() {
       const accessToken = 'access-token';
       localStorage.setItem(authProviderAccessToken, accessToken);
 
-      setupDefaultEndpoint();
-      const spy = spyOn(SearchEndpoint.endpoints['default'].accessToken, 'updateToken');
       initAuthenticationProvider();
+      setupEndpoint();
 
+      const spy = spyOn(test.cmp.queryController.getEndpoint().accessToken, 'updateToken');
       triggerAfterComponentsInitialization();
 
       expect(spy).toHaveBeenCalledWith(accessToken);
@@ -79,12 +78,12 @@ export function AuthenticationProviderTest() {
 
       beforeEach(() => {
         window.location.hash = `handshake_token=${handshakeToken}`;
-        setupDefaultEndpoint();
-
-        exchangeTokenSpy = spyOn(SearchEndpoint.endpoints['default'], 'exchangeAuthenticationProviderToken');
-        exchangeTokenSpy.and.returnValue(Promise.resolve(accessToken));
 
         initAuthenticationProvider();
+        setupEndpoint();
+
+        exchangeTokenSpy = spyOn(test.cmp.queryController.getEndpoint(), 'exchangeAuthenticationProviderToken');
+        exchangeTokenSpy.and.returnValue(Promise.resolve(accessToken));
       });
 
       it('exchanges the token', () => {
@@ -137,7 +136,7 @@ export function AuthenticationProviderTest() {
       });
 
       it('updates the endpoint to use the access token', async done => {
-        const spy = spyOn(SearchEndpoint.endpoints['default'].accessToken, 'updateToken');
+        const spy = spyOn(test.cmp.queryController.getEndpoint().accessToken, 'updateToken');
         triggerAfterComponentsInitialization();
         await Promise.resolve();
 

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -109,8 +109,7 @@ export function AuthenticationProviderTest() {
         expect(exchangeTokenSpy).toHaveBeenCalledWith('test>token');
       });
 
-      it(`when the exchange call throws an error,
-      it logs a message and does not store anything in localstorage`, async done => {
+      it(`when the exchange throws an error, it logs an error`, async done => {
         const errorMessage = 'unable to exchange token';
         exchangeTokenSpy.and.returnValue(Promise.reject(errorMessage));
 

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -25,6 +25,10 @@ export function AuthenticationProviderTest() {
       test = Mock.optionsComponentSetup<AuthenticationProvider, IAuthenticationProviderOptions>(AuthenticationProvider, options);
     }
 
+    function setDataTab(el: HTMLElement, tab: string) {
+      $$(el).setAttribute('data-tab', tab);
+    }
+
     function triggerAfterComponentsInitialization() {
       $$(test.env.root).trigger(InitializationEvents.afterComponentsInitialization, initializationArgs);
     }
@@ -72,6 +76,23 @@ export function AuthenticationProviderTest() {
       expect(spy).toHaveBeenCalledWith(accessToken);
     });
 
+    it(`local storage contains an access token,
+    auth provider has a data-tab configured,
+    when components have initialized,
+    it updates the endpoint to use the access token`, () => {
+      const accessToken = 'access-token';
+      localStorage.setItem(accessTokenStorageKey, accessToken);
+
+      initAuthenticationProvider();
+      setDataTab(test.cmp.element, 'a');
+      setupEndpoint();
+
+      const spy = spyOn(test.cmp.queryController.getEndpoint().accessToken, 'updateToken');
+      triggerAfterComponentsInitialization();
+
+      expect(spy).toHaveBeenCalledWith(accessToken);
+    });
+
     describe(`url hash contains a handshake token, when components have initialized`, () => {
       const handshakeToken = 'handshake-token';
       const accessToken = 'access-token';
@@ -103,7 +124,7 @@ export function AuthenticationProviderTest() {
       auth provider data-tab does not match the active tab,
       it does not exchange the token`, () => {
         window.location.hash = `${QUERY_STATE_ATTRIBUTES.T}=a&handshake_token=${handshakeToken}`;
-        $$(test.cmp.element).setAttribute('data-tab', 'b');
+        setDataTab(test.cmp.element, 'b');
         triggerAfterComponentsInitialization();
         expect(exchangeTokenSpy).not.toHaveBeenCalled();
       });
@@ -112,6 +133,7 @@ export function AuthenticationProviderTest() {
       auth provider data-tab matches the active tab,
       it exchanges the token`, () => {
         window.location.hash = `${QUERY_STATE_ATTRIBUTES.T}=a&handshake_token=${handshakeToken}`;
+        setDataTab(test.cmp.element, 'a');
         $$(test.cmp.element).setAttribute('data-tab', 'a');
         triggerAfterComponentsInitialization();
         expect(exchangeTokenSpy).toHaveBeenCalledWith(handshakeToken);

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -1,5 +1,5 @@
 import * as Mock from '../MockEnvironment';
-import { AuthenticationProvider } from '../../src/ui/AuthenticationProvider/AuthenticationProvider';
+import { AuthenticationProvider, samlTokenStorageKey } from '../../src/ui/AuthenticationProvider/AuthenticationProvider';
 import { ModalBox } from '../../src/ExternalModulesShim';
 import { IAuthenticationProviderOptions } from '../../src/ui/AuthenticationProvider/AuthenticationProvider';
 import { IBuildingCallOptionsEventArgs } from '../../src/events/QueryEvents';
@@ -10,37 +10,89 @@ import { l } from '../../src/strings/Strings';
 import { $$ } from '../../src/utils/Dom';
 import { MissingAuthenticationError } from '../../src/rest/MissingAuthenticationError';
 import _ = require('underscore');
+import { SearchEndpoint } from '../../src/BaseModules';
 
 export function AuthenticationProviderTest() {
-  describe('AuthenticationProvider', function() {
+  describe('AuthenticationProvider', function () {
+    let options: IAuthenticationProviderOptions;
     let test: Mock.IBasicComponentSetup<AuthenticationProvider>;
 
-    beforeEach(function() {
+    function initAuthenticationProvider() {
+      test = Mock.optionsComponentSetup<AuthenticationProvider, IAuthenticationProviderOptions>(AuthenticationProvider, options);
+    }
+
+    function setupDefaultEndpoint() {
+      SearchEndpoint.endpoints['default'] = new SearchEndpoint({
+        restUri: 'https://platform.cloud.coveo.com/rest/search'
+      });
+    }
+
+    beforeEach(function () {
+      window.location.hash = '';
+      localStorage.removeItem(samlTokenStorageKey);
+
+      options = {
+        name: 'foo',
+        caption: 'foobar',
+        useIFrame: true
+      };
+
       spyOn(ModalBox, 'open').and.callFake(() => {});
       spyOn(ModalBox, 'close').and.callFake(() => {});
 
-      test = Mock.optionsComponentSetup<AuthenticationProvider, IAuthenticationProviderOptions>(
-        AuthenticationProvider,
-        <IAuthenticationProviderOptions>{
-          name: 'foo',
-          caption: 'foobar',
-          useIFrame: true
-        }
-      );
+      initAuthenticationProvider();
     });
 
-    afterEach(function() {
+    afterEach(function () {
       test = null;
     });
 
-    describe('exposes options', function() {
-      it('name should push name in buildingCallOptions', function() {
-        test = Mock.optionsComponentSetup<AuthenticationProvider, IAuthenticationProviderOptions>(
-          AuthenticationProvider,
-          <IAuthenticationProviderOptions>{
-            name: 'testpatate'
-          }
-        );
+    it('when the url hash contains an #access_token param, it stores the token in localstorage', () => {
+      const token = 'test-token';
+      window.location.hash = `access_token=${token}`;
+
+      setupDefaultEndpoint();
+      initAuthenticationProvider();
+
+      expect(localStorage.getItem(samlTokenStorageKey)).toBe(token);
+    });
+
+    it('when the url hash contains multiple params and an #access_token param, it stores the token in localstorage', () => {
+      const token = 'test-token';
+      window.location.hash = `a=b&access_token=${token}`;
+
+      setupDefaultEndpoint();
+      initAuthenticationProvider();
+
+      expect(localStorage.getItem(samlTokenStorageKey)).toBe(token);
+    });
+
+    it('when the url hash contains an #access_token param, it decodes the token before storing it', () => {
+      const token = 'test%3Etoken';
+      window.location.hash = `access_token=${token}`;
+
+      setupDefaultEndpoint();
+      initAuthenticationProvider();
+
+      expect(localStorage.getItem(samlTokenStorageKey)).toBe('test>token');
+    });
+
+    it('when local storage contains a saml token, it updates the endpoint to use it', () => {
+      const token = 'test-token';
+      localStorage.setItem(samlTokenStorageKey, token);
+
+      setupDefaultEndpoint();
+      const spy = spyOn(SearchEndpoint.endpoints['default'].accessToken, 'updateToken');
+      initAuthenticationProvider();
+
+      expect(spy).toHaveBeenCalledWith(token);
+    });
+
+    describe('exposes options', function () {
+      it('name should push name in buildingCallOptions', function () {
+        options = { name: 'testpatate' };
+        initAuthenticationProvider();
+
         let eventArgs: IBuildingCallOptionsEventArgs = {
           options: {
             authentication: []
@@ -50,8 +102,8 @@ export function AuthenticationProviderTest() {
         expect(eventArgs.options.authentication).toEqual(jasmine.arrayContaining(['testpatate']));
       });
 
-      describe('caption', function() {
-        it('should set itself in the menu', function() {
+      describe('caption', function () {
+        it('should set itself in the menu', function () {
           let populateMenuArgs: ISettingsPopulateMenuArgs = {
             settings: null,
             menuData: []
@@ -68,12 +120,7 @@ export function AuthenticationProviderTest() {
           );
         });
 
-        it('should be the title of the modal box when iFrame is enabled', function() {
-          test = Mock.optionsComponentSetup<AuthenticationProvider, IAuthenticationProviderOptions>(AuthenticationProvider, {
-            name: 'foo',
-            caption: 'foobar',
-            useIFrame: true
-          });
+        it('should be the title of the modal box when iFrame is enabled', function () {
           $$(test.cmp.root).trigger(QueryEvents.queryError, { error: new MissingAuthenticationError('foo') });
           expect(ModalBox.open).toHaveBeenCalledWith(
             jasmine.anything(),
@@ -84,14 +131,15 @@ export function AuthenticationProviderTest() {
         });
       });
 
-      it('useIFrame set to false should redirect to auth provider URL', function() {
-        let fakeWindow = Mock.mockWindow();
-
-        test = Mock.optionsComponentSetup<AuthenticationProvider, IAuthenticationProviderOptions>(AuthenticationProvider, {
+      it('useIFrame set to false should redirect to auth provider URL', function () {
+        options = {
           name: 'foo',
           caption: 'foobar',
           useIFrame: false
-        });
+        };
+        initAuthenticationProvider();
+
+        let fakeWindow = Mock.mockWindow();
         test.cmp._window = fakeWindow;
         test.env.searchEndpoint.getAuthenticationProviderUri = () => 'coveo.com';
         $$(test.env.root).trigger(QueryEvents.queryError, { error: new MissingAuthenticationError('foo') });
@@ -99,25 +147,30 @@ export function AuthenticationProviderTest() {
         expect(fakeWindow.location.href).toBe('coveo.com');
       });
 
-      it('useIFrame and showIFrame set to true should display a ModalBox containing iframe', function() {
-        test = Mock.optionsComponentSetup<AuthenticationProvider, IAuthenticationProviderOptions>(AuthenticationProvider, {
+      it('useIFrame and showIFrame set to true should display a ModalBox containing iframe', function () {
+        options = {
           name: 'foo',
           caption: 'foobar',
           useIFrame: true,
           showIFrame: true
-        });
+        };
+        initAuthenticationProvider();
+
         test.env.searchEndpoint.getAuthenticationProviderUri = () => 'http://coveo.com/';
         $$(test.env.root).trigger(QueryEvents.queryError, { error: new MissingAuthenticationError('foo') });
         expect(ModalBox.open['calls'].mostRecent().args[0].children[0].src).toBe('http://coveo.com/');
       });
 
-      it('showIFrame set to false should show a waiting popup not containing the iframe', function() {
-        test = Mock.optionsComponentSetup<AuthenticationProvider, IAuthenticationProviderOptions>(AuthenticationProvider, {
+      it('showIFrame set to false should show a waiting popup not containing the iframe', function () {
+        options = {
           name: 'foo',
           caption: 'foobar',
           useIFrame: true,
           showIFrame: false
-        });
+        };
+
+        initAuthenticationProvider();
+
         $$(test.env.root).trigger(QueryEvents.queryError, { error: new MissingAuthenticationError('foo') });
 
         expect(ModalBox.open).toHaveBeenCalledWith(
@@ -129,7 +182,7 @@ export function AuthenticationProviderTest() {
       });
     });
 
-    it('should stop a redirect loop after 3 redirects', function() {
+    it('should stop a redirect loop after 3 redirects', function () {
       spyOn(test.cmp.logger, 'error').and.returnValue(null);
       _.times(3, () => $$(test.env.root).trigger(QueryEvents.queryError, { error: { provider: 'foo' } }));
 


### PR DESCRIPTION
The first PR assumed a single `CoveoAuthenticationProvider` component. This PR makes two adjustments to handle multiple configured providers:

- When a handshake token is found in the url, only the Auth provider matching the active tab in the hash will attempt to exchange.
- During an exchange, if an access token exists, it will be sent as part of the request. The search api will return a new access token that augments the existing privileges. This avoids the UI needing to manage and hot-swap access tokens when a user switches between tabs.

https://coveord.atlassian.net/browse/JSUI-3260


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)