### PR TITLE
add click handler on pager list element

### DIFF
--- a/src/ui/Pager/Pager.ts
+++ b/src/ui/Pager/Pager.ts
@@ -279,7 +279,10 @@ export class Pager extends Component {
             button.setAttribute('aria-current', 'page');
           }
 
-          const clickAction = () => this.handleClickPage(page);
+          const clickAction = (e: Event) => {
+            e.stopPropagation();
+            this.handleClickPage(page);
+          };
 
           new AccessibleButton()
             .withElement(button)
@@ -287,6 +290,8 @@ export class Pager extends Component {
             .withClickAction(clickAction)
             .withEnterKeyboardAction(clickAction)
             .build();
+
+          $$(listItem).on('click', e => clickAction(e));
 
           listItem.appendChild(button);
           this.list.appendChild(listItem);

--- a/src/ui/ResultsPerPage/ResultsPerPage.ts
+++ b/src/ui/ResultsPerPage/ResultsPerPage.ts
@@ -239,7 +239,10 @@ export class ResultsPerPage extends Component {
         $$(listItem).addClass('coveo-active');
       }
 
-      const clickAction = () => this.handleClickPage(resultsPerPage);
+      const clickAction = e => {
+        e.stopPropagation();
+        this.handleClickPage(resultsPerPage);
+      };
 
       const button = $$(
         'span',
@@ -251,6 +254,8 @@ export class ResultsPerPage extends Component {
         numResultsList[i].toString()
       ).el;
       listItem.appendChild(button);
+
+      listItem.addEventListener('click', e => clickAction(e));
 
       new AccessibleButton()
         .withElement(button)


### PR DESCRIPTION
This was a regression that was introduced by: https://github.com/coveo/search-ui/commit/163e75b1adf6f15454aa279538d8b6d1d3d4d7bd

This PR simply adds the same click listener on the list item itself, with a stop propagation to block double queries if you click precisely on the pagination number directly.

https://coveord.atlassian.net/browse/JSUI-3421





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)