### PR TITLE
JSUI-3347 maintained focus on dynamic facet when values are toggled

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -1,6 +1,6 @@
 import 'styling/DynamicFacet/_DynamicFacet';
 import { IDynamicFacet, IDynamicFacetOptions } from './IDynamicFacet';
-import { difference, findIndex } from 'underscore';
+import { defer, difference, findIndex } from 'underscore';
 import { $$ } from '../../utils/Dom';
 import { exportGlobally } from '../../GlobalExports';
 import { Component } from '../Base/Component';
@@ -310,6 +310,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
   private includedAttributeId: string;
   private listenToQueryStateChange = true;
   private search: DynamicFacetSearch;
+  private valueToFocusOnRender: string | null;
   public header: DynamicFacetHeader;
 
   public options: IDynamicFacetOptions;
@@ -444,6 +445,16 @@ export class DynamicFacet extends Component implements IDynamicFacet {
     facetValue.toggleSelect();
     this.logger.info('Toggle select facet value', facetValue);
     this.updateQueryStateModel();
+  }
+
+  /**
+   * Keyboard focuses a value once it has been re-rendered.
+   *
+   * @param value The name of the facet value to focus
+   */
+  public focusValueAfterRerender(value: string) {
+    Assert.exists(value);
+    this.valueToFocusOnRender = value;
   }
 
   /**
@@ -687,6 +698,11 @@ export class DynamicFacet extends Component implements IDynamicFacet {
     this.updateQueryStateModel();
     this.values.render();
     this.updateAppearance();
+    if (this.valueToFocusOnRender) {
+      const value = this.valueToFocusOnRender;
+      this.valueToFocusOnRender = null;
+      defer(() => this.values.focus(value));
+    }
   }
 
   private onNewValues(facetResponse: IFacetResponse) {

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValue.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValue.ts
@@ -57,7 +57,13 @@ export class DynamicFacetValue implements IDynamicFacetValue {
   }
 
   public focus() {
+    if (!this.renderedElement) {
+      return;
+    }
     const checkbox = this.renderedElement.querySelector<HTMLElement>('.coveo-checkbox-button');
+    if (!checkbox) {
+      return;
+    }
     checkbox.focus();
   }
 

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValue.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValue.ts
@@ -56,6 +56,11 @@ export class DynamicFacetValue implements IDynamicFacetValue {
     return value.toLowerCase() === this.value.toLowerCase();
   }
 
+  public focus() {
+    const checkbox = this.renderedElement.querySelector<HTMLElement>('.coveo-checkbox-button');
+    checkbox.focus();
+  }
+
   public get formattedCount(): string {
     return Globalize.format(this.numberOfResults, 'n0');
   }

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueRenderer.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueRenderer.ts
@@ -52,6 +52,7 @@ export class DynamicFacetValueRenderer implements IValueRenderer {
     this.facet.enableFreezeFacetOrderFlag();
     this.facet.enablePreventAutoSelectionFlag();
     this.facet.scrollToTop();
+    this.facet.focusValueAfterRerender(this.facetValue.value);
     this.facet.triggerNewQuery(() => this.facetValue.logSelectActionToAnalytics());
   }
 }

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
@@ -108,6 +108,14 @@ export class DynamicFacetValues implements IDynamicFacetValues {
     return newFacetValue;
   }
 
+  public focus(value: string) {
+    const facetValue = find(this.facetValues, facetValue => facetValue.equals(value));
+    if (!facetValue) {
+      return;
+    }
+    facetValue.focus();
+  }
+
   private buildShowLess() {
     const showLess = new DynamicFacetValueShowMoreLessButton({
       className: 'coveo-dynamic-facet-show-less',

--- a/src/ui/DynamicFacet/IDynamicFacet.ts
+++ b/src/ui/DynamicFacet/IDynamicFacet.ts
@@ -60,6 +60,7 @@ export interface IDynamicFacet
   deselectValue(value: string): void;
   deselectMultipleValues(values: string[]): void;
   toggleSelectValue(value: string): void;
+  focusValueAfterRerender(value: string): void;
   showMoreValues(additionalNumberOfValues?: number): void;
   showLessValues(): void;
   reset(): void;
@@ -109,6 +110,7 @@ export interface IDynamicFacetValue extends IDynamicFacetValueProperties {
   toggleSelect(): void;
   deselect(): void;
   equals(arg: string | IDynamicFacetValue): boolean;
+  focus(): void;
 
   logSelectActionToAnalytics(): void;
 }
@@ -119,6 +121,7 @@ export interface IDynamicFacetValues {
   clearAll(): void;
   hasSelectedValue(arg: string | IDynamicFacetValue): boolean;
   get(arg: string | IDynamicFacetValue): IDynamicFacetValue;
+  focus(value: string): void;
   render(): HTMLElement;
 
   allValues: string[];

--- a/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
@@ -46,6 +46,7 @@ export function DynamicFacetTest() {
       spyOn(test.cmp, 'reset').and.callThrough();
       spyOn(test.cmp, 'enableFreezeFacetOrderFlag').and.callThrough();
       spyOn(test.cmp, 'scrollToTop').and.callThrough();
+      spyOn(test.cmp, 'focusValueAfterRerender').and.callThrough();
       spyOn(test.cmp, 'logAnalyticsEvent').and.callThrough();
       spyOn(test.cmp, 'selectMultipleValues').and.callThrough();
       spyOn(test.cmp, 'deselectMultipleValues').and.callThrough();
@@ -145,6 +146,18 @@ export function DynamicFacetTest() {
 
       expect(test.cmp.values.get(mockFacetValues[0].value).isSelected).toBe(true);
       testQueryStateModelValues();
+    });
+
+    it('does not focus on the value after selecting it with a function', () => {
+      test.cmp.selectValue(mockFacetValues[0].value);
+      expect(test.cmp.focusValueAfterRerender).not.toHaveBeenCalled();
+    });
+
+    it('focuses on the value after clicking it', () => {
+      test.cmp.ensureDom();
+      const facetValue = mockFacetValues[0].value;
+      test.cmp.element.querySelector<HTMLElement>(`[data-value="${facetValue}"] button`).click();
+      expect(test.cmp.focusValueAfterRerender).toHaveBeenCalledWith(facetValue);
     });
 
     it('allows to select a value that did not previously exist', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3347

I didn't fix `DynamicHierarchicalFacet` since it would be more complex to fix, and the loss of focus basically just moves the "next focus" to the first item.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)