### PR TITLE
JSUI-3277 Prefix access token storage key with organization name

### DIFF
--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -211,7 +211,7 @@ export class AuthenticationProvider extends Component {
 
   private get accessTokenStorageKey() {
     const { organizationId } = this.queryController.getEndpoint().options.queryStringArguments;
-    return `${organizationId}-auth-provider-access-token`;
+    return `coveo-auth-provider-access-token-${organizationId}`;
   }
 
   private waitForHandshakeToFinish() {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -288,8 +288,9 @@ export class AuthenticationProvider extends Component {
   }
 
   private shouldClearTokenFollowingErrorEvent(args: IQueryErrorEventArgs) {
+    const exceptions = ['InvalidTokenException', 'ExpiredTokenException', 'InvalidAuthenticationProviderException'];
     const error = args.error.name;
-    return error === 'InvalidTokenException' || error === 'ExpiredTokenException';
+    return exceptions.indexOf(error) !== -1;
   }
 
   private authenticateWithProvider() {

--- a/src/ui/AuthenticationProvider/AuthenticationProvider.ts
+++ b/src/ui/AuthenticationProvider/AuthenticationProvider.ts
@@ -20,7 +20,6 @@ import { HashUtils } from '../../utils/HashUtils';
 import { QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
 import { SafeLocalStorage } from '../../utils/LocalStorageUtils';
 
-export const accessTokenStorageKey = 'coveo-auth-provider-access-token';
 const handshakeTokenParamName = 'handshake_token';
 
 export interface IAuthenticationProviderOptions {
@@ -201,13 +200,18 @@ export class AuthenticationProvider extends Component {
   }
 
   private exchangeHandshakeToken(handshakeToken: string) {
-    const accessToken = this.storage.getItem(accessTokenStorageKey);
+    const accessToken = this.getAccessTokenFromStorage();
     const options = accessToken ? { handshakeToken, accessToken } : { handshakeToken };
     return this.queryController.getEndpoint().exchangeHandshakeToken(options);
   }
 
   private storeAccessToken(accessToken: string) {
-    this.storage.setItem(accessTokenStorageKey, accessToken);
+    this.storage.setItem(this.accessTokenStorageKey, accessToken);
+  }
+
+  private get accessTokenStorageKey() {
+    const { organizationId } = this.queryController.getEndpoint().options.queryStringArguments;
+    return `${organizationId}-auth-provider-access-token`;
   }
 
   private waitForHandshakeToFinish() {
@@ -250,7 +254,7 @@ export class AuthenticationProvider extends Component {
   }
 
   private getAccessTokenFromStorage() {
-    return this.storage.getItem(accessTokenStorageKey);
+    return this.storage.getItem(this.accessTokenStorageKey);
   }
 
   private handleBuildingCallOptions(args: IBuildingCallOptionsEventArgs) {
@@ -262,7 +266,7 @@ export class AuthenticationProvider extends Component {
     const shouldClearToken = this.shouldClearTokenFollowingErrorEvent(args);
 
     if (token && shouldClearToken) {
-      this.storage.removeItem(accessTokenStorageKey);
+      this.storage.removeItem(this.accessTokenStorageKey);
       this._window.location.reload();
       return;
     }

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -1,5 +1,5 @@
 import * as Mock from '../MockEnvironment';
-import { AuthenticationProvider, accessTokenStorageKey } from '../../src/ui/AuthenticationProvider/AuthenticationProvider';
+import { AuthenticationProvider } from '../../src/ui/AuthenticationProvider/AuthenticationProvider';
 import { ModalBox } from '../../src/ExternalModulesShim';
 import { IAuthenticationProviderOptions } from '../../src/ui/AuthenticationProvider/AuthenticationProvider';
 import { IBuildingCallOptionsEventArgs } from '../../src/events/QueryEvents';
@@ -18,6 +18,8 @@ import { Utils } from '../../src/UtilsModules';
 
 export function AuthenticationProviderTest() {
   describe('AuthenticationProvider', function () {
+    const organizationId = 'testorganization';
+    const accessTokenStorageKey = `${organizationId}-auth-provider-access-token`;
     let initializationArgs: IInitializationEventArgs;
     let options: IAuthenticationProviderOptions;
     let test: Mock.IBasicComponentSetup<AuthenticationProvider>;
@@ -35,7 +37,10 @@ export function AuthenticationProviderTest() {
     }
 
     function setupEndpoint() {
-      const endpoint = new SearchEndpoint({ restUri: 'https://platform.cloud.coveo.com/rest/search' });
+      const endpoint = new SearchEndpoint({
+        restUri: 'https://platform.cloud.coveo.com/rest/search',
+        queryStringArguments: { organizationId }
+      });
       test.env.queryController.getEndpoint = () => endpoint;
     }
 
@@ -355,6 +360,7 @@ export function AuthenticationProviderTest() {
       beforeEach(() => {
         fakeWindow = Mock.mockWindow();
         test.cmp._window = fakeWindow;
+        setupEndpoint();
       });
 
       describe('if there is an invalid access token in storage', () => {

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -357,6 +357,11 @@ export function AuthenticationProviderTest() {
         $$(test.env.root).trigger(QueryEvents.queryError, { error });
       }
 
+      function triggerInvalidAuthenticationProviderError() {
+        const error = { name: 'InvalidAuthenticationProviderException' };
+        $$(test.env.root).trigger(QueryEvents.queryError, { error });
+      }
+
       beforeEach(() => {
         fakeWindow = Mock.mockWindow();
         test.cmp._window = fakeWindow;
@@ -386,6 +391,13 @@ export function AuthenticationProviderTest() {
       it('if there is an expired access token is in storage, it clears the token', () => {
         localStorage.setItem(accessTokenStorageKey, 'expired token');
         triggerExpiredTokenError();
+
+        expect(localStorage.getItem(accessTokenStorageKey)).toBe(null);
+      });
+
+      it('if there is a token with an invalid authentication provider in storage, it clears the token', () => {
+        localStorage.setItem(accessTokenStorageKey, 'token with invalid auth provider');
+        triggerInvalidAuthenticationProviderError();
 
         expect(localStorage.getItem(accessTokenStorageKey)).toBe(null);
       });

--- a/unitTests/ui/AuthenticationProviderTest.ts
+++ b/unitTests/ui/AuthenticationProviderTest.ts
@@ -19,7 +19,7 @@ import { Utils } from '../../src/UtilsModules';
 export function AuthenticationProviderTest() {
   describe('AuthenticationProvider', function () {
     const organizationId = 'testorganization';
-    const accessTokenStorageKey = `${organizationId}-auth-provider-access-token`;
+    const accessTokenStorageKey = `coveo-auth-provider-access-token-${organizationId}`;
     let initializationArgs: IInitializationEventArgs;
     let options: IAuthenticationProviderOptions;
     let test: Mock.IBasicComponentSetup<AuthenticationProvider>;


### PR DESCRIPTION
The Intuit team reported 401s when switching from the non-prod to the prod org. This happened because the JSUI was reading the non-prod access token from localstorage.

This PR suffixes the storage key with the organization, to support multiple orgs on the same domain.


https://coveord.atlassian.net/browse/JSUI-3277





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)