### PR TITLE
Replaced selector for quickview iframe (accessibility tests)

### DIFF
--- a/accessibilityTest/AccessibilityQuickview.ts
+++ b/accessibilityTest/AccessibilityQuickview.ts
@@ -6,7 +6,6 @@ export const AccessibilityQuickview = () => {
   describe('Quickview', () => {
     async function openQuickview() {
       await (get(document.querySelector(`.${Component.computeCssClassName(Quickview)}`)) as Quickview).open();
-      console.log(`.${Component.computeCssClassName(Quickview)}`);
     }
 
     function getQuickviewCloseButton(): HTMLElement {


### PR DESCRIPTION
[JSUI-3411](https://coveord.atlassian.net/browse/JSUI-3411)

The test looks for an element like `iframe[title]` which in today's case didn't exist, so the test fails on a time-out before even doing the accessibility check to look for the title.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)