### PR TITLE
JSUI-3292 Improved analytics for smart snippet source

### DIFF
--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -227,7 +227,7 @@ export class ResultLink extends Component {
     }),
 
     /**
-     * Specify this option to override analytics when this result link is pressed.
+     * Specify this option to log additional analytics when this result link is pressed.
      *
      * **Example:**
      * ```javascript
@@ -500,10 +500,9 @@ export class ResultLink extends Component {
       if (documentURL == undefined || documentURL == '') {
         documentURL = this.escapedClickUri;
       }
+      this.logDocumentOpen(documentURL);
       if (this.options.logAnalytics) {
         this.options.logAnalytics(documentURL);
-      } else {
-        this.logDocumentOpen(documentURL);
       }
       Defer.flush();
     },

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -413,7 +413,7 @@ export class SmartSnippet extends Component {
   }
 
   private sendClickSourceAnalytics(element: HTMLElement, href: string) {
-    return this.usageAnalytics.logCustomEvent<IAnalyticsSmartSnippetOpenSourceMeta>(
+    return this.usageAnalytics.logClickEvent<IAnalyticsSmartSnippetOpenSourceMeta>(
       analyticsActionCauseList.openSmartSnippetSource,
       {
         searchQueryUid: this.searchUid,
@@ -421,6 +421,7 @@ export class SmartSnippet extends Component {
         author: Utils.getFieldValue(this.lastRenderedResult, 'author'),
         documentURL: href
       },
+      this.lastRenderedResult,
       element
     );
   }

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -203,7 +203,7 @@ export class SmartSnippetCollapsibleSuggestion {
   }
 
   private sendOpenSourceAnalytics(element: HTMLElement, href: string) {
-    return this.bindings.usageAnalytics.logCustomEvent<IAnalyticsSmartSnippetSuggestionOpenSourceMeta>(
+    return this.bindings.usageAnalytics.logClickEvent<IAnalyticsSmartSnippetSuggestionOpenSourceMeta>(
       analyticsActionCauseList.openSmartSnippetSuggestionSource,
       {
         searchQueryUid: this.searchUid,
@@ -212,6 +212,7 @@ export class SmartSnippetCollapsibleSuggestion {
         documentURL: href,
         documentId: this.questionAnswer.documentId
       },
+      this.source,
       element
     );
   }

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -322,7 +322,7 @@ export function ResultLinkTest() {
         );
       });
 
-      it('should not log analytics when logAnalytics is set', () => {
+      it('should still log analytics when logAnalytics is set', () => {
         const element = $$('a');
         test = Mock.advancedResultComponentSetup<ResultLink>(
           ResultLink,
@@ -333,7 +333,7 @@ export function ResultLinkTest() {
 
         $$(test.cmp.element).trigger('click');
 
-        expect(test.cmp.usageAnalytics.logClickEvent).not.toHaveBeenCalled();
+        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
       });
 
       it("should call logAnalytics when it's set", () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3292

Additionally, I made made the default ResultLink analytics stay instead of being replaced by SmartSnippet's when their source is clicked.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)