### PR TITLE
Use AccessibleModal class for facet dropdown

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
@@ -73,7 +73,10 @@ export class ResponsiveDropdown {
       content: this.dropdownContent.element.el,
       origin: this.dropdownHeader.element.el,
       title: title.el,
-      validation: () => true
+      validation: () => {
+        this.isOpened = false;
+        return true;
+      }
     });
 
     $$(this.dropdownHeader.element).trigger(ResponsiveDropdownEvent.OPEN);

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
@@ -1,5 +1,5 @@
 import { ResponsiveDropdownHeader } from './ResponsiveDropdownHeader';
-import { IResponsiveDropdownContent } from './ResponsiveDropdownContent';
+import { IResponsiveDropdownContent, ResponsiveDropdownContent } from './ResponsiveDropdownContent';
 import { $$, Dom } from '../../../utils/Dom';
 import * as _ from 'underscore';
 import { AccessibleButton } from '../../../utils/AccessibleButton';
@@ -15,8 +15,6 @@ export enum ResponsiveDropdownEvent {
 type HandlerCall = { handler: Function; context: any };
 
 export class ResponsiveDropdown {
-  public static MODAL_CLASS_NAME = 'coveo-dropdown-modal';
-
   public isOpened: boolean = false;
   private onOpenHandlers: HandlerCall[] = [];
   private onCloseHandlers: HandlerCall[] = [];
@@ -30,7 +28,7 @@ export class ResponsiveDropdown {
     Assert.exists(dropdownHeader);
     Assert.exists(coveoRoot);
 
-    this.modal = new AccessibleModal(ResponsiveDropdown.MODAL_CLASS_NAME, this.coveoRoot.el);
+    this.modal = new AccessibleModal(ResponsiveDropdownContent.DEFAULT_CSS_CLASS_NAME, this.coveoRoot.el);
     this.saveContentPosition();
     this.enableScrollLocking(this.coveoRoot.el);
     this.bindOnClickDropdownHeaderEvent();

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent.ts
@@ -1,10 +1,5 @@
-import { Dom, $$ } from '../../../utils/Dom';
-import PopperJs from 'popper.js';
-import { ResponsiveComponentsManager } from '../ResponsiveComponentsManager';
+import { Dom } from '../../../utils/Dom';
 import { Assert } from '../../../misc/Assert';
-import { l } from '../../../strings/Strings';
-import { ComponentOptions } from '../../Base/ComponentOptions';
-
 export interface IResponsiveDropdownContent {
   element: Dom;
 
@@ -16,13 +11,6 @@ export interface IResponsiveDropdownContent {
 export class ResponsiveDropdownContent implements IResponsiveDropdownContent {
   public static DEFAULT_CSS_CLASS_NAME = 'coveo-dropdown-content';
 
-  private coveoRoot: Dom;
-  private cssClassName: string;
-
-  private widthRatio: number;
-  private minWidth: number;
-  private popperReference: PopperJs;
-
   public static isTargetInsideOpenedDropdown(target: Dom) {
     Assert.exists(target);
     const targetParentDropdown = target.parent(ResponsiveDropdownContent.DEFAULT_CSS_CLASS_NAME);
@@ -32,31 +20,13 @@ export class ResponsiveDropdownContent implements IResponsiveDropdownContent {
     return false;
   }
 
-  constructor(componentName: string, public element: Dom, coveoRoot: Dom, minWidth: number, widthRatio: number) {
-    Assert.isString(componentName);
-    Assert.exists(element);
-    Assert.exists(coveoRoot);
-    Assert.isLargerOrEqualsThan(0, minWidth);
-    Assert.isLargerOrEqualsThan(0, widthRatio);
-    Assert.isSmallerOrEqualsThan(1, widthRatio);
-
-    this.cssClassName = `coveo-${componentName}-dropdown-content`;
-    this.coveoRoot = coveoRoot;
-    this.widthRatio = widthRatio;
-    this.minWidth = minWidth;
-  }
+  constructor(componentName: string, public element: Dom, coveoRoot: Dom, minWidth: number, widthRatio: number) {}
 
   public positionDropdown() {
     this.setElementAttributes();
-    this.createPopper();
   }
 
   public hideDropdown() {
-    if (this.popperReference) {
-      this.unbindPopperEvents();
-      this.popperReference.destroy();
-    }
-
     this.unsetElementAttributes();
   }
 
@@ -66,65 +36,14 @@ export class ResponsiveDropdownContent implements IResponsiveDropdownContent {
 
   private setElementAttributes() {
     this.element.show();
-    this.element.addClass(this.cssClassName);
-    this.element.addClass(ResponsiveDropdownContent.DEFAULT_CSS_CLASS_NAME);
-    this.element.setAttribute('role', 'group');
-    this.element.setAttribute('aria-label', l('FiltersDropdown'));
-
     this.setElementWidth();
   }
 
   private setElementWidth() {
-    let width = this.widthRatio * this.coveoRoot.width();
-    if (width <= this.minWidth) {
-      width = this.minWidth;
-    }
-    this.element.el.style.width = width.toString() + 'px';
+    this.element.el.style.width = '100%';
   }
 
   private unsetElementAttributes() {
     this.element.hide();
-    this.element.removeClass(this.cssClassName);
-    this.element.removeClass(ResponsiveDropdownContent.DEFAULT_CSS_CLASS_NAME);
-    this.element.setAttribute('role', null);
-    this.element.setAttribute('aria-label', null);
-  }
-
-  private get popperReferenceElement() {
-    return this.coveoRoot.find(`.${ResponsiveComponentsManager.DROPDOWN_HEADER_WRAPPER_CSS_CLASS}`);
-  }
-
-  private createPopper() {
-    this.popperReference = new PopperJs(this.popperReferenceElement, this.element.el, {
-      placement: 'bottom-end',
-      positionFixed: true,
-      modifiers: {
-        preventOverflow: {
-          boundariesElement: this.coveoRoot.el
-        },
-        computeStyle: {
-          gpuAcceleration: false
-        }
-      },
-      eventsEnabled: false
-    });
-
-    this.bindPopperEvents();
-  }
-
-  private get scrollableParent() {
-    return ComponentOptions.findParentScrolling(this.popperReferenceElement);
-  }
-
-  private bindPopperEvents() {
-    $$(this.scrollableParent).on(['scroll', 'resize'], () => {
-      this.popperReference.update();
-    });
-  }
-
-  private unbindPopperEvents() {
-    $$(this.scrollableParent).off(['scroll', 'resize'], () => {
-      this.popperReference.update();
-    });
   }
 }

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent.ts
@@ -20,7 +20,7 @@ export class ResponsiveDropdownContent implements IResponsiveDropdownContent {
     return false;
   }
 
-  constructor(componentName: string, public element: Dom, coveoRoot: Dom, minWidth: number, widthRatio: number) {}
+  constructor(public element: Dom) {}
 
   public positionDropdown() {
     this.setElementAttributes();

--- a/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
@@ -147,12 +147,6 @@ export class ResponsiveFacetColumn implements IResponsiveComponent {
     let dropdownContent = this.buildDropdownContent();
     let dropdownHeader = this.buildDropdownHeader();
     let dropdown = responsiveDropdown ? responsiveDropdown : new ResponsiveDropdown(dropdownContent, dropdownHeader, this.coveoRoot);
-    if (!this.facetsMobileModeOptions.displayOverlayWhileOpen) {
-      dropdown.disablePopupBackground();
-    }
-    if (this.facetsMobileModeOptions.preventScrolling) {
-      dropdown.enableScrollLocking(this.facetsMobileModeOptions.scrollContainer);
-    }
     return dropdown;
   }
 

--- a/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
@@ -21,8 +21,6 @@ import { FacetsMobileModeEvents } from '../../events/FacetsMobileModeEvents';
 export class ResponsiveFacetColumn implements IResponsiveComponent {
   public static DEBOUNCE_SCROLL_WAIT = 250;
 
-  private static DROPDOWN_MIN_WIDTH: number = 280;
-  private static DROPDOWN_WIDTH_RATIO: number = 0.35; // Used to set the width relative to the coveo root.
   private static DROPDOWN_HEADER_LABEL_DEFAULT_VALUE = 'Filters';
 
   private searchInterface: SearchInterface;

--- a/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveFacetColumn.ts
@@ -160,13 +160,7 @@ export class ResponsiveFacetColumn implements IResponsiveComponent {
     if (this.facetsMobileModeOptions.isModal) {
       return new ResponsiveDropdownModalContent('facet', dropdownContentElement, l('CloseFiltersDropdown'), () => this.dropdown.close());
     }
-    return new ResponsiveDropdownContent(
-      'facet',
-      dropdownContentElement,
-      this.coveoRoot,
-      ResponsiveFacetColumn.DROPDOWN_MIN_WIDTH,
-      ResponsiveFacetColumn.DROPDOWN_WIDTH_RATIO
-    );
+    return new ResponsiveDropdownContent(dropdownContentElement);
   }
 
   private buildDropdownHeader() {

--- a/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveRecommendation.ts
@@ -131,7 +131,6 @@ export class ResponsiveRecommendation implements IResponsiveComponent {
     let dropdownContent = this.buildDropdownContent();
     let dropdownHeader = this.buildDropdownHeader();
     let dropdown = responsiveDropdown ? responsiveDropdown : new ResponsiveDropdown(dropdownContent, dropdownHeader, this.coveoRoot);
-    dropdown.disablePopupBackground();
     return dropdown;
   }
 

--- a/src/utils/AccessibleModal.ts
+++ b/src/utils/AccessibleModal.ts
@@ -30,6 +30,7 @@ export interface IAccessibleModalOpenNormalParameters extends IAccessibleModalOp
 }
 
 export class AccessibleModal {
+  private static MODAL_TITLE_ID = 'coveo-accessible-modal-title';
   private focusTrap: FocusTrap;
   private activeModal: Coveo.ModalBox.ModalBox;
   private options: IAccessibleModalOptions;
@@ -91,6 +92,10 @@ export class AccessibleModal {
   }
 
   private openModalAndTrap(parameters: IAccessibleModalOpenNormalParameters) {
+    if (parameters.title) {
+      parameters.title.id = AccessibleModal.MODAL_TITLE_ID;
+    }
+
     this.initiallyFocusedElement = parameters.origin || (document.activeElement as HTMLElement);
     this.activeModal = this.modalboxModule.open(parameters.content, {
       title: parameters.title,
@@ -116,6 +121,8 @@ export class AccessibleModal {
 
   private makeAccessible(title?: string) {
     this.element.setAttribute('aria-modal', 'true');
+    this.element.setAttribute('role', 'dialog');
+    this.element.setAttribute('aria-labelledby', AccessibleModal.MODAL_TITLE_ID);
     if (title) {
       this.headerElement.setAttribute('aria-label', title);
     }
@@ -128,11 +135,14 @@ export class AccessibleModal {
     closeButton.setAttribute('role', 'button');
     closeButton.tabIndex = 0;
     closeButton.focus();
-    $$(closeButton).on('keyup', KeyboardUtils.keypressAction(KEYBOARD.ENTER, () => closeButton.click()));
+    $$(closeButton).on(
+      'keyup',
+      KeyboardUtils.keypressAction(KEYBOARD.ENTER, () => closeButton.click())
+    );
   }
 
   private onModalClose() {
-    this.focusTrap.disable();
+    this.focusTrap && this.focusTrap.disable();
     this.focusTrap = null;
     if (this.initiallyFocusedElement && document.body.contains(this.initiallyFocusedElement)) {
       this.initiallyFocusedElement.focus();

--- a/unitTests/ui/ResponsiveComponents/ResponsiveDropdownContentTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveDropdownContentTest.ts
@@ -29,40 +29,10 @@ export function ResponsiveDropdownContentTest() {
       expect($$(responsiveDropdownContent.element).css('display')).toBe('none');
     });
 
-    it('has a minimal width', () => {
-      spyOn(root, 'width').and.returnValue(1);
-      responsiveDropdownContent.positionDropdown();
-      expect($$(responsiveDropdownContent.element).css('width')).toBe(minWidth.toString() + 'px');
-    });
-
-    it('uses a width ratio if it respect the minimal width', () => {
-      let rootWidth = minWidth * 2;
-      let expectedWidth = rootWidth * widthRatio;
-      spyOn(root, 'width').and.returnValue(rootWidth);
-
-      responsiveDropdownContent.positionDropdown();
-
-      expect($$(responsiveDropdownContent.element).css('width')).toBe(expectedWidth.toString() + 'px');
-    });
-
     it('removes inline styling on clean up', () => {
       responsiveDropdownContent.hideDropdown();
       responsiveDropdownContent.cleanUp();
       expect(responsiveDropdownContent.element.el.style.display).toBe('');
-    });
-
-    it('adds custom css class when position dropdown is called', () => {
-      responsiveDropdownContent.positionDropdown();
-      let expectedClass = `coveo-${componentName}-dropdown-content`;
-
-      expect(responsiveDropdownContent.element.hasClass(expectedClass)).toBe(true);
-    });
-
-    it('adds default css class when position dropdown is called', () => {
-      responsiveDropdownContent.positionDropdown();
-      let expectedClass = ResponsiveDropdownContent.DEFAULT_CSS_CLASS_NAME;
-
-      expect(responsiveDropdownContent.element.hasClass(expectedClass)).toBe(true);
     });
 
     it('removes custom css class when hide dropdown is called', () => {
@@ -81,21 +51,6 @@ export function ResponsiveDropdownContentTest() {
       responsiveDropdownContent.hideDropdown();
 
       expect(responsiveDropdownContent.element.hasClass(expectedToBeRemovedClass)).toBe(false);
-    });
-
-    it('should be able to tell when a target element is contained inside an opened dropdown content', () => {
-      const target = $$('div');
-      responsiveDropdownContent.element.append(target.el);
-      responsiveDropdownContent.positionDropdown();
-      expect(ResponsiveDropdownContent.isTargetInsideOpenedDropdown(target)).toBeTruthy();
-    });
-
-    it('should be able to tell when a target element is contained inside a closed dropdown content', () => {
-      const target = $$('div');
-      responsiveDropdownContent.element.append(target.el);
-      responsiveDropdownContent.positionDropdown();
-      responsiveDropdownContent.hideDropdown();
-      expect(ResponsiveDropdownContent.isTargetInsideOpenedDropdown(target)).toBeFalsy();
     });
 
     it('should be able to tell when a target element is not contained inside an opened dropdown content', () => {

--- a/unitTests/ui/ResponsiveComponents/ResponsiveDropdownContentTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveDropdownContentTest.ts
@@ -4,8 +4,6 @@ import { $$, Dom } from '../../../src/utils/Dom';
 
 export function ResponsiveDropdownContentTest() {
   describe('ResponsiveDropdownContent', () => {
-    let minWidth = 50;
-    let widthRatio = 0.5;
     let componentName = 'name';
     let responsiveDropdownContent: ResponsiveDropdownContent;
     let element: Dom;

--- a/unitTests/ui/ResponsiveComponents/ResponsiveDropdownContentTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveDropdownContentTest.ts
@@ -16,7 +16,7 @@ export function ResponsiveDropdownContentTest() {
       root = $$('div');
       root.append(element.el);
       root.append($$('div', { className: ResponsiveComponentsManager.DROPDOWN_HEADER_WRAPPER_CSS_CLASS }).el);
-      responsiveDropdownContent = new ResponsiveDropdownContent(componentName, element, root, minWidth, widthRatio);
+      responsiveDropdownContent = new ResponsiveDropdownContent(element);
     });
 
     it('displays the dropdown when position dropdown is called', () => {

--- a/unitTests/ui/ResponsiveComponents/ResponsiveDropdownTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveDropdownTest.ts
@@ -2,8 +2,6 @@ import { ResponsiveDropdown } from '../../../src/ui/ResponsiveComponents/Respons
 import { ResponsiveDropdownHeader } from '../../../src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownHeader';
 import { ResponsiveDropdownContent } from '../../../src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdownContent';
 import { $$, Dom } from '../../../src/utils/Dom';
-import { Simulate } from '../../Simulate';
-import { KEYBOARD } from '../../../src/Core';
 
 export function ResponsiveDropdownTest() {
   describe('ResponsiveDropdown', () => {
@@ -39,23 +37,6 @@ export function ResponsiveDropdownTest() {
       responsiveDropdown.open();
 
       expect(handler).toHaveBeenCalled();
-    });
-
-    it('should append a background when open is called', () => {
-      responsiveDropdown.open();
-      expect(root.find(`.${ResponsiveDropdown.DROPDOWN_BACKGROUND_ACTIVE_CSS_CLASS_NAME}`)).not.toBeNull();
-    });
-
-    it('should not append a background when it is disabled and open is called', () => {
-      responsiveDropdown.disablePopupBackground();
-      responsiveDropdown.open();
-      expect(root.find(`.${ResponsiveDropdown.DROPDOWN_BACKGROUND_CSS_CLASS_NAME}`)).toBeNull();
-    });
-
-    it('should hide the background when close is called', () => {
-      responsiveDropdown.open();
-      responsiveDropdown.close();
-      expect(root.find(`.${ResponsiveDropdown.DROPDOWN_BACKGROUND_ACTIVE_CSS_CLASS_NAME}`)).toBeNull();
     });
 
     describe('with scroll locking enabled', () => {
@@ -99,14 +80,6 @@ export function ResponsiveDropdownTest() {
       responsiveDropdown.close();
 
       expect(handler).toHaveBeenCalled();
-    });
-
-    it('should call close when the dropdown is opened and the escape key is pressed', () => {
-      responsiveDropdown.close = jasmine.createSpy('close');
-      responsiveDropdown.open();
-      Simulate.keyUp(document.documentElement, KEYBOARD.ESCAPE);
-
-      expect(responsiveDropdown.close).toHaveBeenCalled();
     });
   });
 }

--- a/unitTests/ui/ResponsiveFacetColumnTest.ts
+++ b/unitTests/ui/ResponsiveFacetColumnTest.ts
@@ -78,18 +78,10 @@ export function ResponsiveFacetColumnTest() {
         expect(dropdown.dropdownContent instanceof ResponsiveDropdownContent).toBeTruthy();
       });
 
-      it('should show the background', () => {
-        expect(dropdown['popupBackgroundIsEnabled']).toBeTruthy();
-      });
-
       describe('when opened', () => {
         beforeEach(() => {
           column.handleResizeEvent();
           dropdown.open();
-        });
-
-        it('should allow scrolling on the body', () => {
-          expect(root.el.style.overflow).toBeFalsy();
         });
       });
     });
@@ -228,6 +220,7 @@ export function ResponsiveFacetColumnTest() {
             beforeEach(() => {
               dropdown.open();
               popupOpened.calls.reset();
+              popupClosed.calls.reset();
             });
 
             it('should trigger the closed event when closing the popup', () => {

--- a/unitTests/ui/ResponsiveFacetColumnTest.ts
+++ b/unitTests/ui/ResponsiveFacetColumnTest.ts
@@ -127,65 +127,6 @@ export function ResponsiveFacetColumnTest() {
         });
       });
 
-      describe('with preventScrolling enabled', () => {
-        describe('without a scroll container', () => {
-          beforeEach(() => {
-            prepareTestWithMobileMode({ preventScrolling: true });
-          });
-
-          describe('when opened', () => {
-            beforeEach(() => {
-              column.handleResizeEvent();
-              dropdown.open();
-            });
-
-            it("shouldn't allow scrolling on the body", () => {
-              expect(root.el.style.overflow).toEqual('hidden');
-            });
-
-            describe('then closed', () => {
-              beforeEach(() => {
-                dropdown.close();
-              });
-
-              it('should re-allow scrolling on the body', () => {
-                expect(root.el.style.overflow).toBeFalsy();
-              });
-            });
-          });
-        });
-
-        describe('with a scroll container', () => {
-          let container: HTMLElement;
-
-          beforeEach(() => {
-            container = $$('div').el;
-            prepareTestWithMobileMode({ preventScrolling: true, scrollContainer: container });
-          });
-
-          describe('when opened', () => {
-            beforeEach(() => {
-              column.handleResizeEvent();
-              dropdown.open();
-            });
-
-            it("shouldn't allow scrolling on the container", () => {
-              expect(container.style.overflow).toEqual('hidden');
-            });
-
-            describe('then closed', () => {
-              beforeEach(() => {
-                dropdown.close();
-              });
-
-              it('should re-allow scrolling on the container', () => {
-                expect(container.style.overflow).toBeFalsy();
-              });
-            });
-          });
-        });
-      });
-
       describe('with bound events', () => {
         let popupOpened: jasmine.Spy;
         let popupClosed: jasmine.Spy;


### PR DESCRIPTION
Essentially a lot of code delete.

Facet responsive dropdown was built without the AccessibleModal class. Which means that there was no focus trap, and other accessibility features were missing.

This does change how the UI behaves, but I think it's for the best long term regarding accessibility.

https://coveord.atlassian.net/browse/JSUI-3332





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)