### PR TITLE
JSUI-3414 Added alwaysOpenInNewWindow to SmartSnippet and SmartSnippetSuggestions

### DIFF
--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -77,6 +77,7 @@ export interface ISmartSnippetOptions {
   maximumSnippetHeight: number;
   titleField: IFieldOption;
   hrefTemplate?: string;
+  alwaysOpenInNewWindow?: boolean;
   useIFrame?: boolean;
 }
 /**
@@ -136,6 +137,14 @@ export class SmartSnippet extends Component {
      * Default value is `undefined`.
      */
     hrefTemplate: ComponentOptions.buildStringOption(),
+
+    /**
+     * Specifies whether the component should open its links in a new window instead of opening it in the current
+     * context.
+     *
+     * Default value is `false`.
+     */
+    alwaysOpenInNewWindow: ComponentOptions.buildBooleanOption({ defaultValue: false }),
 
     /**
      * Specify if the SmartSnippet should be displayed inside an iframe or not.
@@ -342,7 +351,11 @@ export class SmartSnippet extends Component {
     element.addClass(className);
     new ResultLink(
       element.el,
-      { hrefTemplate: this.options.hrefTemplate, logAnalytics: href => this.sendClickSourceAnalytics(element.el, href) },
+      {
+        hrefTemplate: this.options.hrefTemplate,
+        logAnalytics: href => this.sendClickSourceAnalytics(element.el, href),
+        alwaysOpenInNewWindow: this.options.alwaysOpenInNewWindow
+      },
       { ...this.getBindings(), resultElement: this.element },
       this.lastRenderedResult
     );

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -139,7 +139,7 @@ export class SmartSnippet extends Component {
     hrefTemplate: ComponentOptions.buildStringOption(),
 
     /**
-     * Specifies whether the component should open its links in a new window instead of opening it in the current
+     * Specifies whether the component should open its links in a new window instead of opening them in the current
      * context.
      *
      * Default value is `false`.

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -62,6 +62,7 @@ export class SmartSnippetCollapsibleSuggestion {
       readonly searchUid: string;
       readonly titleField: IFieldOption;
       readonly hrefTemplate?: string;
+      readonly alwaysOpenInNewWindow?: boolean;
       readonly source?: IQueryResult;
       readonly useIFrame?: boolean;
     }
@@ -162,7 +163,11 @@ export class SmartSnippetCollapsibleSuggestion {
     const element = $$('a', { className: `CoveoResultLink ${className}` });
     new ResultLink(
       element.el,
-      { hrefTemplate: this.options.hrefTemplate, logAnalytics: href => this.sendOpenSourceAnalytics(element.el, href) },
+      {
+        hrefTemplate: this.options.hrefTemplate,
+        logAnalytics: href => this.sendOpenSourceAnalytics(element.el, href),
+        alwaysOpenInNewWindow: this.options.alwaysOpenInNewWindow
+      },
       { ...this.options.bindings, resultElement: this.collapsibleContainer.el },
       this.options.source
     );

--- a/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
+++ b/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
@@ -28,6 +28,7 @@ export const SmartSnippetSuggestionsClassNames = {
 export interface ISmartSnippetSuggestionsOptions {
   titleField: IFieldOption;
   hrefTemplate?: string;
+  alwaysOpenInNewWindow?: boolean;
   useIFrame?: boolean;
 }
 
@@ -79,6 +80,14 @@ export class SmartSnippetSuggestions extends Component {
      * Default value is `undefined`.
      */
     hrefTemplate: ComponentOptions.buildStringOption(),
