### PR TITLE
JSUI-3321 Removed generic localization from dynamic facet values

### DIFF
--- a/src/ui/Facet/FacetUtils.ts
+++ b/src/ui/Facet/FacetUtils.ts
@@ -15,7 +15,7 @@ export class FacetUtils {
   }
 
   static getDisplayValueFromValueCaption(value: string, field: string, valueCaption: Record<string, string>) {
-    const returnValue = this.tryToGetTranslatedCaption(field, value);
+    const returnValue = this.tryToGetTranslatedCaption(field, value, false);
     return valueCaption[value] || returnValue;
   }
 
@@ -93,17 +93,17 @@ export class FacetUtils {
     }
   }
 
-  static tryToGetTranslatedCaption(field: string, value: string) {
+  static tryToGetTranslatedCaption(field: string, value: string, fallbackOnLocalization = true) {
     let found: string;
 
     if (QueryUtils.isStratusAgnosticField(field.toLowerCase(), '@filetype')) {
-      found = FileTypes.getFileType(value).caption;
+      found = FileTypes.getFileType(value, fallbackOnLocalization).caption;
     } else if (QueryUtils.isStratusAgnosticField(field.toLowerCase(), '@objecttype')) {
-      found = FileTypes.getObjectType(value).caption;
+      found = FileTypes.getObjectType(value, fallbackOnLocalization).caption;
     } else if (FacetUtils.isMonthFieldValue(field, value)) {
       const month = parseInt(value, 10);
       found = DateUtils.monthToString(month - 1);
-    } else {
+    } else if (fallbackOnLocalization) {
       found = l(value);
     }
     return found != undefined && Utils.isNonEmptyString(found) ? found : value;

--- a/src/ui/Misc/FileTypes.ts
+++ b/src/ui/Misc/FileTypes.ts
@@ -32,7 +32,7 @@ export class FileTypes {
     }
   }
 
-  static getObjectType(objecttype: string): IFileTypeInfo {
+  static getObjectType(objecttype: string, fallbackOnLocalization = true): IFileTypeInfo {
     // We must use lowercase filetypes because that's how the CSS classes
     // are generated (they are case sensitive, alas).
     const loweredCaseObjecttype = objecttype.toLowerCase();
@@ -43,13 +43,13 @@ export class FileTypes {
     // Some strings are sent as `objecttype_[...]` to specify a dictionary to use. If there's no match, try using
     // the main dictionary by using the original value.
     if (localizedString.toLowerCase() == variableValue.toLowerCase()) {
-      localizedString = l(objecttype);
+      localizedString = fallbackOnLocalization ? l(objecttype) : objecttype;
     }
 
     return this.safelyBuildFileTypeInfo('objecttype', loweredCaseObjecttype, localizedString);
   }
 
-  static getFileType(filetype: string): IFileTypeInfo {
+  static getFileType(filetype: string, fallbackOnLocalization = true): IFileTypeInfo {
     // We must use lowercase filetypes because that's how the CSS classes
     // are generated (they are case sensitive, alas).
     let loweredCaseFiletype = filetype.toLowerCase();
@@ -66,7 +66,7 @@ export class FileTypes {
     if (localizedString.toLowerCase() == variableValue.toLowerCase()) {
       // Some strings are sent as `filetype_[...]` to specify a dictionary to use. If there's no match, try using
       // The main dictionary by using the original value.
-      localizedString = l(filetype);
+      localizedString = fallbackOnLocalization ? l(filetype) : filetype;
     }
 
     return this.safelyBuildFileTypeInfo('filetype', loweredCaseFiletype, localizedString);


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3321

Dynamic facet values are being localized by both their captions and `l(facetValue)`. The former is okay because those captions are included with facet search calls, but the latter means that values are not always searchable by their displayed name, which causes confusion.

Here are the potential solutions to this:
* Not localizing by facet value at all, only localizing by captions (the option used in this PR)
  * May be slightly breaking for existing implementations, since some values that may be localized for them right now would suddenly not be localized.
* Adding all localization to `caption` of `facetSearch` calls
* Dynamically detecting when localized values are displayed and adding their captions to upcoming facet search calls
* Documenting that clients should localize every indexed values that happens to be localized.
  * Perhaps a warning could be added in the Admin UI, but that would be a bit weird since the admin UI doesn't necessarily know the correct version of `strings.json` for the client.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)