### PR TITLE
JSUI-3279 when a value is only partially encoded, decode before encoding

### DIFF
--- a/src/utils/UrlUtils.ts
+++ b/src/utils/UrlUtils.ts
@@ -110,11 +110,8 @@ export class UrlUtils {
           }
         }
 
-        if (!this.isEncoded(value)) {
-          return [this.removeProblematicChars(key), Utils.safeEncodeURIComponent(value)].join('=');
-        } else {
-          return [this.removeProblematicChars(key), value].join('=');
-        }
+        const decodedValue = decodeURIComponent(value);
+        return [this.removeProblematicChars(key), Utils.safeEncodeURIComponent(decodedValue)].join('=');
       });
       queryNormalized = queryNormalized.concat(mapped);
     }

--- a/src/utils/UrlUtils.ts
+++ b/src/utils/UrlUtils.ts
@@ -110,8 +110,7 @@ export class UrlUtils {
           }
         }
 
-        const decodedValue = decodeURIComponent(value);
-        return [this.removeProblematicChars(key), Utils.safeEncodeURIComponent(decodedValue)].join('=');
+        return [this.removeProblematicChars(key), this.decodeThenEncode(value)].join('=');
       });
       queryNormalized = queryNormalized.concat(mapped);
     }
@@ -170,9 +169,7 @@ export class UrlUtils {
     }
 
     key = this.removeProblematicChars(key);
-    if (!this.isEncoded(value)) {
-      value = Utils.safeEncodeURIComponent(value);
-    }
+    value = this.decodeThenEncode(value);
 
     return `${key}=${value}`;
   }
@@ -186,8 +183,9 @@ export class UrlUtils {
     return value;
   }
 
-  private static isEncoded(value: string) {
-    return value != decodeURIComponent(value);
+  private static decodeThenEncode(value: string) {
+    const decoded = decodeURIComponent(value);
+    return Utils.safeEncodeURIComponent(decoded);
   }
 
   private static isInvalidQueryStringValue(value: any) {

--- a/unitTests/utils/UrlUtilsTest.ts
+++ b/unitTests/utils/UrlUtilsTest.ts
@@ -131,6 +131,15 @@ export function UrlUtilsTest() {
       expect(url).toBe(`https://a.com?123=4${Utils.safeEncodeURIComponent(' ')}56&abc=${Utils.safeEncodeURIComponent('&')}def`);
     });
 
+    it(`when a query record value contains both encoded and unencoded characters, it encodes all characters once`, () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        query: { redirectUri: 'https://b.com/#q=hello%20world' }
+      });
+
+      expect(url).toBe(`https://a.com?redirectUri=https%3A%2F%2Fb.com%2F%23q%3Dhello%20world`);
+    });
+
     it('should remove query string parameter that are an empty string', () => {
       const url = UrlUtils.normalizeAsString({
         paths: ['https://a.com/'],

--- a/unitTests/utils/UrlUtilsTest.ts
+++ b/unitTests/utils/UrlUtilsTest.ts
@@ -131,13 +131,24 @@ export function UrlUtilsTest() {
       expect(url).toBe(`https://a.com?123=4${Utils.safeEncodeURIComponent(' ')}56&abc=${Utils.safeEncodeURIComponent('&')}def`);
     });
 
-    it(`when a query record value contains both encoded and unencoded characters, it encodes all characters once`, () => {
+    it(`when a query record value contains both encoded and unencoded characters,
+    it encodes all characters once`, () => {
       const url = UrlUtils.normalizeAsString({
         paths: ['https://a.com/'],
         query: { redirectUri: 'https://b.com/#q=hello%20world' }
       });
 
       expect(url).toBe(`https://a.com?redirectUri=https%3A%2F%2Fb.com%2F%23q%3Dhello%20world`);
+    });
+
+    it(`when a query string parameter contains both encoded and unencoded characters,
+    it encodes all characters once`, () => {
+      const url = UrlUtils.normalizeAsString({
+        paths: ['https://a.com/'],
+        queryAsString: ['q=/hello%20world']
+      });
+
+      expect(url).toBe('https://a.com?q=%2Fhello%20world');
     });
 
     it('should remove query string parameter that are an empty string', () => {


### PR DESCRIPTION
When a value is partially encoded, it would not be encoded to avoid double encoding.
However, this created a bug when a value was only partially encoded.

Given a SAML redirect url:

```
https://site.com/?q=hello%20world#t=All
```

The `#` would not be encoded. Query string params after the hash would not be sent to the server, causing the login request to fail.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)