### PR TITLE
fix dependant facet flicker on no results

### DIFF
--- a/sass/DynamicFacet/_DynamicFacet.scss
+++ b/sass/DynamicFacet/_DynamicFacet.scss
@@ -6,6 +6,9 @@
   &.coveo-hidden {
     display: none;
   }
+  &.coveo-hidden-dependant-facet {
+    display: none;
+  }
 }
 
 .coveo-no-visible-facet {

--- a/sass/_CategoryFacet.scss
+++ b/sass/_CategoryFacet.scss
@@ -19,7 +19,8 @@
 }
 
 .CoveoCategoryFacet {
-  &.coveo-hidden {
+  &.coveo-hidden,
+  &.coveo-hidden-dependant-facet {
     display: none;
     &.coveo-with-placeholder {
       display: block;

--- a/sass/_Facet.scss
+++ b/sass/_Facet.scss
@@ -29,7 +29,8 @@
 }
 
 .coveo-facet-empty,
-.coveo-hidden {
+.coveo-hidden,
+.coveo-hidden-dependant-facet {
   display: none;
   &.coveo-with-placeholder {
     display: block;

--- a/src/utils/DependsOnManager.ts
+++ b/src/utils/DependsOnManager.ts
@@ -36,7 +36,7 @@ export class DependsOnManager {
   }
 
   private setupDependentFacet() {
-    $$(this.facet.ref.element).addClass('coveo-hidden');
+    $$(this.facet.ref.element).addClass('coveo-hidden-dependant-facet');
     this.parentFacetRef = this.getParentFacet(this.facet.ref);
 
     if (this.parentFacetRef) {
@@ -104,12 +104,12 @@ export class DependsOnManager {
     this.dependentFacets.forEach(dependentFacet => {
       const condition = this.getDependsOnCondition(dependentFacet);
       if (condition(this.facet.ref)) {
-        $$(dependentFacet.element).removeClass('coveo-hidden');
+        $$(dependentFacet.element).removeClass('coveo-hidden-dependant-facet');
         return dependentFacet.enable();
       }
 
       dependentFacet.disable();
-      $$(dependentFacet.element).addClass('coveo-hidden');
+      $$(dependentFacet.element).addClass('coveo-hidden-dependant-facet');
     });
   }
 

--- a/src/utils/Dom.ts
+++ b/src/utils/Dom.ts
@@ -240,6 +240,10 @@ export class Dom {
       return false;
     }
 
+    if (this.hasClass('coveo-hidden-dependant-facet')) {
+      return false;
+    }
+
     return true;
   }
 

--- a/unitTests/utils/DependsOnManagerTest.ts
+++ b/unitTests/utils/DependsOnManagerTest.ts
@@ -93,7 +93,7 @@ export function DependsOnManagerTest() {
 
       it('shows the facet', () => {
         const facet = $$(dependentMock.facet.ref.element);
-        expect(facet.hasClass('coveo-hidden')).toBe(false);
+        expect(facet.hasClass('coveo-hidden-dependant-facet')).toBe(false);
       });
     });
 
@@ -108,10 +108,10 @@ export function DependsOnManagerTest() {
 
       it('hides the facet', () => {
         const facet = $$(dependentMock.facet.ref.element);
-        facet.removeClass('coveo-hidden');
+        facet.removeClass('coveo-hidden-dependant-facet');
 
         $$(root).trigger(QueryEvents.buildingQuery);
-        expect(facet.hasClass('coveo-hidden')).toBe(true);
+        expect(facet.hasClass('coveo-hidden-dependant-facet')).toBe(true);
       });
     });
 
@@ -138,18 +138,18 @@ export function DependsOnManagerTest() {
 
       it('should hide the first facet', () => {
         const facet = $$(dependentMock.facet.ref.element);
-        facet.removeClass('coveo-hidden');
+        facet.removeClass('coveo-hidden-dependant-facet');
 
         $$(root).trigger(QueryEvents.buildingQuery);
-        expect(facet.hasClass('coveo-hidden')).toBe(true);
+        expect(facet.hasClass('coveo-hidden-dependant-facet')).toBe(true);
       });
 
       it('should hide the second facet', () => {
         const facet = $$(dependent2Mock.facet.ref.element);
-        facet.removeClass('coveo-hidden');
+        facet.removeClass('coveo-hidden-dependant-facet');
 
         $$(root).trigger(QueryEvents.buildingQuery);
-        expect(facet.hasClass('coveo-hidden')).toBe(true);
+        expect(facet.hasClass('coveo-hidden-dependant-facet')).toBe(true);
       });
     });
 
@@ -178,18 +178,18 @@ export function DependsOnManagerTest() {
 
       it('should show the first facet', () => {
         const facet = $$(dependentMock.facet.ref.element);
-        facet.addClass('coveo-hidden');
+        facet.addClass('coveo-hidden-dependant-facet');
 
         $$(root).trigger(QueryEvents.buildingQuery);
-        expect(facet.hasClass('coveo-hidden')).toBe(false);
+        expect(facet.hasClass('coveo-hidden-dependant-facet')).toBe(false);
       });
 
       it('should hide the second facet', () => {
         const facet = $$(dependent2Mock.facet.ref.element);
-        facet.removeClass('coveo-hidden');
+        facet.removeClass('coveo-hidden-dependant-facet');
 
         $$(root).trigger(QueryEvents.buildingQuery);
-        expect(facet.hasClass('coveo-hidden')).toBe(true);
+        expect(facet.hasClass('coveo-hidden-dependant-facet')).toBe(true);
       });
     });
 
@@ -218,18 +218,18 @@ export function DependsOnManagerTest() {
 
       it('should show the first facet', () => {
         const facet = $$(dependentMock.facet.ref.element);
-        facet.addClass('coveo-hidden');
+        facet.addClass('coveo-hidden-dependant-facet');
 
         $$(root).trigger(QueryEvents.buildingQuery);
-        expect(facet.hasClass('coveo-hidden')).toBe(false);
+        expect(facet.hasClass('coveo-hidden-dependant-facet')).toBe(false);
       });
 
       it('should show the second facet', () => {
         const facet = $$(dependent2Mock.facet.ref.element);
-        facet.addClass('coveo-hidden');
+        facet.addClass('coveo-hidden-dependant-facet');
 
         $$(root).trigger(QueryEvents.buildingQuery);
-        expect(facet.hasClass('coveo-hidden')).toBe(false);
+        expect(facet.hasClass('coveo-hidden-dependant-facet')).toBe(false);
       });
     });
 


### PR DESCRIPTION
The problem was related to using `coveo-hidden` inside dependant facet manager.

Since that is also used to control the visibility for dynamic facet on no results, we'd get a quick flicker when a dependant facet with no results was interacted with: 

* Shortly visible because DependsOnManager would remove `coveo-hidden` class.
* Then invisible because the facet itself would add back the class `coveo-hidden` because there's no result.


https://coveord.atlassian.net/browse/JSUI-3272





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)