### PR TITLE
JSUI-3322 Added type button on all button elements I found

### DIFF
--- a/docs/playground/src/Playground.ts
+++ b/docs/playground/src/Playground.ts
@@ -38,12 +38,7 @@ export class Playground {
   }
 
   public isComponentPage() {
-    return (
-      $$(this.getTitle())
-        .text()
-        .toLowerCase()
-        .indexOf('component') != -1
-    );
+    return $$(this.getTitle()).text().toLowerCase().indexOf('component') != -1;
   }
 
   public getComponentName() {
@@ -113,8 +108,8 @@ export class Playground {
 
   public initializePreview() {
     const previewContainer = $$(document.body).find('.preview-container');
-    this.showButton = $$('button', { className: 'preview-toggle' }, `Show a live example of ${this.getComponentName()}`);
-    this.hideButton = $$('button', { className: 'preview-toggle' }, 'Hide example');
+    this.showButton = $$('button', { type: 'button', className: 'preview-toggle' }, `Show a live example of ${this.getComponentName()}`);
+    this.hideButton = $$('button', { type: 'button', className: 'preview-toggle' }, 'Hide example');
     this.componentContainer = $$('div', { className: 'component-container' });
     this.componentContainer.hide();
     this.hideButton.hide();

--- a/src/ui/DidYouMean/DidYouMean.ts
+++ b/src/ui/DidYouMean/DidYouMean.ts
@@ -142,7 +142,7 @@ export class DidYouMean extends Component {
       const correctedSentence = this.buildCorrectedSentence(results.queryCorrections[0]);
       this.correctedTerm = results.queryCorrections[0].correctedQuery;
 
-      const correctedWordEl = $$('button', {}, correctedSentence).el;
+      const correctedWordEl = $$('button', { type: 'button' }, correctedSentence).el;
       const didYouMean = $$('div', { className: 'coveo-did-you-mean-suggestion' }, l('didYouMean', correctedWordEl.outerHTML));
       this.element.appendChild(didYouMean.el);
 

--- a/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
+++ b/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
@@ -42,6 +42,7 @@ export class DynamicFacetBreadcrumbs {
     const valueElement = $$(
       'button',
       {
+        type: 'button',
         className: 'coveo-dynamic-facet-breadcrumb-value',
         ariaLabel: l('RemoveFilterOn', facetValue.displayValue)
       },
@@ -72,6 +73,7 @@ export class DynamicFacetBreadcrumbs {
       'button',
       {
         className: 'coveo-dynamic-facet-breadcrumb-collapse',
+        type: 'button',
         title
       },
       label

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetBreadcrumb.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetBreadcrumb.ts
@@ -31,6 +31,7 @@ export class DynamicHierarchicalFacetBreadcrumb {
     const valueElement = $$(
       'button',
       {
+        type: 'button',
         className: 'coveo-dynamic-facet-breadcrumb-value',
         ariaLabel: l('RemoveFilterOn', caption)
       },

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValueRenderer.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValueRenderer.ts
@@ -11,6 +11,7 @@ export class DynamicHierarchicalFacetValueRenderer {
   public render() {
     this.button = $$('button', {
       className: 'coveo-dynamic-hierarchical-facet-value',
+      type: 'button',
       ariaLabel: this.facetValue.selectAriaLabel
     });
     this.button.on('click', () => this.selectAction());

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValues.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValues.ts
@@ -169,7 +169,11 @@ export class DynamicHierarchicalFacetValues implements IDynamicHierarchicalFacet
   private prependAllCategories() {
     const clearButton = $$(
       'button',
-      { className: 'coveo-dynamic-hierarchical-facet-all', title: this.facet.options.clearLabel },
+      {
+        className: 'coveo-dynamic-hierarchical-facet-all',
+        type: 'button',
+        title: this.facet.options.clearLabel
+      },
       this.facet.options.clearLabel
     );
     clearButton.toggleClass('coveo-show-when-collapsed', this.facet.values.selectedPath.length === 1);

--- a/src/ui/MissingTerm/MissingTermManager.ts
+++ b/src/ui/MissingTerm/MissingTermManager.ts
@@ -70,6 +70,7 @@ export class MissingTermManager {
       const termContainer = $$(
         'button',
         {
+          type: 'button',
           className: 'coveo-missing-term-breadcrumb-value coveo-accessible-button'
         },
         $$('span', { className: 'coveo-missing-term-breadcrumb-caption' }, escape(term)),

--- a/src/ui/MissingTerm/MissingTerms.ts
+++ b/src/ui/MissingTerm/MissingTerms.ts
@@ -164,7 +164,7 @@ export class MissingTerms extends Component {
 
   private makeTermClickableIfEnabled(term: string): Dom {
     if (this.options.clickable) {
-      const termElement = $$('button', { className: 'coveo-missing-term coveo-clickable' }, term);
+      const termElement = $$('button', { className: 'coveo-missing-term coveo-clickable', type: 'button' }, term);
       termElement.on('click', () => {
         this.addTermForcedToAppear(term);
         this.logAnalyticsAddMissingTerm(term);
@@ -196,7 +196,11 @@ export class MissingTerms extends Component {
       $$(allMissingTerms[index]).hide();
     }
     const nbMoreResults = allMissingTerms.length - this.options.numberOfTerms;
-    const showMore = $$('button', { className: 'coveo-missing-term-show-more coveo-clickable' }, l('NMore', [nbMoreResults]));
+    const showMore = $$(
+      'button',
+      { className: 'coveo-missing-term-show-more coveo-clickable', type: 'button' },
+      l('NMore', [nbMoreResults])
+    );
 
     showMore.on('click', () => {
       this.showAllHiddenMissingTerms();

--- a/src/ui/PrintableUri/PrintableUri.ts
+++ b/src/ui/PrintableUri/PrintableUri.ts
@@ -234,7 +234,7 @@ export class PrintableUri extends Component {
   }
 
   private buildEllipsis(action: (e: Event) => void) {
-    const button = $$('button', {}, '...');
+    const button = $$('button', { type: 'button' }, '...');
     const element = $$(
       'span',
       {
@@ -243,11 +243,7 @@ export class PrintableUri extends Component {
       },
       button
     ).el;
-    new AccessibleButton()
-      .withElement(button)
-      .withLabel(l('CollapsedUriParts'))
-      .withSelectAction(action)
-      .build();
+    new AccessibleButton().withElement(button).withLabel(l('CollapsedUriParts')).withSelectAction(action).build();
     return element;
   }
 

--- a/src/ui/RelevanceInspector/AvailableFieldsTable.ts
+++ b/src/ui/RelevanceInspector/AvailableFieldsTable.ts
@@ -89,7 +89,8 @@ export class AvailableFieldsSampleValue implements agGridModule.ICellRendererCom
     const btn = $$(
       'button',
       {
-        className: 'coveo-button coveo-available-fields-table-button'
+        className: 'coveo-button coveo-available-fields-table-button',
+        type: 'button'
       },
       'Hover For Sample Values'
     );

--- a/src/ui/RelevanceInspector/ExecutionReportEffectiveIndexQuerySection.ts
+++ b/src/ui/RelevanceInspector/ExecutionReportEffectiveIndexQuerySection.ts
@@ -34,7 +34,8 @@ export class ExecutionReportEffectiveIndexQuerySection implements IExecutionRepo
           const btn = $$(
             'button',
             {
-              className: 'coveo-button'
+              className: 'coveo-button',
+              type: 'button'
             },
             paramKey
           );

--- a/src/ui/RelevanceInspector/InlineRankingInfo.ts
+++ b/src/ui/RelevanceInspector/InlineRankingInfo.ts
@@ -41,7 +41,7 @@ export class InlineRankingInfo {
   private buildTogglableTermsSection(container: Dom) {
     const termsButton = $$(
       'button',
-      { className: 'coveo-button coveo-relevance-inspector-inline-ranking-button' },
+      { className: 'coveo-button coveo-relevance-inspector-inline-ranking-button', type: 'button' },
       'Toggle Terms Relevancy Breakdown'
     );
     container.append(termsButton.el);
@@ -59,7 +59,11 @@ export class InlineRankingInfo {
   }
 
   private buildTogglableQRESection(container: Dom) {
-    const qreButton = $$('button', { className: 'coveo-button coveo-relevance-inspector-inline-ranking-button' }, 'Toggle QRE Breakdown');
+    const qreButton = $$(
+      'button',
+      { className: 'coveo-button coveo-relevance-inspector-inline-ranking-button', type: 'button' },
+      'Toggle QRE Breakdown'
+    );
     container.append(qreButton.el);
     const qreSection = $$('ul', { className: 'coveo-relevance-inspector-inline-ranking-terms' });
 

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownModalContent.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownModalContent.ts
@@ -44,6 +44,7 @@ export class ResponsiveDropdownModalContent implements IResponsiveDropdownConten
         'button',
         {
           className: 'coveo-facet-modal-close-button',
+          type: 'button',
           ariaLabel: this.closeButtonLabel
         },
         SVGIcons.icons.mainClear

--- a/src/ui/SimpleFilter/SimpleFilter.ts
+++ b/src/ui/SimpleFilter/SimpleFilter.ts
@@ -480,7 +480,8 @@ export class SimpleFilter extends Component {
       {
         title: l('DeselectFilterValues', this.options.title),
         'aria-label': l('Clear', this.options.title),
-        className: 'coveo-simplefilter-eraser'
+        className: 'coveo-simplefilter-eraser',
+        type: 'button'
       },
       SVGIcons.icons.mainClear
     );

--- a/src/ui/SmartSnippet/ExplanationModal.ts
+++ b/src/ui/SmartSnippet/ExplanationModal.ts
@@ -137,7 +137,7 @@ export class ExplanationModal {
   }
 
   private buildSendButton() {
-    const button = $$('button', { className: SEND_BUTTON_CLASSNAME }, l('Send'));
+    const button = $$('button', { className: SEND_BUTTON_CLASSNAME, type: 'button' }, l('Send'));
     button.on('click', () => {
       this.selectedReason.onSelect();
       this.shouldCallCloseEvent = false;
@@ -147,7 +147,7 @@ export class ExplanationModal {
   }
 
   private buildCancelButton() {
-    const button = $$('button', { className: CANCEL_BUTTON_CLASSNAME }, l('Cancel'));
+    const button = $$('button', { className: CANCEL_BUTTON_CLASSNAME, type: 'button' }, l('Cancel'));
     button.on('click', () => this.modal.close());
     return button.el;
   }

--- a/src/ui/SmartSnippet/HeightLimiter.ts
+++ b/src/ui/SmartSnippet/HeightLimiter.ts
@@ -54,7 +54,7 @@ export class HeightLimiter {
   private buildButton() {
     this.button = $$(
       'button',
-      { className: BUTTON_CLASSNAME, ariaLabel: l('ShowMore'), ariaPressed: 'false', ariaHidden: 'true' },
+      { className: BUTTON_CLASSNAME, type: 'button', ariaLabel: l('ShowMore'), ariaPressed: 'false', ariaHidden: 'true' },
       (this.buttonLabel = $$('span', { className: BUTTON_LABEL_CLASSNAME }).el),
       (this.buttonIcon = $$('span', { className: BUTTON_ICON_CLASSNAME }).el)
     ).el;

--- a/src/ui/SmartSnippet/UserFeedbackBanner.ts
+++ b/src/ui/SmartSnippet/UserFeedbackBanner.ts
@@ -152,7 +152,7 @@ export class UserFeedbackBanner {
   }
 
   private buildButton(options: IButtonOptions) {
-    const button = $$('button', { ...(options.attributes || {}), className: options.className }).el;
+    const button = $$('button', { ...(options.attributes || {}), className: options.className, type: 'button' }).el;
 
     if (options.icon) {
       const icon = $$('span', { className: options.icon.className }, options.icon.content).el;

--- a/src/utils/DebugUtils.ts
+++ b/src/utils/DebugUtils.ts
@@ -1,7 +1,7 @@
 import { $$ } from './Dom';
 
 export function actionButton(text: string, callback: () => any) {
-  let btn = $$('button', {}, text);
+  let btn = $$('button', { type: 'button' }, text);
   btn.on('click', callback());
   return btn.el;
 }

--- a/unitTests/ui/DynamicFacet/DynamicFacetBreadcrumbsTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetBreadcrumbsTest.ts
@@ -70,6 +70,12 @@ export function DynamicFacetBreadcrumbsTest() {
       });
     });
 
+    it('should have the correct type for every selected value', () => {
+      _.each(valueElements(), (breadcrumb, index) => {
+        expect(breadcrumb.getAttribute('type')).toBe(`button`);
+      });
+    });
+
     describe('when the breadcrumb has more values than the numberOfValuesInBreadcrumb option', () => {
       beforeEach(() => {
         baseOptions.numberOfValuesInBreadcrumb = 3;


### PR DESCRIPTION
## JSUI-3322

In order to fix the issue we have with the ServiceNow integration using Dynamic facets I needed to add the button type to the button elements of the breadcrumbs. I figured why not add it to all buttons!
Simply, not having `type="button"` on a button element will by default `submit`, so if the JSUI is inside a page-wide form (which is the case for servicenow) it reloads the page when you click on a breadcrumb. It's also good practice to always set the type apparently 😅


https://coveord.atlassian.net/browse/JSUI-3322

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)