### PR TITLE
JSUI-3337 revert to anonymous amd module

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -121,7 +121,7 @@ module.exports = {
     filename: getBaseFileName() + '.js',
     chunkFilename: getChunkFileName() + '.js',
     libraryTarget: 'umd',
-    umdNamedDefine: true,
+    umdNamedDefine: false,
     // See SwapVar.ts as for why this need to be a temporary variable
     library: 'Coveo__temporary',
     publicPath: 'js/',


### PR DESCRIPTION
**Context**

When the `umdNamedDefine` webpack option is `true`, the amd module is named.

```
// umdNamedDefine = false
define([], factory);

// umdNamedDefine = true
define('Coveo__temporary', [], factory);
```
The option was first set to true in response to a [Sitecore maintenance case](https://coveord.atlassian.net/browse/JSUI-1775).
However, when an amd module is named, the `Coveo` global is not set inside Sharepoint.

**So which is correct?**

Reading through the docs, it feels like we should not name the module. The requirejs documentation [mentions this here](https://requirejs.org/docs/whyamd.html#:~:text=You%20should%20avoid%20naming%20modules%20yourself%2C%20and%20only%20place%20one%20module%20in%20a%20file%20while%20developing.%20However%2C%20for%20tooling%20and%20performance%2C%20a%20module%20solution%20needs%20a%20way%20to%20identify%20modules%20in%20built%20resources.), suggesting this parameter is reserved for tooling? Mentioned [here](https://requirejs.org/docs/api.html#:~:text=It%20is%20normally%20best%20to%20avoid%20coding%20in%20a%20name%20for%20the%20module%20and%20just%20let%20the%20optimization%20tool%20burn%20in%20the%20module%20names.) too,

The docs also has a section about the `mismatch` error reported by Sitecore. Givng the anonymous amd module a name is not among the [suggested solutions](https://requirejs.org/docs/errors.html#:~:text=To%20avoid%20the,comment%20style%20instead.).

**Summary**

An anonymous amd module fixes the Sharepoint issue. I'm not sure, but perhaps the error in Sitecore should be fixed in a different way?

**Additional Info**

Using a named amd module works inside Sharepoint if the name is set to `Coveo` instead of `Coveo__Temporary`. However, webpack does not allow configuring a different name, and `Coveo__Temporary` is a work-around used to merge `Coveo` globals rather than overwriting them.

https://coveord.atlassian.net/browse/JSUI-3337





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)