### PR TITLE
JSUI-3420 add withoutLabelOrTitle for expand/collapse button

### DIFF
--- a/src/ui/HierarchicalFacet/HierarchicalFacet.ts
+++ b/src/ui/HierarchicalFacet/HierarchicalFacet.ts
@@ -667,6 +667,7 @@ export class HierarchicalFacet extends Facet implements IComponentBindings {
 
     new AccessibleButton()
       .withElement(openAndCloseChilds)
+      .withoutLabelOrTitle()
       .withSelectAction(() => {
         $$(hierarchyElement).hasClass('coveo-open') ? this.close(hierarchy) : this.open(hierarchy);
       })


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3420
https://github.com/coveo/search-ui/pull/1897/files#r940654585

Set no label/title because it reads the title of the SVG which is expand/collapse




[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)