### PR TITLE
add preventive code for custom code override usage analytics

### DIFF
--- a/src/controllers/QueryController.ts
+++ b/src/controllers/QueryController.ts
@@ -724,8 +724,19 @@ export class QueryController extends RootComponent {
   private getAnalyticsInformation(): AnalyticsInformation {
     const analyticsInfo = new AnalyticsInformation();
     analyticsInfo.pendingSearchEvent = this.usageAnalytics.getPendingSearchEvent();
-    analyticsInfo.originContext = this.usageAnalytics.getOriginContext();
-    analyticsInfo.userDisplayName = this.usageAnalytics.getUserDisplayName();
+
+    // add fallback for custom code that incorrectly implement the interface.
+    if (this.usageAnalytics.getOriginContext) {
+      analyticsInfo.originContext = this.usageAnalytics.getOriginContext();
+    } else {
+      analyticsInfo.originContext = 'Search';
+    }
+    if (this.usageAnalytics.getUserDisplayName) {
+      analyticsInfo.userDisplayName = this.usageAnalytics.getUserDisplayName();
+    } else {
+      analyticsInfo.userDisplayName = undefined;
+    }
+
     return analyticsInfo;
   }
 }

--- a/unitTests/controllers/QueryControllerTest.ts
+++ b/unitTests/controllers/QueryControllerTest.ts
@@ -90,6 +90,11 @@ export function QueryControllerTest() {
       );
     });
 
+    it('should not throw when the analytics instance set on query controller incorrectly implement the interface', () => {
+      test.cmp.searchInterface.usageAnalytics = { ...test.cmp.usageAnalytics, getOriginContext: null, getUserDisplayName: null };
+      expect(() => test.cmp.executeQuery()).not.toThrow();
+    });
+
     it('should allow to get the last query', done => {
       $$(test.cmp.element).on(QueryEvents.buildingQuery, (e, args: IBuildingQueryEventArgs) => {
         args.queryBuilder.expression.add('mamamia');


### PR DESCRIPTION
This was code that was added last release. Normally, this is all internal logic code (the usage analytics client interface).

However, it seems there's popular custom code that override internal functions on the usage analytics client, deployed at different clients.

And since these module don't implement all the functionalities needed, we get null ref error.

This adds defensive code around this, with hardcoded values. 

https://coveord.atlassian.net/browse/JSUI-3383





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)