### PR TITLE
resize responsive components once after initial query

### DIFF
--- a/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
+++ b/src/ui/ResponsiveComponents/ResponsiveComponentsManager.ts
@@ -60,6 +60,7 @@ export class ResponsiveComponentsManager {
     // options.initializationEventRoot can be set in some instance (like recommendation) where the root of the interface triggering the init event
     // is different from the one that will be used for calculation size.
     const initEventRoot = options.initializationEventRoot || root;
+
     initEventRoot.on(InitializationEvents.afterInitialization, () => {
       if (this.shouldEnableResponsiveMode(root)) {
         this.registerComponentIfResponsiveModeEnabled(responsiveComponentConstructor, root, ID, component, options);
@@ -79,6 +80,9 @@ export class ResponsiveComponentsManager {
           this.resizeAllComponentsManager();
         }
       }
+    });
+    initEventRoot.one(QueryEvents.querySuccess, () => {
+      this.resizeAllComponentsManager();
     });
     this.remainingComponentInitializations++;
   }

--- a/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
+++ b/unitTests/ui/ResponsiveComponents/ResponsiveComponentsManagerTest.ts
@@ -9,6 +9,7 @@ import { ITabOptions, Tab } from '../../../src/ui/Tab/Tab';
 import { InitializationEvents } from '../../../src/Core';
 import { ResponsiveFacets } from '../../../src/ui/ResponsiveComponents/ResponsiveFacets';
 import { Facet, IFacetOptions } from '../../../src/ui/Facet/Facet';
+import { Simulate } from '../../Simulate';
 
 export function ResponsiveComponentsManagerTest() {
   const SMALL_RESPONSIVE_MODE = 'small';
@@ -137,6 +138,16 @@ export function ResponsiveComponentsManagerTest() {
       responsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
 
       expect(registerComponent).toHaveBeenCalledTimes(2);
+    });
+
+    it('should trigger a resize event once on the initial query success to account for page layout changes', () => {
+      spyOn(ResponsiveComponentsManager, 'resizeAllComponentsManager').and.callThrough();
+      ResponsiveComponentsManager.register(responsiveComponent, root, 'id', component, {});
+      const env = new Mock.MockEnvironmentBuilder().withRoot(root.el).build();
+      Simulate.query(env);
+      Simulate.query(env);
+      Simulate.query(env);
+      expect(ResponsiveComponentsManager.resizeAllComponentsManager).toHaveBeenCalledTimes(1);
     });
   });
 }


### PR DESCRIPTION
In some scenario (when the interface loads and initialize with hidden tabs, for example) , resizing the responsive component only after initialization is not enough, and we need to also hook into after the initial query is performed.
https://coveord.atlassian.net/browse/JSUI-3401





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)