### PR TITLE
JSUI-3369 Prevented ResultLink from overriding tabindex

### DIFF
--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -284,7 +284,9 @@ export class ResultLink extends Component {
     if (this.options.openQuickview == null) {
       this.options.openQuickview = result.raw['connectortype'] == 'ExchangeCrawler' && DeviceUtils.isMobileDevice();
     }
-    this.element.setAttribute('tabindex', '0');
+    if (!this.element.hasAttribute('tabindex')) {
+      this.element.setAttribute('tabindex', '0');
+    }
 
     Assert.exists(this.componentOptionsModel);
     Assert.exists(this.result);

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -23,531 +23,544 @@ export function ResultLinkTest() {
       return fakeResult;
     }
 
-    function initResultLink() {
-      test = Mock.advancedResultComponentSetup<ResultLink>(ResultLink, fakeResult, undefined);
+    function initResultLink(options?: Mock.AdvancedComponentSetupOptions) {
+      test = Mock.advancedResultComponentSetup<ResultLink>(ResultLink, fakeResult, options);
     }
 
     function htmlContainingXSS() {
       return '<IMG SRC=/ onerror="alert(String.fromCharCode(88,83,83))"></img>';
     }
 
-    beforeEach(() => {
-      fakeResult = buildFakeResult();
-      initResultLink();
-      spyOn(test.cmp, 'openLink');
-      spyOn(window, 'open');
-    });
-
-    afterEach(function () {
-      test = null;
-      fakeResult = null;
-    });
-
-    it('should have its tabindex value set to 0', () => {
-      expect(test.cmp.element.getAttribute('tabindex')).toBe('0');
-    });
-
-    it('should have an aria-label to prevent screen readers from reading the #title attribute', () => {
-      expect(test.cmp.element.getAttribute('aria-label')).toBe('Result');
-    });
-
-    describe('with global result link options', () => {
-      function createEnvWithGlobalResultLinkOptions() {
-        const searchInterface = test.env.searchInterface;
-        searchInterface.options.originalOptionsObject = {
-          [ResultLink.ID]: {
-            alwaysOpenInNewWindow: true
-          }
-        };
-
-        return new Mock.MockEnvironmentBuilder().withResult(fakeResult).withSearchInterface(searchInterface);
-      }
-
-      it('the global options are used', () => {
-        const env = createEnvWithGlobalResultLinkOptions();
-        const cmp = new ResultLink(
-          env.getBindings().element,
-          {},
-          (env.getBindings() as any) as IResultsComponentBindings,
-          env.result,
-          env.os
-        );
-        expect(cmp.options.alwaysOpenInNewWindow).toBe(true);
-      });
-
-      it(`when options are defined on the result link component,
-      the local options override the global options`, () => {
-        const env = createEnvWithGlobalResultLinkOptions();
-        const cmp = new ResultLink(
-          env.getBindings().element,
-          { alwaysOpenInNewWindow: false },
-          (env.getBindings() as any) as IResultsComponentBindings,
-          env.result,
-          env.os
-        );
-
-        expect(cmp.options.alwaysOpenInNewWindow).toBe(false);
-      });
-    });
-
-    describe(`when the template contains two ${ResultLink.ID} elements`, () => {
-      let template: HTMLElement;
-
-      function buildResultWithTwoResultLinks() {
-        const result = $$('div', { className: 'CoveoResult' }).el;
-        $$(result).append(buildResultLink());
-        $$(result).append(buildResultLink());
-
-        return result;
-      }
-
-      function buildResultLink() {
-        return $$('div', { className: 'CoveoResultLink' }).el;
-      }
-
+    describe('with a tabindex', () => {
       beforeEach(() => {
-        template = buildResultWithTwoResultLinks();
-        const result = FakeResults.createFakeResult();
-        Initialization.automaticallyCreateComponentsInsideResult(template, result);
+        fakeResult = buildFakeResult();
+        initResultLink(new Mock.AdvancedComponentSetupOptions($$('a', { className: 'CoveoResultList', tabindex: '1337' }).el));
+      });
+
+      it('does not replace the tabindex', () => {
+        expect(test.cmp.element.getAttribute('tabindex')).toBe('1337');
       });
     });
 
-    it('should hightlight the result title', () => {
-      expect(test.cmp.element.innerHTML).toEqual(
-        HighlightUtils.highlightString(fakeResult.title, fakeResult.titleHighlights, null, 'coveo-highlight')
-      );
-    });
-
-    it(`when the title contains a html element, it does not render the element to prevent XSS`, () => {
-      fakeResult.title = htmlContainingXSS();
-      initResultLink();
-
-      expect(test.cmp.element.innerHTML).toBe(
-        '&lt;I<span class="coveo-highlight">MG S</span>RC=/ onerror="alert(String.fromCharCode(88,83,83))"&gt;&lt;/img&gt;'
-      );
-    });
-
-    it('should set the title attribute to the result title when no options are provided', () => {
-      expect(test.cmp.element.title).toEqual(fakeResult.title);
-    });
-
-    it('should contain the clickUri if the result has no title', () => {
-      fakeResult.title = undefined;
-      fakeResult.clickUri = 'https://www.google.com?q=hello&geo=world';
-      initResultLink();
-
-      const encodedUri = fakeResult.clickUri.replace('&', '&amp;');
-      expect(test.cmp.element.innerHTML).toEqual(encodedUri);
-    });
-
-    it(`when the title is empty and the clickuri contains a html element,
-    it does not render the element to prevent XSS`, () => {
-      fakeResult.title = '';
-      fakeResult.clickUri = htmlContainingXSS();
-      initResultLink();
-
-      expect(test.cmp.element.children.length).toBe(0);
-      expect(test.cmp.element.innerHTML).toBe('&lt;IMG SRC=/ onerror="alert(String.fromCharCode(88,83,83))"&gt;&lt;/img&gt;');
-    });
-
-    it('can receive an onClick option to execute', done => {
-      test = Mock.advancedResultComponentSetup<ResultLink>(
-        ResultLink,
-        fakeResult,
-        new Mock.AdvancedComponentSetupOptions($$('div').el, {
-          onClick: () => {
-            expect(true).toBe(true);
-            done();
-          }
-        })
-      );
-      $$(test.cmp.element).trigger('click');
-    });
-
-    it('sends an analytic event on click', () => {
-      $$(test.cmp.element).trigger('click');
-      expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
-    });
-
-    describe('exposes hrefTemplate', () => {
-      it('when the href starts with a protocol that enables XSS, it returns an empty string', () => {
-        const hrefTemplate = 'javascript:alert(1)';
-        test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
-        test.cmp.openLinkInNewWindow();
-        expect(window.open).toHaveBeenCalledWith('', jasmine.anything());
-      });
-
-      it('should not modify the href template if there are no field specified', () => {
-        let hrefTemplate = 'http://test';
-        test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
-        test.cmp.openLinkInNewWindow();
-        expect(window.open).toHaveBeenCalledWith(hrefTemplate, jasmine.anything());
-      });
-
-      it('should replace fields in the href template by the results equivalent', () => {
-        let hrefTemplate = 'http://${title}';
-        test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
-        test.cmp.openLinkInNewWindow();
-        expect(window.open).toHaveBeenCalledWith(`http://${fakeResult.title}`, jasmine.anything());
-      });
-
-      it('should support nested values in result', () => {
-        let hrefTemplate = 'http://${raw.number}';
-        test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
-        test.cmp.openLinkInNewWindow();
-        expect(window.open).toHaveBeenCalledWith(`http://${fakeResult.raw['number'].toString()}`, jasmine.anything());
-      });
-
-      it('should not parse standalone accolades', () => {
-        let hrefTemplate = 'http://${raw.number}{test}';
-        test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
-        test.cmp.openLinkInNewWindow();
-        expect(window.open).toHaveBeenCalledWith(`http://${fakeResult.raw['number']}{test}`, jasmine.anything());
-      });
-
-      it('should support external fields', () => {
-        window['Coveo']['test'] = 'testExternal';
-        let hrefTemplate = 'http://${Coveo.test}';
-        test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
-        test.cmp.openLinkInNewWindow();
-        expect(window.open).toHaveBeenCalledWith('http://testExternal', jasmine.anything());
-        window['Coveo']['test'] = undefined;
-      });
-
-      it('should support nested external fields with more than 2 keys', () => {
-        window['Coveo']['test'] = { key: 'testExternal' };
-        let hrefTemplate = 'http://${Coveo.test.key}';
-        test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
-        test.cmp.openLinkInNewWindow();
-        expect(window.open).toHaveBeenCalledWith('http://testExternal', jasmine.anything());
-        window['Coveo']['test'] = undefined;
-      });
-    });
-
-    describe('exposes the titleTemplate', () => {
-      let titleTemplate = '';
-
-      afterEach(() => {
-        titleTemplate = '';
-      });
-
-      function initResultLinkWithTitleTemplate() {
-        test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { titleTemplate }, fakeResult);
-      }
-
-      it('should set the title attribute to the text version of the displayed title', () => {
-        titleTemplate = 'foo ${clickUri}';
-        initResultLinkWithTitleTemplate();
-        expect(test.cmp.element.title).toEqual(`foo ${fakeResult.clickUri}`);
-      });
-
-      it('should replaces fields in the title template by the results equivalent', () => {
-        titleTemplate = '${clickUri}';
-        initResultLinkWithTitleTemplate();
-
-        expect($$(test.cmp.element).text()).toEqual(fakeResult.clickUri);
-      });
-
-      it(`when the field referenced in the title template contains XSS html,
-      it escapes the html to prevent XSS`, () => {
-        titleTemplate = '${clickUri}';
-        fakeResult.clickUri = htmlContainingXSS();
-        initResultLinkWithTitleTemplate();
-
-        expect(test.cmp.element.innerHTML).toEqual('&lt;IMG SRC=/ onerror="alert(String.fromCharCode(88,83,83))"&gt;&lt;/img&gt;');
-      });
-
-      it('should support nested values in result', () => {
-        titleTemplate = '${raw.number}';
-        initResultLinkWithTitleTemplate();
-
-        expect(test.cmp.element.innerHTML).toEqual(fakeResult.raw['number'].toString());
-      });
-
-      it('should not parse standalone accolades', () => {
-        titleTemplate = '${raw.number}{test}';
-        initResultLinkWithTitleTemplate();
-
-        expect(test.cmp.element.innerHTML).toEqual(fakeResult.raw['number'].toString() + '{test}');
-      });
-
-      it('should support external fields', () => {
-        window['Coveo']['test'] = 'testExternal';
-        titleTemplate = '${Coveo.test}';
-        initResultLinkWithTitleTemplate();
-
-        expect(test.cmp.element.innerHTML).toEqual('testExternal');
-        window['Coveo']['test'] = undefined;
-      });
-
-      it('should support external fields with more than 2 keys', () => {
-        window['Coveo']['test'] = { key: 'testExternal' };
-        titleTemplate = '${Coveo.test.key}';
-        initResultLinkWithTitleTemplate();
-
-        expect(test.cmp.element.innerHTML).toEqual('testExternal');
-        window['Coveo']['test'] = undefined;
-      });
-
-      it('should print the title if the option is set but the template is empty', () => {
-        titleTemplate = '';
-        initResultLinkWithTitleTemplate();
-
-        expect($$(test.cmp.element).text()).toEqual(fakeResult.title);
-      });
-
-      it('should print the template if the key used in the template is undefined', () => {
-        titleTemplate = '${doesNotExist}';
-        initResultLinkWithTitleTemplate();
-
-        expect($$(test.cmp.element).text()).toEqual('${doesNotExist}');
-      });
-    });
-
-    it('sends an analytics event on context menu', () => {
-      $$(test.cmp.element).trigger('contextmenu');
-      expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
-    });
-
-    it('sends an analytics event on mouseup', () => {
-      $$(test.cmp.element).trigger('mouseup');
-      expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
-    });
-
-    it('sends an analytics event on mousedown', () => {
-      $$(test.cmp.element).trigger('mousedown');
-      expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not send multiple analytics events with multiple mouse events', () => {
-      $$(test.cmp.element).trigger('mousedown');
-      $$(test.cmp.element).trigger('click');
-      $$(test.cmp.element).trigger('mouseup');
-      expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
-    });
-
-    it('sends an event 1s after a long press on mobile', done => {
-      $$(test.cmp.element).trigger('touchstart');
-      expect(test.cmp.usageAnalytics.logClickEvent).not.toHaveBeenCalled();
-      setTimeout(() => {
-        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
-        done();
-      }, 1100);
-    });
-
-    it('does not send an event if a touchend event occurs before a 1s delay', done => {
-      $$(test.cmp.element).trigger('touchstart');
-
-      setTimeout(() => {
-        $$(test.cmp.element).trigger('touchend');
-      }, 300);
-
-      setTimeout(() => {
-        expect(test.cmp.usageAnalytics.logClickEvent).not.toHaveBeenCalled();
-        done();
-      }, 1100);
-    });
-
-    describe('when logging the analytic event', () => {
-      it('should use the href if set', () => {
-        let element = $$('a');
-        let href = 'javascript:void(0)';
-        element.setAttribute('href', href);
-        test = Mock.advancedResultComponentSetup<ResultLink>(ResultLink, fakeResult, new Mock.AdvancedComponentSetupOptions(element.el));
-        spyOn(test.cmp, 'openLink');
-
-        $$(test.cmp.element).trigger('click');
-
-        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledWith(
-          analyticsActionCauseList.documentOpen,
-          jasmine.objectContaining({ documentURL: href }),
-          fakeResult,
-          test.cmp.root
-        );
-      });
-
-      it('should not log analytics when logAnalytics is set', () => {
-        const element = $$('a');
-        test = Mock.advancedResultComponentSetup<ResultLink>(
-          ResultLink,
-          fakeResult,
-          new Mock.AdvancedComponentSetupOptions(element.el, { logAnalytics: () => {} })
-        );
-        spyOn(test.cmp, 'openLink');
-
-        $$(test.cmp.element).trigger('click');
-
-        expect(test.cmp.usageAnalytics.logClickEvent).not.toHaveBeenCalled();
-      });
-
-      it("should call logAnalytics when it's set", () => {
-        const element = $$('a');
-        const logAnalyticsSpy = jasmine.createSpy('logAnalytics');
-        test = Mock.advancedResultComponentSetup<ResultLink>(
-          ResultLink,
-          fakeResult,
-          new Mock.AdvancedComponentSetupOptions(element.el, { logAnalytics: logAnalyticsSpy })
-        );
-        spyOn(test.cmp, 'openLink');
-
-        $$(test.cmp.element).trigger('click');
-
-        expect(logAnalyticsSpy).toHaveBeenCalledTimes(1);
-      });
-
-      it('should use the clickUri if the href is empty', () => {
-        $$(test.cmp.element).trigger('click');
-
-        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledWith(
-          analyticsActionCauseList.documentOpen,
-          jasmine.objectContaining({ documentURL: fakeResult.clickUri }),
-          fakeResult,
-          test.cmp.root
-        );
-      });
-    });
-
-    describe('when the element is a hyperlink', () => {
-      function initHyperLink(options?: IResultLinkOptions) {
-        test = Mock.advancedResultComponentSetup<ResultLink>(
-          ResultLink,
-          fakeResult,
-          new Mock.AdvancedComponentSetupOptions($$('a').el, options)
-        );
-      }
-
+    describe('with default parameters', () => {
       beforeEach(() => {
-        initHyperLink();
+        fakeResult = buildFakeResult();
+        initResultLink();
+        spyOn(test.cmp, 'openLink');
+        spyOn(window, 'open');
       });
 
-      it('should set the href to the result click uri', () => {
-        expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+      afterEach(function () {
+        test = null;
+        fakeResult = null;
       });
 
-      it(`when the href contains "&" characters,
-        should set the href the unescaped the result click uri`, () => {
-        fakeResult.clickUri =
-          'https://testing.com/supportcenter/portal?DataSource=Solutions&eventSubmit_doNavigate=&PageNumber=Prev&tab=Solutions&ts=6';
-        initHyperLink();
-        expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+      it('should have its tabindex value set to 0', () => {
+        expect(test.cmp.element.getAttribute('tabindex')).toBe('0');
       });
 
-      it('when the clickUri is a relative url with a slash, it sets the href to the uri', () => {
-        fakeResult.clickUri = '/casemgmt/sc_KnowledgeArticle?sfdcid=ka32C0000009t9CQAQ&type=Solution';
-        initHyperLink();
-        expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+      it('should have an aria-label to prevent screen readers from reading the #title attribute', () => {
+        expect(test.cmp.element.getAttribute('aria-label')).toBe('Result');
       });
 
-      it('when the uri is a relative url with a period, it sets the href to the uri', () => {
-        fakeResult.clickUri = './articles/ka32C0000009t9CQAQ';
-        initHyperLink();
-        expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+      describe('with global result link options', () => {
+        function createEnvWithGlobalResultLinkOptions() {
+          const searchInterface = test.env.searchInterface;
+          searchInterface.options.originalOptionsObject = {
+            [ResultLink.ID]: {
+              alwaysOpenInNewWindow: true
+            }
+          };
+
+          return new Mock.MockEnvironmentBuilder().withResult(fakeResult).withSearchInterface(searchInterface);
+        }
+
+        it('the global options are used', () => {
+          const env = createEnvWithGlobalResultLinkOptions();
+          const cmp = new ResultLink(
+            env.getBindings().element,
+            {},
+            (env.getBindings() as any) as IResultsComponentBindings,
+            env.result,
+            env.os
+          );
+          expect(cmp.options.alwaysOpenInNewWindow).toBe(true);
+        });
+
+        it(`when options are defined on the result link component,
+        the local options override the global options`, () => {
+          const env = createEnvWithGlobalResultLinkOptions();
+          const cmp = new ResultLink(
+            env.getBindings().element,
+            { alwaysOpenInNewWindow: false },
+            (env.getBindings() as any) as IResultsComponentBindings,
+            env.result,
+            env.os
+          );
+
+          expect(cmp.options.alwaysOpenInNewWindow).toBe(false);
+        });
       });
 
-      it('when the uri is a relative url with two periods, it sets the href to the uri', () => {
-        fakeResult.clickUri = '../articles/ka32C0000009t9CQAQ';
-        initHyperLink();
-        expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
-      });
+      describe(`when the template contains two ${ResultLink.ID} elements`, () => {
+        let template: HTMLElement;
 
-      it('when the clickUri is a string containing but not starting with a slash, it sets the href to an empty string', () => {
-        fakeResult.clickUri = 'casemgmt/sc_KnowledgeArticle';
-        initHyperLink();
-        expect(test.cmp.element.getAttribute('href')).toEqual('');
-      });
+        function buildResultWithTwoResultLinks() {
+          const result = $$('div', { className: 'CoveoResult' }).el;
+          $$(result).append(buildResultLink());
+          $$(result).append(buildResultLink());
 
-      it(`when the uri (clickUri) defined in the results contains the javascript protocol,
-        it clears the value to prevent XSS`, () => {
-        fakeResult.clickUri = 'JavaScript:void(0)';
-        initHyperLink();
-        expect(test.cmp.element.getAttribute('href')).toEqual('');
-      });
+          return result;
+        }
 
-      it(`when the field option is defined and the field contains the javascript protocol,
-        it clears the value to prevent XSS`, () => {
-        fakeResult.raw['test'] = 'javascript:void(0)';
-        initHyperLink({ field: '@test' });
-        expect(test.cmp.element.getAttribute('href')).toEqual('');
-      });
+        function buildResultLink() {
+          return $$('div', { className: 'CoveoResultLink' }).el;
+        }
 
-      it(`when the uri uses the javascript protocol and contains a relative uri with a slash,
-        it clears the value to prevent XSS`, () => {
-        fakeResult.clickUri = 'javascript:"/casemgmt/sc_KnowledgeArticle"';
-        initHyperLink();
-        expect(test.cmp.element.getAttribute('href')).toEqual('');
-      });
-
-      it(`when the uri uses the javascript protocol and contains a relative uri with a period,
-        it clears the value to prevent XSS`, () => {
-        fakeResult.clickUri = 'javascript:"./articles/ka32C0000009t9CQAQ"';
-        initHyperLink();
-        expect(test.cmp.element.getAttribute('href')).toEqual('');
-      });
-
-      it(`when the uri uses the javascript protocol and contains a relative uri with two periods,
-        it clears the value to prevent XSS`, () => {
-        fakeResult.clickUri = 'javascript:"../articles/ka32C0000009t9CQAQ"';
-        initHyperLink();
-        expect(test.cmp.element.getAttribute('href')).toEqual('');
-      });
-
-      it('should not override the href if it is set before the initialization', () => {
-        let element = $$('a');
-        let href = 'javascript:void(0)';
-        element.setAttribute('href', href);
-        test = Mock.advancedResultComponentSetup<ResultLink>(ResultLink, fakeResult, new Mock.AdvancedComponentSetupOptions(element.el));
-
-        expect(test.cmp.element.getAttribute('href')).toEqual(href);
-      });
-
-      describe('and the result has the outlookfield', () => {
         beforeEach(() => {
-          fakeResult.raw['outlookuri'] = 'mailto:test@coveo.comm';
-          fakeResult.raw['outlookformacuri'] = 'mailto:test.mac@coveo.comm';
+          template = buildResultWithTwoResultLinks();
+          const result = FakeResults.createFakeResult();
+          Initialization.automaticallyCreateComponentsInsideResult(template, result);
+        });
+      });
+
+      it('should hightlight the result title', () => {
+        expect(test.cmp.element.innerHTML).toEqual(
+          HighlightUtils.highlightString(fakeResult.title, fakeResult.titleHighlights, null, 'coveo-highlight')
+        );
+      });
+
+      it(`when the title contains a html element, it does not render the element to prevent XSS`, () => {
+        fakeResult.title = htmlContainingXSS();
+        initResultLink();
+
+        expect(test.cmp.element.innerHTML).toBe(
+          '&lt;I<span class="coveo-highlight">MG S</span>RC=/ onerror="alert(String.fromCharCode(88,83,83))"&gt;&lt;/img&gt;'
+        );
+      });
+
+      it('should set the title attribute to the result title when no options are provided', () => {
+        expect(test.cmp.element.title).toEqual(fakeResult.title);
+      });
+
+      it('should contain the clickUri if the result has no title', () => {
+        fakeResult.title = undefined;
+        fakeResult.clickUri = 'https://www.google.com?q=hello&geo=world';
+        initResultLink();
+
+        const encodedUri = fakeResult.clickUri.replace('&', '&amp;');
+        expect(test.cmp.element.innerHTML).toEqual(encodedUri);
+      });
+
+      it(`when the title is empty and the clickuri contains a html element,
+      it does not render the element to prevent XSS`, () => {
+        fakeResult.title = '';
+        fakeResult.clickUri = htmlContainingXSS();
+        initResultLink();
+
+        expect(test.cmp.element.children.length).toBe(0);
+        expect(test.cmp.element.innerHTML).toBe('&lt;IMG SRC=/ onerror="alert(String.fromCharCode(88,83,83))"&gt;&lt;/img&gt;');
+      });
+
+      it('can receive an onClick option to execute', done => {
+        test = Mock.advancedResultComponentSetup<ResultLink>(
+          ResultLink,
+          fakeResult,
+          new Mock.AdvancedComponentSetupOptions($$('div').el, {
+            onClick: () => {
+              expect(true).toBe(true);
+              done();
+            }
+          })
+        );
+        $$(test.cmp.element).trigger('click');
+      });
+
+      it('sends an analytic event on click', () => {
+        $$(test.cmp.element).trigger('click');
+        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
+      });
+
+      describe('exposes hrefTemplate', () => {
+        it('when the href starts with a protocol that enables XSS, it returns an empty string', () => {
+          const hrefTemplate = 'javascript:alert(1)';
+          test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
+          test.cmp.openLinkInNewWindow();
+          expect(window.open).toHaveBeenCalledWith('', jasmine.anything());
         });
 
-        it('should generate the correct href if the os is windows and the option is openInOutlook', () => {
+        it('should not modify the href template if there are no field specified', () => {
+          let hrefTemplate = 'http://test';
+          test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
+          test.cmp.openLinkInNewWindow();
+          expect(window.open).toHaveBeenCalledWith(hrefTemplate, jasmine.anything());
+        });
+
+        it('should replace fields in the href template by the results equivalent', () => {
+          let hrefTemplate = 'http://${title}';
+          test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
+          test.cmp.openLinkInNewWindow();
+          expect(window.open).toHaveBeenCalledWith(`http://${fakeResult.title}`, jasmine.anything());
+        });
+
+        it('should support nested values in result', () => {
+          let hrefTemplate = 'http://${raw.number}';
+          test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
+          test.cmp.openLinkInNewWindow();
+          expect(window.open).toHaveBeenCalledWith(`http://${fakeResult.raw['number'].toString()}`, jasmine.anything());
+        });
+
+        it('should not parse standalone accolades', () => {
+          let hrefTemplate = 'http://${raw.number}{test}';
+          test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
+          test.cmp.openLinkInNewWindow();
+          expect(window.open).toHaveBeenCalledWith(`http://${fakeResult.raw['number']}{test}`, jasmine.anything());
+        });
+
+        it('should support external fields', () => {
+          window['Coveo']['test'] = 'testExternal';
+          let hrefTemplate = 'http://${Coveo.test}';
+          test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
+          test.cmp.openLinkInNewWindow();
+          expect(window.open).toHaveBeenCalledWith('http://testExternal', jasmine.anything());
+          window['Coveo']['test'] = undefined;
+        });
+
+        it('should support nested external fields with more than 2 keys', () => {
+          window['Coveo']['test'] = { key: 'testExternal' };
+          let hrefTemplate = 'http://${Coveo.test.key}';
+          test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { hrefTemplate: hrefTemplate }, fakeResult);
+          test.cmp.openLinkInNewWindow();
+          expect(window.open).toHaveBeenCalledWith('http://testExternal', jasmine.anything());
+          window['Coveo']['test'] = undefined;
+        });
+      });
+
+      describe('exposes the titleTemplate', () => {
+        let titleTemplate = '';
+
+        afterEach(() => {
+          titleTemplate = '';
+        });
+
+        function initResultLinkWithTitleTemplate() {
+          test = Mock.optionsResultComponentSetup<ResultLink, IResultLinkOptions>(ResultLink, { titleTemplate }, fakeResult);
+        }
+
+        it('should set the title attribute to the text version of the displayed title', () => {
+          titleTemplate = 'foo ${clickUri}';
+          initResultLinkWithTitleTemplate();
+          expect(test.cmp.element.title).toEqual(`foo ${fakeResult.clickUri}`);
+        });
+
+        it('should replaces fields in the title template by the results equivalent', () => {
+          titleTemplate = '${clickUri}';
+          initResultLinkWithTitleTemplate();
+
+          expect($$(test.cmp.element).text()).toEqual(fakeResult.clickUri);
+        });
+
+        it(`when the field referenced in the title template contains XSS html,
+        it escapes the html to prevent XSS`, () => {
+          titleTemplate = '${clickUri}';
+          fakeResult.clickUri = htmlContainingXSS();
+          initResultLinkWithTitleTemplate();
+
+          expect(test.cmp.element.innerHTML).toEqual('&lt;IMG SRC=/ onerror="alert(String.fromCharCode(88,83,83))"&gt;&lt;/img&gt;');
+        });
+
+        it('should support nested values in result', () => {
+          titleTemplate = '${raw.number}';
+          initResultLinkWithTitleTemplate();
+
+          expect(test.cmp.element.innerHTML).toEqual(fakeResult.raw['number'].toString());
+        });
+
+        it('should not parse standalone accolades', () => {
+          titleTemplate = '${raw.number}{test}';
+          initResultLinkWithTitleTemplate();
+
+          expect(test.cmp.element.innerHTML).toEqual(fakeResult.raw['number'].toString() + '{test}');
+        });
+
+        it('should support external fields', () => {
+          window['Coveo']['test'] = 'testExternal';
+          titleTemplate = '${Coveo.test}';
+          initResultLinkWithTitleTemplate();
+
+          expect(test.cmp.element.innerHTML).toEqual('testExternal');
+          window['Coveo']['test'] = undefined;
+        });
+
+        it('should support external fields with more than 2 keys', () => {
+          window['Coveo']['test'] = { key: 'testExternal' };
+          titleTemplate = '${Coveo.test.key}';
+          initResultLinkWithTitleTemplate();
+
+          expect(test.cmp.element.innerHTML).toEqual('testExternal');
+          window['Coveo']['test'] = undefined;
+        });
+
+        it('should print the title if the option is set but the template is empty', () => {
+          titleTemplate = '';
+          initResultLinkWithTitleTemplate();
+
+          expect($$(test.cmp.element).text()).toEqual(fakeResult.title);
+        });
+
+        it('should print the template if the key used in the template is undefined', () => {
+          titleTemplate = '${doesNotExist}';
+          initResultLinkWithTitleTemplate();
+
+          expect($$(test.cmp.element).text()).toEqual('${doesNotExist}');
+        });
+      });
+
+      it('sends an analytics event on context menu', () => {
+        $$(test.cmp.element).trigger('contextmenu');
+        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
+      });
+
+      it('sends an analytics event on mouseup', () => {
+        $$(test.cmp.element).trigger('mouseup');
+        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
+      });
+
+      it('sends an analytics event on mousedown', () => {
+        $$(test.cmp.element).trigger('mousedown');
+        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
+      });
+
+      it('does not send multiple analytics events with multiple mouse events', () => {
+        $$(test.cmp.element).trigger('mousedown');
+        $$(test.cmp.element).trigger('click');
+        $$(test.cmp.element).trigger('mouseup');
+        expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
+      });
+
+      it('sends an event 1s after a long press on mobile', done => {
+        $$(test.cmp.element).trigger('touchstart');
+        expect(test.cmp.usageAnalytics.logClickEvent).not.toHaveBeenCalled();
+        setTimeout(() => {
+          expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledTimes(1);
+          done();
+        }, 1100);
+      });
+
+      it('does not send an event if a touchend event occurs before a 1s delay', done => {
+        $$(test.cmp.element).trigger('touchstart');
+
+        setTimeout(() => {
+          $$(test.cmp.element).trigger('touchend');
+        }, 300);
+
+        setTimeout(() => {
+          expect(test.cmp.usageAnalytics.logClickEvent).not.toHaveBeenCalled();
+          done();
+        }, 1100);
+      });
+
+      describe('when logging the analytic event', () => {
+        it('should use the href if set', () => {
+          let element = $$('a');
+          let href = 'javascript:void(0)';
+          element.setAttribute('href', href);
+          test = Mock.advancedResultComponentSetup<ResultLink>(ResultLink, fakeResult, new Mock.AdvancedComponentSetupOptions(element.el));
+          spyOn(test.cmp, 'openLink');
+
+          $$(test.cmp.element).trigger('click');
+
+          expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledWith(
+            analyticsActionCauseList.documentOpen,
+            jasmine.objectContaining({ documentURL: href }),
+            fakeResult,
+            test.cmp.root
+          );
+        });
+
+        it('should not log analytics when logAnalytics is set', () => {
+          const element = $$('a');
           test = Mock.advancedResultComponentSetup<ResultLink>(
             ResultLink,
             fakeResult,
-            new Mock.AdvancedComponentSetupOptions($$('a').el, { openInOutlook: true }, (env: Mock.MockEnvironmentBuilder) => {
-              return env.withOs(OS_NAME.WINDOWS);
-            })
+            new Mock.AdvancedComponentSetupOptions(element.el, { logAnalytics: () => {} })
           );
-          expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.raw['outlookuri']);
+          spyOn(test.cmp, 'openLink');
+
+          $$(test.cmp.element).trigger('click');
+
+          expect(test.cmp.usageAnalytics.logClickEvent).not.toHaveBeenCalled();
         });
 
-        it('should generate the correct href if the os is windows and the option is not openInOutlook', () => {
+        it("should call logAnalytics when it's set", () => {
+          const element = $$('a');
+          const logAnalyticsSpy = jasmine.createSpy('logAnalytics');
           test = Mock.advancedResultComponentSetup<ResultLink>(
             ResultLink,
             fakeResult,
-            new Mock.AdvancedComponentSetupOptions($$('a').el, { openInOutlook: false }, (env: Mock.MockEnvironmentBuilder) => {
-              return env.withOs(OS_NAME.WINDOWS);
-            })
+            new Mock.AdvancedComponentSetupOptions(element.el, { logAnalytics: logAnalyticsSpy })
           );
-          expect(test.cmp.element.getAttribute('href')).not.toEqual(fakeResult.raw['outlookuri']);
+          spyOn(test.cmp, 'openLink');
+
+          $$(test.cmp.element).trigger('click');
+
+          expect(logAnalyticsSpy).toHaveBeenCalledTimes(1);
         });
 
-        it('should generate the correct href if the os is mac and the option is openInOutlook', () => {
+        it('should use the clickUri if the href is empty', () => {
+          $$(test.cmp.element).trigger('click');
+
+          expect(test.cmp.usageAnalytics.logClickEvent).toHaveBeenCalledWith(
+            analyticsActionCauseList.documentOpen,
+            jasmine.objectContaining({ documentURL: fakeResult.clickUri }),
+            fakeResult,
+            test.cmp.root
+          );
+        });
+      });
+
+      describe('when the element is a hyperlink', () => {
+        function initHyperLink(options?: IResultLinkOptions) {
           test = Mock.advancedResultComponentSetup<ResultLink>(
             ResultLink,
             fakeResult,
-            new Mock.AdvancedComponentSetupOptions($$('a').el, { openInOutlook: true }, (env: Mock.MockEnvironmentBuilder) => {
-              return env.withOs(OS_NAME.MACOSX);
-            })
+            new Mock.AdvancedComponentSetupOptions($$('a').el, options)
           );
-          expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.raw['outlookformacuri']);
+        }
+
+        beforeEach(() => {
+          initHyperLink();
         });
 
-        it('should generate the correct href if the os is mac and the option is not openInOutlook', () => {
-          test = Mock.advancedResultComponentSetup<ResultLink>(
-            ResultLink,
-            fakeResult,
-            new Mock.AdvancedComponentSetupOptions($$('a').el, { openInOutlook: false }, (env: Mock.MockEnvironmentBuilder) => {
-              return env.withOs(OS_NAME.MACOSX);
-            })
-          );
-          expect(test.cmp.element.getAttribute('href')).not.toEqual(fakeResult.raw['outlookformacuri']);
+        it('should set the href to the result click uri', () => {
+          expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+        });
+
+        it(`when the href contains "&" characters,
+          should set the href the unescaped the result click uri`, () => {
+          fakeResult.clickUri =
+            'https://testing.com/supportcenter/portal?DataSource=Solutions&eventSubmit_doNavigate=&PageNumber=Prev&tab=Solutions&ts=6';
+          initHyperLink();
+          expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+        });
+
+        it('when the clickUri is a relative url with a slash, it sets the href to the uri', () => {
+          fakeResult.clickUri = '/casemgmt/sc_KnowledgeArticle?sfdcid=ka32C0000009t9CQAQ&type=Solution';
+          initHyperLink();
+          expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+        });
+
+        it('when the uri is a relative url with a period, it sets the href to the uri', () => {
+          fakeResult.clickUri = './articles/ka32C0000009t9CQAQ';
+          initHyperLink();
+          expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+        });
+
+        it('when the uri is a relative url with two periods, it sets the href to the uri', () => {
+          fakeResult.clickUri = '../articles/ka32C0000009t9CQAQ';
+          initHyperLink();
+          expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.clickUri);
+        });
+
+        it('when the clickUri is a string containing but not starting with a slash, it sets the href to an empty string', () => {
+          fakeResult.clickUri = 'casemgmt/sc_KnowledgeArticle';
+          initHyperLink();
+          expect(test.cmp.element.getAttribute('href')).toEqual('');
+        });
+
+        it(`when the uri (clickUri) defined in the results contains the javascript protocol,
+          it clears the value to prevent XSS`, () => {
+          fakeResult.clickUri = 'JavaScript:void(0)';
+          initHyperLink();
+          expect(test.cmp.element.getAttribute('href')).toEqual('');
+        });
+
+        it(`when the field option is defined and the field contains the javascript protocol,
+          it clears the value to prevent XSS`, () => {
+          fakeResult.raw['test'] = 'javascript:void(0)';
+          initHyperLink({ field: '@test' });
+          expect(test.cmp.element.getAttribute('href')).toEqual('');
+        });
+
+        it(`when the uri uses the javascript protocol and contains a relative uri with a slash,
+          it clears the value to prevent XSS`, () => {
+          fakeResult.clickUri = 'javascript:"/casemgmt/sc_KnowledgeArticle"';
+          initHyperLink();
+          expect(test.cmp.element.getAttribute('href')).toEqual('');
+        });
+
+        it(`when the uri uses the javascript protocol and contains a relative uri with a period,
+          it clears the value to prevent XSS`, () => {
+          fakeResult.clickUri = 'javascript:"./articles/ka32C0000009t9CQAQ"';
+          initHyperLink();
+          expect(test.cmp.element.getAttribute('href')).toEqual('');
+        });
+
+        it(`when the uri uses the javascript protocol and contains a relative uri with two periods,
+          it clears the value to prevent XSS`, () => {
+          fakeResult.clickUri = 'javascript:"../articles/ka32C0000009t9CQAQ"';
+          initHyperLink();
+          expect(test.cmp.element.getAttribute('href')).toEqual('');
+        });
+
+        it('should not override the href if it is set before the initialization', () => {
+          let element = $$('a');
+          let href = 'javascript:void(0)';
+          element.setAttribute('href', href);
+          test = Mock.advancedResultComponentSetup<ResultLink>(ResultLink, fakeResult, new Mock.AdvancedComponentSetupOptions(element.el));
+
+          expect(test.cmp.element.getAttribute('href')).toEqual(href);
+        });
+
+        describe('and the result has the outlookfield', () => {
+          beforeEach(() => {
+            fakeResult.raw['outlookuri'] = 'mailto:test@coveo.comm';
+            fakeResult.raw['outlookformacuri'] = 'mailto:test.mac@coveo.comm';
+          });
+
+          it('should generate the correct href if the os is windows and the option is openInOutlook', () => {
+            test = Mock.advancedResultComponentSetup<ResultLink>(
+              ResultLink,
+              fakeResult,
+              new Mock.AdvancedComponentSetupOptions($$('a').el, { openInOutlook: true }, (env: Mock.MockEnvironmentBuilder) => {
+                return env.withOs(OS_NAME.WINDOWS);
+              })
+            );
+            expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.raw['outlookuri']);
+          });
+
+          it('should generate the correct href if the os is windows and the option is not openInOutlook', () => {
+            test = Mock.advancedResultComponentSetup<ResultLink>(
+              ResultLink,
+              fakeResult,
+              new Mock.AdvancedComponentSetupOptions($$('a').el, { openInOutlook: false }, (env: Mock.MockEnvironmentBuilder) => {
+                return env.withOs(OS_NAME.WINDOWS);
+              })
+            );
+            expect(test.cmp.element.getAttribute('href')).not.toEqual(fakeResult.raw['outlookuri']);
+          });
+
+          it('should generate the correct href if the os is mac and the option is openInOutlook', () => {
+            test = Mock.advancedResultComponentSetup<ResultLink>(
+              ResultLink,
+              fakeResult,
+              new Mock.AdvancedComponentSetupOptions($$('a').el, { openInOutlook: true }, (env: Mock.MockEnvironmentBuilder) => {
+                return env.withOs(OS_NAME.MACOSX);
+              })
+            );
+            expect(test.cmp.element.getAttribute('href')).toEqual(fakeResult.raw['outlookformacuri']);
+          });
+
+          it('should generate the correct href if the os is mac and the option is not openInOutlook', () => {
+            test = Mock.advancedResultComponentSetup<ResultLink>(
+              ResultLink,
+              fakeResult,
+              new Mock.AdvancedComponentSetupOptions($$('a').el, { openInOutlook: false }, (env: Mock.MockEnvironmentBuilder) => {
+                return env.withOs(OS_NAME.MACOSX);
+              })
+            );
+            expect(test.cmp.element.getAttribute('href')).not.toEqual(fakeResult.raw['outlookformacuri']);
+          });
         });
       });
     });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3369

A client needs to set `tabindex="-1"` to a result link which contains an image, which is also the approach I recommended for the visual section in Atomic. Unfortunately, the ResultLink always sets the tabindex to 0.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)