### PR TITLE
JSUI-3400 changed result link aria label

### DIFF
--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -22,7 +22,6 @@ import { exportGlobally } from '../../GlobalExports';
 
 import 'styling/_ResultLink';
 import { AccessibleButton } from '../../utils/AccessibleButton';
-import { l } from '../../MiscModules';
 
 /**
  * The `ResultLink` component automatically transform a search result title into a clickable link pointing to the
@@ -319,7 +318,7 @@ export class ResultLink extends Component {
     if (/^\s*$/.test(this.element.innerHTML)) {
       const title = this.getDisplayedTitle();
       this.element.innerHTML = title;
-      this.element.setAttribute('aria-label', l('Result'));
+      this.element.setAttribute('aria-label', title);
 
       if (!this.element.title) {
         this.element.title = this.getDisplayedTitleAsText();

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -318,10 +318,14 @@ export class ResultLink extends Component {
     if (/^\s*$/.test(this.element.innerHTML)) {
       const title = this.getDisplayedTitle();
       this.element.innerHTML = title;
-      this.element.setAttribute('aria-label', title);
+
+      const titleAsText = this.getDisplayedTitleAsText();
+      if (!this.element.hasAttribute('aria-label')) {
+        this.element.setAttribute('aria-label', titleAsText);
+      }
 
       if (!this.element.title) {
-        this.element.title = this.getDisplayedTitleAsText();
+        this.element.title = titleAsText;
       }
     }
   }

--- a/unitTests/ui/ResultLinkTest.ts
+++ b/unitTests/ui/ResultLinkTest.ts
@@ -60,7 +60,7 @@ export function ResultLinkTest() {
       });
 
       it('should have an aria-label to prevent screen readers from reading the #title attribute', () => {
-        expect(test.cmp.element.getAttribute('aria-label')).toBe('Result');
+        expect(test.cmp.element.getAttribute('aria-label')).toBe(test.cmp.element.title);
       });
 
       describe('with global result link options', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3400

The "Result" label was added in response to a ticket saying that the "title" attribute caused the element's title to be read twice.

IMO, reading the title twice isn't so bad, it seems a lot more like a screen reader error to me than a problem with the UI. We can't remove the title because it gives a useful hint under the cursor, but overriding the label with "Result", in theory, removes the title from every result.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)