### PR TITLE
JSUI-3318 build fileTypes before buildStrings 

### DIFF
--- a/gulpTasks/strings.js
+++ b/gulpTasks/strings.js
@@ -6,7 +6,7 @@ function buildStrings(cb) {
   dict.merge(strings.load('./strings/strings.json', { module: 'Coveo' }));
 
   dict.writeDeclarationFile('./src/strings/Strings.ts');
-  dict.writeDefaultLanguage('./src/strings/DefaultLanguage.ts', 'en', './strings/cultures/globalize.culture.en-US.js', true);
+  dict.writeDefaultLanguage('./src/strings/DefaultLanguage.ts', 'en');
   dict.writeLanguageFile('./bin/js/cultures/en.js', 'en', './strings/cultures/globalize.culture.en-US.js', false);
   dict.writeLanguageFile('./bin/js/cultures/fr.js', 'fr', './strings/cultures/globalize.culture.fr-FR.js', false);
   dict.writeLanguageFile('./bin/js/cultures/cs.js', 'cs', './strings/cultures/globalize.culture.cs.js', false);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,9 +17,9 @@ const { injectVersion } = require('./gulpTasks/injectVersion');
 
 const src = series(compile, definitions);
 
-const build = series(setNodeProdEnv, parallel(fileTypes, iconList, setup, templates), src);
+const build = series(setNodeProdEnv, parallel(iconList, setup, templates), src);
 
-const defaultTask = series(buildStrings, parallel(buildLegacy, build, doc));
+const defaultTask = series(fileTypes, buildStrings, parallel(buildLegacy, build, doc));
 
 exports.default = defaultTask;
 exports.compileTSOnly = compileTSOnly;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,9 +17,9 @@ const { injectVersion } = require('./gulpTasks/injectVersion');
 
 const src = series(compile, definitions);
 
-const build = series(setNodeProdEnv, parallel(fileTypes, iconList, setup, templates), buildStrings, src);
+const build = series(setNodeProdEnv, parallel(fileTypes, iconList, setup, templates), buildStrings, src, doc);
 
-const defaultTask = parallel(buildLegacy, build, doc);
+const defaultTask = parallel(buildLegacy, build);
 
 exports.default = defaultTask;
 exports.compileTSOnly = compileTSOnly;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,12 +14,13 @@ const { zipForGitReleases, zipForVeracode } = require('./gulpTasks/zip');
 const { coverage, uploadCoverage, unitTests, accessibilityTests } = require('./gulpTasks/test');
 const { docsitemap } = require('./gulpTasks/docsitemap');
 const { injectVersion } = require('./gulpTasks/injectVersion');
+const del = require('del');
 
+const cleanBin = () => del(['./bin']);
 const src = series(compile, definitions);
 
 const build = series(setNodeProdEnv, parallel(iconList, setup, templates), src);
-
-const defaultTask = series(fileTypes, buildStrings, parallel(buildLegacy, build, doc));
+const defaultTask = series(cleanBin, fileTypes, buildStrings, parallel(buildLegacy, build, doc));
 
 exports.default = defaultTask;
 exports.compileTSOnly = compileTSOnly;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,9 +17,9 @@ const { injectVersion } = require('./gulpTasks/injectVersion');
 
 const src = series(compile, definitions);
 
-const build = series(setNodeProdEnv, parallel(fileTypes, iconList, setup, templates), buildStrings, src, doc);
+const build = series(setNodeProdEnv, parallel(fileTypes, iconList, setup, templates), src);
 
-const defaultTask = parallel(buildLegacy, build);
+const defaultTask = series(buildStrings, parallel(buildLegacy, build, doc));
 
 exports.default = defaultTask;
 exports.compileTSOnly = compileTSOnly;


### PR DESCRIPTION
The `buildStrings` job uses a file generated by `fileTypes`. This did not show up on CI in the initial PR because the `bin` directory already existed on the machine used to run the build.

The `fileTypes` job now runs before `buildStrings`. I also added a step to clean the bin to prevent such errors in the future,


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)