### PR TITLE
JSUI-3345 resolve parent element when inside folded result template

### DIFF
--- a/src/ui/Base/Component.ts
+++ b/src/ui/Base/Component.ts
@@ -446,6 +446,11 @@ export class Component extends BaseComponent {
     }
   }
 
+  static bindFoldedResultToElement(element: HTMLElement) {
+    Assert.exists(element);
+    $$(element).addClass('coveo-result-folding-child-result');
+  }
+
   static resolveRoot(element: HTMLElement): HTMLElement {
     Assert.exists(element);
     const resolvedSearchInterface = Component.resolveBinding(element, SearchInterface);

--- a/src/ui/ResultActions/ResultActionsMenu.ts
+++ b/src/ui/ResultActions/ResultActionsMenu.ts
@@ -104,7 +104,7 @@ export class ResultActionsMenu extends Component {
 
   private initializeParentResult() {
     // Find the result containing this ResultActionsMenu
-    this.parentResult = $$(this.element).closest('CoveoResult');
+    this.parentResult = $$(this.element).closest('CoveoResult') || $$(this.element).closest('coveo-result-folding-child-result');
     Assert.check(this.parentResult !== undefined, 'ResultActionsMenu needs to be a child of a Result');
 
     $$(this.parentResult).addClass('coveo-clickable');

--- a/unitTests/MockEnvironment.ts
+++ b/unitTests/MockEnvironment.ts
@@ -40,6 +40,7 @@ export class MockEnvironmentBuilder {
   public root: HTMLElement = $$('div').el;
   public element: HTMLElement = $$('div').el;
   public result: IQueryResult = undefined;
+  public isFoldedResult = false;
   public searchEndpoint = mockSearchEndpoint();
   public searchInterface = mockSearchInterface();
   public queryController = mockQueryController();
@@ -83,6 +84,13 @@ export class MockEnvironmentBuilder {
 
   public withResult(result: IQueryResult = FakeResults.createFakeResult()): MockEnvironmentBuilder {
     this.result = result;
+    this.isFoldedResult = false;
+    return this;
+  }
+
+  public withFoldedResult(result: IQueryResult = FakeResults.createFakeResult()): MockEnvironmentBuilder {
+    this.result = result;
+    this.isFoldedResult = true;
     return this;
   }
 
@@ -128,7 +136,8 @@ export class MockEnvironmentBuilder {
     };
 
     if (this.result) {
-      Component.bindResultToElement(this.element, this.result);
+      const bind = this.isFoldedResult ? Component.bindFoldedResultToElement : Component.bindResultToElement;
+      bind(this.element, this.result);
     }
     this.built = true;
     return this.getBindings();
@@ -337,6 +346,14 @@ export function basicComponentSetupWithModalBox<T>(klass, options = {}) {
 
 export function basicResultComponentSetup<T>(klass, options = {}) {
   const envBuilder = new MockEnvironmentBuilder().withResult();
+  return {
+    env: envBuilder.build(),
+    cmp: <T>new klass(envBuilder.getBindings().element, options, envBuilder.getBindings(), envBuilder.result)
+  };
+}
+
+export function basicFoldedResultComponentSetup<T>(klass, options = {}) {
+  const envBuilder = new MockEnvironmentBuilder().withFoldedResult();
   return {
     env: envBuilder.build(),
     cmp: <T>new klass(envBuilder.getBindings().element, options, envBuilder.getBindings(), envBuilder.result)

--- a/unitTests/ui/ResultActionsMenuTest.ts
+++ b/unitTests/ui/ResultActionsMenuTest.ts
@@ -55,5 +55,10 @@ export function ResultActionsMenuTest() {
       component.trigger('mouseenter');
       expect(componentHasShowClass()).toBe(false);
     });
+
+    it('when set inside a folded result, it resolves the parent correctly', () => {
+      test = Mock.basicFoldedResultComponentSetup<ResultActionsMenu>(ResultActionsMenu);
+      expect(test.cmp.parentResult).toBeDefined();
+    });
   });
 }


### PR DESCRIPTION
When a `ResultActionContext` is instantiated inside a result folding template, it is still not attached to the DOM. The `CoveoResult` element is not found, throwing an error, and not rendering the `ResultActionContext` component.

This PR adjusts the ResultActionContext component to check if it is a child of a folded result template.

https://coveord.atlassian.net/browse/JSUI-3345





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)