### PR TITLE
added analytics when clicking smart snippet links

### DIFF
--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -243,17 +243,28 @@ export interface IAnalyticsSmartSnippetFeedbackMeta extends IAnalyticsSmartSnipp
 
 export interface IAnalyticsSmartSnippetOpenSourceMeta extends IAnalyticsSmartSnippetMeta {
   /**
-   * The URL of the clicked item.
+   * The URL of the snippet's source.
    */
   documentURL: string;
   /**
-   * The title of the clicked item.
+   * The title of the snippet's source.
    */
   documentTitle: string;
   /**
-   * The author of the clicked item.
+   * The author of the snippet's source..
    */
   author: string;
+}
+
+export interface IAnalyticsSmartSnippetOpenSnippetLinkMeta extends IAnalyticsSmartSnippetMeta {
+  /**
+   * The URL of the clicked link.
+   */
+  linkURL: string;
+  /**
+   * The text of the clicked link.
+   */
+  linkText: string;
 }
 
 export interface IAnalyticsSmartSnippetSuggestionMeta extends IAnalyticsSmartSnippetMeta {
@@ -262,17 +273,28 @@ export interface IAnalyticsSmartSnippetSuggestionMeta extends IAnalyticsSmartSni
 
 export interface IAnalyticsSmartSnippetSuggestionOpenSourceMeta extends IAnalyticsSmartSnippetSuggestionMeta {
   /**
-   * The URL of the clicked item.
+   * The URL of the snippet's source.
    */
   documentURL: string;
   /**
-   * The title of the clicked item.
+   * The title of the snippet's source.
    */
   documentTitle: string;
   /**
-   * The author of the clicked item.
+   * The author of the snippet's source..
    */
   author: string;
+}
+
+export interface IAnalyticsSmartSnippetSuggestionOpenSnippetLinkMeta extends IAnalyticsSmartSnippetSuggestionMeta {
+  /**
+   * The URL of the clicked link.
+   */
+  linkURL: string;
+  /**
+   * The text of the clicked link.
+   */
+  linkText: string;
 }
 
 /**
@@ -1505,6 +1527,20 @@ export var analyticsActionCauseList = {
     type: 'smartSnippet'
   },
   /**
+   * The custom event logged when a user clicks on a link inside of an answer in a [SmartSnippet]{@link SmartSnippet}..
+   *
+   * ```javascript
+   * {
+   *  actionCause: "openSmartSnippetSnippetLink",
+   *  actionType: "smartSnippet"
+   * }
+   * ```
+   */
+  openSmartSnippetSnippetLink: <IAnalyticsActionCause>{
+    name: 'openSmartSnippetSnippetLink',
+    type: 'smartSnippet'
+  },
+  /**
    * The custom event logged when a suggestion from [SmartSnippetSuggestions]{@link SmartSnippetSuggestions} is expanded.
    *
    * Implements the [IAnalyticsActionCause]{@link IAnalyticsActionCause} interface as such:
@@ -1548,6 +1584,20 @@ export var analyticsActionCauseList = {
    */
   openSmartSnippetSuggestionSource: <IAnalyticsActionCause>{
     name: 'openSmartSnippetSuggestionSource',
+    type: 'smartSnippet'
+  },
+  /**
+   * The custom event logged when a user clicks on a link inside of an answer in a [SmartSnippet]{@link SmartSnippet}..
+   *
+   * ```javascript
+   * {
+   *  actionCause: "openSmartSnippetSuggestionSnippetLink",
+   *  actionType: "smartSnippet"
+   * }
+   * ```
+   */
+  openSmartSnippetSuggestionSnippetLink: <IAnalyticsActionCause>{
+    name: 'openSmartSnippetSuggestionSnippetLink',
     type: 'smartSnippet'
   }
 };

--- a/src/ui/ResultLink/ResultLink.ts
+++ b/src/ui/ResultLink/ResultLink.ts
@@ -17,11 +17,12 @@ import { Defer } from '../../misc/Defer';
 import { $$ } from '../../utils/Dom';
 import { StreamHighlightUtils } from '../../utils/StreamHighlightUtils';
 import { StringUtils } from '../../utils/StringUtils';
-import { once, debounce, extend, escape } from 'underscore';
+import { debounce, extend, escape } from 'underscore';
 import { exportGlobally } from '../../GlobalExports';
 
 import 'styling/_ResultLink';
 import { AccessibleButton } from '../../utils/AccessibleButton';
