### PR TITLE
JSUI-3330 fixed smart snippets suggestions size

### DIFF
--- a/sass/_SmartSnippetSuggestions.scss
+++ b/sass/_SmartSnippetSuggestions.scss
@@ -61,10 +61,6 @@
         &-content {
           padding: 16px $inner-padding 24px $inner-padding;
         }
-
-        &-hidden * {
-          display: none;
-        }
       }
 
       @at-root a.CoveoResultLink.coveo-smart-snippet-suggestions-question-source {

--- a/src/misc/AttachShadowPolyfill.ts
+++ b/src/misc/AttachShadowPolyfill.ts
@@ -13,6 +13,7 @@ export async function attachShadow(element: HTMLElement, options: IShadowOptions
   let contentBody: HTMLElement;
   if (options.useIFrame) {
     autoUpdateContainer = $$('iframe', elementOptions).el;
+    autoUpdateContainer.setAttribute('tabindex', '-1');
     const onLoad = new Promise(resolve => autoUpdateContainer.addEventListener('load', () => resolve()));
     element.appendChild(autoUpdateContainer);
     await onLoad;

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -174,7 +174,6 @@ export class SmartSnippetCollapsibleSuggestion {
   private updateExpanded() {
     this.checkbox.setAttribute('aria-expanded', this.expanded.toString());
     this.checkbox.setHtml(this.expanded ? SVGIcons.icons.arrowUp : SVGIcons.icons.arrowDown);
-    this.collapsibleContainer.setAttribute('tabindex', `${this.expanded ? 0 : -1}`);
     this.collapsibleContainer.setAttribute('aria-hidden', (!this.expanded).toString());
     this.collapsibleContainer.toggleClass(QUESTION_SNIPPET_HIDDEN_CLASSNAME, !this.expanded);
     this.collapsibleContainer.el.style.height = this.expanded ? `${this.snippetAndSourceContainer.el.clientHeight}px` : '0px';


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3330

I reverted a18622356e222eab1fd88d4beed27766b76bae3e and I removed tabindex from the contents of smart snippet suggestions instead.

I used to believe tabindex was necessary on desktop in order to read elements on the screen, but I have since learned that:
1. Desktop screen readers have shortcuts other than the tab key to navigate pages the same was as mobile screen readers
2. [Most users navigate by headings](https://webaim.org/projects/screenreadersurvey9/#finding), meaning they do use said shortcuts.

I could be wrong, maybe they use the shortcuts only for headings and then press tab, but most pages I visited don't seem to put a `tabindex` on text elements.

Edit: Turns out that this PR breaks accessibility (at-least for VoiceOver on iOS). The contents of smart snippet suggestions becomes unreadable with VoiceOver on iOS. Merging it anyway since we're releasing soon and this issue affects more users than the accessibility issue, but I'll open another PR soon to fix accessibility for the next release.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)