### PR TITLE
JSUI-3275 Add SafeLocalStorage, replace direct calls to localStorage

### DIFF
--- a/src/controllers/LocalStorageHistoryController.ts
+++ b/src/controllers/LocalStorageHistoryController.ts
@@ -1,4 +1,4 @@
-import { LocalStorageUtils } from '../utils/LocalStorageUtils';
+import { localStorageExists, LocalStorageUtils } from '../utils/LocalStorageUtils';
 import { Model } from '../models/Model';
 import { QueryController } from './QueryController';
 import { Logger } from '../misc/Logger';
@@ -29,7 +29,7 @@ export class LocalStorageHistoryController extends RootComponent implements IHis
    */
   constructor(element: HTMLElement, public windoh: Window, public model: Model, public queryController: QueryController) {
     super(element, LocalStorageHistoryController.ID);
-    if (!windoh['localStorage']) {
+    if (!localStorageExists) {
       new Logger(element).info(
         'No local storage available in current browser. LocalStorageHistoryController cannot initialize itself',
         this

--- a/src/ui/Analytics/AnalyticsInformation.ts
+++ b/src/ui/Analytics/AnalyticsInformation.ts
@@ -2,20 +2,22 @@ import { findLastIndex } from 'underscore';
 import { LocalStorageUtils } from '../../Core';
 import { Cookie } from '../../utils/CookieUtils';
 import { buildHistoryStore } from '../../utils/HistoryStore';
+import { SafeLocalStorage } from '../../utils/LocalStorageUtils';
 
 export class AnalyticsInformation {
   private readonly visitorIdKey = 'visitorId';
   private readonly clientIdKey = 'clientId';
+  private readonly storage = new SafeLocalStorage();
 
   public get clientId() {
     // Yes, its backwards: We are using a key named "visitorId" to fetched something for "clientId"
     // This is done to synchronize with https://github.com/coveo/coveo.analytics.js
     // This is intentional.
-    return localStorage.getItem(this.visitorIdKey) || null;
+    return this.storage.getItem(this.visitorIdKey) || null;
   }
 
   public set clientId(id: string) {
-    localStorage.setItem(this.visitorIdKey, id);
+    this.storage.setItem(this.visitorIdKey, id);
   }
 
   public get lastPageId() {
@@ -42,7 +44,7 @@ export class AnalyticsInformation {
   }
 
   private clearLocalStorage() {
-    localStorage.removeItem(this.visitorIdKey);
+    this.storage.removeItem(this.visitorIdKey);
     new LocalStorageUtils(this.clientIdKey).remove();
   }
 

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -18,6 +18,7 @@ import 'styling/_AuthenticationProvider';
 import { SVGIcons } from '../../utils/SVGIcons';
 import { HashUtils } from '../../utils/HashUtils';
 import { QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
+import { SafeLocalStorage } from '../../utils/LocalStorageUtils';
 
 export const accessTokenStorageKey = 'coveo-auth-provider-access-token';
 const handshakeTokenParamName = 'handshake_token';
@@ -102,6 +103,7 @@ export class AuthenticationProvider extends Component {
 
   private handlers: ((...args: any[]) => void)[];
   private redirectCount: number;
+  private storage = new SafeLocalStorage();
 
   /**
    * Creates a new `AuthenticationProvider` component.
@@ -199,13 +201,13 @@ export class AuthenticationProvider extends Component {
   }
 
   private exchangeHandshakeToken(handshakeToken: string) {
-    const accessToken = localStorage.getItem(accessTokenStorageKey);
+    const accessToken = this.storage.getItem(accessTokenStorageKey);
     const options = accessToken ? { handshakeToken, accessToken } : { handshakeToken };
     return this.queryController.getEndpoint().exchangeHandshakeToken(options);
   }
 
   private storeAccessToken(accessToken: string) {
-    localStorage.setItem(accessTokenStorageKey, accessToken);
+    this.storage.setItem(accessTokenStorageKey, accessToken);
   }
 
   private waitForHandshakeToFinish() {
@@ -248,7 +250,7 @@ export class AuthenticationProvider extends Component {
   }
 
   private getAccessTokenFromStorage() {
-    return localStorage.getItem(accessTokenStorageKey);
+    return this.storage.getItem(accessTokenStorageKey);
   }
 
   private handleBuildingCallOptions(args: IBuildingCallOptionsEventArgs) {
@@ -260,7 +262,7 @@ export class AuthenticationProvider extends Component {
     const shouldClearToken = this.shouldClearTokenFollowingErrorEvent(args);
 
     if (token && shouldClearToken) {
-      localStorage.removeItem(accessTokenStorageKey);
+      this.storage.removeItem(accessTokenStorageKey);
       this._window.location.reload();
       return;
     }

--- a/src/ui/ResultsPreferences/ResultsPreferences.ts
+++ b/src/ui/ResultsPreferences/ResultsPreferences.ts
@@ -103,7 +103,6 @@ export class ResultsPreferences extends Component {
     this.preferencesPanel = $$(this.element).closest(Component.computeCssClassNameForType('PreferencesPanel'));
     this.preferencePanelLocalStorage = new StorageUtils(ResultsPreferences.ID);
     Assert.exists(this.componentOptionsModel);
-    Assert.exists(window.localStorage);
     Assert.exists(this.preferencesPanel);
 
     this.preferences = this.preferencePanelLocalStorage.load() || {};

--- a/src/utils/LocalStorageUtils.ts
+++ b/src/utils/LocalStorageUtils.ts
@@ -1,4 +1,4 @@
-var localStorage;
+var localStorage: Storage;
 
 // This check must be made in a try/catch. If cookies are disabled for a
 // browser then window.localStorage will throw an undefined exception.
@@ -7,6 +7,8 @@ try {
 } catch (error) {
   localStorage = null;
 }
+
+export const localStorageExists = !!localStorage;
 
 export class LocalStorageUtils<T> {
   constructor(public id: string) {}
@@ -47,5 +49,49 @@ export class LocalStorageUtils<T> {
 
   private getLocalStorageKey() {
     return 'coveo-' + this.id;
+  }
+}
+
+export class SafeLocalStorage implements Storage {
+  public getItem(key: string) {
+    try {
+      return localStorage.getItem(key);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  public removeItem(key: string) {
+    try {
+      localStorage.removeItem(key);
+    } catch (e) {}
+  }
+
+  public setItem(key: string, value: string) {
+    try {
+      localStorage.setItem(key, value);
+    } catch (e) {}
+  }
+
+  public clear() {
+    try {
+      localStorage.clear();
+    } catch (e) {}
+  }
+
+  public key(index: number) {
+    try {
+      return localStorage.key(index);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  get length() {
+    try {
+      return localStorage.length;
+    } catch (e) {
+      return 0;
+    }
   }
 }

--- a/src/utils/LocalStorageUtils.ts
+++ b/src/utils/LocalStorageUtils.ts
@@ -57,6 +57,8 @@ export class LocalStorageUtils<T> {
 }
 
 export class SafeLocalStorage implements Storage {
+  [key: string]: any;
+
   public getItem(key: string) {
     try {
       return localStorage.getItem(key);

--- a/src/utils/LocalStorageUtils.ts
+++ b/src/utils/LocalStorageUtils.ts
@@ -5,6 +5,10 @@ var localStorage: Storage;
 try {
   localStorage = window.localStorage;
 } catch (error) {
+  console.warn(
+    'Unable to access localStorage. Certain features like analytics will not work. If this is unintended, consider adjusting your browser settings to allow third-party cookies and data.\n\n',
+    error
+  );
   localStorage = null;
 }
 


### PR DESCRIPTION
If the JSUI is running in a third-party context, and access to third-party data is disabled, the JSUI crashes due to the browser throwing an error when it tries to access `localStorage`.

The issue was reported by someone using IPX in Chrome Incognito. Since the JSUI is inside an iframe, the browser considers this JSUI instance third-party. In incognito, third-party access to storage is blocked by default.

This PR adds `SafeLocalStorage` , and replaces direct calls to `localStorage`.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)