### PR TITLE
JSUI-3338 filter duplicate facet values

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueDuplicateResolver.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueDuplicateResolver.ts
@@ -1,0 +1,37 @@
+import { IFacetResponseValue } from '../../../rest/Facet/FacetResponse';
+import { FacetValueState } from '../../../rest/Facet/FacetValueState';
+
+export function filterDuplicateFacetValues(values: IFacetResponseValue[]) {
+  let resolvedValues: IFacetResponseValue[] = [];
+  const map: Record<string, IFacetResponseValue[]> = {};
+
+  values.forEach(facetValue => {
+    const value = facetValue.value;
+    const lowercase = value.toLowerCase();
+
+    const entry = map[lowercase];
+
+    map[lowercase] = entry ? entry.concat(facetValue) : [facetValue];
+  });
+
+  Object.keys(map).forEach(key => {
+    const collection = map[key];
+
+    if (collection.length < 2) {
+      resolvedValues = resolvedValues.concat(collection);
+      return;
+    }
+
+    const sorted = collection.sort((a, b) => b.numberOfResults - a.numberOfResults);
+    const state = resolveState(sorted);
+    const [facetValueSourceOfTruth] = sorted;
+    resolvedValues.push({ ...facetValueSourceOfTruth, state });
+  });
+
+  return resolvedValues;
+}
+
+function resolveState(facetValues: IFacetResponseValue[]) {
+  const hasNonIdleValue = facetValues.some(facetValue => facetValue.state !== FacetValueState.idle);
+  return hasNonIdleValue ? FacetValueState.selected : FacetValueState.idle;
+}

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
@@ -9,6 +9,7 @@ import { IDynamicFacet, IValueCreator, IDynamicFacetValue, IDynamicFacetValues }
 import { DynamicFacetValueShowMoreLessButton } from './DynamicFacetValueMoreLessButton';
 import { Utils } from '../../../utils/Utils';
 import { getDynamicFacetHeaderId } from '../DynamicFacetHeader/DynamicFacetHeader';
+import { filterDuplicateFacetValues } from './DynamicFacetValueDuplicateResolver';
 
 export interface IDynamicFacetValueCreatorKlass {
   new (facet: IDynamicFacet): IValueCreator;
@@ -26,7 +27,8 @@ export class DynamicFacetValues implements IDynamicFacetValues {
   }
 
   public createFromResponse(response: IFacetResponse) {
-    this.facetValues = response.values.map((facetValue, index) => this.valueCreator.createFromResponse(facetValue, index));
+    const values = filterDuplicateFacetValues(response.values);
+    this.facetValues = values.map((facetValue, index) => this.valueCreator.createFromResponse(facetValue, index));
   }
 
   public reorderValues(order: string[]) {


### PR DESCRIPTION
PoC to de-duplicate facet values and resolve state. Fixing the issue at the search-api level would be ideal though, so that all clients get it (e.g. atomic, quantic).

https://coveord.atlassian.net/browse/JSUI-3338





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)