### PR TITLE
JSUI-3405 added field values for DynamicHierarchicalFacet

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -325,6 +325,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
   public isCollapsed: boolean;
   public isDynamicFacet = true;
   public isFieldValueCompatible = true;
+  public isFieldValueHierarchical = false;
 
   /**
    * Creates a new `DynamicFacet` instance.

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -723,6 +723,7 @@ export class Facet extends Component implements IFieldValueCompatibleFacet {
   public firstQuery = true;
   public operatorAttributeId: string;
   public isFieldValueCompatible = true;
+  public isFieldValueHierarchical = false;
 
   /**
    * Renders and handles the facet **Search** part of the component.

--- a/src/ui/FieldValue/FieldValue.ts
+++ b/src/ui/FieldValue/FieldValue.ts
@@ -280,6 +280,9 @@ export class FieldValue extends Component {
       loadedValueFromComponent = loadedValueFromComponent.toString();
       values = [loadedValueFromComponent];
     }
+    if (values.length > 1 && this.isValueHierarchical) {
+      values = values.slice(-1);
+    }
     this.appendValuesToDom(values);
     if (this.options.textCaption != null) {
       this.prependTextCaptionToDom();
@@ -430,6 +433,15 @@ export class FieldValue extends Component {
       return facetsWithMatchingId;
     }
     return facets.filter(facet => facet.options.field === this.options.field);
+  }
+
+  private get isValueHierarchical() {
+    for (let facet of this.getFacets()) {
+      if (facet.isFieldValueHierarchical) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private bindFacets(element: HTMLElement, originalFacetValue: string, renderedFacetValue: string) {

--- a/src/ui/FieldValue/IFieldValueCompatibleFacet.ts
+++ b/src/ui/FieldValue/IFieldValueCompatibleFacet.ts
@@ -6,6 +6,7 @@ export function isFacetFieldValueCompatible(facet: Component): facet is IFieldVa
 
 export interface IFieldValueCompatibleFacet extends Component {
   isFieldValueCompatible: boolean;
+  isFieldValueHierarchical: boolean;
   hasSelectedValue(value: string): boolean;
   selectValue(value: string): void;
   deselectValue(value: string): void;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3405

I don't think this is a breaking change, since we couldn't even display hierarchical facet values, the whole path was displayed.

I tested, and value captions work.

# Pictures with the "Country" facet
* When the value is not selected in the facet OR
* When an ancestor is selected OR
* When the value was selected in the facet, then the field value was clicked
![image](https://user-images.githubusercontent.com/54454747/171491898-caaa8298-348a-48c5-932e-4a0fd1a22c7f.png)

* When the value is selected OR
* When the field value was clicked
![image](https://user-images.githubusercontent.com/54454747/171492304-11864661-cb6b-4a43-8ac6-909884d548cd.png)

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)