+
+    /**
+     * Specifies whether the component should open its links in a new window instead of opening it in the current
+     * context.
+     *
+     * Default value is `false`.
+     */
+    alwaysOpenInNewWindow: ComponentOptions.buildBooleanOption({ defaultValue: false }),
 
     /**
      * Specify if the SmartSnippetSuggestion snippet should be displayed inside an iframe or not.
@@ -164,6 +173,7 @@ export class SmartSnippetSuggestions extends Component {
           searchUid: this.searchUid,
           titleField: this.options.titleField,
           hrefTemplate: this.options.hrefTemplate,
+          alwaysOpenInNewWindow: this.options.alwaysOpenInNewWindow,
           source: this.getCorrespondingResult(questionAnswer),
           useIFrame: this.options.useIFrame
         })

--- a/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
+++ b/src/ui/SmartSnippet/SmartSnippetSuggestions.ts
@@ -82,7 +82,7 @@ export class SmartSnippetSuggestions extends Component {
     hrefTemplate: ComponentOptions.buildStringOption(),
 
     /**
-     * Specifies whether the component should open its links in a new window instead of opening it in the current
+     * Specifies whether the component should open its links in a new window instead of opening them in the current
      * context.
      *
      * Default value is `false`.

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -126,10 +126,10 @@ export function SmartSnippetSuggestionsTest() {
     let test: IBasicComponentSetup<SmartSnippetSuggestions>;
     let searchUid: string;
 
-    function instantiateSmartSnippetSuggestions(styling: string, options: Partial<ISmartSnippetSuggestionsOptions> = {}) {
+    function instantiateSmartSnippetSuggestions(styling: string | null, options: Partial<ISmartSnippetSuggestionsOptions> = {}) {
       test = advancedComponentSetup<SmartSnippetSuggestions>(
         SmartSnippetSuggestions,
-        new AdvancedComponentSetupOptions($$('div', {}, ...(Utils.isNullOrUndefined(styling) ? [] : [mockStyling(styling)])).el, options)
+        new AdvancedComponentSetupOptions($$('div', {}, ...(Utils.isNullOrUndefined(styling) ? [] : [mockStyling(styling!)])).el, options)
       );
     }
 
@@ -483,6 +483,26 @@ export function SmartSnippetSuggestionsTest() {
       await Promise.resolve();
       expect('XSSInjected' in window).toBeFalsy();
       delete window['XSSInjected'];
+      test.env.root.remove();
+      done();
+    });
+
+    it("doesn't set the target when alwaysOpenInNewWindow is unset", async done => {
+      instantiateSmartSnippetSuggestions(null);
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      expect(findClass<HTMLAnchorElement>(ClassNames.SOURCE_URL_CLASSNAME)[0].target).toEqual('');
+      expect(findClass<HTMLAnchorElement>(ClassNames.SOURCE_TITLE_CLASSNAME)[0].target).toEqual('');
+      test.env.root.remove();
+      done();
+    });
+
+    it('sets the target when alwaysOpenInNewWindow is set', async done => {
+      instantiateSmartSnippetSuggestions(null, { alwaysOpenInNewWindow: true });
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      expect(findClass<HTMLAnchorElement>(ClassNames.SOURCE_URL_CLASSNAME)[0].target).toEqual('_blank');
+      expect(findClass<HTMLAnchorElement>(ClassNames.SOURCE_TITLE_CLASSNAME)[0].target).toEqual('_blank');
       test.env.root.remove();
       done();
     });

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -84,7 +84,7 @@ export function SmartSnippetTest() {
     function instantiateSmartSnippet(styling: string | null, options: Partial<ISmartSnippetOptions> = {}) {
       test = advancedComponentSetup<SmartSnippet>(
         SmartSnippet,
-        new AdvancedComponentSetupOptions($$('div', {}, ...(Utils.isNullOrUndefined(styling) ? [] : [mockStyling(styling)])).el, options)
+        new AdvancedComponentSetupOptions($$('div', {}, ...(Utils.isNullOrUndefined(styling) ? [] : [mockStyling(styling!)])).el, options)
       );
     }
 
@@ -224,6 +224,26 @@ export function SmartSnippetTest() {
       await Promise.resolve();
       expect('XSSInjected' in window).toBeFalsy();
       delete window['XSSInjected'];
+      test.env.root.remove();
+      done();
+    });
+
+    it("doesn't set the target when alwaysOpenInNewWindow is unset", async done => {
+      instantiateSmartSnippet(null);
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      expect(getFirstChild<HTMLAnchorElement>(ClassNames.SOURCE_URL_CLASSNAME).target).toEqual('');
+      expect(getFirstChild<HTMLAnchorElement>(ClassNames.SOURCE_TITLE_CLASSNAME).target).toEqual('');
+      test.env.root.remove();
+      done();
+    });
+
+    it('sets the target when alwaysOpenInNewWindow is set', async done => {
+      instantiateSmartSnippet(null, { alwaysOpenInNewWindow: true });
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      expect(getFirstChild<HTMLAnchorElement>(ClassNames.SOURCE_URL_CLASSNAME).target).toEqual('_blank');
+      expect(getFirstChild<HTMLAnchorElement>(ClassNames.SOURCE_TITLE_CLASSNAME).target).toEqual('_blank');
       test.env.root.remove();
       done();
     });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3414

Copied the doc and option name from ResultLink.

This option causes the source of results to open in a new tab.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)