### PR TITLE
fix quickview accessibility tests

### DIFF
--- a/accessibilityTest/AccessibilityQuickview.ts
+++ b/accessibilityTest/AccessibilityQuickview.ts
@@ -1,6 +1,6 @@
 import * as axe from 'axe-core';
 import { $$, Quickview, Component, get, Dom } from 'coveo-search-ui';
-import { afterQuerySuccess, getRoot, testResultElement, getModal, waitUntilSelectorIsPresent } from './Testing';
+import { afterQuerySuccess, getRoot, testResultElement, getModal, waitUntilSelectorIsPresent, addFieldEqualFilter } from './Testing';
 
 export const AccessibilityQuickview = () => {
   describe('Quickview', () => {
@@ -17,6 +17,7 @@ export const AccessibilityQuickview = () => {
       quickviewElement = $$('div', {
         className: Component.computeCssClassName(Quickview)
       });
+      addFieldEqualFilter('@author', ['Marie']);
 
       testResultElement(quickviewElement.el);
       await afterQuerySuccess();
@@ -38,9 +39,7 @@ export const AccessibilityQuickview = () => {
 
     it('should open an accessible modal', async done => {
       await openQuickview();
-      if (!getModal().querySelector('.coveo-iframeWrapper iframe')) {
-        await waitUntilSelectorIsPresent(getModal(), '.coveo-iframeWrapper iframe');
-      }
+      await waitUntilSelectorIsPresent(document.body, 'iframe[title]');
       const axeResults = await axe.run(getModal());
       expect(axeResults).toBeAccessible();
       done();


### PR DESCRIPTION
This kinda revert what you changed @wmannard with https://github.com/coveo/search-ui/commit/145b8dcfed3fbcb9f1b7e616d812fe32c2a8c997

The reason this started to fail was that there was some changes in the documents in the index, and the quickview tests were not specific enough to filter on something more "stable". 

So the random Quickview that got opened would not load quick enough, and axe-core tests would incorrectly report them as un-accessible since it would not get the full iframe with all attributes set properly.

Another solution would have been to simply wait for ~1s before running axe-core. Adding a filter for a specific type of document seems better.


https://coveord.atlassian.net/browse/JSUI-3410





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)