### PR TITLE
JSUI-3265 extract handshake token from Angular url before removing; prevent multiple AuthProviders from shaking hands; clear invalid token from localstorage

### DIFF
--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -340,8 +340,7 @@ export class SearchEndpoint implements ISearchEndpoint {
     callOptions?: IEndpointCallOptions,
     callParams?: IEndpointCallParameters
   ) {
-    const token = options.handshakeToken;
-    const call = this.buildCompleteCall({ token }, callOptions, callParams);
+    const call = this.buildCompleteCall(options, callOptions, callParams);
     const data = await this.performOneCall<{ token: string }>(call.params, call.options);
 
     if (!data.token) {

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -340,7 +340,8 @@ export class SearchEndpoint implements ISearchEndpoint {
     callOptions?: IEndpointCallOptions,
     callParams?: IEndpointCallParameters
   ) {
-    const call = this.buildCompleteCall(options, callOptions, callParams);
+    const token = options.handshakeToken;
+    const call = this.buildCompleteCall({ token }, callOptions, callParams);
     const data = await this.performOneCall<{ token: string }>(call.params, call.options);
 
     if (!data.token) {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -145,8 +145,8 @@ export class AuthenticationProvider extends Component {
 
   private getHandshakeTokenFromUrl() {
     const rawHash = HashUtils.getHash();
-    const slashAfterHash = rawHash.indexOf('#/') === 0;
-    const hash = slashAfterHash ? `#${rawHash.slice(2)}` : rawHash;
+    const hasSlashAfterHash = rawHash.indexOf('#/') === 0;
+    const hash = hasSlashAfterHash ? `#${rawHash.slice(2)}` : rawHash;
     const token = HashUtils.getValue('handshake_token', hash);
 
     return typeof token === 'string' ? token : '';

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -146,17 +146,17 @@ export class AuthenticationProvider extends Component {
   }
 
   private getHandshakeTokenFromUrl() {
-    const hash = this.getHashAfterAdjustingForSharepoint();
+    const hash = this.getHashAfterAdjustingForAngular();
     const token = HashUtils.getValue(handshakeTokenParamName, hash);
     return typeof token === 'string' ? token : '';
   }
 
-  private getHashAfterAdjustingForSharepoint() {
+  private getHashAfterAdjustingForAngular() {
     const hash = HashUtils.getHash();
-    return this.isSharepointHash ? `#${hash.slice(2)}` : hash;
+    return this.isAngularHash ? `#${hash.slice(2)}` : hash;
   }
 
-  private get isSharepointHash() {
+  private get isAngularHash() {
     const rawHash = HashUtils.getHash();
     return rawHash.indexOf('#/') === 0;
   }
@@ -231,13 +231,13 @@ export class AuthenticationProvider extends Component {
 
   private removeHandshakeTokenFromUrl() {
     const delimiter = `&`;
-    const hash = this.getHashAfterAdjustingForSharepoint();
+    const hash = this.getHashAfterAdjustingForAngular();
     const token = this.getHandshakeTokenFromUrl();
     const handshakeEntry = `${handshakeTokenParamName}=${token}`;
 
     const entries = hash.substr(1).split(delimiter);
     const newHash = entries.filter(param => param !== handshakeEntry).join(delimiter);
-    const adjustedHash = this.isSharepointHash ? `/${newHash}` : newHash;
+    const adjustedHash = this.isAngularHash ? `/${newHash}` : newHash;
 
     this._window.history.replaceState(null, '', `#${adjustedHash}`);
   }

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -20,6 +20,7 @@ import { HashUtils } from '../../utils/HashUtils';
 import { QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
 
 export const accessTokenStorageKey = 'coveo-auth-provider-access-token';
+const handshakeTokenParamName = 'handshake_token';
 
 export interface IAuthenticationProviderOptions {
   name?: string;
@@ -40,6 +41,7 @@ export interface IAuthenticationProviderOptions {
  */
 export class AuthenticationProvider extends Component {
   static ID = 'AuthenticationProvider';
+  static handshakeInProgress = false;
 
   static doExport = () => {
     exportGlobally({
@@ -144,15 +146,29 @@ export class AuthenticationProvider extends Component {
   }
 
   private getHandshakeTokenFromUrl() {
-    const rawHash = HashUtils.getHash();
-    const hasSlashAfterHash = rawHash.indexOf('#/') === 0;
-    const hash = hasSlashAfterHash ? `#${rawHash.slice(2)}` : rawHash;
-    const token = HashUtils.getValue('handshake_token', hash);
-
+    const hash = this.getHashAfterAdjustingForSharepoint();
+    const token = HashUtils.getValue(handshakeTokenParamName, hash);
     return typeof token === 'string' ? token : '';
   }
 
+  private getHashAfterAdjustingForSharepoint() {
+    const hash = HashUtils.getHash();
+    return this.isSharepointHash ? `#${hash.slice(2)}` : hash;
+  }
+
+  private get isSharepointHash() {
+    const rawHash = HashUtils.getHash();
+    return rawHash.indexOf('#/') === 0;
+  }
+
   private onAfterComponentsInitialization(args: IInitializationEventArgs) {
+    if (AuthenticationProvider.handshakeInProgress) {
+      const promise = this.waitForHandshakeToFinish().then(() => this.loadAccessTokenFromStorage());
+
+      args.defer.push(promise);
+      return;
+    }
+
     const handshakeToken = this.getHandshakeTokenFromUrl();
 
     if (!handshakeToken) {
@@ -163,10 +179,14 @@ export class AuthenticationProvider extends Component {
       return;
     }
 
+    this.enableHandshakeInProgressFlag();
+
     const promise = this.exchangeHandshakeToken(handshakeToken)
       .then(token => this.storeAccessToken(token))
+      .then(() => this.removeHandshakeTokenFromUrl())
       .then(() => this.loadAccessTokenFromStorage())
-      .catch(e => this.logger.error(e));
+      .catch(e => this.logger.error(e))
+      .finally(() => this.disableHandshakeInProgressFlag());
 
     args.defer.push(promise);
   }
@@ -188,9 +208,47 @@ export class AuthenticationProvider extends Component {
     localStorage.setItem(accessTokenStorageKey, accessToken);
   }
 
+  private waitForHandshakeToFinish() {
+    return new Promise(resolve => {
+      const interval = setInterval(() => {
+        if (AuthenticationProvider.handshakeInProgress) {
+          return;
+        }
+
+        clearInterval(interval);
+        resolve();
+      }, 100);
+    });
+  }
+
+  private enableHandshakeInProgressFlag() {
+    AuthenticationProvider.handshakeInProgress = true;
+  }
+
+  private disableHandshakeInProgressFlag() {
+    AuthenticationProvider.handshakeInProgress = false;
+  }
+
+  private removeHandshakeTokenFromUrl() {
+    const delimiter = `&`;
+    const hash = this.getHashAfterAdjustingForSharepoint();
+    const token = this.getHandshakeTokenFromUrl();
+    const handshakeEntry = `${handshakeTokenParamName}=${token}`;
+
+    const entries = hash.substr(1).split(delimiter);
+    const newHash = entries.filter(param => param !== handshakeEntry).join(delimiter);
+    const adjustedHash = this.isSharepointHash ? `/${newHash}` : newHash;
+
+    this._window.history.replaceState(null, '', `#${adjustedHash}`);
+  }
+
   private loadAccessTokenFromStorage() {
-    const token = localStorage.getItem(accessTokenStorageKey);
+    const token = this.getAccessTokenFromStorage();
     token && this.queryController.getEndpoint().accessToken.updateToken(token);
+  }
+
+  private getAccessTokenFromStorage() {
+    return localStorage.getItem(accessTokenStorageKey);
   }
 
   private handleBuildingCallOptions(args: IBuildingCallOptionsEventArgs) {
@@ -198,6 +256,15 @@ export class AuthenticationProvider extends Component {
   }
 
   private handleQueryError(args: IQueryErrorEventArgs) {
+    const token = this.getAccessTokenFromStorage();
+    const shouldClearToken = this.shouldClearTokenFollowingErrorEvent(args);
+
+    if (token && shouldClearToken) {
+      localStorage.removeItem(accessTokenStorageKey);
+      this._window.location.reload();
+      return;
+    }
+
     let missingAuthError = <MissingAuthenticationError>args.error;
 
     if (
@@ -212,6 +279,11 @@ export class AuthenticationProvider extends Component {
       this.logger.error('The AuthenticationProvider is in a redirect loop. This may be due to a back-end configuration problem.');
       this.redirectCount = -1;
     }
+  }
+
+  private shouldClearTokenFollowingErrorEvent(args: IQueryErrorEventArgs) {
+    const error = args.error.name;
+    return error === 'InvalidTokenException' || error === 'ExpiredTokenException';
   }
 
   private authenticateWithProvider() {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -144,8 +144,11 @@ export class AuthenticationProvider extends Component {
   }
 
   private getHandshakeTokenFromUrl() {
-    const hash = HashUtils.getHash();
+    const rawHash = HashUtils.getHash();
+    const slashAfterHash = rawHash.indexOf('#/') === 0;
+    const hash = slashAfterHash ? `#${rawHash.slice(2)}` : rawHash;
     const token = HashUtils.getValue('handshake_token', hash);
+
     return typeof token === 'string' ? token : '';
   }
 

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -200,7 +200,8 @@ export function mockWindow(): Window {
     href: '',
     hash: '',
     pathname: '',
-    search: ''
+    search: '',
+    reload: () => {}
   };
   mockWindow.location.assign = mockWindow.location.replace = (newHref: string) => {
     newHref = newHref || '';
@@ -220,6 +221,7 @@ export function mockWindow(): Window {
   };
   spyOn(mockWindow.location, 'replace').and.callThrough();
   spyOn(mockWindow.location, 'assign').and.callThrough();
+  spyOn(mockWindow.location, 'reload').and.callThrough();
   mockWindow.addEventListener = jasmine.createSpy('addEventListener');
   mockWindow.removeEventListener = jasmine.createSpy('removeEventListener');
   mockWindow.dispatchEvent = jasmine.createSpy('dispatchEvent');

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -123,7 +123,7 @@ export function AuthenticationProviderTest() {
 
       it(`url hash starts with / followed by #handshake_token param,
       it exchanges the token`, () => {
-        // Sharepoint adds a / betwe the # and the hash parameters.
+        // Sharepoint adds a / between the # and the hash parameters.
         window.location.hash = `/handshake_token=${handshakeToken}`;
         triggerAfterComponentsInitialization();
         expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken });

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -130,7 +130,7 @@ export function AuthenticationProviderTest() {
 
       it(`url hash starts with / followed by #handshake_token param,
       it exchanges the token`, () => {
-        // Sharepoint adds a / between the # and the hash parameters.
+        // Angular by default adds a / between the hash and the hash parameters.
         window.location.hash = `/handshake_token=${handshakeToken}`;
         triggerAfterComponentsInitialization();
         expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken });

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -14,6 +14,7 @@ import { SearchEndpoint } from '../../src/BaseModules';
 import { InitializationEvents } from '../../src/EventsModules';
 import { IInitializationEventArgs } from '../../src/events/InitializationEvents';
 import { QUERY_STATE_ATTRIBUTES } from '../../src/models/QueryStateModel';
+import { Utils } from '../../src/UtilsModules';
 
 export function AuthenticationProviderTest() {
   describe('AuthenticationProvider', function () {
@@ -94,18 +95,24 @@ export function AuthenticationProviderTest() {
     });
 
     describe(`url hash contains a handshake token, when components have initialized`, () => {
-      const handshakeToken = 'handshake-token';
+      const handshakeToken = '04212242-fd27-4825-be27-53844ed83ac9';
       const accessToken = 'access-token';
       let exchangeTokenSpy: jasmine.Spy;
 
       beforeEach(() => {
         window.location.hash = `handshake_token=${handshakeToken}`;
+        AuthenticationProvider.handshakeInProgress = false;
 
         initAuthenticationProvider();
         setupEndpoint();
 
         exchangeTokenSpy = spyOn(test.cmp.queryController.getEndpoint(), 'exchangeHandshakeToken');
         exchangeTokenSpy.and.returnValue(Promise.resolve(accessToken));
+      });
+
+      it('sets the handshake-in-progress flag to true', () => {
+        triggerAfterComponentsInitialization();
+        expect(AuthenticationProvider.handshakeInProgress).toBe(true);
       });
 
       it('exchanges the token', () => {
@@ -188,19 +195,6 @@ export function AuthenticationProviderTest() {
         expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken: 'test>token' });
       });
 
-      it(`when the exchange throws an error, it logs an error`, async done => {
-        const errorMessage = 'unable to exchange token';
-        exchangeTokenSpy.and.returnValue(Promise.reject(errorMessage));
-
-        const logggerSpy = spyOn(test.cmp.logger, 'error');
-        triggerAfterComponentsInitialization();
-
-        await Promise.resolve();
-
-        expect(logggerSpy).toHaveBeenCalledWith(errorMessage);
-        done();
-      });
-
       it('adds an entry to the initialization args #defer array', () => {
         triggerAfterComponentsInitialization();
         expect(initializationArgs.defer.length).toBe(1);
@@ -208,20 +202,186 @@ export function AuthenticationProviderTest() {
 
       it('adds the access token to local storage', async done => {
         triggerAfterComponentsInitialization();
-        await Promise.resolve();
+
+        await Utils.resolveAfter(0);
 
         const token = localStorage.getItem(accessTokenStorageKey);
         expect(token).toBe(accessToken);
         done();
       });
 
+      it('sets the handshake-in-progress flag to false', async done => {
+        triggerAfterComponentsInitialization();
+
+        await Utils.resolveAfter(0);
+
+        expect(AuthenticationProvider.handshakeInProgress).toBe(false);
+        done();
+      });
+
+      it('it removes the handshake token from the url', async done => {
+        window.location.hash = `a=b&handshake_token=${handshakeToken}`;
+        triggerAfterComponentsInitialization();
+
+        await Utils.resolveAfter(0);
+
+        expect(window.location.hash).toBe(`#a=b`);
+        done();
+      });
+
+      it('when the hash starts with a /, it removes the handshake token from the url but keeps the slash', async done => {
+        window.location.hash = `/handshake_token=${handshakeToken}`;
+        triggerAfterComponentsInitialization();
+
+        await Utils.resolveAfter(0);
+
+        expect(window.location.hash).toBe(`#/`);
+        done();
+      });
+
+      it('when the handshake token is between two parameters, it removes the handshake token correctly', async done => {
+        window.location.hash = `/a=b&handshake_token=${handshakeToken}&c=d`;
+        triggerAfterComponentsInitialization();
+
+        await Utils.resolveAfter(0);
+
+        expect(window.location.hash).toBe(`#/a=b&c=d`);
+        done();
+      });
+
+      it('when the hash starts with a /, it removes the handshake token from the url but keeps the slash', async done => {
+        window.location.hash = `/a=b&handshake_token=${handshakeToken}`;
+        triggerAfterComponentsInitialization();
+
+        await Utils.resolveAfter(0);
+
+        expect(window.location.hash).toBe(`#/a=b`);
+        done();
+      });
+
       it('updates the endpoint to use the access token', async done => {
         const spy = spyOn(test.cmp.queryController.getEndpoint().accessToken, 'updateToken');
         triggerAfterComponentsInitialization();
-        await Promise.resolve();
+
+        await Utils.resolveAfter(0);
 
         expect(spy).toHaveBeenCalledWith(accessToken);
         done();
+      });
+    });
+
+    describe('url hash contains a handshake token, when the exchange throws an error', () => {
+      const errorMessage = 'unable to exchange token';
+      let exchangeTokenSpy: jasmine.Spy;
+
+      beforeEach(() => {
+        window.location.hash = `handshake_token=token`;
+
+        initAuthenticationProvider();
+        setupEndpoint();
+
+        exchangeTokenSpy = spyOn(test.cmp.queryController.getEndpoint(), 'exchangeHandshakeToken');
+        exchangeTokenSpy.and.returnValue(Promise.reject(errorMessage));
+      });
+
+      it(`it logs an error`, async done => {
+        const logggerSpy = spyOn(test.cmp.logger, 'error');
+        triggerAfterComponentsInitialization();
+
+        await Utils.resolveAfter(0);
+
+        expect(logggerSpy).toHaveBeenCalledWith(errorMessage);
+        done();
+      });
+
+      it('sets the handshake-in-progress flag to false', async done => {
+        triggerAfterComponentsInitialization();
+
+        await Utils.resolveAfter(0);
+
+        expect(AuthenticationProvider.handshakeInProgress).toBe(false);
+        done();
+      });
+    });
+
+    describe(`a handshake is in progress`, () => {
+      const accessToken = 'access-token';
+
+      beforeEach(() => {
+        AuthenticationProvider.handshakeInProgress = true;
+
+        initAuthenticationProvider();
+        setupEndpoint();
+      });
+
+      it('when the handshake completes, it loads the access token', async done => {
+        jasmine.clock().install();
+        const spy = spyOn(test.cmp.queryController.getEndpoint().accessToken, 'updateToken');
+        triggerAfterComponentsInitialization();
+
+        jasmine.clock().tick(500);
+
+        localStorage.setItem(accessTokenStorageKey, accessToken);
+        AuthenticationProvider.handshakeInProgress = false;
+
+        jasmine.clock().tick(100);
+        jasmine.clock().uninstall();
+
+        await Utils.resolveAfter(0);
+
+        expect(spy).toHaveBeenCalledWith(accessToken);
+        done();
+      });
+
+      it('adds an entry to the initialization args #defer array', () => {
+        triggerAfterComponentsInitialization();
+        expect(initializationArgs.defer.length).toBe(1);
+      });
+    });
+
+    describe('when encountering an invalid token error', () => {
+      let fakeWindow: Window;
+
+      function triggerInvalidTokenError() {
+        const error = { name: 'InvalidTokenException' };
+        $$(test.env.root).trigger(QueryEvents.queryError, { error });
+      }
+
+      function triggerExpiredTokenError() {
+        const error = { name: 'ExpiredTokenException' };
+        $$(test.env.root).trigger(QueryEvents.queryError, { error });
+      }
+
+      beforeEach(() => {
+        fakeWindow = Mock.mockWindow();
+        test.cmp._window = fakeWindow;
+      });
+
+      describe('if there is an invalid access token in storage', () => {
+        beforeEach(() => {
+          localStorage.setItem(accessTokenStorageKey, 'invalid token');
+          triggerInvalidTokenError();
+        });
+
+        it('clears the access token from localstorage', () => {
+          expect(localStorage.getItem(accessTokenStorageKey)).toBe(null);
+        });
+
+        it('reloads the page', () => {
+          expect(fakeWindow.location.reload).toHaveBeenCalledTimes(1);
+        });
+      });
+
+      it('if there is no access token in storage, it does not reload the page', () => {
+        triggerInvalidTokenError();
+        expect(fakeWindow.location.reload).not.toHaveBeenCalled();
+      });
+
+      it('if there is an expired access token is in storage, it clears the token', () => {
+        localStorage.setItem(accessTokenStorageKey, 'expired token');
+        triggerExpiredTokenError();
+
+        expect(localStorage.getItem(accessTokenStorageKey)).toBe(null);
       });
     });
 

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -121,6 +121,14 @@ export function AuthenticationProviderTest() {
         expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken, accessToken });
       });
 
+      it(`url hash starts with / followed by #handshake_token param,
+      it exchanges the token`, () => {
+        // Sharepoint adds a / betwe the # and the hash parameters.
+        window.location.hash = `/handshake_token=${handshakeToken}`;
+        triggerAfterComponentsInitialization();
+        expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken });
+      });
+
       it(`url hash contains multiple params including an #handshake_token param,
       it exchanges the token`, () => {
         window.location.hash = `a=b&handshake_token=${handshakeToken}`;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3265

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)