### PR TITLE
JSUI-3319 Highlight facet value match without escaping

### DIFF
--- a/src/ui/Combobox/ComboboxValues.ts
+++ b/src/ui/Combobox/ComboboxValues.ts
@@ -2,7 +2,7 @@ import { ICombobox, IComboboxValues, IComboboxValue } from './ICombobox';
 import { $$ } from '../../utils/Dom';
 import { find } from 'underscore';
 import { l } from '../../strings/Strings';
-import { escape } from 'underscore';
+import { HighlightUtils } from '../../UtilsModules';
 
 export class ComboboxValues implements IComboboxValues {
   public element: HTMLElement;
@@ -65,13 +65,16 @@ export class ComboboxValues implements IComboboxValues {
 
   private highlightCurrentQueryInSearchResults(searchResult: HTMLElement) {
     if (this.combobox.options.highlightValueClassName) {
-      const regex = new RegExp('(' + this.combobox.element.querySelector('input').value + ')', 'ig');
+      const query = this.combobox.element.querySelector('input').value;
       const result = $$(searchResult).hasClass(this.combobox.options.highlightValueClassName)
         ? searchResult
         : $$(searchResult).find(`.${this.combobox.options.highlightValueClassName}`);
       if (result) {
-        const text = escape($$(result).text());
-        result.innerHTML = text.replace(regex, '<span class="coveo-highlight">$1</span>');
+        const text = $$(result).text();
+        const nodes = HighlightUtils.highlight(text, query, 'coveo-highlight');
+
+        $$(result).empty();
+        nodes.forEach(node => result.appendChild(node));
       }
     }
   }

--- a/src/utils/HighlightUtils.ts
+++ b/src/utils/HighlightUtils.ts
@@ -289,23 +289,31 @@ export class HighlightUtils {
 
     parts.forEach(part => {
       if (part) {
-        const unhighlighted = $$('span', {}, part);
+        const unhighlighted = createSpanWithText(part);
+
         elements.push(unhighlighted.el);
         index += part.length;
       }
 
       const matchedSubstring = text.substring(index, index + match.length);
-      const highlighted = $$('span', { class: className }, matchedSubstring);
+      const highlighted = createSpanWithText(matchedSubstring);
+      highlighted.addClass(className);
 
       elements.push(highlighted.el);
       index += match.length;
     });
 
     if (lastPart) {
-      const last = $$('span', {}, lastPart);
+      const last = createSpanWithText(lastPart);
       elements.push(last.el);
     }
 
     return elements;
   }
+}
+
+function createSpanWithText(text: string) {
+  const span = $$('span');
+  span.text(text);
+  return span;
 }

--- a/src/utils/HighlightUtils.ts
+++ b/src/utils/HighlightUtils.ts
@@ -2,6 +2,7 @@ import { Utils } from './Utils';
 import { IHighlight } from '../rest/Highlight';
 import { Assert } from '../misc/Assert';
 import * as _ from 'underscore';
+import { $$ } from './Dom';
 
 export interface IStringHole {
   begin: number;
@@ -276,5 +277,35 @@ export class HighlightUtils {
       highlighted += _.escape(content.slice(last));
     }
     return highlighted;
+  }
+
+  static highlight(text: string, match: string, className: string): HTMLElement[] {
+    const elements: HTMLElement[] = [];
+    const regex = RegExp(match, 'i');
+    const parts = text.split(regex);
+    const lastPart = parts.pop();
+
+    let index = 0;
+
+    parts.forEach(part => {
+      if (part) {
+        const unhighlighted = $$('span', {}, part);
+        elements.push(unhighlighted.el);
+        index += part.length;
+      }
+
+      const matchedSubstring = text.substring(index, index + match.length);
+      const highlighted = $$('span', { class: className }, matchedSubstring);
+
+      elements.push(highlighted.el);
+      index += match.length;
+    });
+
+    if (lastPart) {
+      const last = $$('span', {}, lastPart);
+      elements.push(last.el);
+    }
+
+    return elements;
   }
 }

