### PR TITLE
JSUI-3316 [POC] store and retrieve globally configured options

### DIFF
--- a/src/ui/Base/Component.ts
+++ b/src/ui/Base/Component.ts
@@ -262,6 +262,8 @@ export class ComponentEvents {
  * The base class for every component in the framework.
  */
 export class Component extends BaseComponent {
+  static globallyConfiguredOptions: Object = {};
+
   static ComponentEventClass: typeof ComponentEvents = ComponentEvents;
   /**
    * Allows the component to bind events and execute them only when it is enabled.

--- a/src/ui/Base/Initialization.ts
+++ b/src/ui/Base/Initialization.ts
@@ -785,6 +785,7 @@ export class LazyInitialization {
           // also for the element id. Merge them and pass those to the factory method.
           let optionsToUse;
           if (Utils.exists(initParameters.options)) {
+            Component.globallyConfiguredOptions = initParameters.options;
             const optionsForComponentClass = initParameters.options[componentClassId];
             const optionsForElementId = initParameters.options[matchingElement.id];
             const initOptions = initParameters.options['initOptions'] ? initParameters.options['initOptions'][componentClassId] : {};

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -273,9 +273,10 @@ export class ResultLink extends Component {
   ) {
     super(element, ResultLink.ID, bindings);
 
+    const globalOptions = Component.globallyConfiguredOptions[ResultLink.ID] || {};
     const initialOptions = ComponentOptions.initComponentOptions(element, ResultLink, options);
     const resultLinkOptions = this.componentOptionsModel.get(ComponentOptionsModel.attributesEnum.resultLink);
-    this.options = extend({}, initialOptions, resultLinkOptions);
+    this.options = extend({}, initialOptions, globalOptions, resultLinkOptions);
 
     this.result = result || this.resolveResult();
 


### PR DESCRIPTION
**Context**

When a component is instantiated inside another component (e.g. `ResultLink` inside `Smartsnippet`, `ResultLink` inside `PrintableUri`), globally configured options are not used.

Global options are [segmented by component](https://github.com/coveo/search-ui/blob/master/src/ui/Base/Initialization.ts#L788) and passed during initialization. This segmentation means that a `SmartSnippet` never sees `ResultLink` global options.

**Suggested Solution**

This PR attempts to work around the limitation by storing the global options in a `static` variable on the `Component` class all components inherit from. Each component can retrieve it's global options on init.

**Drawbacks**
 
Each component needs a line of code to retrieve and merge it's options. This PoC PR only does this for `ResultLink`. I'm prepared to do a pass-through unless there is a better solution 🤷 


**Alternative**

Expose result link options on `SmartSnippet`, and pass them when instantiating `ResultLink`. The disadvantage of this is developers need to configure the options on multiple components instead of just once for `ResultLink`.

https://coveord.atlassian.net/browse/JSUI-3316





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)