### PR TITLE
JSUI-3265 Remove Sharepoint (actually Angular) work-around

### DIFF
--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -146,17 +146,17 @@ export class AuthenticationProvider extends Component {
   }
 
   private getHandshakeTokenFromUrl() {
-    const hash = this.getHashAfterAdjustingForSharepoint();
+    const hash = this.getHashAfterAdjustingForAngular();
     const token = HashUtils.getValue(handshakeTokenParamName, hash);
     return typeof token === 'string' ? token : '';
   }
 
-  private getHashAfterAdjustingForSharepoint() {
+  private getHashAfterAdjustingForAngular() {
     const hash = HashUtils.getHash();
-    return this.isSharepointHash ? `#${hash.slice(2)}` : hash;
+    return this.isAngularHash ? `#${hash.slice(2)}` : hash;
   }
 
-  private get isSharepointHash() {
+  private get isAngularHash() {
     const rawHash = HashUtils.getHash();
     return rawHash.indexOf('#/') === 0;
   }
@@ -231,13 +231,13 @@ export class AuthenticationProvider extends Component {
 
   private removeHandshakeTokenFromUrl() {
     const delimiter = `&`;
-    const hash = this.getHashAfterAdjustingForSharepoint();
+    const hash = this.getHashAfterAdjustingForAngular();
     const token = this.getHandshakeTokenFromUrl();
     const handshakeEntry = `${handshakeTokenParamName}=${token}`;
 
     const entries = hash.substr(1).split(delimiter);
     const newHash = entries.filter(param => param !== handshakeEntry).join(delimiter);
-    const adjustedHash = this.isSharepointHash ? `/${newHash}` : newHash;
+    const adjustedHash = this.isAngularHash ? `/${newHash}` : newHash;
 
     this._window.history.replaceState(null, '', `#${adjustedHash}`);
   }

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -130,7 +130,7 @@ export function AuthenticationProviderTest() {
 
       it(`url hash starts with / followed by #handshake_token param,
       it exchanges the token`, () => {
-        // Sharepoint adds a / between the # and the hash parameters.
+        // Angular by default adds a / between the hash and the hash parameters.
         window.location.hash = `/handshake_token=${handshakeToken}`;
         triggerAfterComponentsInitialization();
         expect(exchangeTokenSpy).toHaveBeenCalledWith({ handshakeToken });


### PR DESCRIPTION
I learned on Friday that the leading `/` was not introduced by Sharepoint, but rather the Angular framework being used to build the app. The Intuit team has fixed the behavior by setting an option on the framework.

In theory, this means we the work-around in the JSUI is no longer needed. This PR removes the lines.

Or do you prefer to keep the logic? If so, then I will rename Sharepoint to Angular for clarity,


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)