### PR TITLE
JSUI-3315 Add aria label on result link to prevent announcing link text twice

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValue.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValue.ts
@@ -63,7 +63,7 @@ export class DynamicFacetValue implements IDynamicFacetValue {
   public get selectAriaLabel() {
     const resultCount = l('ResultCount', this.formattedCount, this.numberOfResults);
 
-    return `${l('IncludeValueWithResultCount', this.displayValue, resultCount)}`;
+    return `${this.displayValue} ${resultCount}`;
   }
 
   private get isRange() {

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValue.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValue.ts
@@ -74,7 +74,7 @@ export class DynamicHierarchicalFacetValue implements IDynamicHierarchicalFacetV
 
   public get selectAriaLabel() {
     const resultCount = l('ResultCount', this.formattedCount, this.numberOfResults);
-    return `${l('IncludeValueWithResultCount', this.displayValue, resultCount)}`;
+    return `${this.displayValue} ${resultCount}`;
   }
 
   public get formattedCount(): string {

--- a/src/ui/DynamicHierarchicalFacetSearch/DynamicHierarchicalFacetSearchValueRenderer.ts
+++ b/src/ui/DynamicHierarchicalFacetSearch/DynamicHierarchicalFacetSearchValueRenderer.ts
@@ -45,13 +45,10 @@ export class DynamicHierarchicalFacetSearchValueRenderer {
 
   private get label() {
     const { start, end } = this.pathToRender;
+    const resultCount = l('ResultCount', this.facetValue.numberOfResults, this.facetValue.numberOfResults);
     return l(
       'HierarchicalFacetValueIndentedUnder',
-      l(
-        'IncludeValueWithResultCount',
-        this.facetValue.displayValue,
-        l('ResultCount', this.facetValue.numberOfResults, this.facetValue.numberOfResults)
-      ),
+      `${this.facetValue.displayValue} ${resultCount}`,
       [...start, ...(end || [])].join(', ')
     );
   }

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -22,6 +22,7 @@ import { exportGlobally } from '../../GlobalExports';
 
 import 'styling/_ResultLink';
 import { AccessibleButton } from '../../utils/AccessibleButton';
+import { l } from '../../MiscModules';
 
 /**
  * The `ResultLink` component automatically transform a search result title into a clickable link pointing to the
@@ -315,6 +316,8 @@ export class ResultLink extends Component {
     if (/^\s*$/.test(this.element.innerHTML)) {
       const title = this.getDisplayedTitle();
       this.element.innerHTML = title;
+      this.element.setAttribute('aria-label', l('Result'));
+
       if (!this.element.title) {
         this.element.title = this.getDisplayedTitleAsText();
       }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -7354,6 +7354,10 @@
     "en": "{0} <span class=\"coveo-omnibox-suggestion-category\">in {1}</span>",
     "fr": "{0} <span class=\"coveo-omnibox-suggestion-category\">dans {1}</span>"
   },
+  "Result": {
+    "en": "Result",
+    "fr": "Résultat"
+  },
   "ResultCount": {
     "en": "{0} result<pl>s</pl>",
     "fr": "{0} résultat<pl>s</pl>"

--- a/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueTest.ts
@@ -147,7 +147,7 @@ export function DynamicFacetValueTest() {
 
     describe('when the value has the state "idle"', () => {
       it('should return the correct aria-label', () => {
-        const expectedAriaLabel = `Inclusion filter on ${dynamicFacetValue.value}; ${dynamicFacetValue.formattedCount} results`;
+        const expectedAriaLabel = `${dynamicFacetValue.value} ${dynamicFacetValue.formattedCount} results`;
         expect(dynamicFacetValue.selectAriaLabel).toBe(expectedAriaLabel);
       });
 
@@ -166,7 +166,7 @@ export function DynamicFacetValueTest() {
       });
 
       it('should return the correct aria-label', () => {
-        const expectedAriaLabel = `Inclusion filter on ${dynamicFacetValue.value}; ${dynamicFacetValue.formattedCount} results`;
+        const expectedAriaLabel = `${dynamicFacetValue.value} ${dynamicFacetValue.formattedCount} results`;
         expect(dynamicFacetValue.selectAriaLabel).toBe(expectedAriaLabel);
       });
 

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValueTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValueTest.ts
@@ -40,7 +40,7 @@ export function DynamicHierarchicalFacetValueTest() {
     });
 
     it('should return the correct aria-label', () => {
-      const expectedAriaLabel = `Inclusion filter on ${facetValue.value}; ${facetValue.formattedCount} results`;
+      const expectedAriaLabel = `${facetValue.value} ${facetValue.formattedCount} results`;
       expect(facetValue.selectAriaLabel).toBe(expectedAriaLabel);
     });
 

--- a/unitTests/ui/DynamicHierarchicalFacetSearchValueRendererTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacetSearchValueRendererTest.ts
@@ -42,6 +42,11 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
       return (renderer = new DynamicHierarchicalFacetSearchValueRenderer(initializeFacetValue(parents), initializeFacet()));
     }
 
+    function getFacetValueLabel() {
+      const resultCount = l('ResultCount', facetValue.numberOfResults, facetValue.numberOfResults);
+      return `${facetValue.displayValue} ${resultCount}`;
+    }
+
     describe('without any parent', () => {
       beforeEach(() => {
         initializeRenderer();
@@ -88,15 +93,7 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
         });
 
         it('should have an accessible label', () => {
-          const expectedLabel = l(
-            'HierarchicalFacetValueIndentedUnder',
-            l(
-              'IncludeValueWithResultCount',
-              facetValue.displayValue,
-              l('ResultCount', facetValue.numberOfResults, facetValue.numberOfResults)
-            ),
-            l('AllCategories')
-          );
+          const expectedLabel = l('HierarchicalFacetValueIndentedUnder', getFacetValueLabel(), l('AllCategories'));
           expect(render.getAttribute('aria-label')).toEqual(expectedLabel);
         });
 
@@ -141,15 +138,7 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
       });
 
       it('should show the parent value in the label', () => {
-        const expectedLabel = l(
-          'HierarchicalFacetValueIndentedUnder',
-          l(
-            'IncludeValueWithResultCount',
-            facetValue.displayValue,
-            l('ResultCount', facetValue.numberOfResults, facetValue.numberOfResults)
-          ),
-          parentValue
-        );
+        const expectedLabel = l('HierarchicalFacetValueIndentedUnder', getFacetValueLabel(), parentValue);
         expect(render.getAttribute('aria-label')).toEqual(expectedLabel);
       });
 
@@ -170,15 +159,7 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
       });
 
       it('should show every parent value in the label', () => {
-        const expectedLabel = l(
-          'HierarchicalFacetValueIndentedUnder',
-          l(
-            'IncludeValueWithResultCount',
-            facetValue.displayValue,
-            l('ResultCount', facetValue.numberOfResults, facetValue.numberOfResults)
-          ),
-          parentValues.join(', ')
-        );
+        const expectedLabel = l('HierarchicalFacetValueIndentedUnder', getFacetValueLabel(), parentValues.join(', '));
         expect(render.getAttribute('aria-label')).toEqual(expectedLabel);
       });
 
@@ -224,11 +205,7 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
       it('should only show the first and last two values in the label', () => {
         const expectedLabel = l(
           'HierarchicalFacetValueIndentedUnder',
-          l(
-            'IncludeValueWithResultCount',
-            facetValue.displayValue,
-            l('ResultCount', facetValue.numberOfResults, facetValue.numberOfResults)
-          ),
+          getFacetValueLabel(),
           [parentValues[0], parentValues[2], parentValues[3]].join(', ')
         );
         expect(render.getAttribute('aria-label')).toEqual(expectedLabel);

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -46,6 +46,10 @@ export function ResultLinkTest() {
       expect(test.cmp.element.getAttribute('tabindex')).toBe('0');
     });
 
+    it('should have an aria-label to prevent screen readers from reading the #title attribute', () => {
+      expect(test.cmp.element.getAttribute('aria-label')).toBe('Result');
+    });
+
     describe(`when the template contains two ${ResultLink.ID} elements`, () => {
       let template: HTMLElement;
 


### PR DESCRIPTION
**Context**

A `title` attribute [was added](https://github.com/coveo/search-ui/pull/1448) to result links to allow seeing the full text on hover in case the result link was being clipped ([Discuss](https://discuss.coveo.com/t/add-data-title-for-anchor-tooltip/3424)).

The change caused screen readers to read result links twice, once for the `title` attribute, once for the anchor element text.

`<title> link <anchor link text>`

**Suggested solution**

Specifying an [aria-label](https://github.com/nvaccess/nvda/issues/7841#issuecomment-664912888) prevents screen readers from reading the title attribute. A screen reader will now read:

`Result link <anchor link text>`


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)