### PR TITLE
WIP: XMLHttpRequest withCredentials bugfix

### DIFF
--- a/src/rest/EndpointCaller.ts
+++ b/src/rest/EndpointCaller.ts
@@ -296,8 +296,19 @@ export class EndpointCaller implements IEndpointCaller {
       xmlHttpRequest.onreadystatechange = ev => {
         if (xmlHttpRequest.readyState == XMLHttpRequestStatus.OPENED && !sent) {
           sent = true;
-          xmlHttpRequest.withCredentials = true;
 
+          const calculateWithCredentials = () => {
+            // allows for custom xmlhttprequest value to be used from ISearchEndpointOptions
+            // https://coveo.github.io/search-ui/interfaces/isearchendpointoptions.html#xmlhttprequest
+            if(xmlHttpRequest.withCredentials === false) return false;
+            // ISearchEndpointOptions.anonymous
+            // https://coveo.github.io/search-ui/interfaces/isearchendpointoptions.html#anonymous
+            if(this.options.anonymous) return false;
+            return true;
+          }
+          
+          xmlHttpRequest.withCredentials = calculateWithCredentials();
+          
           _.each(requestInfo.headers, (headerValue, headerKey) => {
             xmlHttpRequest.setRequestHeader(headerKey, headerValue);
           });


### PR DESCRIPTION
Allows for explicity assigning the withCredentials property on XMLHttpRequest from ISearchEndpointOptions by either passing the anonymous option or your custom xmlHttpRequest constructor

Coveo Connect Post: https://connect.coveo.com/s/question/0D56Q0000852ietSAA/isearchendpointcaller-anonymous-property-does-not-work-as-intended-can-we-get-a-fix-out


My company ran into a CORS issue with an error message described in the `anonymous` description in the docs. I noticed that it did not work.
https://coveo.github.io/search-ui/interfaces/isearchendpointoptions.html#anonymous

example
`Coveo.SearchEndpoint.configureOnPremiseEndpoint("/api/search", undefined, { anonymous: true });`

I also tried supplying my own custom XMLHttpRequest implementation and then noticed that failed to do anything too.

`class MyCustomHttpRequest extends XMLHttpRequest{
  constructor(){
    super();
    this.withCredentials = false;
  }
}`
`Coveo.SearchEndpoint.configureOnPremiseEndpoint("/api/search", undefined, {
  xmlHttpRequest: MyCustomHttpRequest
});`


I then jumped into the node_modules and found where the issue was by doing a `xmlHtmlRequest.withCredentials = true ` `replaceAll` to `false` and then process of elimination until I found the right file. It was `EndpointCaller.ts` that was setting withCredentials to true no matter what.


Work left that I am leaving someone else to look into:

- Adjust TS type so that it is happy with `this.options.anonymous`
- See if this needs to be applied anywhere else
- See if this affects unit test


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)