### PR TITLE
fix accessibility insights reports

### DIFF
--- a/src/ui/Pager/Pager.ts
+++ b/src/ui/Pager/Pager.ts
@@ -140,12 +140,7 @@ export class Pager extends Component {
       this.handleQueryStateNumberOfResultsPerPageChanged(data)
     );
     this.addAlwaysActiveListeners();
-    if (!this.element.getAttribute('role')) {
-      this.element.setAttribute('role', 'navigation');
-    }
-    if (!this.element.hasAttribute('aria-label')) {
-      this.element.setAttribute('aria-label', l('Pagination'));
-    }
+    this.addAccessibilityAttributes();
 
     this.list = $$('ul', {
       className: 'coveo-pager-list'
@@ -212,6 +207,15 @@ export class Pager extends Component {
     this.setPage(this.currentPage + 1, analyticsActionCauseList.pagerNext);
   }
 
+  private addAccessibilityAttributes() {
+    if (!this.element.getAttribute('role')) {
+      this.element.setAttribute('role', 'navigation');
+    }
+    if (!this.element.hasAttribute('aria-label')) {
+      this.element.setAttribute('aria-label', l('Pagination'));
+    }
+  }
+
   private addAlwaysActiveListeners() {
     this.searchInterface.element.addEventListener(ResultListEvents.newResultsDisplayed, () =>
       ResultListUtils.hideIfInfiniteScrollEnabled(this)
@@ -255,38 +259,36 @@ export class Pager extends Component {
       this.currentPage = pagerBoundary.currentPage;
       if (pagerBoundary.end - pagerBoundary.start > 0) {
         for (let i = pagerBoundary.start; i <= pagerBoundary.end; i++) {
-          const listItemValue = $$(
-            'a',
+          const page = i;
+          const isCurrentPage = page === this.currentPage;
+          const button = $$(
+            'span',
             {
               className: 'coveo-pager-list-item-text coveo-pager-anchor',
-              tabindex: -1,
-              ariaHidden: 'true'
+              tabindex: 0,
+              ariaPressed: `${isCurrentPage}`
             },
             i.toString(10)
           ).el;
 
-          const page = i;
           const listItem = $$('li', {
-            className: 'coveo-pager-list-item',
-            tabindex: 0
+            className: 'coveo-pager-list-item'
           }).el;
-          const isCurrentPage = page === this.currentPage;
           if (isCurrentPage) {
             $$(listItem).addClass('coveo-active');
-            listItem.setAttribute('aria-current', 'page');
+            button.setAttribute('aria-current', 'page');
           }
 
           const clickAction = () => this.handleClickPage(page);
 
           new AccessibleButton()
-            .withElement(listItem)
+            .withElement(button)
             .withLabel(l('PageNumber', i.toString(10)))
             .withClickAction(clickAction)
             .withEnterKeyboardAction(clickAction)
-            .withRole('listitem')
             .build();
 
-          listItem.appendChild(listItemValue);
+          listItem.appendChild(button);
           this.list.appendChild(listItem);
         }
 
@@ -377,14 +379,13 @@ export class Pager extends Component {
   }
 
   private renderPreviousButton() {
-    const previousButton = $$('li', {
+    const previousListItem = $$('li', {
       className: 'coveo-pager-previous coveo-pager-anchor coveo-pager-list-item'
     });
 
-    const previousLink = $$('a', {
+    const previousButton = $$('span', {
       title: l('Previous'),
-      tabindex: -1,
-      ariaHidden: 'true'
+      tabindex: 0
     });
 
     const previousIcon = $$(
@@ -397,28 +398,26 @@ export class Pager extends Component {
 
     SVGDom.addClassToSVGInContainer(previousIcon.el, 'coveo-pager-previous-icon-svg');
 
-    previousLink.append(previousIcon.el);
-    previousButton.append(previousLink.el);
+    previousButton.append(previousIcon.el);
+    previousListItem.append(previousButton.el);
 
     new AccessibleButton()
       .withElement(previousButton)
       .withLabel(l('Previous'))
       .withSelectAction(() => this.handleClickPrevious())
-      .withRole('listitem')
       .build();
 
-    return previousButton;
+    return previousListItem;
   }
 
   private renderNextButton() {
-    const nextButton = $$('li', {
+    const nextListItem = $$('li', {
       className: 'coveo-pager-next coveo-pager-anchor coveo-pager-list-item'
     });
 
-    const nextLink = $$('a', {
+    const nextButton = $$('span', {
       title: l('Next'),
-      tabindex: -1,
-      ariaHidden: 'true'
+      tabindex: 0
     });
 
     const nextIcon = $$(
@@ -431,17 +430,16 @@ export class Pager extends Component {
 
     SVGDom.addClassToSVGInContainer(nextIcon.el, 'coveo-pager-next-icon-svg');
 
-    nextLink.append(nextIcon.el);
-    nextButton.append(nextLink.el);
+    nextButton.append(nextIcon.el);
+    nextListItem.append(nextButton.el);
 
     new AccessibleButton()
       .withElement(nextButton)
       .withLabel(l('Next'))
       .withSelectAction(() => this.handleClickNext())
-      .withRole('listitem')
       .build();
 
-    return nextButton;
+    return nextListItem;
   }
 
   private handleQueryStateFirstResultChanged(data: IAttributeChangedEventArg) {

--- a/src/ui/Pager/Pager.ts
+++ b/src/ui/Pager/Pager.ts
@@ -140,11 +140,15 @@ export class Pager extends Component {
       this.handleQueryStateNumberOfResultsPerPageChanged(data)
     );
     this.addAlwaysActiveListeners();
+    if (!this.element.getAttribute('role')) {
+      this.element.setAttribute('role', 'navigation');
+    }
+    if (!this.element.hasAttribute('aria-label')) {
+      this.element.setAttribute('aria-label', l('Pagination'));
+    }
 
     this.list = $$('ul', {
-      className: 'coveo-pager-list',
-      role: 'navigation',
-      ariaLabel: l('Pagination')
+      className: 'coveo-pager-list'
     }).el;
     element.appendChild(this.list);
   }
@@ -269,8 +273,8 @@ export class Pager extends Component {
           const isCurrentPage = page === this.currentPage;
           if (isCurrentPage) {
             $$(listItem).addClass('coveo-active');
+            listItem.setAttribute('aria-current', 'page');
           }
-          $$(listItem).setAttribute('aria-pressed', isCurrentPage.toString());
 
           const clickAction = () => this.handleClickPage(page);
 
@@ -279,6 +283,7 @@ export class Pager extends Component {
             .withLabel(l('PageNumber', i.toString(10)))
             .withClickAction(clickAction)
             .withEnterKeyboardAction(clickAction)
+            .withRole('listitem')
             .build();
 
           listItem.appendChild(listItemValue);
@@ -399,6 +404,7 @@ export class Pager extends Component {
       .withElement(previousButton)
       .withLabel(l('Previous'))
       .withSelectAction(() => this.handleClickPrevious())
+      .withRole('listitem')
       .build();
 
     return previousButton;
@@ -432,6 +438,7 @@ export class Pager extends Component {
       .withElement(nextButton)
       .withLabel(l('Next'))
       .withSelectAction(() => this.handleClickNext())
+      .withRole('listitem')
       .build();
 
     return nextButton;

--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -221,7 +221,6 @@ export class ResultsPerPage extends Component {
     this.element.appendChild(this.span);
     this.list = $$('ul', {
       className: 'coveo-results-per-page-list',
-      role: 'radiogroup',
       'aria-labelledby': this.span.id
     }).el;
     this.element.appendChild(this.list);
@@ -232,36 +231,34 @@ export class ResultsPerPage extends Component {
     const numResultsList: number[] = this.options.choicesDisplayed;
     for (var i = 0; i < numResultsList.length; i++) {
       const listItem = $$('li', {
-        className: 'coveo-results-per-page-list-item',
-        role: 'radio',
-        tabindex: 0
+        className: 'coveo-results-per-page-list-item'
       }).el;
       const resultsPerPage = numResultsList[i];
       const isActive = resultsPerPage === this.currentResultsPerPage;
       if (isActive) {
         $$(listItem).addClass('coveo-active');
       }
-      listItem.setAttribute('aria-checked', isActive.toString());
 
       const clickAction = () => this.handleClickPage(resultsPerPage);
 
+      const button = $$(
+        'span',
+        {
+          className: 'coveo-results-per-page-list-item-text',
+          tabindex: 0,
+          ariaPressed: isActive.toString()
+        },
+        numResultsList[i].toString()
+      ).el;
+      listItem.appendChild(button);
+
       new AccessibleButton()
-        .withElement(listItem)
+        .withElement(button)
         .withLabel(l('DisplayResultsPerPage', numResultsList[i].toString()))
         .withClickAction(clickAction)
         .withEnterKeyboardAction(clickAction)
         .build();
 
-      listItem.appendChild(
-        $$(
-          'span',
-          {
-            className: 'coveo-results-per-page-list-item-text',
-            ariaHidden: 'true'
-          },
-          numResultsList[i].toString()
-        ).el
-      );
       this.list.appendChild(listItem);
     }
   }

--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -53,8 +53,8 @@ export class ResultsPerPage extends Component {
      * Default value is `[10, 25, 50, 100]`.
      */
     choicesDisplayed: ComponentOptions.buildCustomListOption<number[]>(
-      function(list: string[]) {
-        const values = _.map(list, function(value) {
+      function (list: string[]) {
+        const values = _.map(list, function (value) {
           return parseInt(value, 10);
         });
         return values.length == 0 ? null : values;
@@ -254,10 +254,9 @@ export class ResultsPerPage extends Component {
 
       listItem.appendChild(
         $$(
-          'a',
+          'span',
           {
             className: 'coveo-results-per-page-list-item-text',
-            tabindex: -1,
             ariaHidden: 'true'
           },
           numResultsList[i].toString()

--- a/unitTests/ui/PagerTest.ts
+++ b/unitTests/ui/PagerTest.ts
@@ -27,7 +27,7 @@ export function PagerTest() {
 
     function getRenderedButtonLabels() {
       return $$(test.cmp.element)
-        .findAll('a.coveo-pager-list-item-text')
+        .findAll('span.coveo-pager-list-item-text')
         .map(item => item.innerText);
     }
 
@@ -129,9 +129,9 @@ export function PagerTest() {
     it('should render the pager boundary correctly', () => {
       simulatePageCount(100, 8);
 
-      const anchors = $$(test.cmp.element).findAll('a.coveo-pager-list-item-text');
+      const anchors = $$(test.cmp.element).findAll('span.coveo-pager-list-item-text');
       expect($$(anchors[0]).text()).toBe('6');
-      expect(anchors[0].parentElement.getAttribute('tabindex')).toBe('0');
+      expect(anchors[0].getAttribute('tabindex')).toBe('0');
       expect($$(anchors[anchors.length - 1]).text()).toBe('10');
     });
 
@@ -188,7 +188,7 @@ export function PagerTest() {
     });
 
     describe('with 100 fake results', () => {
-      let listItems: HTMLElement[];
+      let buttons: HTMLElement[];
       beforeEach(() => {
         const builder = new QueryBuilder();
         builder.firstResult = 50;
@@ -196,20 +196,20 @@ export function PagerTest() {
           query: builder.build(),
           results: FakeResults.createFakeResults(100)
         });
-        listItems = $$(test.cmp.element).findAll('.coveo-pager-list-item');
+        buttons = $$(test.cmp.element).findAll('[role="button"]');
       });
 
       it('should set the aria-label on the navigation element', () => {
-        expect(test.cmp['list'].getAttribute('aria-label')).toEqual(l('Pagination'));
+        expect(test.cmp.element.getAttribute('aria-label')).toEqual(l('Pagination'));
       });
 
       it('should set the role on the navigation element', () => {
-        expect(test.cmp['list'].getAttribute('role')).toEqual('navigation');
+        expect(test.cmp.element.getAttribute('role')).toEqual('navigation');
       });
 
       it('should set the aria-label on elements correctly', () => {
-        listItems.forEach((listItem, index) => {
-          if (index !== 0 && index !== listItems.length - 1) {
+        buttons.forEach((listItem, index) => {
+          if (index !== 0 && index !== buttons.length - 1) {
             const pageNumber = parseInt($$(listItem).text());
             expect(listItem.getAttribute('aria-label')).toEqual(l('PageNumber', pageNumber.toString()));
           }
@@ -217,7 +217,7 @@ export function PagerTest() {
       });
 
       it('should set the role on elements', () => {
-        listItems.forEach(listItem => expect(listItem.getAttribute('role')).toEqual('button'));
+        buttons.forEach(listItem => expect(listItem.getAttribute('role')).toEqual('button'));
       });
 
       it('should not make the next arrow a toggle', () => {
@@ -229,13 +229,13 @@ export function PagerTest() {
       });
 
       it('should set aria-pressed to true on the active page element', () => {
-        const activeElement = find(listItems, listItem => $$(listItem).text() === test.cmp.currentPage.toString());
+        const activeElement = find(buttons, listItem => $$(listItem).text() === test.cmp.currentPage.toString());
         expect(activeElement.getAttribute('aria-pressed')).toEqual(true.toString());
       });
 
       it('should set aria-pressed to false on every inactive page element', () => {
-        listItems.forEach((listItem, index) => {
-          if (index !== 0 && index !== listItems.length - 1) {
+        buttons.forEach((listItem, index) => {
+          if (index !== 0 && index !== buttons.length - 1) {
             if ($$(listItem).text() !== test.cmp.currentPage.toString()) {
               expect(listItem.getAttribute('aria-pressed')).toEqual(false.toString());
             }
@@ -243,12 +243,8 @@ export function PagerTest() {
         });
       });
 
-      it('should set tabindex to -1 on every link element', () => {
-        listItems.forEach(listItem => expect(listItem.children.item(0).getAttribute('tabindex')).toEqual('-1'));
-      });
-
-      it('should set aria-hidden to true on every link element', () => {
-        listItems.forEach(listItem => expect(listItem.children.item(0).getAttribute('aria-hidden')).toEqual('true'));
+      it('should set tabindex to 0 on every button element', () => {
+        buttons.forEach(button => expect(button.getAttribute('tabindex')).toEqual('0'));
       });
     });
 
@@ -316,7 +312,7 @@ export function PagerTest() {
         // Page 1 to 5
         execQuery(test, 10, 0, 1000);
 
-        let anchors = $$(test.cmp.element).findAll('a.coveo-pager-list-item-text');
+        let anchors = $$(test.cmp.element).findAll('span.coveo-pager-list-item-text');
         expect($$(anchors[0]).text()).toBe('1');
         expect($$(anchors[anchors.length - 1]).text()).toBe('5');
 
@@ -324,7 +320,7 @@ export function PagerTest() {
         // Page 1 to 2
         execQuery(test, 500, 0, 1000);
 
-        anchors = $$(test.cmp.element).findAll('a.coveo-pager-list-item-text');
+        anchors = $$(test.cmp.element).findAll('span.coveo-pager-list-item-text');
         expect($$(anchors[0]).text()).toBe('1');
         expect($$(anchors[anchors.length - 1]).text()).toBe('2');
       });
@@ -410,7 +406,7 @@ export function PagerTest() {
         Simulate.query(test.env, {
           results: FakeResults.createFakeResults(1000)
         });
-        expect($$(test.cmp.element).findAll('a.coveo-pager-list-item-text').length).toBe(22);
+        expect($$(test.cmp.element).findAll('span.coveo-pager-list-item-text').length).toBe(22);
       });
 
       it('enableNavigationButton can enable or disable nav buttons', () => {
@@ -451,7 +447,7 @@ export function PagerTest() {
           results: FakeResults.createFakeResults(1000) // return much more results than 31, but the option should still work properly
         });
 
-        const anchors = $$(test.cmp.element).findAll('a.coveo-pager-list-item-text');
+        const anchors = $$(test.cmp.element).findAll('span.coveo-pager-list-item-text');
         // 31 results max from the index
         // divided by 10 results per page
         // means 4 pages

--- a/unitTests/ui/ResultsPerPageTest.ts
+++ b/unitTests/ui/ResultsPerPageTest.ts
@@ -29,7 +29,6 @@ export function ResultsPerPageTest() {
 
       expect(label.id).toBeTruthy();
       expect(list.getAttribute('aria-labelledby')).toEqual(label.id);
-      expect(list.getAttribute('role')).toEqual('radiogroup');
     });
 
     describe('when calling #setResultsPerPage', () => {
@@ -167,11 +166,11 @@ export function ResultsPerPageTest() {
         Simulate.query(test.env, {
           results: FakeResults.createFakeResults(100)
         });
-        expect($$(test.cmp.element).findAll('a.coveo-results-per-page-list-item-text').length).toBe(4);
+        expect($$(test.cmp.element).findAll('span.coveo-results-per-page-list-item-text').length).toBe(4);
         expect(test.env.queryController.options.resultsPerPage).toBe(15);
       });
 
-      it('choicesDisplayed links display the right aria-label', () => {
+      it('choicesDisplayed buttons display the right aria-label', () => {
         test = Mock.optionsComponentSetup<ResultsPerPage, IResultsPerPageOptions>(ResultsPerPage, {
           choicesDisplayed: [10, 25, 50]
         });
@@ -179,9 +178,9 @@ export function ResultsPerPageTest() {
           results: FakeResults.createFakeResults(100)
         });
 
-        const anchors = $$(test.cmp.element).findAll('a.coveo-results-per-page-list-item-text');
-        expect($$(anchors[0]).text()).toBe('10');
-        expect(anchors[0].parentElement.getAttribute('aria-label')).toBe('Display 10 results per page');
+        const buttons = $$(test.cmp.element).findAll('[role="button"]');
+        expect($$(buttons[0]).text()).toBe('10');
+        expect(buttons[0].getAttribute('aria-label')).toBe('Display 10 results per page');
       });
 
       it('initialChoice allows to choose the first choice of the number of results per page options', () => {
@@ -241,7 +240,7 @@ export function ResultsPerPageTest() {
       describe('with choices displayed 5, 10, 15 and 20', () => {
         const initialChoice = 10;
         const choicesDisplayed = [5, initialChoice, 15, 20];
-        let choiceElements: HTMLElement[];
+        let buttons: HTMLElement[];
         beforeEach(() => {
           test = Mock.optionsComponentSetup<ResultsPerPage, IResultsPerPageOptions>(ResultsPerPage, {
             initialChoice,
@@ -251,32 +250,22 @@ export function ResultsPerPageTest() {
           Simulate.query(test.env, {
             results: FakeResults.createFakeResults(100)
           });
-          choiceElements = $$(test.cmp['list']).children();
+          buttons = $$(test.cmp.element).findAll('[role="button"]');
         });
 
-        it('gives the radiogroup role to the container', () => {
-          expect(test.cmp['list'].getAttribute('role')).toEqual('radiogroup');
+        it('gives the button role to the choices', () => {
+          buttons.forEach(choiceElement => expect(choiceElement.getAttribute('role')).toEqual('button'));
         });
 
-        it('gives the radio role to the choices', () => {
-          choiceElements.forEach(choiceElement => expect(choiceElement.getAttribute('role')).toEqual('radio'));
-        });
-
-        it('sets the aria-checked attribute on choice elements', () => {
-          choiceElements.forEach((choiceElement, index) => {
-            expect(choiceElement.getAttribute('aria-checked')).toEqual((index === 1).toString());
+        it('sets the aria-pressed attribute on choice elements', () => {
+          buttons.forEach((choiceElement, index) => {
+            expect(choiceElement.getAttribute('aria-pressed')).toEqual((index === 1).toString());
           });
         });
 
-        it('sets tabindex to -1 on every link element', () => {
-          choiceElements.forEach(choiceElement => {
-            expect(choiceElement.children.item(0).getAttribute('tabindex')).toEqual('-1');
-          });
-        });
-
-        it('sets aria-hidden to true on every link element', () => {
-          choiceElements.forEach(choiceElement => {
-            expect(choiceElement.children.item(0).getAttribute('aria-hidden')).toEqual('true');
+        it('sets tabindex to 0 on every button element', () => {
+          buttons.forEach(choiceElement => {
+            expect(choiceElement.getAttribute('tabindex')).toEqual('0');
           });
         });
       });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3382

Follow-up to Olivier's PR: https://github.com/coveo/search-ui/pull/1867

# The problem

[FastPass](https://accessibilityinsights.io/docs/en/web/getstarted/fastpass/) (which uses axe-core) is reporting an error and two clients reported it separately:
![image](https://user-images.githubusercontent.com/54454747/163456847-3f54abf5-b079-49e1-86a9-49ac96af7ef9.png)
(screenshot from Olivier's PR)

The accessibility DOM structure we had for the pager (and similar for the results per page) was like so:
* `ul[role="navigation"]`
  * `li[role="button"]`
    * `a[aria-hidden][tabindex=-1]`

Technically, since `role` and `aria-hidden` *should* (at-least in my experience so far) override the default roles of their respective elements, this shouldn't count as an interactive element being inside another interactive element. However, I suspect that axe-core dislikes an `a` element being inside a button (even with `aria-hidden`).

# The solution

I changed the structure to be like so:
* `.CoveoPager[role="navigation"]` (just like Olivier suggested)
  * `ul` (default role)
    * `li` (default role)
      * `span[role="button"][tabindex=0]`

I ran FastPass before and after the change, and the error disappeared after the changes.

Another change I did was that I switched the ResultsPerPage from being a radiogroup with radio buttons to a list of toggle buttons, since radio buttons convey to screen readers that arrow keys should work, which is a pain to support given that the page refreshes every time we select a different option.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)