### PR TITLE
JSUI-3329 Add numberOfDecimals to DynamicFacetRange

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacetRange.ts
+++ b/src/ui/DynamicFacet/DynamicFacetRange.ts
@@ -79,7 +79,7 @@ export class DynamicFacetRange extends DynamicFacet implements IComponentBinding
       section: 'CommonOptions'
     }),
     /**
-     * The number of decimal to display when the [`valueFormat`]{@link DynamicFacetRange.options.valueFormat} is [`number`]{@link DynamicFacetRangeValueFormat.number}
+     * The number of decimals to display when the [`valueFormat`]{@link DynamicFacetRange.options.valueFormat} is [`number`]{@link DynamicFacetRangeValueFormat.number}
      *
      * By default, the number will be the one returned by the index.
      *

--- a/src/ui/DynamicFacet/DynamicFacetRange.ts
+++ b/src/ui/DynamicFacet/DynamicFacetRange.ts
@@ -79,6 +79,14 @@ export class DynamicFacetRange extends DynamicFacet implements IComponentBinding
       section: 'CommonOptions'
     }),
     /**
+     * The number of decimal to display when the [`valueFormat`]{@link DynamicFacetRange.options.valueFormat} is [`number`]{@link DynamicFacetRangeValueFormat.number}
+     *
+     * By default, the number will be the one returned by the index.
+     *
+     * @examples 2
+     */
+    numberOfDecimals: ComponentOptions.buildNumberOption(),
+    /**
      * The currency symbol to use if the [`valueFormat`]{@link DynamicFacetRange.options.valueFormat} is [`currency`]{@link DynamicFacetRangeValueFormat.currency}.
      *
      * By default, the component uses the currency associated with the currently loaded culture file (see [Changing the Language of Your Search Interface](https://docs.coveo.com/421/)).

--- a/src/ui/DynamicFacet/DynamicFacetRange.ts
+++ b/src/ui/DynamicFacet/DynamicFacetRange.ts
@@ -81,7 +81,7 @@ export class DynamicFacetRange extends DynamicFacet implements IComponentBinding
     /**
      * The number of decimals to display when the [`valueFormat`]{@link DynamicFacetRange.options.valueFormat} is [`number`]{@link DynamicFacetRangeValueFormat.number}
      *
-     * By default, the number will be the one returned by the index.
+     * By default, the number of decimals is what's returned by the index.
      *
      * @examples 2
      */

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetRangeValueParser.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetRangeValueParser.ts
@@ -6,6 +6,7 @@ import { DateUtils } from '../../../utils/DateUtils';
 import { IDynamicFacetRange, DynamicFacetRangeValueFormat } from '../IDynamicFacetRange';
 import { Logger } from '../../../misc/Logger';
 import { CurrencyUtils } from '../../../Core';
+import { isUndefined } from 'underscore';
 
 export class DynamicFacetRangeValueParser {
   constructor(private facet: IDynamicFacetRange) {}
@@ -31,7 +32,9 @@ export class DynamicFacetRangeValueParser {
   private formatDisplayValueFromLimit(value: RangeType) {
     switch (this.valueFormat) {
       case DynamicFacetRangeValueFormat.number:
-        const numberOfDecimals = NumberUtils.countDecimals(`${value}`);
+        const numberOfDecimals = isUndefined(this.facet.options.numberOfDecimals)
+          ? NumberUtils.countDecimals(`${value}`)
+          : this.facet.options.numberOfDecimals;
         return Globalize.format(value, `n${numberOfDecimals}`);
 
       case DynamicFacetRangeValueFormat.currency:

--- a/src/ui/DynamicFacet/IDynamicFacetRange.ts
+++ b/src/ui/DynamicFacet/IDynamicFacetRange.ts
@@ -29,6 +29,7 @@ export interface IDynamicFacetRangeOptions extends IDynamicFacetOptions {
   valueSeparator?: string;
   valueFormat?: DynamicFacetRangeValueFormat;
   ranges?: IRangeValue[];
+  numberOfDecimals?: number;
   currencySymbol?: string;
   sortOrder?: FacetRangeSortOrder;
 }

--- a/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetRangeValueParserTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetRangeValueParserTest.ts
@@ -50,7 +50,7 @@ export function DynamicFacetRangeValueParserTest() {
         });
 
         describe('testing formatDisplayValue', () => {
-          it(`when the value is a integer
+          it(`when the value is an integer
             should return the format correctly`, () => {
             const value = parser.formatDisplayValue({ start: 10, end: 20 });
             expect(value).toBe('10.00000 to 20.00000');

--- a/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetRangeValueParserTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetValues/DynamicFacetRangeValueParserTest.ts
@@ -13,7 +13,7 @@ export function DynamicFacetRangeValueParserTest() {
       facet = DynamicFacetRangeTestUtils.createAdvancedFakeFacet(facetOptions).cmp;
     }
 
-    describe('testing with the number format', () => {
+    describe('testing with the number format & numberOfDecimals not defined', () => {
       beforeEach(() => {
         facetOptions = { valueFormat: DynamicFacetRangeValueFormat.number, valueSeparator: 'to' };
         initFacet();
@@ -38,6 +38,35 @@ export function DynamicFacetRangeValueParserTest() {
           should return the format correctly`, () => {
           const value = parser.formatDisplayValue({ start: 0.99, end: 1.001 });
           expect(value).toBe('0.99 to 1.001');
+        });
+      });
+
+      describe('testing with the number format & numberOfDecimals defined', () => {
+        beforeEach(() => {
+          facetOptions = { valueFormat: DynamicFacetRangeValueFormat.number, valueSeparator: 'to', numberOfDecimals: 5 };
+          initFacet();
+
+          parser = new DynamicFacetRangeValueParser(facet);
+        });
+
+        describe('testing formatDisplayValue', () => {
+          it(`when the value is a integer
+            should return the format correctly`, () => {
+            const value = parser.formatDisplayValue({ start: 10, end: 20 });
+            expect(value).toBe('10.00000 to 20.00000');
+          });
+
+          it(`when the value is a big integer
+            should return the format correctly`, () => {
+            const value = parser.formatDisplayValue({ start: 1000, end: 100000 });
+            expect(value).toBe('1,000.00000 to 100,000.00000');
+          });
+
+          it(`when the value is a float
+            should return the format correctly`, () => {
+            const value = parser.formatDisplayValue({ start: 0.995452324, end: 1.000000000001 });
+            expect(value).toBe('0.99545 to 1.00000');
+          });
         });
       });
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3329

Something that was possible for the legacy FacetRange but not the new one. The option is undefined by default so there are no breaking changes




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)