### PR TITLE
JSUI-3315 Announce facet value immediately; remove "inclusion filter" phrase

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValue.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValue.ts
@@ -63,7 +63,7 @@ export class DynamicFacetValue implements IDynamicFacetValue {
   public get selectAriaLabel() {
     const resultCount = l('ResultCount', this.formattedCount, this.numberOfResults);
 
-    return `${l('IncludeValueWithResultCount', this.displayValue, resultCount)}`;
+    return `${this.displayValue} ${resultCount}`;
   }
 
   private get isRange() {

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValue.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValue.ts
@@ -74,7 +74,7 @@ export class DynamicHierarchicalFacetValue implements IDynamicHierarchicalFacetV
 
   public get selectAriaLabel() {
     const resultCount = l('ResultCount', this.formattedCount, this.numberOfResults);
-    return `${l('IncludeValueWithResultCount', this.displayValue, resultCount)}`;
+    return `${this.displayValue} ${resultCount}`;
   }
 
   public get formattedCount(): string {

--- a/src/ui/DynamicHierarchicalFacetSearch/DynamicHierarchicalFacetSearchValueRenderer.ts
+++ b/src/ui/DynamicHierarchicalFacetSearch/DynamicHierarchicalFacetSearchValueRenderer.ts
@@ -45,13 +45,10 @@ export class DynamicHierarchicalFacetSearchValueRenderer {
 
   private get label() {
     const { start, end } = this.pathToRender;
+    const resultCount = l('ResultCount', this.facetValue.numberOfResults, this.facetValue.numberOfResults);
     return l(
       'HierarchicalFacetValueIndentedUnder',
-      l(
-        'IncludeValueWithResultCount',
-        this.facetValue.displayValue,
-        l('ResultCount', this.facetValue.numberOfResults, this.facetValue.numberOfResults)
-      ),
+      `${this.facetValue.displayValue} ${resultCount}`,
       [...start, ...(end || [])].join(', ')
     );
   }

--- a/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueTest.ts
@@ -147,7 +147,7 @@ export function DynamicFacetValueTest() {
 
     describe('when the value has the state "idle"', () => {
       it('should return the correct aria-label', () => {
-        const expectedAriaLabel = `Inclusion filter on ${dynamicFacetValue.value}; ${dynamicFacetValue.formattedCount} results`;
+        const expectedAriaLabel = `${dynamicFacetValue.value} ${dynamicFacetValue.formattedCount} results`;
         expect(dynamicFacetValue.selectAriaLabel).toBe(expectedAriaLabel);
       });
 
@@ -166,7 +166,7 @@ export function DynamicFacetValueTest() {
       });
 
       it('should return the correct aria-label', () => {
-        const expectedAriaLabel = `Inclusion filter on ${dynamicFacetValue.value}; ${dynamicFacetValue.formattedCount} results`;
+        const expectedAriaLabel = `${dynamicFacetValue.value} ${dynamicFacetValue.formattedCount} results`;
         expect(dynamicFacetValue.selectAriaLabel).toBe(expectedAriaLabel);
       });
 

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValueTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValueTest.ts
@@ -40,7 +40,7 @@ export function DynamicHierarchicalFacetValueTest() {
     });
 
     it('should return the correct aria-label', () => {
-      const expectedAriaLabel = `Inclusion filter on ${facetValue.value}; ${facetValue.formattedCount} results`;
+      const expectedAriaLabel = `${facetValue.value} ${facetValue.formattedCount} results`;
       expect(facetValue.selectAriaLabel).toBe(expectedAriaLabel);
     });
 

--- a/unitTests/ui/DynamicHierarchicalFacetSearchValueRendererTest.ts
+++ b/unitTests/ui/DynamicHierarchicalFacetSearchValueRendererTest.ts
@@ -42,6 +42,11 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
       return (renderer = new DynamicHierarchicalFacetSearchValueRenderer(initializeFacetValue(parents), initializeFacet()));
     }
 
+    function getFacetValueLabel() {
+      const resultCount = l('ResultCount', facetValue.numberOfResults, facetValue.numberOfResults);
+      return `${facetValue.displayValue} ${resultCount}`;
+    }
+
     describe('without any parent', () => {
       beforeEach(() => {
         initializeRenderer();
@@ -88,15 +93,7 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
         });
 
         it('should have an accessible label', () => {
-          const expectedLabel = l(
-            'HierarchicalFacetValueIndentedUnder',
-            l(
-              'IncludeValueWithResultCount',
-              facetValue.displayValue,
-              l('ResultCount', facetValue.numberOfResults, facetValue.numberOfResults)
-            ),
-            l('AllCategories')
-          );
+          const expectedLabel = l('HierarchicalFacetValueIndentedUnder', getFacetValueLabel(), l('AllCategories'));
           expect(render.getAttribute('aria-label')).toEqual(expectedLabel);
         });
 
@@ -141,15 +138,7 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
       });
 
       it('should show the parent value in the label', () => {
-        const expectedLabel = l(
-          'HierarchicalFacetValueIndentedUnder',
-          l(
-            'IncludeValueWithResultCount',
-            facetValue.displayValue,
-            l('ResultCount', facetValue.numberOfResults, facetValue.numberOfResults)
-          ),
-          parentValue
-        );
+        const expectedLabel = l('HierarchicalFacetValueIndentedUnder', getFacetValueLabel(), parentValue);
         expect(render.getAttribute('aria-label')).toEqual(expectedLabel);
       });
 
@@ -170,15 +159,7 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
       });
 
       it('should show every parent value in the label', () => {
-        const expectedLabel = l(
-          'HierarchicalFacetValueIndentedUnder',
-          l(
-            'IncludeValueWithResultCount',
-            facetValue.displayValue,
-            l('ResultCount', facetValue.numberOfResults, facetValue.numberOfResults)
-          ),
-          parentValues.join(', ')
-        );
+        const expectedLabel = l('HierarchicalFacetValueIndentedUnder', getFacetValueLabel(), parentValues.join(', '));
         expect(render.getAttribute('aria-label')).toEqual(expectedLabel);
       });
 
@@ -224,11 +205,7 @@ export function DynamicHierarchicalFacetSearchValueRendererTest() {
       it('should only show the first and last two values in the label', () => {
         const expectedLabel = l(
           'HierarchicalFacetValueIndentedUnder',
-          l(
-            'IncludeValueWithResultCount',
-            facetValue.displayValue,
-            l('ResultCount', facetValue.numberOfResults, facetValue.numberOfResults)
-          ),
+          getFacetValueLabel(),
           [parentValues[0], parentValues[2], parentValues[3]].join(', ')
         );
         expect(render.getAttribute('aria-label')).toEqual(expectedLabel);


### PR DESCRIPTION
**Background**

The inclusion filter text was added by this [PR](https://github.com/coveo/search-ui/pull/1607) in response to this [maintenance case](https://coveord.atlassian.net/browse/JSUI-3057).

However, the final result of that PR does not follow the WCAG 2.1 label-in-name recommendation:

> ... the visible label (should) be at the beginning of every non-visible label (e.g. aria-label)

**Context**

Laurie's feedback is that starting every facet value focus announcement with "inclusion filter ..." adds redundancy and unnecessary verbosity for the screen reader users. I think what she's saying makes sense,

This change goes with the [aria-labelledby change](https://github.com/coveo/search-ui/pull/1797). Now, when a user focuses on the first facet value, they will be notified that they are in "X facet". From there, the value, count and state of the button are read.

~~One thing I did not figure out is how to have the state be announced first (pressed/not-pressed). Will continue searching on Monday,~~ (edit: did not find a way)

Also, I focused on just the dynamic facets. The CategoryFacet could be adjusted too ...


For additional context, see point 3 in the jira

https://coveord.atlassian.net/browse/JSUI-3315


**Some recommendations I did not implement**
- Removing the `button` element because it would be breaking.
- Announcing "results" using a screen-reader-only span tag (compared to using aria-label) because with this approach, the screen reader pauses between the count and the word "results". I did not find that nice,


