### PR TITLE
JSUI-2383 Log query in action history when clicking search button

### DIFF
--- a/src/ui/SearchButton/SearchButton.ts
+++ b/src/ui/SearchButton/SearchButton.ts
@@ -76,7 +76,7 @@ export class SearchButton extends Component {
     this.logger.debug('Performing query following button click');
     this.updateQueryStateModelWithSearchboxQuery();
     this.usageAnalytics.logSearchEvent<IAnalyticsNoMeta>(analyticsActionCauseList.searchboxSubmit, {});
-    this.queryController.executeQuery({ origin: this });
+    this.queryController.executeQuery({ origin: this, logInActionsHistory: true });
   }
 
   private updateQueryStateModelWithSearchboxQuery() {

--- a/unitTests/ui/SearchButtonTest.ts
+++ b/unitTests/ui/SearchButtonTest.ts
@@ -7,24 +7,24 @@ export function SearchButtonTest() {
   describe('SearchButton', () => {
     var test: Mock.IBasicComponentSetup<SearchButton>;
 
-    beforeEach(function() {
+    beforeEach(function () {
       test = Mock.basicComponentSetup<SearchButton>(SearchButton);
     });
 
-    afterEach(function() {
+    afterEach(function () {
       test = null;
     });
 
-    it('can be initialized', function() {
+    it('can be initialized', function () {
       expect(test.cmp).toBeDefined();
     });
 
-    it('will trigger a query on click', function() {
+    it('will trigger a query on click', function () {
       test.cmp.click();
-      expect(test.env.queryController.executeQuery).toHaveBeenCalled();
+      expect(test.env.queryController.executeQuery).toHaveBeenCalledWith(jasmine.objectContaining({ logInActionsHistory: true }));
     });
 
-    it('will log an analytics event', function() {
+    it('will log an analytics event', function () {
       test.cmp.click();
       expect(test.env.usageAnalytics.logSearchEvent).toHaveBeenCalledWith(analyticsActionCauseList.searchboxSubmit, {});
     });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3407

Any reason why this wasn't the case? 


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)