### PR TITLE
JSUI-3283 Smart snippet without iframe

### DIFF
--- a/src/misc/AttachShadowPolyfill.ts
+++ b/src/misc/AttachShadowPolyfill.ts
@@ -24,6 +24,21 @@ export async function attachShadow(element: HTMLElement, options: IShadowOptions
   return shadowRoot;
 }
 
+export async function attachWithoutShadow(element: HTMLElement, options: IShadowOptions & ShadowRootInit): Promise<HTMLElement> {
+  const container = $$('div', { className: 'coveo-shadow-iframe', scrolling: 'no', title: options.title }).el as HTMLElement;
+  element.appendChild(container);
+
+  container.style.margin = '0';
+  const shadowRoot = $$('div', { style: 'overflow: auto;' }).el;
+  container.appendChild(shadowRoot);
+  autoUpdateHeight(container, shadowRoot, options.onSizeChanged);
+  if (options.mode === 'open') {
+    Object.defineProperty(element, 'shadowRoot', { get: () => shadowRoot });
+  }
+
+  return shadowRoot;
+}
+
 function autoUpdateHeight(elementToResize: HTMLElement, content: HTMLElement, onUpdate?: Function) {
   let lastWidth = content.clientWidth;
   let lastHeight = content.clientHeight;

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -18,7 +18,7 @@ import {
 import { HeightLimiter } from './HeightLimiter';
 import { ExplanationModal, IReason } from './ExplanationModal';
 import { l } from '../../strings/Strings';
-import { attachShadow, attachWithoutShadow } from '../../misc/AttachShadowPolyfill';
+import { attachShadow } from '../../misc/AttachShadowPolyfill';
 import { Utils } from '../../utils/Utils';
 import { ComponentOptions } from '../Base/ComponentOptions';
 import { getDefaultSnippetStyle } from './SmartSnippetCommon';
@@ -76,7 +76,7 @@ export interface ISmartSnippetOptions {
   maximumSnippetHeight: number;
   titleField: IFieldOption;
   hrefTemplate?: string;
-  withoutFrame?: boolean;
+  useIFrame?: boolean;
 }
 /**
  * The SmartSnippet component displays the excerpt of a document that would be most likely to answer a particular query.
@@ -145,8 +145,9 @@ export class SmartSnippet extends Component {
      *
      * ```html
      * <div class='CoveoSmartSnippet' data-without-frame='true'></div>
+     * ```
      */
-    withoutFrame: ComponentOptions.buildBooleanOption({ defaultValue: false })
+    useIFrame: ComponentOptions.buildBooleanOption({ defaultValue: true })
   };
 
   private lastRenderedResult: IQueryResult = null;
@@ -230,11 +231,11 @@ export class SmartSnippet extends Component {
   private buildShadow() {
     this.shadowContainer = $$('div', { className: SHADOW_CLASSNAME }).el;
     this.snippetContainer = $$('section', { className: CONTENT_CLASSNAME }).el;
-    const attachShadowPromise = this.options.withoutFrame ? attachWithoutShadow : attachShadow;
-    this.shadowLoading = attachShadowPromise(this.shadowContainer, {
+    this.shadowLoading = attachShadow(this.shadowContainer, {
       mode: 'open',
       title: l('AnswerSnippet'),
-      onSizeChanged: () => this.handleAnswerSizeChanged()
+      onSizeChanged: () => this.handleAnswerSizeChanged(),
+      useIFrame: this.options.useIFrame
     }).then(shadow => {
       shadow.appendChild(this.snippetContainer);
       const style = this.buildStyle();

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -18,7 +18,7 @@ import {
 import { HeightLimiter } from './HeightLimiter';
 import { ExplanationModal, IReason } from './ExplanationModal';
 import { l } from '../../strings/Strings';
-import { attachShadow } from '../../misc/AttachShadowPolyfill';
+import { attachShadow, attachWithoutShadow } from '../../misc/AttachShadowPolyfill';
 import { Utils } from '../../utils/Utils';
 import { ComponentOptions } from '../Base/ComponentOptions';
 import { getDefaultSnippetStyle } from './SmartSnippetCommon';
@@ -76,6 +76,7 @@ export interface ISmartSnippetOptions {
   maximumSnippetHeight: number;
   titleField: IFieldOption;
   hrefTemplate?: string;
+  withoutShadow?: boolean;
 }
 /**
  * The SmartSnippet component displays the excerpt of a document that would be most likely to answer a particular query.
@@ -133,7 +134,19 @@ export class SmartSnippet extends Component {
      *
      * Default value is `undefined`.
      */
-    hrefTemplate: ComponentOptions.buildStringOption()
+    hrefTemplate: ComponentOptions.buildStringOption(),
+
+    /**
+     * Specify if the SmartSnippet should be displayed inside an iframe or not.
+     *
+     * Use this option in specific cases where your environment has limitations around iframe usage.
+     *
+     * **Examples:**
+     *
+     * ```html
+     * <div class='CoveoSmartSnippet' data-without-shadow='true'></div>
+     */
+    withoutShadow: ComponentOptions.buildBooleanOption({ defaultValue: false })
   };
 
   private lastRenderedResult: IQueryResult = null;
@@ -217,7 +230,8 @@ export class SmartSnippet extends Component {
   private buildShadow() {
     this.shadowContainer = $$('div', { className: SHADOW_CLASSNAME }).el;
     this.snippetContainer = $$('section', { className: CONTENT_CLASSNAME }).el;
-    this.shadowLoading = attachShadow(this.shadowContainer, {
+    const attachShadowPromise = this.options.withoutShadow ? attachWithoutShadow : attachShadow;
+    this.shadowLoading = attachShadowPromise(this.shadowContainer, {
       mode: 'open',
       title: l('AnswerSnippet'),
       onSizeChanged: () => this.handleAnswerSizeChanged()

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -76,7 +76,7 @@ export interface ISmartSnippetOptions {
   maximumSnippetHeight: number;
   titleField: IFieldOption;
   hrefTemplate?: string;
-  withoutShadow?: boolean;
+  withoutFrame?: boolean;
 }
 /**
  * The SmartSnippet component displays the excerpt of a document that would be most likely to answer a particular query.
@@ -144,9 +144,9 @@ export class SmartSnippet extends Component {
      * **Examples:**
      *
      * ```html
-     * <div class='CoveoSmartSnippet' data-without-shadow='true'></div>
+     * <div class='CoveoSmartSnippet' data-without-frame='true'></div>
      */
-    withoutShadow: ComponentOptions.buildBooleanOption({ defaultValue: false })
+    withoutFrame: ComponentOptions.buildBooleanOption({ defaultValue: false })
   };
 
   private lastRenderedResult: IQueryResult = null;
@@ -230,7 +230,7 @@ export class SmartSnippet extends Component {
   private buildShadow() {
     this.shadowContainer = $$('div', { className: SHADOW_CLASSNAME }).el;
     this.snippetContainer = $$('section', { className: CONTENT_CLASSNAME }).el;
-    const attachShadowPromise = this.options.withoutShadow ? attachWithoutShadow : attachShadow;
+    const attachShadowPromise = this.options.withoutFrame ? attachWithoutShadow : attachShadow;
     this.shadowLoading = attachShadowPromise(this.shadowContainer, {
       mode: 'open',
       title: l('AnswerSnippet'),

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -2,7 +2,7 @@ import { IRelatedQuestionAnswerResponse } from '../../rest/QuestionAnswerRespons
 import { uniqueId } from 'underscore';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import { SVGIcons } from '../../utils/SVGIcons';
-import { attachShadow, attachWithoutShadow } from '../../misc/AttachShadowPolyfill';
+import { attachShadow } from '../../misc/AttachShadowPolyfill';
 import { $$, Dom } from '../../utils/Dom';
 import { l } from '../../strings/Strings';
 import { IQueryResult } from '../../rest/QueryResult';
@@ -54,7 +54,7 @@ export class SmartSnippetCollapsibleSuggestion {
     private readonly innerCSS: string,
     private readonly searchUid: string,
     private readonly source?: IQueryResult,
-    private readonly withoutFrame?: boolean
+    private readonly useIFrame?: boolean
   ) {}
 
   public get loading() {
@@ -115,12 +115,13 @@ export class SmartSnippetCollapsibleSuggestion {
     const shadowContainer = $$('div', { className: SHADOW_CLASSNAME });
     this.snippetAndSourceContainer = $$('div', { className: QUESTION_SNIPPET_CONTAINER_CLASSNAME }, shadowContainer);
     this.collapsibleContainer = $$('div', { className: QUESTION_SNIPPET_CLASSNAME, id: this.snippetId }, this.snippetAndSourceContainer);
-    const attachShadowPromise = this.withoutFrame ? attachWithoutShadow : attachShadow;
-    this.contentLoaded = attachShadowPromise(shadowContainer.el, { mode: 'open', title: l('AnswerSpecificSnippet', title) }).then(
-      shadowRoot => {
-        shadowRoot.appendChild(this.buildAnswerSnippetContent(innerHTML, style).el);
-      }
-    );
+    this.contentLoaded = attachShadow(shadowContainer.el, {
+      mode: 'open',
+      title: l('AnswerSpecificSnippet', title),
+      useIFrame: this.useIFrame
+    }).then(shadowRoot => {
+      shadowRoot.appendChild(this.buildAnswerSnippetContent(innerHTML, style).el);
+    });
     if (this.source) {
       this.snippetAndSourceContainer.append(this.buildSourceUrl());
       this.snippetAndSourceContainer.append(this.buildSourceTitle());

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -2,7 +2,7 @@ import { IRelatedQuestionAnswerResponse } from '../../rest/QuestionAnswerRespons
 import { uniqueId } from 'underscore';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import { SVGIcons } from '../../utils/SVGIcons';
-import { attachShadow } from '../../misc/AttachShadowPolyfill';
+import { attachShadow, attachWithoutShadow } from '../../misc/AttachShadowPolyfill';
 import { $$, Dom } from '../../utils/Dom';
 import { l } from '../../strings/Strings';
 import { IQueryResult } from '../../rest/QueryResult';
@@ -53,7 +53,8 @@ export class SmartSnippetCollapsibleSuggestion {
     private readonly bindings: IComponentBindings,
     private readonly innerCSS: string,
     private readonly searchUid: string,
-    private readonly source?: IQueryResult
+    private readonly source?: IQueryResult,
+    private readonly withoutShadow?: boolean
   ) {}
 
   public get loading() {
@@ -114,9 +115,12 @@ export class SmartSnippetCollapsibleSuggestion {
     const shadowContainer = $$('div', { className: SHADOW_CLASSNAME });
     this.snippetAndSourceContainer = $$('div', { className: QUESTION_SNIPPET_CONTAINER_CLASSNAME }, shadowContainer);
     this.collapsibleContainer = $$('div', { className: QUESTION_SNIPPET_CLASSNAME, id: this.snippetId }, this.snippetAndSourceContainer);
-    this.contentLoaded = attachShadow(shadowContainer.el, { mode: 'open', title: l('AnswerSpecificSnippet', title) }).then(shadowRoot => {
-      shadowRoot.appendChild(this.buildAnswerSnippetContent(innerHTML, style).el);
-    });
+    const attachShadowPromise = this.withoutShadow ? attachWithoutShadow : attachShadow;
+    this.contentLoaded = attachShadowPromise(shadowContainer.el, { mode: 'open', title: l('AnswerSpecificSnippet', title) }).then(
+      shadowRoot => {
+        shadowRoot.appendChild(this.buildAnswerSnippetContent(innerHTML, style).el);
+      }
+    );
     if (this.source) {
       this.snippetAndSourceContainer.append(this.buildSourceUrl());
       this.snippetAndSourceContainer.append(this.buildSourceTitle());

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -54,7 +54,7 @@ export class SmartSnippetCollapsibleSuggestion {
     private readonly innerCSS: string,
     private readonly searchUid: string,
     private readonly source?: IQueryResult,
-    private readonly withoutShadow?: boolean
+    private readonly withoutFrame?: boolean
   ) {}
 
   public get loading() {
@@ -115,7 +115,7 @@ export class SmartSnippetCollapsibleSuggestion {
     const shadowContainer = $$('div', { className: SHADOW_CLASSNAME });
     this.snippetAndSourceContainer = $$('div', { className: QUESTION_SNIPPET_CONTAINER_CLASSNAME }, shadowContainer);
     this.collapsibleContainer = $$('div', { className: QUESTION_SNIPPET_CLASSNAME, id: this.snippetId }, this.snippetAndSourceContainer);
-    const attachShadowPromise = this.withoutShadow ? attachWithoutShadow : attachShadow;
+    const attachShadowPromise = this.withoutFrame ? attachWithoutShadow : attachShadow;
     this.contentLoaded = attachShadowPromise(shadowContainer.el, { mode: 'open', title: l('AnswerSpecificSnippet', title) }).then(
       shadowRoot => {
         shadowRoot.appendChild(this.buildAnswerSnippetContent(innerHTML, style).el);

--- a/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
+++ b/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
@@ -25,7 +25,7 @@ export const SmartSnippetSuggestionsClassNames = {
 };
 
 export interface ISmartSnippetSuggestionsOptions {
-  withoutFrame?: boolean;
+  useIFrame?: boolean;
 }
 
 /**
@@ -54,8 +54,9 @@ export class SmartSnippetSuggestions extends Component {
      *
      * ```html
      * <div class='CoveoSmartSnippetSuggestions' data-without-shadow='true'></div>
+     * ```
      */
-    withoutFrame: ComponentOptions.buildBooleanOption({ defaultValue: false })
+    useIFrame: ComponentOptions.buildBooleanOption({ defaultValue: true })
   };
 
   private readonly titleId = uniqueId(QUESTIONS_LIST_TITLE_CLASSNAME);
@@ -125,7 +126,7 @@ export class SmartSnippetSuggestions extends Component {
             : innerCSS,
           this.searchUid,
           this.getCorrespondingResult(questionAnswer),
-          this.options.withoutFrame
+          this.options.useIFrame
         )
     );
     const container = $$(

--- a/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
+++ b/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
@@ -25,7 +25,7 @@ export const SmartSnippetSuggestionsClassNames = {
 };
 
 export interface ISmartSnippetSuggestionsOptions {
-  withoutShadow?: boolean;
+  withoutFrame?: boolean;
 }
 
 /**
@@ -55,7 +55,7 @@ export class SmartSnippetSuggestions extends Component {
      * ```html
      * <div class='CoveoSmartSnippetSuggestions' data-without-shadow='true'></div>
      */
-    withoutShadow: ComponentOptions.buildBooleanOption({ defaultValue: false })
+    withoutFrame: ComponentOptions.buildBooleanOption({ defaultValue: false })
   };
 
   private readonly titleId = uniqueId(QUESTIONS_LIST_TITLE_CLASSNAME);
@@ -125,7 +125,7 @@ export class SmartSnippetSuggestions extends Component {
             : innerCSS,
           this.searchUid,
           this.getCorrespondingResult(questionAnswer),
-          this.options.withoutShadow
+          this.options.withoutFrame
         )
     );
     const container = $$(

--- a/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
+++ b/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
@@ -11,6 +11,7 @@ import { l } from '../../strings/Strings';
 import { Initialization } from '../Base/Initialization';
 import { Utils } from '../../utils/Utils';
 import { getDefaultSnippetStyle } from './SmartSnippetCommon';
+import { ComponentOptions } from '../Base/ComponentOptions';
 
 const BASE_CLASSNAME = 'coveo-smart-snippet-suggestions';
 const HAS_QUESTIONS_CLASSNAME = `${BASE_CLASSNAME}-has-questions`;
@@ -22,6 +23,10 @@ export const SmartSnippetSuggestionsClassNames = {
   QUESTIONS_LIST_CLASSNAME,
   QUESTIONS_LIST_TITLE_CLASSNAME
 };
+
+export interface ISmartSnippetSuggestionsOptions {
+  withoutShadow?: boolean;
+}
 
 /**
  * The SmartSnippetSuggestions component displays additional queries for which a Coveo Smart Snippets model can provide relevant excerpts.
@@ -35,6 +40,24 @@ export class SmartSnippetSuggestions extends Component {
     });
   };
 
+  /**
+   * The options for the SmartSnippetSuggestions
+   * @componentOptions
+   */
+  static options: ISmartSnippetSuggestionsOptions = {
+    /**
+     * Specify if the SmartSnippetSuggestion snippet should be displayed inside an iframe or not.
+     *
+     * Use this option in specific cases where your environment has limitations around iframe usage.
+     *
+     * **Examples:**
+     *
+     * ```html
+     * <div class='CoveoSmartSnippetSuggestions' data-without-shadow='true'></div>
+     */
+    withoutShadow: ComponentOptions.buildBooleanOption({ defaultValue: false })
+  };
+
   private readonly titleId = uniqueId(QUESTIONS_LIST_TITLE_CLASSNAME);
   private contentLoaded: Promise<SmartSnippetCollapsibleSuggestion[]>;
   private title: Dom;
@@ -42,8 +65,9 @@ export class SmartSnippetSuggestions extends Component {
   private renderedQuestionAnswer: IQuestionAnswerResponse;
   private searchUid: string;
 
-  constructor(public element: HTMLElement, public options?: {}, bindings?: IComponentBindings) {
+  constructor(public element: HTMLElement, public options?: ISmartSnippetSuggestionsOptions, bindings?: IComponentBindings) {
     super(element, SmartSnippetSuggestions.ID, bindings);
+    this.options = ComponentOptions.initComponentOptions(element, SmartSnippetSuggestions, options);
     this.bind.onRootElement(QueryEvents.deferredQuerySuccess, (data: IQuerySuccessEventArgs) => this.handleQuerySuccess(data));
   }
 
@@ -100,7 +124,8 @@ export class SmartSnippetSuggestions extends Component {
             ? getDefaultSnippetStyle(SmartSnippetCollapsibleSuggestionClassNames.RAW_CONTENT_CLASSNAME)
             : innerCSS,
           this.searchUid,
-          this.getCorrespondingResult(questionAnswer)
+          this.getCorrespondingResult(questionAnswer),
+          this.options.withoutShadow
         )
     );
     const container = $$(

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -366,15 +366,15 @@ export function SmartSnippetSuggestionsTest() {
       });
     });
 
-    describe('with the withoutFrame option', () => {
+    describe('with the useIFrame option', () => {
       afterEach(() => {
         test.env.root.remove();
       });
 
-      it('renders a div instead of an iframe when the option is true', async done => {
+      it('renders a div instead of an iframe when the option is false', async done => {
         const IFRAME_CLASSNAME = 'coveo-shadow-iframe';
         instantiateSmartSnippetSuggestions(null, {
-          withoutFrame: true
+          useIFrame: false
         });
         document.body.appendChild(test.env.root);
         await triggerQuestionAnswerQuery(true);
@@ -384,9 +384,7 @@ export function SmartSnippetSuggestionsTest() {
 
       it('renders an iframe by default', async done => {
         const IFRAME_CLASSNAME = 'coveo-shadow-iframe';
-        instantiateSmartSnippetSuggestions(null, {
-          withoutFrame: false
-        });
+        instantiateSmartSnippetSuggestions(null);
         document.body.appendChild(test.env.root);
         await triggerQuestionAnswerQuery(true);
         expect(test.cmp.element.querySelector(`.${IFRAME_CLASSNAME}`).nodeName).toEqual('IFRAME');

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -1,7 +1,11 @@
 import { IQuerySuccessEventArgs, QueryEvents } from '../../src/events/QueryEvents';
 import { IQueryResult } from '../../src/rest/QueryResult';
 import { IQuestionAnswerResponse, IRelatedQuestionAnswerResponse } from '../../src/rest/QuestionAnswerResponse';
-import { SmartSnippetSuggestions, SmartSnippetSuggestionsClassNames } from '../../src/ui/SmartSnippet/SmartSnippetSuggestions';
+import {
+  ISmartSnippetSuggestionsOptions,
+  SmartSnippetSuggestions,
+  SmartSnippetSuggestionsClassNames
+} from '../../src/ui/SmartSnippet/SmartSnippetSuggestions';
 import { advancedComponentSetup, AdvancedComponentSetupOptions, IBasicComponentSetup } from '../MockEnvironment';
 import { SmartSnippetCollapsibleSuggestionClassNames } from '../../src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion';
 import { $$ } from '../../src/utils/Dom';
@@ -117,10 +121,10 @@ export function SmartSnippetSuggestionsTest() {
     let test: IBasicComponentSetup<SmartSnippetSuggestions>;
     let searchUid: string;
 
-    function instantiateSmartSnippetSuggestions(styling: string) {
+    function instantiateSmartSnippetSuggestions(styling: string, options: Partial<ISmartSnippetSuggestionsOptions> = {}) {
       test = advancedComponentSetup<SmartSnippetSuggestions>(
         SmartSnippetSuggestions,
-        new AdvancedComponentSetupOptions($$('div', {}, ...(Utils.isNullOrUndefined(styling) ? [] : [mockStyling(styling)])).el)
+        new AdvancedComponentSetupOptions($$('div', {}, ...(Utils.isNullOrUndefined(styling) ? [] : [mockStyling(styling)])).el, options)
       );
     }
 
@@ -359,6 +363,34 @@ export function SmartSnippetSuggestionsTest() {
             });
           });
         });
+      });
+    });
+
+    describe('with the withoutFrame option', () => {
+      afterEach(() => {
+        test.env.root.remove();
+      });
+
+      it('renders a div instead of an iframe when the option is true', async done => {
+        const IFRAME_CLASSNAME = 'coveo-shadow-iframe';
+        instantiateSmartSnippetSuggestions(null, {
+          withoutFrame: true
+        });
+        document.body.appendChild(test.env.root);
+        await triggerQuestionAnswerQuery(true);
+        expect(test.cmp.element.querySelector(`.${IFRAME_CLASSNAME}`).nodeName).toEqual('DIV');
+        done();
+      });
+
+      it('renders an iframe by default', async done => {
+        const IFRAME_CLASSNAME = 'coveo-shadow-iframe';
+        instantiateSmartSnippetSuggestions(null, {
+          withoutFrame: false
+        });
+        document.body.appendChild(test.env.root);
+        await triggerQuestionAnswerQuery(true);
+        expect(test.cmp.element.querySelector(`.${IFRAME_CLASSNAME}`).nodeName).toEqual('IFRAME');
+        done();
       });
     });
 

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -227,10 +227,20 @@ export function SmartSnippetTest() {
       done();
     });
 
-    it('omits the iframe when the option withoutFrame is true', async done => {
+    it('creates an iframe if the option withIFrame is omitted', async done => {
+      const IFRAME_CLASSNAME = 'coveo-shadow-iframe';
+      instantiateSmartSnippet(null);
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      expect(getFirstChild(IFRAME_CLASSNAME).nodeName).toEqual('IFRAME');
+      test.env.root.remove();
+      done();
+    });
+
+    it("doesn't create an iframe if the option useIFrame is false", async done => {
       const IFRAME_CLASSNAME = 'coveo-shadow-iframe';
       instantiateSmartSnippet(null, {
-        withoutFrame: true
+        useIFrame: false
       });
       document.body.appendChild(test.env.root);
       await triggerQuestionAnswerQuery(true);

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -227,6 +227,18 @@ export function SmartSnippetTest() {
       done();
     });
 
+    it('omits the iframe when the option withoutFrame is true', async done => {
+      const IFRAME_CLASSNAME = 'coveo-shadow-iframe';
+      instantiateSmartSnippet(null, {
+        withoutFrame: true
+      });
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      expect(getFirstChild(IFRAME_CLASSNAME).nodeName).toEqual('DIV');
+      test.env.root.remove();
+      done();
+    });
+
     describe('with styling without a source', () => {
       beforeEach(async done => {
         instantiateSmartSnippet(style);


### PR DESCRIPTION
The iframes cause an issue with this component within Salesforce.
I added an option that defaults to changing nothing, that lets us create a simple div instead of injecting an iframe to display the SmartSnippet and the SmartSnippetSuggestions.

the option is called `withoutFrame` on both these components.

It will just render this instead of an iframe:
`<div class="coveo-shadow-iframe">`

Also added unit tests to test that option


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)