### PR TITLE
JSUI-3317 Send filterFacetCount in search request; adjust default to be true if undefined 

### DIFF
--- a/src/controllers/DynamicFacetQueryController.ts
+++ b/src/controllers/DynamicFacetQueryController.ts
@@ -6,7 +6,6 @@ import { findIndex } from 'underscore';
 import { IQueryResults } from '../rest/QueryResults';
 import { IDynamicFacet } from '../ui/DynamicFacet/IDynamicFacet';
 import { DynamicFacetRequestBuilder } from './DynamicFacetRequestBuilder';
-import { IQuery } from '../rest/Query';
 
 export class DynamicFacetQueryController {
   protected requestBuilder: DynamicFacetRequestBuilder;
@@ -79,15 +78,15 @@ export class DynamicFacetQueryController {
   public putFacetIntoQueryBuilder(queryBuilder: QueryBuilder) {
     Assert.exists(queryBuilder);
 
-    queryBuilder.facetRequests.push(this.buildFacetRequest(queryBuilder.build()));
+    queryBuilder.facetRequests.push(this.buildFacetRequest());
     if (this.freezeFacetOrder) {
       queryBuilder.facetOptions.freezeFacetOrder = true;
     }
   }
 
-  public buildFacetRequest(query: IQuery): IFacetRequest {
+  public buildFacetRequest(): IFacetRequest {
     return {
-      ...this.requestBuilder.buildBaseRequestForQuery(query),
+      ...this.requestBuilder.buildBaseRequestForQuery(),
       currentValues: this.currentValues,
       numberOfValues: this.numberOfValues,
       freezeCurrentValues: this.freezeCurrentValues,
@@ -104,11 +103,11 @@ export class DynamicFacetQueryController {
 
     const previousFacetRequestIndex = findIndex(query.facets, { facetId: this.facet.options.id });
     if (previousFacetRequestIndex !== -1) {
-      query.facets[previousFacetRequestIndex] = this.buildFacetRequest(query);
+      query.facets[previousFacetRequestIndex] = this.buildFacetRequest();
     } else if (query.facets) {
-      query.facets.push(this.buildFacetRequest(query));
+      query.facets.push(this.buildFacetRequest());
     } else {
-      query.facets = [this.buildFacetRequest(query)];
+      query.facets = [this.buildFacetRequest()];
     }
 
     return this.facet.queryController.getEndpoint().search(query);

--- a/src/controllers/DynamicFacetRangeQueryController.ts
+++ b/src/controllers/DynamicFacetRangeQueryController.ts
@@ -1,14 +1,13 @@
 import { DynamicFacetQueryController } from './DynamicFacetQueryController';
 import { IFacetRequest, IFacetRequestValue } from '../rest/Facet/FacetRequest';
-import { IQuery } from '../rest/Query';
 import { IDynamicFacetRange } from '../ui/DynamicFacet/IDynamicFacetRange';
 
 export class DynamicFacetRangeQueryController extends DynamicFacetQueryController {
   protected facet: IDynamicFacetRange;
 
-  public buildFacetRequest(query: IQuery): IFacetRequest {
+  public buildFacetRequest(): IFacetRequest {
     return {
-      ...this.requestBuilder.buildBaseRequestForQuery(query),
+      ...this.requestBuilder.buildBaseRequestForQuery(),
       currentValues: this.currentValues,
       numberOfValues: this.numberOfValues,
       freezeCurrentValues: false,

--- a/src/controllers/DynamicFacetRequestBuilder.ts
+++ b/src/controllers/DynamicFacetRequestBuilder.ts
@@ -1,7 +1,5 @@
-import { isUndefined } from 'underscore';
 import { FacetType, IFacetRequest } from '../rest/Facet/FacetRequest';
 import { FacetSortCriteria } from '../rest/Facet/FacetSortCriteria';
-import { IQuery } from '../rest/Query';
 import { Utils } from '../utils/Utils';
 
 export interface IBasicFacetRequestParameters {
@@ -17,23 +15,15 @@ export interface IBasicFacetRequestParameters {
 export class DynamicFacetRequestBuilder {
   constructor(private request: IFacetRequest) {}
 
-  public buildBaseRequestForQuery(query: IQuery): IFacetRequest {
+  public buildBaseRequestForQuery(): IFacetRequest {
     return {
       ...this.request,
-      filterFacetCount: this.getFilterFacetCount(!!query.filterField)
+      filterFacetCount: determineFilterFacetCount(this.request)
     };
-  }
-
-  private getFilterFacetCount(isFoldingEnabled: boolean) {
-    if (Utils.isUndefined(this.request.filterFacetCount)) {
-      return !isFoldingEnabled;
-    }
-
-    return this.request.filterFacetCount;
   }
 }
 
 export function determineFilterFacetCount(options: { filterFacetCount?: boolean }) {
   const { filterFacetCount } = options;
-  return isUndefined(filterFacetCount) ? true : filterFacetCount;
+  return Utils.isUndefined(filterFacetCount) ? true : filterFacetCount;
 }

--- a/src/controllers/DynamicFacetRequestBuilder.ts
+++ b/src/controllers/DynamicFacetRequestBuilder.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from 'underscore';
 import { FacetType, IFacetRequest } from '../rest/Facet/FacetRequest';
 import { FacetSortCriteria } from '../rest/Facet/FacetSortCriteria';
 import { IQuery } from '../rest/Query';
@@ -30,4 +31,9 @@ export class DynamicFacetRequestBuilder {
 
     return this.request.filterFacetCount;
   }
+}
+
+export function determineFilterFacetCount(options: { filterFacetCount?: boolean }) {
+  const { filterFacetCount } = options;
+  return isUndefined(filterFacetCount) ? true : filterFacetCount;
 }

--- a/src/controllers/DynamicHierarchicalFacetQueryController.ts
+++ b/src/controllers/DynamicHierarchicalFacetQueryController.ts
@@ -7,7 +7,6 @@ import { IQueryResults } from '../rest/QueryResults';
 import { findIndex } from 'underscore';
 import { IDynamicHierarchicalFacet, IDynamicHierarchicalFacetValue } from '../ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet';
 import { DynamicFacetRequestBuilder } from './DynamicFacetRequestBuilder';
-import { IQuery } from '../rest/Query';
 import { FacetSortCriteria } from '../rest/Facet/FacetSortCriteria';
 
 export class DynamicHierarchicalFacetQueryController {
@@ -59,15 +58,15 @@ export class DynamicHierarchicalFacetQueryController {
   public putFacetIntoQueryBuilder(queryBuilder: QueryBuilder) {
     Assert.exists(queryBuilder);
 
-    queryBuilder.facetRequests.push(this.buildFacetRequest(queryBuilder.build()));
+    queryBuilder.facetRequests.push(this.buildFacetRequest());
     if (this.freezeFacetOrder) {
       queryBuilder.facetOptions.freezeFacetOrder = this.freezeFacetOrder;
     }
   }
 
-  public buildFacetRequest(query: IQuery): IFacetRequest {
+  public buildFacetRequest(): IFacetRequest {
     return {
-      ...this.requestBuilder.buildBaseRequestForQuery(query),
+      ...this.requestBuilder.buildBaseRequestForQuery(),
       currentValues: this.currentValues,
       preventAutoSelect: this.preventAutoSelection,
       numberOfValues: this.facet.values.hasSelectedValue ? 1 : this.numberOfValuesToRequest,
@@ -83,11 +82,11 @@ export class DynamicHierarchicalFacetQueryController {
 
     const previousFacetRequestIndex = findIndex(query.facets, { facetId: this.facet.options.id });
     if (previousFacetRequestIndex !== -1) {
-      query.facets[previousFacetRequestIndex] = this.buildFacetRequest(query);
+      query.facets[previousFacetRequestIndex] = this.buildFacetRequest();
     } else if (query.facets) {
-      query.facets.push(this.buildFacetRequest(query));
+      query.facets.push(this.buildFacetRequest());
     } else {
-      query.facets = [this.buildFacetRequest(query)];
+      query.facets = [this.buildFacetRequest()];
     }
 
     return this.facet.queryController.getEndpoint().search(query);

--- a/src/controllers/FacetSearchController.ts
+++ b/src/controllers/FacetSearchController.ts
@@ -4,6 +4,7 @@ import { QueryUtils } from '../utils/QueryUtils';
 import { DateUtils } from '../utils/DateUtils';
 import { IDynamicFacet } from '../ui/DynamicFacet/IDynamicFacet';
 import { IFacetSearchRequest } from '../rest/Facet/FacetSearchRequest';
+import { determineFilterFacetCount } from './DynamicFacetRequestBuilder';
 
 export class FacetSearchController {
   private terms = '';
@@ -54,8 +55,10 @@ export class FacetSearchController {
 
   private get request(): IFacetSearchRequest {
     const optionalLeadingWildcard = this.facet.options.useLeadingWildcardInFacetSearch ? '*' : '';
+
     return {
       field: this.facet.fieldName,
+      filterFacetCount: determineFilterFacetCount(this.facet.options),
       numberOfValues: this.numberOfValues,
       ignoreValues: this.facet.values.activeValues.map(value => value.value),
       captions: this.captions,

--- a/src/controllers/HierarchicalFacetSearchController.ts
+++ b/src/controllers/HierarchicalFacetSearchController.ts
@@ -2,6 +2,7 @@ import { IDynamicHierarchicalFacet } from '../ui/DynamicHierarchicalFacet/IDynam
 import { FacetSearchType, IFacetSearchRequest } from '../rest/Facet/FacetSearchRequest';
 import { flatten } from 'underscore';
 import { IFacetSearchResponse } from '../rest/Facet/FacetSearchResponse';
+import { determineFilterFacetCount } from './DynamicFacetRequestBuilder';
 
 export class HierarchicalFacetSearchController {
   private terms = '';
@@ -23,6 +24,7 @@ export class HierarchicalFacetSearchController {
   private get request(): IFacetSearchRequest {
     return {
       field: this.facet.fieldName,
+      filterFacetCount: determineFilterFacetCount(this.facet.options),
       type: FacetSearchType.hierarchical,
       numberOfValues: this.numberOfValues,
       ignorePaths: this.ignoredPaths,

--- a/src/rest/Facet/FacetSearchRequest.ts
+++ b/src/rest/Facet/FacetSearchRequest.ts
@@ -23,6 +23,18 @@ export interface IFacetSearchRequest {
    */
   field: string;
   /**
+   * Whether to exclude folded result parents when estimating result counts for facet values.
+   *
+   * **Note:** The target folding field must be a facet field with the **Use cache for nested queries** options enabled (see [Add or Edit a Field](https://docs.coveo.com/en/1982)).
+   *
+   * See also the [`Folding`]{@link Folding} and [`FoldingForThread`]{@link FoldingForThread} components.
+   *
+   * **Default:** `true`.
+   *
+   * @availablesince [March 2020 Release (v2.8521)](https://docs.coveo.com/en/3203/)
+   */
+  filterFacetCount: boolean;
+  /**
    * The kind of facet values against which the search request is being made.
    *
    * **Default:** `specific`

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -300,7 +300,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
      *
      * See also the [`Folding`]{@link Folding} and [`FoldingForThread`]{@link FoldingForThread} components.
      *
-     * **Default:** `false` if folded results are requested; `true` otherwise.
+     * **Default:** `true`.
      *
      * @availablesince [March 2020 Release (v2.8521)](https://docs.coveo.com/en/3203/)
      */

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -212,7 +212,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
      *
      * See also the [`Folding`]{@link Folding} and [`FoldingForThread`]{@link FoldingForThread} components.
      *
-     * **Default:** `false` if folded results are requested; `true` otherwise.
+     * **Default:** `true`.
      */
     filterFacetCount: ComponentOptions.buildBooleanOption({ section: 'Filtering' }),
 

--- a/unitTests/controllers/DynamicFacetQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicFacetQueryControllerTest.ts
@@ -34,7 +34,7 @@ export function DynamicFacetQueryControllerTest() {
     }
 
     function facetRequest() {
-      return dynamicFacetQueryController.buildFacetRequest(queryBuilder.build());
+      return dynamicFacetQueryController.buildFacetRequest();
     }
 
     function queryFacetRequests() {
@@ -240,7 +240,7 @@ export function DynamicFacetQueryControllerTest() {
         dynamicFacetQueryController.getQueryResults();
         expect(mockEndpoint.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            facets: [dynamicFacetQueryController.buildFacetRequest(new QueryBuilder().build())]
+            facets: [dynamicFacetQueryController.buildFacetRequest()]
           })
         );
       });
@@ -254,7 +254,7 @@ export function DynamicFacetQueryControllerTest() {
 
         expect(mockEndpoint.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            facets: [queryFacetRequests()[0], dynamicFacetQueryController.buildFacetRequest(new QueryBuilder().build())]
+            facets: [queryFacetRequests()[0], dynamicFacetQueryController.buildFacetRequest()]
           })
         );
       });

--- a/unitTests/controllers/DynamicFacetRangeQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicFacetRangeQueryControllerTest.ts
@@ -2,7 +2,6 @@ import { DynamicFacetRangeQueryController } from '../../src/controllers/DynamicF
 import { DynamicFacetRangeTestUtils } from '../ui/DynamicFacet/DynamicFacetRangeTestUtils';
 import { DynamicFacetRange } from '../../src/ui/DynamicFacet/DynamicFacetRange';
 import { IDynamicFacetRangeOptions } from '../../src/ui/DynamicFacet/IDynamicFacetRange';
-import { QueryBuilder } from '../../src/Core';
 import { FacetValueState } from '../../src/rest/Facet/FacetValueState';
 import { FacetRangeSortOrder } from '../../src/rest/Facet/FacetRangeSortOrder';
 
@@ -24,7 +23,7 @@ export function DynamicFacetRangeQueryControllerTest() {
     }
 
     function facetRequest() {
-      return dynamicFacetRangeQueryController.buildFacetRequest(new QueryBuilder().build());
+      return dynamicFacetRangeQueryController.buildFacetRequest();
     }
 
     it('should send the right basic facetRequest parameters', () => {

--- a/unitTests/controllers/DynamicFacetRequestBuilderTest.ts
+++ b/unitTests/controllers/DynamicFacetRequestBuilderTest.ts
@@ -1,6 +1,5 @@
 import { DynamicFacetRequestBuilder } from '../../src/controllers/DynamicFacetRequestBuilder';
 import { IFacetRequest } from '../../src/rest/Facet/FacetRequest';
-import { QueryBuilder } from '../../src/Core';
 
 export function DynamicFacetRequestBuilderTest() {
   describe('DynamicFacetRequestBuilder', () => {
@@ -16,28 +15,16 @@ export function DynamicFacetRequestBuilderTest() {
 
     describe('testing "filterFacetCount"', () => {
       it(`when "filterFacetCount" is not initially defined
-      when the "query" has no "filterField" defined
       "filterFacetCount" should be "true"`, () => {
         initializeRequestBuilder();
-        const query = new QueryBuilder().build();
-        expect(requestBuilder.buildBaseRequestForQuery(query).filterFacetCount).toBe(true);
-      });
-
-      it(`when "filterFacetCount" is not initially defined
-      when the "query" has a "filterField" defined
-      "filterFacetCount" should be "false"`, () => {
-        initializeRequestBuilder();
-        const query = new QueryBuilder().build();
-        query.filterField = '@foldingCollection';
-        expect(requestBuilder.buildBaseRequestForQuery(query).filterFacetCount).toBe(false);
+        expect(requestBuilder.buildBaseRequestForQuery().filterFacetCount).toBe(true);
       });
 
       it(`when "filterFacetCount" is initially defined
       "filterFacetCount" should stay the same`, () => {
         facetRequest.filterFacetCount = false;
         initializeRequestBuilder();
-        const query = new QueryBuilder().build();
-        expect(requestBuilder.buildBaseRequestForQuery(query).filterFacetCount).toBe(false);
+        expect(requestBuilder.buildBaseRequestForQuery().filterFacetCount).toBe(false);
       });
     });
   });

--- a/unitTests/controllers/DynamicHierarchicalFacetQueryControllerTest.ts
+++ b/unitTests/controllers/DynamicHierarchicalFacetQueryControllerTest.ts
@@ -34,7 +34,7 @@ export function DynamicHierarchicalFacetQueryControllerTest() {
     }
 
     function facetRequest() {
-      return dynamicHierarchicalFacetQueryController.buildFacetRequest(queryBuilder.build());
+      return dynamicHierarchicalFacetQueryController.buildFacetRequest();
     }
 
     function queryFacetRequests() {
@@ -180,7 +180,7 @@ export function DynamicHierarchicalFacetQueryControllerTest() {
         dynamicHierarchicalFacetQueryController.getQueryResults();
         expect(mockEndpoint.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            facets: [dynamicHierarchicalFacetQueryController.buildFacetRequest(new QueryBuilder().build())]
+            facets: [dynamicHierarchicalFacetQueryController.buildFacetRequest()]
           })
         );
       });
@@ -194,7 +194,7 @@ export function DynamicHierarchicalFacetQueryControllerTest() {
 
         expect(mockEndpoint.search).toHaveBeenCalledWith(
           jasmine.objectContaining({
-            facets: [queryFacetRequests()[0], dynamicHierarchicalFacetQueryController.buildFacetRequest(new QueryBuilder().build())]
+            facets: [queryFacetRequests()[0], dynamicHierarchicalFacetQueryController.buildFacetRequest()]
           })
         );
       });

--- a/unitTests/controllers/FacetSearchControllerTest.ts
+++ b/unitTests/controllers/FacetSearchControllerTest.ts
@@ -14,7 +14,6 @@ export function FacetSearchControllerTest() {
 
     beforeEach(() => {
       initializeComponents();
-      facetSearchSpy = facet.queryController.getEndpoint().facetSearch as jasmine.Spy;
     });
 
     function initializeComponents(options?: IDynamicFacetOptions) {
@@ -22,6 +21,7 @@ export function FacetSearchControllerTest() {
       facet.values.createFromResponse(DynamicFacetTestUtils.getCompleteFacetResponse(facet));
 
       facetSearchController = new FacetSearchController(facet);
+      facetSearchSpy = facet.queryController.getEndpoint().facetSearch as jasmine.Spy;
     }
 
     it('should trigger a facet search request with the right parameters', () => {
@@ -30,6 +30,7 @@ export function FacetSearchControllerTest() {
 
       const expectedRequest: IFacetSearchRequest = {
         field: facet.fieldName,
+        filterFacetCount: true,
         numberOfValues: facet.options.numberOfValues * facetValuesMultiplier,
         ignoreValues: facet.values.activeValues.map(value => value.value),
         captions: {},
@@ -38,6 +39,14 @@ export function FacetSearchControllerTest() {
       };
 
       expect(facetSearchSpy).toHaveBeenCalledWith(expectedRequest);
+    });
+
+    it(`when facet option #filterFacetCount is false,
+    the facet search request #filterFacetCount is also false`, () => {
+      initializeComponents({ filterFacetCount: false });
+      facetSearchController.search('');
+
+      expect(facetSearchSpy.calls.mostRecent().args[0].filterFacetCount).toBe(false);
     });
 
     it(`when calling fetchMoreResults

--- a/unitTests/rest/SearchEndpointTest.ts
+++ b/unitTests/rest/SearchEndpointTest.ts
@@ -809,7 +809,8 @@ export function SearchEndpointTest() {
 
         it('for facetSearch', done => {
           const promiseSuccess = ep.facetSearch({
-            field: 'test'
+            field: 'test',
+            filterFacetCount: true
           });
 
           expect(jasmine.Ajax.requests.mostRecent().url).toContain(ep.getBaseUri() + '/facet?');


### PR DESCRIPTION
The JSUI is more complex, because the default value of `filterFacetCount` depends on whether folding is being used.
Sharing this state happens on building query. This life cycle is not used by facet search.

I wanted to explore simplifying the default to always be `true`, regardless of whether folding is configured or not.
Do you see this causing any problems?

**Update**

Confirmed with Daniel Lavoie that the logic is flipped. Adjusted the default to always be `true`.

https://coveord.atlassian.net/browse/JSUI-3317





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)