### PR TITLE
JSUI-3269 Remove token from storage if invalid

### DIFF
--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -340,8 +340,7 @@ export class SearchEndpoint implements ISearchEndpoint {
     callOptions?: IEndpointCallOptions,
     callParams?: IEndpointCallParameters
   ) {
-    const token = options.handshakeToken;
-    const call = this.buildCompleteCall({ token }, callOptions, callParams);
+    const call = this.buildCompleteCall(options, callOptions, callParams);
     const data = await this.performOneCall<{ token: string }>(call.params, call.options);
 
     if (!data.token) {

--- a/src/rest/SearchEndpoint.ts
+++ b/src/rest/SearchEndpoint.ts
@@ -340,7 +340,8 @@ export class SearchEndpoint implements ISearchEndpoint {
     callOptions?: IEndpointCallOptions,
     callParams?: IEndpointCallParameters
   ) {
-    const call = this.buildCompleteCall(options, callOptions, callParams);
+    const token = options.handshakeToken;
+    const call = this.buildCompleteCall({ token }, callOptions, callParams);
     const data = await this.performOneCall<{ token: string }>(call.params, call.options);
 
     if (!data.token) {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -239,7 +239,7 @@ export class AuthenticationProvider extends Component {
     const newHash = entries.filter(param => param !== handshakeEntry).join(delimiter);
     const adjustedHash = this.isSharepointHash ? `/${newHash}` : newHash;
 
-    window.history.replaceState(null, '', `#${adjustedHash}`);
+    this._window.history.replaceState(null, '', `#${adjustedHash}`);
   }
 
   private loadAccessTokenFromStorage() {
@@ -254,7 +254,7 @@ export class AuthenticationProvider extends Component {
   private handleQueryError(args: IQueryErrorEventArgs) {
     if (args.error.name === 'InvalidTokenException') {
       localStorage.removeItem(accessTokenStorageKey);
-      this.authenticateWithProvider();
+      this._window.location.reload();
       return;
     }
 

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -243,8 +243,12 @@ export class AuthenticationProvider extends Component {
   }
 
   private loadAccessTokenFromStorage() {
-    const token = localStorage.getItem(accessTokenStorageKey);
+    const token = this.getAccessTokenFromStorage();
     token && this.queryController.getEndpoint().accessToken.updateToken(token);
+  }
+
+  private getAccessTokenFromStorage() {
+    return localStorage.getItem(accessTokenStorageKey);
   }
 
   private handleBuildingCallOptions(args: IBuildingCallOptionsEventArgs) {
@@ -252,7 +256,9 @@ export class AuthenticationProvider extends Component {
   }
 
   private handleQueryError(args: IQueryErrorEventArgs) {
-    if (args.error.name === 'InvalidTokenException') {
+    const token = this.getAccessTokenFromStorage();
+
+    if (token && args.error.name === 'InvalidTokenException') {
       localStorage.removeItem(accessTokenStorageKey);
       this._window.location.reload();
       return;

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -257,8 +257,9 @@ export class AuthenticationProvider extends Component {
 
   private handleQueryError(args: IQueryErrorEventArgs) {
     const token = this.getAccessTokenFromStorage();
+    const shouldClearToken = this.shouldClearTokenFollowingErrorEvent(args);
 
-    if (token && args.error.name === 'InvalidTokenException') {
+    if (token && shouldClearToken) {
       localStorage.removeItem(accessTokenStorageKey);
       this._window.location.reload();
       return;
@@ -278,6 +279,11 @@ export class AuthenticationProvider extends Component {
       this.logger.error('The AuthenticationProvider is in a redirect loop. This may be due to a back-end configuration problem.');
       this.redirectCount = -1;
     }
+  }
+
+  private shouldClearTokenFollowingErrorEvent(args: IQueryErrorEventArgs) {
+    const error = args.error.name;
+    return error === 'InvalidTokenException' || error === 'ExpiredTokenException';
   }
 
   private authenticateWithProvider() {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -252,6 +252,12 @@ export class AuthenticationProvider extends Component {
   }
 
   private handleQueryError(args: IQueryErrorEventArgs) {
+    if (args.error.name === 'InvalidTokenException') {
+      localStorage.removeItem(accessTokenStorageKey);
+      this.authenticateWithProvider();
+      return;
+    }
+
     let missingAuthError = <MissingAuthenticationError>args.error;
 
     if (

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -200,7 +200,8 @@ export function mockWindow(): Window {
     href: '',
     hash: '',
     pathname: '',
-    search: ''
+    search: '',
+    reload: () => {}
   };
   mockWindow.location.assign = mockWindow.location.replace = (newHref: string) => {
     newHref = newHref || '';
@@ -220,6 +221,7 @@ export function mockWindow(): Window {
   };
   spyOn(mockWindow.location, 'replace').and.callThrough();
   spyOn(mockWindow.location, 'assign').and.callThrough();
+  spyOn(mockWindow.location, 'reload').and.callThrough();
   mockWindow.addEventListener = jasmine.createSpy('addEventListener');
   mockWindow.removeEventListener = jasmine.createSpy('removeEventListener');
   mockWindow.dispatchEvent = jasmine.createSpy('dispatchEvent');

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -347,12 +347,17 @@ export function AuthenticationProviderTest() {
         $$(test.env.root).trigger(QueryEvents.queryError, { error });
       }
 
+      function triggerExpiredTokenError() {
+        const error = { name: 'ExpiredTokenException' };
+        $$(test.env.root).trigger(QueryEvents.queryError, { error });
+      }
+
       beforeEach(() => {
         fakeWindow = Mock.mockWindow();
         test.cmp._window = fakeWindow;
       });
 
-      describe('if there is an access token in storage', () => {
+      describe('if there is an invalid access token in storage', () => {
         beforeEach(() => {
           localStorage.setItem(accessTokenStorageKey, 'invalid token');
           triggerInvalidTokenError();
@@ -370,6 +375,13 @@ export function AuthenticationProviderTest() {
       it('if there is no access token in storage, it does not reload the page', () => {
         triggerInvalidTokenError();
         expect(fakeWindow.location.reload).not.toHaveBeenCalled();
+      });
+
+      it('if there is an expired access token is in storage, it clears the token', () => {
+        localStorage.setItem(accessTokenStorageKey, 'expired token');
+        triggerExpiredTokenError();
+
+        expect(localStorage.getItem(accessTokenStorageKey)).toBe(null);
       });
     });
 

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -352,15 +352,24 @@ export function AuthenticationProviderTest() {
         test.cmp._window = fakeWindow;
       });
 
-      it('clears the access token from localstorage', () => {
-        localStorage.setItem(accessTokenStorageKey, 'invalid token');
-        triggerInvalidTokenError();
-        expect(localStorage.getItem(accessTokenStorageKey)).toBe(null);
+      describe('if there is an access token in storage', () => {
+        beforeEach(() => {
+          localStorage.setItem(accessTokenStorageKey, 'invalid token');
+          triggerInvalidTokenError();
+        });
+
+        it('clears the access token from localstorage', () => {
+          expect(localStorage.getItem(accessTokenStorageKey)).toBe(null);
+        });
+
+        it('reloads the page', () => {
+          expect(fakeWindow.location.reload).toHaveBeenCalledTimes(1);
+        });
       });
 
-      it('reloads the page', () => {
+      it('if there is no access token in storage, it does not reload the page', () => {
         triggerInvalidTokenError();
-        expect(fakeWindow.location.reload).toHaveBeenCalledTimes(1);
+        expect(fakeWindow.location.reload).not.toHaveBeenCalled();
       });
     });
 

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -340,10 +340,17 @@ export function AuthenticationProviderTest() {
     });
 
     describe('when encountering an invalid token error', () => {
+      let fakeWindow: Window;
+
       function triggerInvalidTokenError() {
         const error = { name: 'InvalidTokenException' };
         $$(test.env.root).trigger(QueryEvents.queryError, { error });
       }
+
+      beforeEach(() => {
+        fakeWindow = Mock.mockWindow();
+        test.cmp._window = fakeWindow;
+      });
 
       it('clears the access token from localstorage', () => {
         localStorage.setItem(accessTokenStorageKey, 'invalid token');
@@ -351,17 +358,9 @@ export function AuthenticationProviderTest() {
         expect(localStorage.getItem(accessTokenStorageKey)).toBe(null);
       });
 
-      it('redirects to the third party provider', () => {
-        options.useIFrame = false;
-        initAuthenticationProvider();
-
-        const fakeWindow = Mock.mockWindow();
-        test.cmp._window = fakeWindow;
-        test.env.searchEndpoint.getAuthenticationProviderUri = () => 'coveo.com';
-
+      it('reloads the page', () => {
         triggerInvalidTokenError();
-
-        expect(fakeWindow.location.href).toBe('coveo.com');
+        expect(fakeWindow.location.reload).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -339,6 +339,32 @@ export function AuthenticationProviderTest() {
       });
     });
 
+    describe('when encountering an invalid token error', () => {
+      function triggerInvalidTokenError() {
+        const error = { name: 'InvalidTokenException' };
+        $$(test.env.root).trigger(QueryEvents.queryError, { error });
+      }
+
+      it('clears the access token from localstorage', () => {
+        localStorage.setItem(accessTokenStorageKey, 'invalid token');
+        triggerInvalidTokenError();
+        expect(localStorage.getItem(accessTokenStorageKey)).toBe(null);
+      });
+
+      it('redirects to the third party provider', () => {
+        options.useIFrame = false;
+        initAuthenticationProvider();
+
+        const fakeWindow = Mock.mockWindow();
+        test.cmp._window = fakeWindow;
+        test.env.searchEndpoint.getAuthenticationProviderUri = () => 'coveo.com';
+
+        triggerInvalidTokenError();
+
+        expect(fakeWindow.location.href).toBe('coveo.com');
+      });
+    });
+
     describe('exposes options', function () {
       it('name should push name in buildingCallOptions', function () {
         options = { name: 'testpatate' };


### PR DESCRIPTION
If the token is invalid, users would need to manually clear localstorage to get the JSUI to redirect.

This PR clears the token. More work would be needed to auto redirect though because the starting api key is no longer in memory when the error is received (the bad request was made with the invalid token).

I could explore storing the key in state. Another option could be to just trigger a refresh using `window.location.reload`.


https://coveord.atlassian.net/browse/JSUI-3269





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)