### PR TITLE
[DOC-9965] DynamicFacet and Facet: adds a note on the field type

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -112,6 +112,8 @@ export class DynamicFacet extends Component implements IDynamicFacet {
     /**
      * The name of the field on which to base this facet.
      *
+     * The field must of the `string` type.
+     *
      * Must be prefixed by `@`, and must reference an existing field whose
      * **Facet** option is enabled.
      *

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -164,6 +164,8 @@ export class Facet extends Component implements IFieldValueCompatibleFacet {
     /**
      * Specifies the index field whose values the facet should use.
      *
+     * The field must of the `string` type.
+     *
      * This requires the given field to be configured correctly in the index as a *Facet field* (see
      * [Add or Edit Fields](https://docs.coveo.com/en/1982/)).
      *


### PR DESCRIPTION
It was unclear, fields of what type can be used in the `DynamicFacet` and `Facet` components. This led to that a one user tried to use a numerical field in those components and didn't understand why the components wouldn't render.

This PR adds a note that `string` is the only acceptable type for the `field` option.

JIRA: https://coveord.atlassian.net/browse/DOC-9965


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)