### PR TITLE
JSUI-3263 add noConflict method to exported underscore

### DIFF
--- a/src/ui/Base/CoveoUnderscore.ts
+++ b/src/ui/Base/CoveoUnderscore.ts
@@ -20,6 +20,13 @@ function setTemplateSettings({ templateSettings }: { templateSettings: _.Templat
   templateSettings.escape = /(?:<%|{{)-([\s\S]+?)(?:%>|}})/g;
 }
 
+const previousUnderscore = window['_'];
 window['_'] = _;
+// Run Underscore.js in "noConflict" mode, returning the `_` variable to its previous owner.
+// Returns a reference to the Underscore object. This method was removed from the module in v1.10.0
+window['_'].noConflict = function () {
+  window['_'] = previousUnderscore;
+  return _;
+};
 
 setTemplateSettings(window['_']);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3263

Basically since version 1.10.0 of underscore, the noConflict method is not available for EcmaScript 6, AMD or CommonJS module system. It’s only available with the “window embed” mode, meaning when you load the code directly in the browser. In CoveoUnderscore, we import it as a module (`import * as _ from 'underscore’;`) and set the imported “_” to the window, without the noConflict method.

A solution, which I implement here, is to add the noConflict method on the “_” we export, reproducing the previous implementation.

PR in underscore https://github.com/jashkenas/underscore/pull/2826 (where you can see the previous implementation)
PR where we bumped https://github.com/coveo/search-ui/pull/1627 (introduced in our release versions 2.9659 to 2.9856)

Found a comment about the issue in SNOW integration https://github.com/coveo/servicenowintegration/commit/466a684bb475139e9925a8caf87bb8f110e59ef6

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)