### PR TITLE
fix accessibility insights reports

### DIFF
--- a/src/ui/Pager/Pager.ts
+++ b/src/ui/Pager/Pager.ts
@@ -140,11 +140,15 @@ export class Pager extends Component {
       this.handleQueryStateNumberOfResultsPerPageChanged(data)
     );
     this.addAlwaysActiveListeners();
+    if (!this.element.getAttribute('role')) {
+      this.element.setAttribute('role', 'navigation');
+    }
+    if (!this.element.hasAttribute('aria-label')) {
+      this.element.setAttribute('aria-label', l('Pagination'));
+    }
 
     this.list = $$('ul', {
-      className: 'coveo-pager-list',
-      role: 'navigation',
-      ariaLabel: l('Pagination')
+      className: 'coveo-pager-list'
     }).el;
     element.appendChild(this.list);
   }
@@ -269,8 +273,8 @@ export class Pager extends Component {
           const isCurrentPage = page === this.currentPage;
           if (isCurrentPage) {
             $$(listItem).addClass('coveo-active');
+            listItem.setAttribute('aria-current', 'page');
           }
-          $$(listItem).setAttribute('aria-pressed', isCurrentPage.toString());
 
           const clickAction = () => this.handleClickPage(page);
 
@@ -279,6 +283,7 @@ export class Pager extends Component {
             .withLabel(l('PageNumber', i.toString(10)))
             .withClickAction(clickAction)
             .withEnterKeyboardAction(clickAction)
+            .withRole('listitem')
             .build();
 
           listItem.appendChild(listItemValue);
@@ -399,6 +404,7 @@ export class Pager extends Component {
       .withElement(previousButton)
       .withLabel(l('Previous'))
       .withSelectAction(() => this.handleClickPrevious())
+      .withRole('listitem')
       .build();
 
     return previousButton;
@@ -432,6 +438,7 @@ export class Pager extends Component {
       .withElement(nextButton)
       .withLabel(l('Next'))
       .withSelectAction(() => this.handleClickNext())
+      .withRole('listitem')
       .build();
 
     return nextButton;

--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -53,8 +53,8 @@ export class ResultsPerPage extends Component {
      * Default value is `[10, 25, 50, 100]`.
      */
     choicesDisplayed: ComponentOptions.buildCustomListOption<number[]>(
-      function(list: string[]) {
-        const values = _.map(list, function(value) {
+      function (list: string[]) {
+        const values = _.map(list, function (value) {
           return parseInt(value, 10);
         });
         return values.length == 0 ? null : values;
@@ -254,10 +254,9 @@ export class ResultsPerPage extends Component {
 
       listItem.appendChild(
         $$(
-          'a',
+          'span',
           {
             className: 'coveo-results-per-page-list-item-text',
-            tabindex: -1,
             ariaHidden: 'true'
           },
           numResultsList[i].toString()


### PR DESCRIPTION
These changes are aimed to fix issues reported by this tool: https://accessibilityinsights.io/

<img width="1477" alt="image" src="https://user-images.githubusercontent.com/1591893/162481147-d56cccf3-a9fc-44ff-a2f0-d1932578c5ac.png">


The Chrome lighthouse report tool did not pick those up (score was 100%, still is 100% after this).

I also ran the local tests with axe-core and everything seems good... 🤷 


* Moved `navigation` role to the Pager itself, instead of the list inside the pager
* Made the links in pager `role="listitem"`, since the parent is now a list instead of `navigation`
* In results per page, removed `-1` tabindex and changed to a simple span, so that it's no longer detected as interactive

https://coveord.atlassian.net/browse/JSUI-3382



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)