### PR TITLE
JSUI-3281 append /rest only if legacy endpoint

### DIFF
--- a/src/ui/Analytics/Analytics.ts
+++ b/src/ui/Analytics/Analytics.ts
@@ -114,8 +114,14 @@ export class Analytics extends Component {
           return AnalyticsEndpoint.getURLFromSearchEndpoint(SearchEndpoint.defaultEndpoint);
         }
 
-        const [basePlatform] = value.split('/rest');
-        return basePlatform + '/rest';
+        const isLegacy = value.indexOf('usageanalytics') !== -1;
+
+        if (isLegacy) {
+          const [basePlatform] = value.split('/rest');
+          return basePlatform + '/rest';
+        }
+
+        return value;
       }
     }),
 

--- a/unitTests/ui/AnalyticsTest.ts
+++ b/unitTests/ui/AnalyticsTest.ts
@@ -318,13 +318,11 @@ export function AnalyticsTest() {
 
         it(`when a legacy usage analytics endpoint is defined that does not end with /rest,
         it ensures the endpoint ends with /rest`, () => {
-          const endpoints = ['https://usageanalytics.coveo.com', 'https://usageanalyticshipaa.cloud.coveo.com'];
+          const endpoint = 'https://usageanalyticshipaa.cloud.coveo.com';
 
-          endpoints.forEach(endpoint => {
-            options = { endpoint };
-            initAnalytics();
-            expect(test.cmp.options.endpoint).toBe(`${endpoint}/rest`);
-          });
+          options = { endpoint };
+          initAnalytics();
+          expect(test.cmp.options.endpoint).toBe(`${endpoint}/rest`);
         });
 
         it(`when a non-legacy endpoint is defined (i.e. not usageanalytics), it is not modified`, () => {

--- a/unitTests/ui/AnalyticsTest.ts
+++ b/unitTests/ui/AnalyticsTest.ts
@@ -316,13 +316,23 @@ export function AnalyticsTest() {
           expect(analyticsClient().endpoint.endpointCaller.options.accessToken).toBe('qwerty123');
         });
 
-        it(`when an endpoint is defined that does not end with /rest,
+        it(`when a legacy usage analytics endpoint is defined that does not end with /rest,
         it ensures the endpoint ends with /rest`, () => {
-          const endpoint = 'https://usageanalyticshipaa.cloud.coveo.com';
+          const endpoints = ['https://usageanalytics.coveo.com', 'https://usageanalyticshipaa.cloud.coveo.com'];
+
+          endpoints.forEach(endpoint => {
+            options = { endpoint };
+            initAnalytics();
+            expect(test.cmp.options.endpoint).toBe(`${endpoint}/rest`);
+          });
+        });
+
+        it(`when a non-legacy endpoint is defined (i.e. not usageanalytics), it is not modified`, () => {
+          const endpoint = 'https://platformhipaa.cloud.coveo.com/rest/ua';
           options = { endpoint };
           initAnalytics();
 
-          expect(test.cmp.options.endpoint).toBe(`${endpoint}/rest`);
+          expect(test.cmp.options.endpoint).toBe(endpoint);
         });
 
         it(`when an endpoint is defined that ends with /rest,


### PR DESCRIPTION
There is some history behind this issue:

- Initially, [this PR](https://github.com/coveo/search-ui/pull/1458) transitioned the JSUI to default to using the new UA endpoint.
- This was a breaking change for people upgrading, who were specifying the old UA endpoint. This [was fixed here](https://github.com/coveo/search-ui/pull/1507).
- However, the fix introduced a bug. It assumed manually specified endpoints were pointing to the legacy hipaa endpoint (`https://usageanalyticshipaa.cloud.coveo.com`), but some clients were using it to point to the new hipaa endpoint (`https://platformhipaa.cloud.coveo.com/rest/ua`). The changes would strip `/ua`.

This PR only appends `/rest` if a legacy endpoint is detected. Otherwise, it leaves it intact,

https://coveord.atlassian.net/browse/JSUI-3281





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)