--- a/unitTests/ui/Combobox/ComboboxValuesTest.ts
+++ b/unitTests/ui/Combobox/ComboboxValuesTest.ts
@@ -123,7 +123,13 @@ export function ComboboxValuesTest() {
         combobox.element.querySelector('input').value = 'e';
         triggerRenderFromResponse(['hello']);
         const element = $$(comboboxValues.element).findAll('.coveo-checkbox-span-label')[0];
-        expect(element.innerHTML).toBe('h<span class="coveo-highlight">e</span>llo');
+        expect(element.innerHTML).toBe('<span>h</span><span class="coveo-highlight">e</span><span>llo</span>');
+      });
+
+      it('does not escape & character', () => {
+        triggerRenderFromResponse(['&']);
+        const element = $$(comboboxValues.element).findAll('.coveo-checkbox-span-label')[0];
+        expect(element.textContent).toBe('&');
       });
 
       it('should highlight text that matches the input value when a child has the right class', () => {
@@ -142,7 +148,7 @@ export function ComboboxValuesTest() {
         combobox.element.querySelector('input').value = 'e';
         triggerRenderFromResponse(['hello']);
         const element = $$(comboboxValues.element).findAll('.coveo-checkbox-span-label')[0];
-        expect(element.innerHTML).toBe('h<span class="coveo-highlight">e</span>llo');
+        expect(element.innerHTML).toBe('<span>h</span><span class="coveo-highlight">e</span><span>llo</span>');
       });
 
       describe('when a value is clicked', () => {

--- a/unitTests/ui/Combobox/ComboboxValuesTest.ts
+++ b/unitTests/ui/Combobox/ComboboxValuesTest.ts
@@ -126,12 +126,6 @@ export function ComboboxValuesTest() {
         expect(element.innerHTML).toBe('<span>h</span><span class="coveo-highlight">e</span><span>llo</span>');
       });
 
-      it('does not escape & character', () => {
-        triggerRenderFromResponse(['&']);
-        const element = $$(comboboxValues.element).findAll('.coveo-checkbox-span-label')[0];
-        expect(element.textContent).toBe('&');
-      });
-
       it('should highlight text that matches the input value when a child has the right class', () => {
         const createValuesFromResponseWithWrapper = (response: string[]) => {
           return response.map(value => {
@@ -149,6 +143,12 @@ export function ComboboxValuesTest() {
         triggerRenderFromResponse(['hello']);
         const element = $$(comboboxValues.element).findAll('.coveo-checkbox-span-label')[0];
         expect(element.innerHTML).toBe('<span>h</span><span class="coveo-highlight">e</span><span>llo</span>');
+      });
+
+      it('does not escape & character', () => {
+        triggerRenderFromResponse(['&']);
+        const element = $$(comboboxValues.element).findAll('.coveo-checkbox-span-label')[0];
+        expect(element.textContent).toBe('&');
       });
 
       describe('when a value is clicked', () => {

--- a/unitTests/utils/HighlightUtilsTest.ts
+++ b/unitTests/utils/HighlightUtilsTest.ts
@@ -245,6 +245,32 @@ export function HighlightUtilsTest() {
         expect(result[2].textContent).toBe('a');
         expect(result[2].className).toBe(highlightClass);
       });
+
+      it('when the text contains valid html, it treats it as text', () => {
+        const text = '<script>hax</script>';
+        const result = HighlightUtils.highlight(text, 'hax', highlightClass);
+
+        expect(result.length).toBe(3);
+
+        expect(result[0].textContent).toBe('<script>');
+        expect(result[0].className).toBe('');
+
+        expect(result[1].textContent).toBe('hax');
+        expect(result[1].className).toBe(highlightClass);
+
+        expect(result[2].textContent).toBe('</script>');
+        expect(result[2].className).toBe('');
+      });
+
+      it('when the match contains valid html, it treats it as text', () => {
+        const text = '<script>hax</script>';
+        const result = HighlightUtils.highlight(text, text, highlightClass);
+
+        expect(result.length).toBe(1);
+
+        expect(result[0].textContent).toBe(text);
+        expect(result[0].className).toBe(highlightClass);
+      });
     });
   });
 }

--- a/unitTests/utils/HighlightUtilsTest.ts
+++ b/unitTests/utils/HighlightUtilsTest.ts
@@ -3,14 +3,14 @@ import { HighlightUtils } from '../../src/utils/HighlightUtils';
 import { StringAndHoles } from '../../src/utils/HighlightUtils';
 
 export function HighlightUtilsTest() {
-  describe('HighlightUtils', function() {
+  describe('HighlightUtils', function () {
     const lorem = 'Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut';
     const uri = 'http://onlinehelp.coveo.com/en/CES/7.0/Administrator/Moving_the_Index_to_a_Different_Drive.htm';
     const netPath = '\\\\Programmes\\Ces\\config\\sources\\salesforce';
     const localPath = 'C:\\Programmes\\Ces\\config\\sources\\salesforce';
 
-    describe('highlightString', function() {
-      it('should wrap the passed highlights with tags using the specified class name', function() {
+    describe('highlightString', function () {
+      it('should wrap the passed highlights with tags using the specified class name', function () {
         let highlights: IHighlight[] = [
           { offset: 3, length: 5 },
           { offset: 10, length: 4 },
@@ -22,7 +22,7 @@ export function HighlightUtilsTest() {
         expect(HighlightUtils.highlightString(lorem, highlights, null, 'coveo-highlight')).toBe(expectedHighlight);
       });
 
-      it("should ignore highlights that are out of a shortened string's bounds", function() {
+      it("should ignore highlights that are out of a shortened string's bounds", function () {
         let shortenedString: StringAndHoles = StringAndHoles.shortenString(lorem, 35, '...');
         let highlights: IHighlight[] = [
           { offset: 3, length: 5 },
@@ -36,7 +36,7 @@ export function HighlightUtilsTest() {
         expect(highlightedString).toBe(expectedHighlight);
       });
 
-      it("should ignore highlights that are out of a shortened local path's bounds", function() {
+      it("should ignore highlights that are out of a shortened local path's bounds", function () {
         let shortenedString: StringAndHoles = StringAndHoles.shortenPath(localPath, 15);
         let highlights: IHighlight[] = [
           { offset: 3, length: 5 },
@@ -54,7 +54,7 @@ export function HighlightUtilsTest() {
         expect(highlightedString).toBe(expectedHighlight);
       });
 
-      it("should ignore highlights that are out of a shortened network path's bounds", function() {
+      it("should ignore highlights that are out of a shortened network path's bounds", function () {
         let shortenedString: StringAndHoles = StringAndHoles.shortenPath(netPath, 30);
         let highlights: IHighlight[] = [
           { offset: 3, length: 5 },
@@ -67,9 +67,13 @@ export function HighlightUtilsTest() {
         expect(highlightedString).toBe(expectedHighlight);
       });
 
-      it("should ignore highlights that are out of a shortened uri's bounds", function() {
+      it("should ignore highlights that are out of a shortened uri's bounds", function () {
         let shortenedString: StringAndHoles = StringAndHoles.shortenUri(uri, 60);
-        let highlights: IHighlight[] = [{ offset: 12, length: 4 }, { offset: 18, length: 15 }, { offset: 45, length: 10 }];
+        let highlights: IHighlight[] = [
+          { offset: 12, length: 4 },
+          { offset: 18, length: 15 },
+          { offset: 45, length: 10 }
+        ];
         let expectedHighlight =
           'http://onlin<span class="coveo-highlight">ehel</span>p.<span class="coveo-highlight">coveo.com/</span>...<span class="coveo-highlight">/Mo</span>ving_the_Index_to_a_Dif...';
         let highlightedString = HighlightUtils.highlightString(shortenedString.value, highlights, shortenedString.holes, 'coveo-highlight');
@@ -77,8 +81,8 @@ export function HighlightUtilsTest() {
       });
     });
 
-    describe('shortenString', function() {
-      it('should shorten the string to the specified number of characters and append the specified value', function() {
+    describe('shortenString', function () {
+      it('should shorten the string to the specified number of characters and append the specified value', function () {
         let shortenedString = StringAndHoles.shortenString(lorem, 60, '...');
         expect(shortenedString).toEqual(
           jasmine.objectContaining({
@@ -88,15 +92,15 @@ export function HighlightUtilsTest() {
         );
       });
 
-      it('should not shorten string that is shorter than the specified value', function() {
+      it('should not shorten string that is shorter than the specified value', function () {
         let shortenedString = StringAndHoles.shortenString(lorem, 9000, '...');
         expect(shortenedString.value).toBe(lorem);
         expect(shortenedString.holes).toBeUndefined();
       });
     });
 
-    describe('shortenPath', function() {
-      it('should shorten local path properly', function() {
+    describe('shortenPath', function () {
+      it('should shorten local path properly', function () {
         let shortenedPath = StringAndHoles.shortenPath(localPath, 30);
         expect(shortenedPath).toEqual(
           jasmine.objectContaining({
@@ -106,7 +110,7 @@ export function HighlightUtilsTest() {
         );
       });
 
-      it('should shorten network path properly', function() {
+      it('should shorten network path properly', function () {
         let shortenedNetPath = StringAndHoles.shortenPath(netPath, 30);
         expect(shortenedNetPath).toEqual(
           jasmine.objectContaining({
@@ -116,39 +120,48 @@ export function HighlightUtilsTest() {
         );
       });
 
-      it('should shorten network path to an absurd amount', function() {
+      it('should shorten network path to an absurd amount', function () {
         let shortenedNetPath = StringAndHoles.shortenPath(netPath, 15);
         expect(shortenedNetPath).toEqual(
           jasmine.objectContaining({
             value: '\\\\...es\\sale...',
-            holes: [{ begin: 2, size: 26, replacementSize: 3 }, { begin: 12, size: 6, replacementSize: 3 }]
+            holes: [
+              { begin: 2, size: 26, replacementSize: 3 },
+              { begin: 12, size: 6, replacementSize: 3 }
+            ]
           })
         );
       });
     });
 
-    describe('shortenUri', function() {
-      it('should shorten an uri properly', function() {
+    describe('shortenUri', function () {
+      it('should shorten an uri properly', function () {
         let shortenedUri = StringAndHoles.shortenUri(uri, 60);
         expect(shortenedUri).toEqual(
           jasmine.objectContaining({
             value: 'http://onlinehelp.coveo.com/.../Moving_the_Index_to_a_Dif...',
-            holes: [{ begin: 28, size: 24, replacementSize: 3 }, { begin: 57, size: 16, replacementSize: 3 }]
+            holes: [
+              { begin: 28, size: 24, replacementSize: 3 },
+              { begin: 57, size: 16, replacementSize: 3 }
+            ]
           })
         );
       });
 
-      it('should shorten an uri to an absurd amount', function() {
+      it('should shorten an uri to an absurd amount', function () {
         let shortenedUri = StringAndHoles.shortenUri(uri, 15);
         expect(shortenedUri).toEqual(
           jasmine.objectContaining({
             value: 'http://onlin...',
-            holes: [{ begin: 28, size: 24, replacementSize: 3 }, { begin: 12, size: 61, replacementSize: 3 }]
+            holes: [
+              { begin: 28, size: 24, replacementSize: 3 },
+              { begin: 12, size: 61, replacementSize: 3 }
+            ]
           })
         );
       });
 
-      it('should not strip end characters if there is enough room for them', function() {
+      it('should not strip end characters if there is enough room for them', function () {
         let shortenedUri = StringAndHoles.shortenUri(uri, 80);
         expect(shortenedUri).toEqual(
           jasmine.objectContaining({
@@ -156,6 +169,81 @@ export function HighlightUtilsTest() {
             holes: [{ begin: 28, size: 24, replacementSize: 3 }]
           })
         );
+      });
+    });
+
+    describe('highlight', () => {
+      const highlightClass = 'coveo-highlight';
+
+      it('text is empty string, it returns an empty array', () => {
+        const result = HighlightUtils.highlight('', '', highlightClass);
+        expect(result.length).toBe(0);
+      });
+
+      it('text, match is an empty string, it returns the text in one not highlighted node', () => {
+        const result = HighlightUtils.highlight('a', '', highlightClass);
+        expect(result.length).toBe(1);
+        expect(result[0].textContent).toBe('a');
+        expect(result[0].className).toBe('');
+      });
+
+      it('text contains the match, it returns the text in one highlighted node', () => {
+        const result = HighlightUtils.highlight('a', 'a', highlightClass);
+        expect(result.length).toBe(1);
+        expect(result[0].textContent).toBe('a');
+        expect(result[0].className).toBe(highlightClass);
+      });
+
+      it('text contains the match but in a different case, it returns the text in one highlighted node', () => {
+        const result = HighlightUtils.highlight('a', 'A', highlightClass);
+        expect(result.length).toBe(1);
+        expect(result[0].textContent).toBe('a');
+        expect(result[0].className).toBe(highlightClass);
+      });
+
+      it('text contains a multi-character match, it returns the text in one highlighted node', () => {
+        const result = HighlightUtils.highlight('ab', 'Ab', highlightClass);
+        expect(result.length).toBe(1);
+        expect(result[0].textContent).toBe('ab');
+        expect(result[0].className).toBe(highlightClass);
+      });
+
+      it('text contains a multi-character match not at start, it returns the expected nodes', () => {
+        const result = HighlightUtils.highlight('abc', 'bc', highlightClass);
+        expect(result.length).toBe(2);
+
+        expect(result[0].textContent).toBe('a');
+        expect(result[0].className).toBe('');
+
+        expect(result[1].textContent).toBe('bc');
+        expect(result[1].className).toBe(highlightClass);
+      });
+
+      it('text contains match not at the start, it returns one not highlighted and one higlighted node', () => {
+        const result = HighlightUtils.highlight('ab', 'b', highlightClass);
+
+        expect(result.length).toBe(2);
+
+        expect(result[0].textContent).toBe('a');
+        expect(result[0].className).toBe('');
+
+        expect(result[1].textContent).toBe('b');
+        expect(result[1].className).toBe(highlightClass);
+      });
+
+      it('text contains the match twice separated by a non-match, it returns the expected nodes', () => {
+        const result = HighlightUtils.highlight('aba', 'a', highlightClass);
+
+        expect(result.length).toBe(3);
+
+        expect(result[0].textContent).toBe('a');
+        expect(result[0].className).toBe(highlightClass);
+
+        expect(result[1].textContent).toBe('b');
+        expect(result[1].className).toBe('');
+
+        expect(result[2].textContent).toBe('a');
+        expect(result[2].className).toBe(highlightClass);
       });
     });
   });


### PR DESCRIPTION
**Context**

Facet values were being escaped before render to prevent XSS. However, if a value actually contains one of the dangerous characters (an `&` in Humana's case), then it would appear as `&amp;`.

**Approach**

Instead of escaping and rendering as `innerHtml`, I created DOM elements that hold the text content. If a facet value contains valid html, it will be not be evaluated. The string will be treated as text.

**Further work**

The current PR will solve the client's issue.

However, dynamic facets configured using `filetype` or `objecttype` fields still have the issue because the JSUI has a [special code path](https://github.com/coveo/search-ui/blob/master/src/ui/Facet/FacetUtils.ts#L100) that tries to get value captions, and [escapes the caption](https://github.com/coveo/search-ui/blob/master/src/ui/Misc/FileTypes.ts#L95) before returning it.

Removing the escape is easy enough, but it will take some time to ensure no instances calling the function are vulnerable to XSS. There are also other `escape` instances in the code base not related to facets.

Debating whether to bite the bullet, or tackle these when (if) they are reported by clients.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)