+import { bindAnalyticsToLink } from './ResultLinkCommon';
 
 /**
  * The `ResultLink` component automatically transform a search result title into a clickable link pointing to the
@@ -298,18 +299,7 @@ export class ResultLink extends Component {
       // It's still only one "click" event as far as UA is concerned.
       // Also need to handle "longpress" on mobile (the contextual menu), which we assume to be 1 s long.
 
-      const executeOnlyOnce = once(() => this.logAnalytics());
-
-      $$(element).on(['contextmenu', 'click', 'mousedown', 'mouseup'], executeOnlyOnce);
-      let longPressTimer: number;
-      $$(element).on('touchstart', () => {
-        longPressTimer = window.setTimeout(executeOnlyOnce, 1000);
-      });
-      $$(element).on('touchend', () => {
-        if (longPressTimer) {
-          clearTimeout(longPressTimer);
-        }
-      });
+      bindAnalyticsToLink(element, () => this.logAnalytics());
     }
     this.renderUri(element, result);
     this.bindEventToOpen();

--- a/src/ui/ResultLink/ResultLinkCommon.ts
+++ b/src/ui/ResultLink/ResultLinkCommon.ts
@@ -1,0 +1,17 @@
+import { once } from 'underscore';
+import { $$ } from '../../utils/Dom';
+
+export function bindAnalyticsToLink(element: HTMLElement, logAnalytics: () => void) {
+  const executeOnlyOnce = once(() => logAnalytics());
+
+  $$(element).on(['contextmenu', 'click', 'mousedown', 'mouseup'], executeOnlyOnce);
+  let longPressTimer: number;
+  $$(element).on('touchstart', () => {
+    longPressTimer = window.setTimeout(executeOnlyOnce, 1000);
+  });
+  $$(element).on('touchend', () => {
+    if (longPressTimer) {
+      clearTimeout(longPressTimer);
+    }
+  });
+}

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -14,7 +14,8 @@ import {
   IAnalyticsNoMeta,
   IAnalyticsSmartSnippetFeedbackMeta,
   AnalyticsSmartSnippetFeedbackReason,
-  IAnalyticsSmartSnippetOpenSourceMeta
+  IAnalyticsSmartSnippetOpenSourceMeta,
+  IAnalyticsSmartSnippetOpenSnippetLinkMeta
 } from '../Analytics/AnalyticsActionListMeta';
 import { HeightLimiter } from './HeightLimiter';
 import { ExplanationModal, IReason } from './ExplanationModal';
@@ -22,7 +23,7 @@ import { l } from '../../strings/Strings';
 import { attachShadow } from '../../misc/AttachShadowPolyfill';
 import { Utils } from '../../utils/Utils';
 import { ComponentOptions } from '../Base/ComponentOptions';
-import { getDefaultSnippetStyle } from './SmartSnippetCommon';
+import { bindAnalyticsToSnippetLinks, getDefaultSnippetStyle } from './SmartSnippetCommon';
 import { ResultLink } from '../ResultLink/ResultLink';
 import { IFieldOption } from '../Base/IComponentOptions';
 
@@ -325,6 +326,7 @@ export class SmartSnippet extends Component {
 
   private renderSnippet(content: string) {
     this.snippetContainer.innerHTML = content;
+    bindAnalyticsToSnippetLinks(this.snippetContainer, link => this.sendClickSnippetLinkAnalytics(link));
   }
 
   private renderSource() {
@@ -438,6 +440,19 @@ export class SmartSnippet extends Component {
       },
       this.lastRenderedResult,
       element
+    );
+  }
+
+  private sendClickSnippetLinkAnalytics(link: HTMLAnchorElement) {
+    return this.usageAnalytics.logClickEvent<IAnalyticsSmartSnippetOpenSnippetLinkMeta>(
+      analyticsActionCauseList.openSmartSnippetSnippetLink,
+      {
+        searchQueryUid: this.searchUid,
+        linkText: link.innerText,
+        linkURL: link.href
+      },
+      this.lastRenderedResult,
+      link
     );
   }
 }

--- a/src/ui/SmartSnippet/SmartSnippet.ts
+++ b/src/ui/SmartSnippet/SmartSnippet.ts
@@ -23,7 +23,7 @@ import { l } from '../../strings/Strings';
 import { attachShadow } from '../../misc/AttachShadowPolyfill';
 import { Utils } from '../../utils/Utils';
 import { ComponentOptions } from '../Base/ComponentOptions';
-import { bindAnalyticsToSnippetLinks, getDefaultSnippetStyle } from './SmartSnippetCommon';
+import { transformSnippetLinks, getDefaultSnippetStyle } from './SmartSnippetCommon';
 import { ResultLink } from '../ResultLink/ResultLink';
 import { IFieldOption } from '../Base/IComponentOptions';
 
@@ -326,7 +326,7 @@ export class SmartSnippet extends Component {
 
   private renderSnippet(content: string) {
     this.snippetContainer.innerHTML = content;
-    bindAnalyticsToSnippetLinks(this.snippetContainer, link => this.sendClickSnippetLinkAnalytics(link));
+    transformSnippetLinks(this.snippetContainer, this.options.alwaysOpenInNewWindow, link => this.sendClickSnippetLinkAnalytics(link));
   }
 
   private renderSource() {

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -9,12 +9,14 @@ import { IQueryResult } from '../../rest/QueryResult';
 import {
   analyticsActionCauseList,
   IAnalyticsSmartSnippetSuggestionMeta,
+  IAnalyticsSmartSnippetSuggestionOpenSnippetLinkMeta,
   IAnalyticsSmartSnippetSuggestionOpenSourceMeta
 } from '../Analytics/AnalyticsActionListMeta';
 import { ResultLink } from '../ResultLink/ResultLink';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { Utils } from '../../utils/Utils';
 import { IFieldOption } from '../Base/IComponentOptions';
+import { bindAnalyticsToSnippetLinks } from './SmartSnippetCommon';
 
 const QUESTION_CLASSNAME = `coveo-smart-snippet-suggestions-question`;
 const QUESTION_TITLE_CLASSNAME = `${QUESTION_CLASSNAME}-title`;
@@ -142,6 +144,7 @@ export class SmartSnippetCollapsibleSuggestion {
 
   private buildAnswerSnippetContent(innerHTML: string, style: HTMLStyleElement) {
     const snippet = $$('div', { className: RAW_CONTENT_CLASSNAME }, innerHTML);
+    bindAnalyticsToSnippetLinks(snippet.el, link => this.sendOpenSnippetLinkAnalytics(link));
     const container = $$('div', {}, snippet);
     container.append(style);
     return container;
@@ -235,6 +238,20 @@ export class SmartSnippetCollapsibleSuggestion {
       },
       this.options.source,
       element
+    );
+  }
+
+  private sendOpenSnippetLinkAnalytics(link: HTMLAnchorElement) {
+    return this.options.bindings.usageAnalytics.logClickEvent<IAnalyticsSmartSnippetSuggestionOpenSnippetLinkMeta>(
+      analyticsActionCauseList.openSmartSnippetSuggestionSnippetLink,
+      {
+        searchQueryUid: this.options.searchUid,
+        linkText: link.innerText,
+        linkURL: link.href,
+        documentId: this.options.questionAnswer.documentId
+      },
+      this.options.source,
+      link
     );
   }
 }

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -16,7 +16,7 @@ import { ResultLink } from '../ResultLink/ResultLink';
 import { IComponentBindings } from '../Base/ComponentBindings';
 import { Utils } from '../../utils/Utils';
 import { IFieldOption } from '../Base/IComponentOptions';
-import { bindAnalyticsToSnippetLinks } from './SmartSnippetCommon';
+import { transformSnippetLinks } from './SmartSnippetCommon';
 
 const QUESTION_CLASSNAME = `coveo-smart-snippet-suggestions-question`;
 const QUESTION_TITLE_CLASSNAME = `${QUESTION_CLASSNAME}-title`;
@@ -144,7 +144,7 @@ export class SmartSnippetCollapsibleSuggestion {
 
   private buildAnswerSnippetContent(innerHTML: string, style: HTMLStyleElement) {
     const snippet = $$('div', { className: RAW_CONTENT_CLASSNAME }, innerHTML);
-    bindAnalyticsToSnippetLinks(snippet.el, link => this.sendOpenSnippetLinkAnalytics(link));
+    transformSnippetLinks(snippet.el, this.options.alwaysOpenInNewWindow, link => this.sendOpenSnippetLinkAnalytics(link));
     const container = $$('div', {}, snippet);
     container.append(style);
     return container;

--- a/src/ui/SmartSnippet/SmartSnippetCommon.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCommon.ts
@@ -15,8 +15,13 @@ export const getDefaultSnippetStyle = (contentClassName: string) => `
   }
 `;
 
-export const bindAnalyticsToSnippetLinks = (renderedSnippetParent: HTMLElement, logAnalytics: (link: HTMLAnchorElement) => void) => {
-  Dom.nodeListToArray(renderedSnippetParent.querySelectorAll('a')).forEach(link =>
-    bindAnalyticsToLink(link, () => logAnalytics(link as HTMLAnchorElement))
-  );
+export const transformSnippetLinks = (
+  renderedSnippetParent: HTMLElement,
+  alwaysOpenInNewWindow: boolean,
+  logAnalytics: (link: HTMLAnchorElement) => void
+) => {
+  Dom.nodeListToArray(renderedSnippetParent.querySelectorAll('a')).forEach((link: HTMLAnchorElement) => {
+    bindAnalyticsToLink(link, () => logAnalytics(link));
+    link.target = alwaysOpenInNewWindow ? '_blank' : '_top';
+  });
 };

--- a/src/ui/SmartSnippet/SmartSnippetCommon.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCommon.ts
@@ -1,3 +1,6 @@
+import { Dom } from '../../utils/Dom';
+import { bindAnalyticsToLink } from '../ResultLink/ResultLinkCommon';
+
 export const getDefaultSnippetStyle = (contentClassName: string) => `
   body {
     font-family: "Lato", "Helvetica Neue", Helvetica, Arial, sans-serif, sans-serif;
@@ -11,3 +14,9 @@ export const getDefaultSnippetStyle = (contentClassName: string) => `
     margin-bottom: 0;
   }
 `;
+
+export const bindAnalyticsToSnippetLinks = (renderedSnippetParent: HTMLElement, logAnalytics: (link: HTMLAnchorElement) => void) => {
+  Dom.nodeListToArray(renderedSnippetParent.querySelectorAll('a')).forEach(link =>
+    bindAnalyticsToLink(link, () => logAnalytics(link as HTMLAnchorElement))
+  );
+};

--- a/unitTests/TestUtils.ts
+++ b/unitTests/TestUtils.ts
@@ -1,4 +1,6 @@
-export function expectChildren(element: HTMLElement | DocumentFragment, classNames: string[]) {
+import { toArray } from 'underscore';
+
+export function expectChildren(element: HTMLElement | DocumentFragment, classNames: (string | null)[]) {
   expect(element.childNodes.length).toEqual(classNames.length, `Expected only ${classNames.length} children.`);
   return classNames.map((className, index) => {
     const childAtIndex = element.childNodes.item(index) as HTMLElement;
@@ -7,4 +9,48 @@ export function expectChildren(element: HTMLElement | DocumentFragment, classNam
     }
     return childAtIndex;
   });
+}
+
+export function expectEquivalentDOM(
+  actual: HTMLElement,
+  expected: HTMLElement,
+  options?: { ignoreRoot?: boolean; ignoreAttributes?: string[] | boolean }
+): boolean {
+  const getAttributes = (element: HTMLElement) => {
+    let attributes = toArray<Attr>(element.attributes).map(({ name, value }) => ({ name, value }));
+    if (options) {
+      if (options.ignoreAttributes === true) {
+        attributes = [];
+      } else if (Array.isArray(options.ignoreAttributes) && options.ignoreAttributes.length) {
+        const attributesToIgnore = options.ignoreAttributes;
+        attributes = attributes.filter(attribute => attributesToIgnore.indexOf(attribute.name) === -1);
+      }
+    }
+    return attributes;
+  };
+
+  if (!options || !options.ignoreRoot) {
+    if (expect(actual.tagName).toEqual(expected.tagName)) {
+      return true;
+    }
+    if (expect(getAttributes(actual)).toEqual(getAttributes(expected))) {
+      return true;
+    }
+  }
+  const actualChildren = toArray<HTMLElement>(actual.children);
+  const expectedChildren = toArray<HTMLElement>(expected.children);
+  if (
+    expect(actualChildren.length).toEqual(
+      expectedChildren.length,
+      `${actual.tagName} is expected to have ${expectedChildren.length} children but has ${actualChildren.length}.`
+    )
+  ) {
+    return true;
+  }
+  return actualChildren.some((actualChild, index) =>
+    expectEquivalentDOM(actualChild, expectedChildren[index], {
+      ignoreRoot: false,
+      ignoreAttributes: options && options.ignoreAttributes
+    })
+  );
 }

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -9,11 +9,12 @@ import {
 import { advancedComponentSetup, AdvancedComponentSetupOptions, IBasicComponentSetup } from '../MockEnvironment';
 import { SmartSnippetCollapsibleSuggestionClassNames } from '../../src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion';
 import { $$ } from '../../src/utils/Dom';
-import { expectChildren } from '../TestUtils';
+import { expectChildren, expectEquivalentDOM } from '../TestUtils';
 import { analyticsActionCauseList, IAnalyticsSmartSnippetSuggestionMeta } from '../../src/ui/Analytics/AnalyticsActionListMeta';
 import { IQueryResults } from '../../src/rest/QueryResults';
 import { Utils } from '../../src/Core';
 import { getDefaultSnippetStyle } from '../../src/ui/SmartSnippet/SmartSnippetCommon';
+import { flatten, toArray } from 'underscore';
 
 const ClassNames = {
   ...SmartSnippetSuggestionsClassNames,
@@ -78,25 +79,23 @@ export function SmartSnippetSuggestionsTest() {
 
   function mockSnippet(id: number) {
     return $$(
-      'main',
-      {
-        className: 'abc'
-      },
-      $$(
-        'header',
-        {
-          className: 'def--abc'
-        },
-        $$('span', {}, `Hello, my id is ${id}!`)
-      ),
-      $$('span', {}, 'Some more text'),
-      $$(
-        'a',
-        {
-          href: 'https://somewebsite.com'
-        },
-        'Some external link'
-      )
+      'div',
+      {},
+      `
+    <span>I am snippet #${id}!</span>
+
+    <ol>
+      <li>On the <a href="https://platform.cloud.coveo.com/admin/#/orgid/search/in-app-widgets/">In-Product Experiences</a> page, click Add <b>In-Product Experience</b>.</li>
+      <li>In the Configuration tab, fill the Basic settings section.</li>
+      <li>(Optional) Use the Design and Content access tabs to <a href="https://docs.coveo.com/en/3160/#customizing-an-ipx-interface">customize your <b>IPX</b> interface</a>.</li>
+      <li>Click Save.</li>
+      <li>In the Loader snippet panel that appears, you may click Copy to save the loader snippet for your <b>IPX</b> interface to your clipboard, and then click Save.  You can Always retrieve the loader snippet later.</li>
+    </ol>
+    
+    <p>
+      You're now ready to <a href="https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#embed-your-ipx-interface-in-sites-and-applications">embed your IPX interface</a>. However, we recommend that you <a href="https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#configuring-query-pipelines-for-an-ipx-interface-recommended">configure query pipelines for your IPX interface</a> before.
+    </p>
+  `
     ).el;
   }
 
@@ -160,7 +159,7 @@ export function SmartSnippetSuggestionsTest() {
     }
 
     function getShadowRoots() {
-      return findClass(ClassNames.SHADOW_CLASSNAME).map(shadowContainer => shadowContainer.shadowRoot.childNodes.item(0) as HTMLElement);
+      return findClass(ClassNames.SHADOW_CLASSNAME).map(shadowContainer => shadowContainer.shadowRoot!.childNodes.item(0) as HTMLElement);
     }
 
     function resetAnalyticsSpyHistory() {
@@ -180,7 +179,7 @@ export function SmartSnippetSuggestionsTest() {
       });
 
       it('should render the style', () => {
-        const renderedStyles = getShadowRoots().map(shadowRoot => shadowRoot.querySelector('style').innerHTML);
+        const renderedStyles = getShadowRoots().map(shadowRoot => shadowRoot.querySelector('style')!.innerHTML);
         expect(renderedStyles).toEqual([style, style, style]);
       });
 
@@ -240,7 +239,7 @@ export function SmartSnippetSuggestionsTest() {
         });
 
         it('the iframe of the second question has tabindex=-1', () => {
-          expect(findClass(ClassNames.SHADOW_CLASSNAME)[1].querySelector('iframe').getAttribute('tabindex')).toEqual('-1');
+          expect(findClass(ClassNames.SHADOW_CLASSNAME)[1].querySelector('iframe')!.getAttribute('tabindex')).toEqual('-1');
         });
 
         it('has the has-question class', () => {
@@ -314,7 +313,7 @@ export function SmartSnippetSuggestionsTest() {
             getShadowRoots().forEach((shadowRoot, i) => {
               const [shadowContainer] = expectChildren(shadowRoot, [ClassNames.RAW_CONTENT_CLASSNAME, null]);
 
-              expect(shadowContainer.innerHTML).toEqual(mockSnippet(i).innerHTML);
+              expectEquivalentDOM(shadowContainer, mockSnippet(i), { ignoreRoot: true, ignoreAttributes: ['target'] });
             });
           });
         });
@@ -326,7 +325,7 @@ export function SmartSnippetSuggestionsTest() {
           });
 
           it("the iframe doesn't have a tabindex", () => {
-            expect(findClass(ClassNames.SHADOW_CLASSNAME)[1].querySelector('iframe').hasAttribute('tabindex')).toBeFalsy();
+            expect(findClass(ClassNames.SHADOW_CLASSNAME)[1].querySelector('iframe')!.hasAttribute('tabindex')).toBeFalsy();
           });
 
           it('sends expand analytics', () => {
@@ -364,7 +363,7 @@ export function SmartSnippetSuggestionsTest() {
             getShadowRoots().forEach((shadowRoot, i) => {
               const [shadowContainer] = expectChildren(shadowRoot, [ClassNames.RAW_CONTENT_CLASSNAME, null]);
 
-              expect(shadowContainer.innerHTML).toEqual(mockSnippet(i).innerHTML);
+              expectEquivalentDOM(shadowContainer, mockSnippet(i), { ignoreRoot: true, ignoreAttributes: ['target'] });
             });
           });
 
@@ -391,7 +390,7 @@ export function SmartSnippetSuggestionsTest() {
         });
         document.body.appendChild(test.env.root);
         await triggerQuestionAnswerQuery(true);
-        expect(test.cmp.element.querySelector(`.${IFRAME_CLASSNAME}`).nodeName).toEqual('DIV');
+        expect(test.cmp.element.querySelector(`.${IFRAME_CLASSNAME}`)!.nodeName).toEqual('DIV');
         done();
       });
 
@@ -400,7 +399,7 @@ export function SmartSnippetSuggestionsTest() {
         instantiateSmartSnippetSuggestions(null);
         document.body.appendChild(test.env.root);
         await triggerQuestionAnswerQuery(true);
-        expect(test.cmp.element.querySelector(`.${IFRAME_CLASSNAME}`).nodeName).toEqual('IFRAME');
+        expect(test.cmp.element.querySelector(`.${IFRAME_CLASSNAME}`)!.nodeName).toEqual('IFRAME');
         done();
       });
     });
@@ -487,7 +486,7 @@ export function SmartSnippetSuggestionsTest() {
       done();
     });
 
-    it("doesn't set the target when alwaysOpenInNewWindow is unset", async done => {
+    it("doesn't set the target of the source when alwaysOpenInNewWindow is unset", async done => {
       instantiateSmartSnippetSuggestions(null);
       document.body.appendChild(test.env.root);
       await triggerQuestionAnswerQuery(true);
@@ -497,12 +496,34 @@ export function SmartSnippetSuggestionsTest() {
       done();
     });
 
-    it('sets the target when alwaysOpenInNewWindow is set', async done => {
+    it('sets the target of the links to _top when alwaysOpenInNewWindow is false/unset', async done => {
+      instantiateSmartSnippetSuggestions(null, { useIFrame: false });
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      flatten(
+        findClass(ClassNames.RAW_CONTENT_CLASSNAME).map(content => toArray<HTMLAnchorElement>(content.querySelectorAll('a')))
+      ).forEach(link => expect(link.target).toEqual('_top'));
+      test.env.root.remove();
+      done();
+    });
+
+    it('sets the target of the source when alwaysOpenInNewWindow is set', async done => {
       instantiateSmartSnippetSuggestions(null, { alwaysOpenInNewWindow: true });
       document.body.appendChild(test.env.root);
       await triggerQuestionAnswerQuery(true);
       expect(findClass<HTMLAnchorElement>(ClassNames.SOURCE_URL_CLASSNAME)[0].target).toEqual('_blank');
       expect(findClass<HTMLAnchorElement>(ClassNames.SOURCE_TITLE_CLASSNAME)[0].target).toEqual('_blank');
+      test.env.root.remove();
+      done();
+    });
+
+    it('sets the target of the links to _blank when alwaysOpenInNewWindow is set', async done => {
+      instantiateSmartSnippetSuggestions(null, { alwaysOpenInNewWindow: true, useIFrame: false });
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      flatten(
+        findClass(ClassNames.RAW_CONTENT_CLASSNAME).map(content => toArray<HTMLAnchorElement>(content.querySelectorAll('a')))
+      ).forEach(link => expect(link.target).toEqual('_blank'));
       test.env.root.remove();
       done();
     });

--- a/unitTests/ui/SmartSnippetTest.ts
+++ b/unitTests/ui/SmartSnippetTest.ts
@@ -3,7 +3,7 @@ import { IQueryResult } from '../../src/rest/QueryResult';
 import { $$ } from '../../src/utils/Dom';
 import { QueryEvents, IQuerySuccessEventArgs } from '../../src/events/QueryEvents';
 import { ISmartSnippetOptions, SmartSnippet, SmartSnippetClassNames as ClassNames } from '../../src/ui/SmartSnippet/SmartSnippet';
-import { expectChildren } from '../TestUtils';
+import { expectChildren, expectEquivalentDOM } from '../TestUtils';
 import { UserFeedbackBannerClassNames } from '../../src/ui/SmartSnippet/UserFeedbackBanner';
 import { IBasicComponentSetup, advancedComponentSetup, AdvancedComponentSetupOptions } from '../MockEnvironment';
 import { HeightLimiterClassNames } from '../../src/ui/SmartSnippet/HeightLimiter';
@@ -11,6 +11,7 @@ import { IQueryResults } from '../../src/rest/QueryResults';
 import { Utils } from '../../src/Core';
 import { getDefaultSnippetStyle } from '../../src/ui/SmartSnippet/SmartSnippetCommon';
 import { ExplanationModalClassNames } from '../../src/ui/SmartSnippet/ExplanationModal';
+import { toArray } from 'underscore';
 
 export function SmartSnippetTest() {
   const sourceTitle = 'Google!';
@@ -44,25 +45,21 @@ export function SmartSnippetTest() {
 
   function mockSnippet() {
     return $$(
-      'main',
-      {
-        className: 'abc'
-      },
-      $$(
-        'header',
-        {
-          className: 'def--abc'
-        },
-        $$('span', {}, 'Some text here')
-      ),
-      $$('span', {}, 'Some more text'),
-      $$(
-        'a',
-        {
-          href: 'https://somewebsite.com'
-        },
-        'Some external link'
-      )
+      'div',
+      {},
+      `
+        <ol>
+          <li>On the <a href="https://platform.cloud.coveo.com/admin/#/orgid/search/in-app-widgets/">In-Product Experiences</a> page, click Add <b>In-Product Experience</b>.</li>
+          <li>In the Configuration tab, fill the Basic settings section.</li>
+          <li>(Optional) Use the Design and Content access tabs to <a href="https://docs.coveo.com/en/3160/#customizing-an-ipx-interface">customize your <b>IPX</b> interface</a>.</li>
+          <li>Click Save.</li>
+          <li>In the Loader snippet panel that appears, you may click Copy to save the loader snippet for your <b>IPX</b> interface to your clipboard, and then click Save.  You can Always retrieve the loader snippet later.</li>
+        </ol>
+        
+        <p>
+          You're now ready to <a href="https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#embed-your-ipx-interface-in-sites-and-applications">embed your IPX interface</a>. However, we recommend that you <a href="https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#configuring-query-pipelines-for-an-ipx-interface-recommended">configure query pipelines for your IPX interface</a> before.
+        </p>
+      `
     ).el;
   }
 
@@ -108,7 +105,7 @@ export function SmartSnippetTest() {
     }
 
     function getShadowRoot() {
-      return getFirstChild(ClassNames.SHADOW_CLASSNAME).shadowRoot;
+      return getFirstChild(ClassNames.SHADOW_CLASSNAME).shadowRoot!;
     }
 
     describe('when resolving result to build result link', () => {
@@ -228,7 +225,7 @@ export function SmartSnippetTest() {
       done();
     });
 
-    it("doesn't set the target when alwaysOpenInNewWindow is unset", async done => {
+    it("doesn't set the target of the source when alwaysOpenInNewWindow is unset", async done => {
       instantiateSmartSnippet(null);
       document.body.appendChild(test.env.root);
       await triggerQuestionAnswerQuery(true);
@@ -238,12 +235,34 @@ export function SmartSnippetTest() {
       done();
     });
 
-    it('sets the target when alwaysOpenInNewWindow is set', async done => {
+    it('sets the target of the links to _top when alwaysOpenInNewWindow is false/unset', async done => {
+      instantiateSmartSnippet(null, { useIFrame: false });
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      toArray<HTMLAnchorElement>(getFirstChild(ClassNames.CONTENT_CLASSNAME).querySelectorAll('a')).forEach(link =>
+        expect(link.target).toEqual('_top')
+      );
+      test.env.root.remove();
+      done();
+    });
+
+    it('sets the target of the source when alwaysOpenInNewWindow is set', async done => {
       instantiateSmartSnippet(null, { alwaysOpenInNewWindow: true });
       document.body.appendChild(test.env.root);
       await triggerQuestionAnswerQuery(true);
       expect(getFirstChild<HTMLAnchorElement>(ClassNames.SOURCE_URL_CLASSNAME).target).toEqual('_blank');
       expect(getFirstChild<HTMLAnchorElement>(ClassNames.SOURCE_TITLE_CLASSNAME).target).toEqual('_blank');
+      test.env.root.remove();
+      done();
+    });
+
+    it('sets the target of the links to _blank when alwaysOpenInNewWindow is set', async done => {
+      instantiateSmartSnippet(null, { alwaysOpenInNewWindow: true, useIFrame: false });
+      document.body.appendChild(test.env.root);
+      await triggerQuestionAnswerQuery(true);
+      toArray<HTMLAnchorElement>(getFirstChild(ClassNames.CONTENT_CLASSNAME).querySelectorAll('a')).forEach(link =>
+        expect(link.target).toEqual('_blank')
+      );
       test.env.root.remove();
       done();
     });
@@ -423,7 +442,7 @@ export function SmartSnippetTest() {
         it('should wrap the snippet in a container in a shadow DOM', () => {
           const [shadowContainer] = expectChildren(getShadowRoot(), [ClassNames.CONTENT_CLASSNAME, null]);
 
-          expect(shadowContainer.innerHTML).toEqual(mockSnippet().innerHTML);
+          expectEquivalentDOM(shadowContainer, mockSnippet(), { ignoreRoot: true, ignoreAttributes: ['target'] });
         });
 
         it('should render the default style', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3435

![image](https://user-images.githubusercontent.com/54454747/189215651-e92e9c66-9f92-449a-988c-865405cdd580.png)

Also passed down "alwaysOpenInNewWindow" to smart snippet links.

Here's an example of analytics logged when clicking on a smart snippet link:
```json
{
  "actionCause": "openSmartSnippetSnippetLink",
  "actionType": "smartSnippet",
  "anonymous": false,
  "device": "Firefox",
  "mobile": false,
  "language": "en",
  "responseTime": 0,
  "originLevel1": "default",
  "originLevel2": "All",
  "originLevel3": "",
  "originContext": "Search",
  "customData": {
    "searchQueryUid": "512331e5-2c7b-414b-b42a-030a37b1c5f8",
    "linkText": "embed your IPX interface",
    "linkURL": "https://docs.coveo.com/en/3160/build-a-search-ui/manage-coveo-in-product-experiences-ipx#embed-your-ipx-interface-in-sites-and-applications",
    "JSUIVersion": "0.0.0.0;0.0.0.0",
    "contentIDKey": "permanentid",
    "contentIDValue": "80c8afce739d2d9acdb005284edc8a5c0c5f186f9093ce5171caaba464e5"
  },
  "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:104.0) Gecko/20100101 Firefox/104.0",
  "clientId": "72ba13b1-74e4-3e83-9bb1-b5c5fbdc3965",
  "searchQueryUid": "512331e5-2c7b-414b-b42a-030a37b1c5f8",
  "queryPipeline": "default",
  "documentUri": "https://community.lithium.com/community:lithosphere/user:20816",
  "documentUriHash": "LDx3mcIy7xuxKk7T",
  "documentUrl": "https://community.khoros.com/t5/user/viewprofilepage/user-id/20816",
  "documentTitle": "Unlakesencica",
  "documentCategory": "People",
  "collectionName": "default",
  "sourceName": "Coveo Sample - Lithium Community",
  "documentPosition": 1,
  "viewMethod": "openSmartSnippetSnippetLink"
}

```

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)