### PR TITLE
JSUI-3305 bump latinize to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "es6-promise": "^4.0.5",
     "exponential-backoff": "^2.2.0",
     "jstimezonedetect": "^1.0.6",
-    "latinize": "^0.4.0",
+    "latinize": "^0.5.0",
     "modal-box": "^2.0.10",
     "moment": "~2.22.2",
     "pikaday": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6171,9 +6171,10 @@ latest-version@^5.0.0:
   dependencies:
     package-json "^6.3.0"
 
-latinize@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/latinize/-/latinize-0.4.0.tgz#27439b21e4eb7506c37717b638f1df2c49075a48"
+latinize@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/latinize/-/latinize-0.5.0.tgz#b81cc6faf3b4e6373b771c50c1a6d96df653f392"
+  integrity sha512-SHzxgdcFP/64lUEfX3183QALY2KdSQxad3gmhCc/b03QN1mbx0AnJWvsQjqoJLbucY9pJuK+NMbnasUIocDmnQ==
 
 lazy-cache@^0.2.3:
   version "0.2.7"


### PR DESCRIPTION
It is use to highlight strings, and it appears to still work correctly 😄 
https://coveord.atlassian.net/browse/JSUI-3305





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)