### PR TITLE
JSUI-3318 Build doc after building strings

### DIFF
--- a/gulpTasks/strings.js
+++ b/gulpTasks/strings.js
@@ -6,7 +6,7 @@ function buildStrings(cb) {
   dict.merge(strings.load('./strings/strings.json', { module: 'Coveo' }));
 
   dict.writeDeclarationFile('./src/strings/Strings.ts');
-  dict.writeDefaultLanguage('./src/strings/DefaultLanguage.ts', 'en', './strings/cultures/globalize.culture.en-US.js', true);
+  dict.writeDefaultLanguage('./src/strings/DefaultLanguage.ts', 'en');
   dict.writeLanguageFile('./bin/js/cultures/en.js', 'en', './strings/cultures/globalize.culture.en-US.js', false);
   dict.writeLanguageFile('./bin/js/cultures/fr.js', 'fr', './strings/cultures/globalize.culture.fr-FR.js', false);
   dict.writeLanguageFile('./bin/js/cultures/cs.js', 'cs', './strings/cultures/globalize.culture.cs.js', false);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,9 +17,9 @@ const { injectVersion } = require('./gulpTasks/injectVersion');
 
 const src = series(compile, definitions);
 
-const build = series(setNodeProdEnv, parallel(fileTypes, iconList, setup, templates), buildStrings, src);
+const build = series(setNodeProdEnv, parallel(fileTypes, iconList, setup, templates), buildStrings, src, doc);
 
-const defaultTask = parallel(buildLegacy, build, doc);
+const defaultTask = parallel(buildLegacy, build);
 
 exports.default = defaultTask;
 exports.compileTSOnly = compileTSOnly;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,9 +17,9 @@ const { injectVersion } = require('./gulpTasks/injectVersion');
 
 const src = series(compile, definitions);
 
-const build = series(setNodeProdEnv, parallel(fileTypes, iconList, setup, templates), buildStrings, src, doc);
+const build = series(setNodeProdEnv, parallel(fileTypes, iconList, setup, templates), src);
 
-const defaultTask = parallel(buildLegacy, build);
+const defaultTask = series(buildStrings, parallel(buildLegacy, build, doc));
 
 exports.default = defaultTask;
 exports.compileTSOnly = compileTSOnly;


### PR DESCRIPTION
The `doc` step was running in parallel to the `build`. Sometimes, this would be fine. Other times, the doc step would fail due to missing string files generated by `buildStrings` step part of `build` (see last two merge [build errors on master](https://github.com/coveo/search-ui/commits/master)).

```
ERROR in ./src/BaseModules.ts
(12,33): error TS2307: Cannot find module './strings/DefaultLanguage'.

...

Error: Command `npx webpack --config ./webpack.playground.config.js` failed with exit code 2
```

~~This PR adjusts to run the doc step only after the strings have been created.~~
This PR adjusts to build the strings first, followed by running `build` and `doc` in parallel to not increase the build time by 27 seconds. 


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)