### PR TITLE
JSUI-3335 Removed smart snippet suggestion answers from tab order while collapsed

### DIFF
--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -182,7 +182,6 @@ export class SmartSnippetCollapsibleSuggestion {
   private updateExpanded() {
     this.checkbox.setAttribute('aria-expanded', this.expanded.toString());
     this.checkbox.setHtml(this.expanded ? SVGIcons.icons.arrowUp : SVGIcons.icons.arrowDown);
-    this.collapsibleContainer.setAttribute('tabindex', `${this.expanded ? 0 : -1}`);
     this.collapsibleContainer.setAttribute('aria-hidden', (!this.expanded).toString());
     this.collapsibleContainer.toggleClass(QUESTION_SNIPPET_HIDDEN_CLASSNAME, !this.expanded);
     this.collapsibleContainer.el.style.height = this.expanded ? `${this.snippetAndSourceContainer.el.clientHeight}px` : '0px';

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -171,6 +171,14 @@ export class SmartSnippetCollapsibleSuggestion {
     }
   }
 
+  private updateIFrameExpanded() {
+    const iframe = this.snippetAndSourceContainer.find('iframe');
+    if (!iframe) {
+      return;
+    }
+    this.expanded ? iframe.removeAttribute('tabindex') : iframe.setAttribute('tabindex', '-1');
+  }
+
   private updateExpanded() {
     this.checkbox.setAttribute('aria-expanded', this.expanded.toString());
     this.checkbox.setHtml(this.expanded ? SVGIcons.icons.arrowUp : SVGIcons.icons.arrowDown);
@@ -178,6 +186,7 @@ export class SmartSnippetCollapsibleSuggestion {
     this.collapsibleContainer.setAttribute('aria-hidden', (!this.expanded).toString());
     this.collapsibleContainer.toggleClass(QUESTION_SNIPPET_HIDDEN_CLASSNAME, !this.expanded);
     this.collapsibleContainer.el.style.height = this.expanded ? `${this.snippetAndSourceContainer.el.clientHeight}px` : '0px';
+    this.updateIFrameExpanded();
   }
 
   private sendExpandAnalytics() {

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -234,6 +234,10 @@ export function SmartSnippetSuggestionsTest() {
           done();
         });
 
+        it('the iframe of the second question has tabindex=-1', () => {
+          expect(findClass(ClassNames.SHADOW_CLASSNAME)[1].querySelector('iframe').getAttribute('tabindex')).toEqual('-1');
+        });
+
         it('has the has-question class', () => {
           expect(test.cmp.element.classList.contains(ClassNames.HAS_QUESTIONS_CLASSNAME)).toBeTruthy();
         });
@@ -314,6 +318,10 @@ export function SmartSnippetSuggestionsTest() {
           beforeEach(() => {
             resetAnalyticsSpyHistory();
             findClass(ClassNames.QUESTION_TITLE_CHECKBOX_CLASSNAME)[1].click();
+          });
+
+          it("the iframe doesn't have a tabindex", () => {
+            expect(findClass(ClassNames.SHADOW_CLASSNAME)[1].querySelector('iframe').hasAttribute('tabindex')).toBeFalsy();
           });
 
           it('sends expand analytics', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3335

I couldn't test accessibility for VoiceOver on iOS due to inconsistencies with iframes, but I tested with VoiceOver on Mac OS and TalkBack on Android and both worked.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)