### PR TITLE
JSUI-3326 hide content of SmartSnippetSuggestion when collapsed

### DIFF
--- a/sass/_SmartSnippetSuggestions.scss
+++ b/sass/_SmartSnippetSuggestions.scss
@@ -61,6 +61,10 @@
         &-content {
           padding: 16px $inner-padding 24px $inner-padding;
         }
+
+        &-hidden * {
+          display: none;
+        }
       }
 
       @at-root a.CoveoResultLink.coveo-smart-snippet-suggestions-question-source {


### PR DESCRIPTION
The tabindex was already set correctly to -1 along with the other aria attributes, but some children had tabindex=0 (such as the result link). I just hide the content, while keeping the parent visible so it doesn't affect accessibility. 
https://coveord.atlassian.net/browse/JSUI-3326





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)