### PR TITLE
JSUI-3296 Made SmartSnippet only log 1 analytics event when clicking on source

### DIFF
--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -500,9 +500,10 @@ export class ResultLink extends Component {
       if (documentURL == undefined || documentURL == '') {
         documentURL = this.escapedClickUri;
       }
-      this.logDocumentOpen(documentURL);
       if (this.options.logAnalytics) {
         this.options.logAnalytics(documentURL);
+      } else {
+        this.logDocumentOpen(documentURL);
       }
       Defer.flush();
     },

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -322,7 +322,7 @@ export function ResultLinkTest() {
         );
       });
 
-      it('should still log analytics when logAnalytics is set', () => {
+      it('should not log analytics when logAnalytics is set', () => {
         const element = $$('a');
         test = Mock.advancedResultComponentSetup<ResultLink>(
           ResultLink,
@@ -333,7 +333,7 @@ export function ResultLinkTest() {
 
         $$(test.cmp.element).trigger('click');
 
-        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
+        expect(test.cmp.usageAnalytics.logClickEvent).not.toHaveBeenCalled();
       });
 
       it("should call logAnalytics when it's set", () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3296

With this PR, clicking on the source of a SmartSnippet or SmartSnippetSuggestions logs a single click event (`openSmartSnippetSource`/`openSmartSnippetSuggestionSource`). The [last PR](https://github.com/coveo/search-ui/pull/1783) logged `documentOpen`, which is removed from this PR.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)