### PR TITLE
WORK-1270: slack icon size

### DIFF
--- a/image/svg/filetypes/slack.svg
+++ b/image/svg/filetypes/slack.svg
@@ -1,4 +1,4 @@
-<svg version="1.2" baseProfile="tiny-ps" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 124 124" width="124" height="124">
+<svg version="1.2" baseProfile="tiny-ps" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 124 124" width="60" height="60">
 	<title>Slack_Mark-svg</title>
 	<style>
 		tspan { white-space:pre }


### PR DESCRIPTION
[WORK-1270](https://coveord.atlassian.net/browse/WORK-1270)

- Fixed Slack Icon Size



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)