### PR TITLE
JSUI-3346 Improved accessibility for dynamic facet breadcrumbs

### DIFF
--- a/sass/DynamicFacet/_DynamicFacetBreadcrumbs.scss
+++ b/sass/DynamicFacet/_DynamicFacetBreadcrumbs.scss
@@ -14,9 +14,10 @@
   @include breadcrumb-value-clear();
 }
 
-ul.coveo-dynamic-facet-breadcrumb.coveo-breadcrumb-item {
-  display: block;
+ul.coveo-dynamic-facet-breadcrumb-values {
+  display: inline-block;
   list-style: none;
+  margin: 0;
   padding: 0;
 }
 

--- a/sass/DynamicFacet/_DynamicFacetBreadcrumbs.scss
+++ b/sass/DynamicFacet/_DynamicFacetBreadcrumbs.scss
@@ -14,10 +14,9 @@
   @include breadcrumb-value-clear();
 }
 
-ul.coveo-dynamic-facet-breadcrumb-values {
-  display: inline-block;
+ul.coveo-dynamic-facet-breadcrumb.coveo-breadcrumb-item {
+  display: block;
   list-style: none;
-  margin: 0;
   padding: 0;
 }
 

--- a/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
+++ b/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
@@ -14,7 +14,7 @@ export class DynamicFacetBreadcrumbs {
   }
 
   private create() {
-    this.element = $$('ul', { className: 'coveo-dynamic-facet-breadcrumb coveo-breadcrumb-item' }).el;
+    this.element = $$('div', { className: 'coveo-dynamic-facet-breadcrumb coveo-breadcrumb-item' }).el;
     this.createAndAppendTitle();
 
     const activeFacetValues = this.facet.values.activeValues;
@@ -34,10 +34,12 @@ export class DynamicFacetBreadcrumbs {
   }
 
   private createAndAppendBreadcrumbValues(facetValues: IDynamicFacetValue[]) {
-    facetValues.forEach(facetValue => this.createAndAppendBreadcrumbValue(facetValue));
+    const valuesElement = $$('ul', { className: 'coveo-dynamic-facet-breadcrumb-values' }).el;
+    facetValues.forEach(facetValue => this.createAndAppendBreadcrumbValue(valuesElement, facetValue));
+    this.element.appendChild(valuesElement);
   }
 
-  private createAndAppendBreadcrumbValue(facetValue: IDynamicFacetValue) {
+  private createAndAppendBreadcrumbValue(container: HTMLElement, facetValue: IDynamicFacetValue) {
     const listContainer = $$('li', { className: 'coveo-dynamic-facet-breadcrumb-value-list-item' }).el;
     const valueElement = $$(
       'button',
@@ -53,7 +55,7 @@ export class DynamicFacetBreadcrumbs {
 
     $$(valueElement).on('click', () => this.valueSelectAction(facetValue));
     listContainer.appendChild(valueElement);
-    this.element.appendChild(listContainer);
+    container.appendChild(listContainer);
   }
 
   private valueSelectAction(facetValue: IDynamicFacetValue) {

--- a/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
+++ b/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
@@ -14,7 +14,7 @@ export class DynamicFacetBreadcrumbs {
   }
 
   private create() {
-    this.element = $$('ul', { className: 'coveo-dynamic-facet-breadcrumb coveo-breadcrumb-item' }).el;
+    this.element = $$('ul', { className: 'coveo-dynamic-facet-breadcrumb coveo-breadcrumb-item', ariaLabel: this.facet.options.title }).el;
     this.createAndAppendTitle();
 
     const activeFacetValues = this.facet.values.activeValues;
@@ -29,7 +29,8 @@ export class DynamicFacetBreadcrumbs {
   }
 
   private createAndAppendTitle() {
-    const titleElement = $$('h3', { className: 'coveo-dynamic-facet-breadcrumb-title' }, `${this.facet.options.title}:`).el;
+    const titleElement = $$('h3', { className: 'coveo-dynamic-facet-breadcrumb-title', ariaHidden: 'true' }, `${this.facet.options.title}:`)
+      .el;
     this.element.appendChild(titleElement);
   }
 

--- a/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
+++ b/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
@@ -14,7 +14,7 @@ export class DynamicFacetBreadcrumbs {
   }
 
   private create() {
-    this.element = $$('div', { className: 'coveo-dynamic-facet-breadcrumb coveo-breadcrumb-item' }).el;
+    this.element = $$('ul', { className: 'coveo-dynamic-facet-breadcrumb coveo-breadcrumb-item' }).el;
     this.createAndAppendTitle();
 
     const activeFacetValues = this.facet.values.activeValues;
@@ -34,12 +34,10 @@ export class DynamicFacetBreadcrumbs {
   }
 
   private createAndAppendBreadcrumbValues(facetValues: IDynamicFacetValue[]) {
-    const valuesElement = $$('ul', { className: 'coveo-dynamic-facet-breadcrumb-values' }).el;
-    facetValues.forEach(facetValue => this.createAndAppendBreadcrumbValue(valuesElement, facetValue));
-    this.element.appendChild(valuesElement);
+    facetValues.forEach(facetValue => this.createAndAppendBreadcrumbValue(facetValue));
   }
 
-  private createAndAppendBreadcrumbValue(container: HTMLElement, facetValue: IDynamicFacetValue) {
+  private createAndAppendBreadcrumbValue(facetValue: IDynamicFacetValue) {
     const listContainer = $$('li', { className: 'coveo-dynamic-facet-breadcrumb-value-list-item' }).el;
     const valueElement = $$(
       'button',
@@ -55,7 +53,7 @@ export class DynamicFacetBreadcrumbs {
 
     $$(valueElement).on('click', () => this.valueSelectAction(facetValue));
     listContainer.appendChild(valueElement);
-    container.appendChild(listContainer);
+    this.element.appendChild(listContainer);
   }
 
   private valueSelectAction(facetValue: IDynamicFacetValue) {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3346

The `ul` contained a `h3`, which was reported as an accessibility issue. IMO, I would prefer to avoid having anything readable in a list other than listitems.

# HTML (per breadcrumbs)
The changes to the HTML may be slightly breaking for existing implementations. After this change, the structure of dynamic facet breadcrumbs matches the structure of legacy facet breadcrumbs.

## Before
* `ul.coveo-dynamic-facet-breadcrumb.coveo-breadcrumb-item`
  * `h3.coveo-dynamic-facet-breadcrumb-title`
  * `li.coveo-dynamic-facet-breadcrumb-title`
  * `li.coveo-dynamic-facet-breadcrumb-title`
  * ...

## After
* `div.coveo-dynamic-facet-breadcrumb.coveo-breadcrumb-item`
  * `h3.coveo-dynamic-facet-breadcrumb-title`
  * `ul.coveo-dynamic-facet-breadcrumb-values`
    * `li.coveo-dynamic-facet-breadcrumb-title`
    * `li.coveo-dynamic-facet-breadcrumb-title`
    * ...

## Legacy facet breadcrumbs (for comparison)
* `div.coveo-facet-breadcrumb.coveo-breadcrumb-item`
  * `span.coveo-facet-breadcrumb-title`
  * `ul.coveo-facet-breadcrumb-values`
    * `li.coveo-facet-breadcrumb-value-list-item`
    * `li.coveo-facet-breadcrumb-value-list-item`
    * ...

# Visual comparison
yes, those are different images. I just made sure to crop them the same.

| Before | After |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/54454747/152007967-0f2654ba-1485-4eb2-8025-c5c24f920cbe.png) | ![image](https://user-images.githubusercontent.com/54454747/152008295-26e1ea66-5ec9-453b-849e-384ab2b5ca5f.png) |

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)