### PR TITLE
fix issues related to responsive dropdown rework

### DIFF
--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -48,6 +48,7 @@ import {
 } from '../../utils/DependsOnManager';
 import { ResultListUtils } from '../../utils/ResultListUtils';
 import { CategoryFacetValuesTree } from './CategoryFacetValuesTree';
+import { ResponsiveComponentsUtils } from '../ResponsiveComponents/ResponsiveComponentsUtils';
 
 export interface ICategoryFacetOptions extends IResponsiveComponentOptions, IDependsOnCompatibleFacetOptions {
   field: IFieldOption;
@@ -516,7 +517,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
   public async executeQuery() {
     this.showWaitingAnimation();
     try {
-      await this.queryController.executeQuery();
+      await this.queryController.executeQuery({ closeModalBox: !ResponsiveComponentsUtils.isSmallFacetActivated($$(this.root)) });
     } finally {
       this.hideWaitingAnimation();
     }

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -37,6 +37,7 @@ import { DependsOnManager, IDependentFacet, IDependentFacetCondition } from '../
 import { DynamicFacetValueCreator } from './DynamicFacetValues/DynamicFacetValueCreator';
 import { Logger } from '../../misc/Logger';
 import { FacetUtils } from '../Facet/FacetUtils';
+import { ResponsiveComponentsUtils } from '../ResponsiveComponents/ResponsiveComponentsUtils';
 
 /**
  * The `DynamicFacet` component displays a *facet* of the results for the current query. A facet is a list of values for a
@@ -817,8 +818,10 @@ export class DynamicFacet extends Component implements IDynamicFacet {
 
   public triggerNewQuery(beforeExecuteQuery?: () => void) {
     this.beforeSendingQuery();
-
-    const options: IQueryOptions = beforeExecuteQuery ? { beforeExecuteQuery } : { ignoreWarningSearchEvent: true };
+    const options: IQueryOptions = {
+      ...(beforeExecuteQuery ? { beforeExecuteQuery } : { ignoreWarningSearchEvent: true }),
+      closeModalBox: !ResponsiveComponentsUtils.isSmallFacetActivated($$(this.root))
+    };
 
     this.queryController.executeQuery(options);
   }

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -40,6 +40,7 @@ import { FacetValueState } from '../../rest/Facet/FacetValueState';
 import { FacetSortCriteria } from '../../rest/Facet/FacetSortCriteria';
 import { Logger } from '../../misc/Logger';
 import { DynamicHierarchicalFacetSearch } from '../DynamicHierarchicalFacetSearch/DynamicHierarchicalFacetSearch';
+import { ResponsiveComponentsUtils } from '../ResponsiveComponents/ResponsiveComponentsUtils';
 
 /**
  * The `DynamicHierarchicalFacet` component is a facet that renders values in a hierarchical fashion. It determines the filter to apply depending on the
@@ -483,7 +484,10 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
 
   public triggerNewQuery(beforeExecuteQuery?: () => void) {
     this.beforeSendingQuery();
-    const options: IQueryOptions = beforeExecuteQuery ? { beforeExecuteQuery } : { ignoreWarningSearchEvent: true };
+    const options: IQueryOptions = {
+      ...(beforeExecuteQuery ? { beforeExecuteQuery } : { ignoreWarningSearchEvent: true }),
+      closeModalBox: !ResponsiveComponentsUtils.isSmallFacetActivated($$(this.root))
+    };
     this.queryController.executeQuery(options);
   }
 

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -66,6 +66,8 @@ import { OmniboxValuesList } from './OmniboxValuesList';
 import { ValueElement } from './ValueElement';
 import { ValueElementRenderer } from './ValueElementRenderer';
 import { IFieldValueCompatibleFacet } from '../FieldValue/IFieldValueCompatibleFacet';
+import { IQueryOptions } from '../../controllers/QueryController';
+import { ResponsiveComponentsUtils } from '../ResponsiveComponents/ResponsiveComponentsUtils';
 
 type ComputedFieldOperation = 'sum' | 'average' | 'minimum' | 'maximum';
 type ComputedFieldFormat = 'c0' | 'n0' | 'n2';
@@ -1265,11 +1267,11 @@ export class Facet extends Component implements IFieldValueCompatibleFacet {
   }
 
   public triggerNewQuery(beforeExecuteQuery?: () => void) {
-    if (!beforeExecuteQuery) {
-      this.queryController.executeQuery({ ignoreWarningSearchEvent: true });
-    } else {
-      this.queryController.executeQuery({ beforeExecuteQuery });
-    }
+    const options: IQueryOptions = {
+      ...(beforeExecuteQuery ? beforeExecuteQuery : { ignoreWarningSearchEvent: true }),
+      closeModalBox: !ResponsiveComponentsUtils.isSmallFacetActivated($$(this.root))
+    };
+    this.queryController.executeQuery(options);
     this.showWaitingAnimation();
   }
 

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1268,7 +1268,7 @@ export class Facet extends Component implements IFieldValueCompatibleFacet {
 
   public triggerNewQuery(beforeExecuteQuery?: () => void) {
     const options: IQueryOptions = {
-      ...(beforeExecuteQuery ? beforeExecuteQuery : { ignoreWarningSearchEvent: true }),
+      ...(beforeExecuteQuery ? { beforeExecuteQuery } : { ignoreWarningSearchEvent: true }),
       closeModalBox: !ResponsiveComponentsUtils.isSmallFacetActivated($$(this.root))
     };
     this.queryController.executeQuery(options);

--- a/src/ui/Facet/FacetSettings.ts
+++ b/src/ui/Facet/FacetSettings.ts
@@ -14,6 +14,7 @@ import { Utils } from '../../utils/Utils';
 import { analyticsActionCauseList, IAnalyticsFacetMeta } from '../Analytics/AnalyticsActionListMeta';
 import { Facet } from './Facet';
 import { FacetSort, IFacetSortDescription } from './FacetSort';
+import { ResponsiveComponentsUtils } from '../ResponsiveComponents/ResponsiveComponentsUtils';
 
 export interface IFacetSettingsKlass {
   new (sorts: string[], facet: Facet): FacetSettings;
@@ -300,7 +301,7 @@ export class FacetSettings extends FacetSort {
       this.facet.updateSort('nosort');
       if (this.customSortDirectionChange) {
         this.customSortDirectionChange = false;
-        this.facet.queryController.executeQuery();
+        this.facet.queryController.executeQuery({ closeModalBox: !ResponsiveComponentsUtils.isSmallFacetActivated($$(this.facet.root)) });
       }
     }
   }

--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -631,7 +631,7 @@ export class FacetSlider extends Component {
         facetField: this.options.field.toString(),
         facetTitle: this.options.title
       });
-      this.queryController.executeQuery();
+      this.executeQuery();
     });
     return elem;
   }
@@ -726,7 +726,7 @@ export class FacetSlider extends Component {
         facetRangeStart: this.startOfSlider.toString(),
         facetRangeEnd: this.endOfSlider.toString()
       });
-      this.queryController.executeQuery();
+      this.executeQuery();
     }
   }
 
@@ -752,7 +752,7 @@ export class FacetSlider extends Component {
         facetRangeStart: this.startOfSlider.toString(),
         facetRangeEnd: this.endOfSlider.toString()
       });
-      this.queryController.executeQuery();
+      this.executeQuery();
     }
   }
 
@@ -1052,6 +1052,10 @@ export class FacetSlider extends Component {
       every(groupByResults.values, value => Utils.isNullOrUndefined(value) || value.numberOfResults === 0) ||
       data.results.results.length == 0
     );
+  }
+
+  private executeQuery() {
+    this.queryController.executeQuery({ closeModalBox: !ResponsiveComponentsUtils.isSmallFacetActivated($$(this.root)) });
   }
 }
 

--- a/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveDropdown/ResponsiveDropdown.ts
@@ -74,7 +74,7 @@ export class ResponsiveDropdown {
       origin: this.dropdownHeader.element.el,
       title: title.el,
       validation: () => {
-        this.isOpened = false;
+        this.close();
         return true;
       }
     });

--- a/unitTests/ui/ResponsiveFacetColumnTest.ts
+++ b/unitTests/ui/ResponsiveFacetColumnTest.ts
@@ -167,14 +167,14 @@ export function ResponsiveFacetColumnTest() {
             it('should trigger the closed event when closing the popup', () => {
               dropdown.close();
               expect(popupOpened).not.toHaveBeenCalled();
-              expect(popupClosed).toHaveBeenCalledTimes(1);
+              expect(popupClosed).toHaveBeenCalled();
             });
 
             it('should trigger the closed event when large mode is activated', () => {
               setScreenWidth(TEST_SCREEN_WIDTH_DESKTOP);
               column.handleResizeEvent();
               expect(popupOpened).not.toHaveBeenCalled();
-              expect(popupClosed).toHaveBeenCalledTimes(1);
+              expect(popupClosed).toHaveBeenCalled();
             });
           });
         });


### PR DESCRIPTION
This was a piece that was reworked during maintenance, due to a report with accessibility issues with the facet modal.

It introduced some regressions: 
* Facet modal needlessly closing when doing a selection (all the various `closeModalBox: !ResponsiveComponentsUtils.isSmallFacetActivated($$(this.root))` for all facets)
* Some css issues with zIndex, fixed with calling `close()` properly, which modifies css classes on the dropdown.


https://coveord.atlassian.net/browse/JSUI-3351





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)