### PR TITLE
JSUI-3432 Made heading levels adjustable

### DIFF
--- a/src/events/BreadcrumbEvents.ts
+++ b/src/events/BreadcrumbEvents.ts
@@ -13,6 +13,7 @@ export interface IBreadcrumbItem {
  */
 export interface IPopulateBreadcrumbEventArgs {
   breadcrumbs: IBreadcrumbItem[];
+  headingLevel?: number;
 }
 
 export interface IClearBreadcrumbEventArgs {}

--- a/src/ui/AdvancedSearch/AdvancedSearch.ts
+++ b/src/ui/AdvancedSearch/AdvancedSearch.ts
@@ -30,6 +30,7 @@ import { ModalBox as ModalBoxModule } from '../../ExternalModulesShim';
 import { BreadcrumbEvents, IPopulateBreadcrumbEventArgs, IClearBreadcrumbEventArgs } from '../../events/BreadcrumbEvents';
 import { SVGIcons } from '../../utils/SVGIcons';
 import { AccessibleButton } from '../../utils/AccessibleButton';
+import { getHeadingTag } from '../../utils/AccessibilityUtils';
 
 export interface IAdvancedSearchOptions {
   includeKeywords?: boolean;
@@ -169,7 +170,7 @@ export class AdvancedSearch extends Component {
 
   private handlePopulateBreadcrumb(args: IPopulateBreadcrumbEventArgs) {
     if (this.needToPopulateBreadcrumb) {
-      const { container, title, clear } = this.buildBreadcrumbElements();
+      const { container, title, clear } = this.buildBreadcrumbElements(args.headingLevel);
 
       container.append(title.el);
       container.append(clear.el);
@@ -180,10 +181,10 @@ export class AdvancedSearch extends Component {
     }
   }
 
-  private buildBreadcrumbElements() {
+  private buildBreadcrumbElements(headingLevel?: number) {
     return {
       container: this.buildBreadcrumbContainer(),
-      title: this.buildBreadcrumbTitle(),
+      title: this.buildBreadcrumbTitle(headingLevel),
       clear: this.buildBreacrumbClear()
     };
   }
@@ -194,9 +195,9 @@ export class AdvancedSearch extends Component {
     });
   }
 
-  private buildBreadcrumbTitle() {
+  private buildBreadcrumbTitle(headingLevel?: number) {
     return $$(
-      'span',
+      getHeadingTag(headingLevel, 'span'),
       {
         className: 'coveo-advanced-search-breadcrumb-title'
       },

--- a/src/ui/Breadcrumb/Breadcrumb.ts
+++ b/src/ui/Breadcrumb/Breadcrumb.ts
@@ -13,7 +13,9 @@ import { IComponentBindings } from '../Base/ComponentBindings';
 import { ComponentOptions } from '../Base/ComponentOptions';
 import { Initialization } from '../Base/Initialization';
 
-export interface IBreadcrumbOptions {}
+export interface IBreadcrumbOptions {
+  headingLevel?: number;
+}
 
 /**
  * The Breadcrumb component displays a summary of the currently active query filters.
@@ -32,7 +34,19 @@ export interface IBreadcrumbOptions {}
  */
 export class Breadcrumb extends Component {
   static ID = 'Breadcrumb';
-  static options: IBreadcrumbOptions = {};
+
+  /**
+   * The options for the Breadcrumb
+   * @componentOptions
+   */
+  static options: IBreadcrumbOptions = {
+    /**
+     * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading before the breadcrumbs.
+     *
+     * A value of 0 will render a [`div`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div) element instead.
+     */
+    headingLevel: ComponentOptions.buildNumberOption({ min: 0, max: 6 })
+  };
 
   static doExport = () => {
     exportGlobally({
@@ -70,7 +84,7 @@ export class Breadcrumb extends Component {
    * @returns {IBreadcrumbItem[]} A populated breadcrumb item list.
    */
   public getBreadcrumbs(): IBreadcrumbItem[] {
-    const args = <IPopulateBreadcrumbEventArgs>{ breadcrumbs: [] };
+    const args = <IPopulateBreadcrumbEventArgs>{ breadcrumbs: [], headingLevel: this.options.headingLevel };
     this.bind.trigger(this.root, BreadcrumbEvents.populateBreadcrumb, args);
     this.logger.debug('Retrieved breadcrumbs', args.breadcrumbs);
 

--- a/src/ui/CategoryFacet/CategoryFacet.ts
+++ b/src/ui/CategoryFacet/CategoryFacet.ts
@@ -951,7 +951,7 @@ export class CategoryFacet extends Component implements IAutoLayoutAdjustableIns
       this.reset();
     };
 
-    const categoryFacetBreadcrumbBuilder = new CategoryFacetBreadcrumb(this, resetFacet, descriptor);
+    const categoryFacetBreadcrumbBuilder = new CategoryFacetBreadcrumb(this, resetFacet, descriptor, { headingLevel: args.headingLevel });
 
     args.breadcrumbs.push({ element: categoryFacetBreadcrumbBuilder.build() });
   }

--- a/src/ui/CategoryFacet/CategoryFacetBreadcrumb.ts
+++ b/src/ui/CategoryFacet/CategoryFacetBreadcrumb.ts
@@ -4,12 +4,18 @@ import { CategoryValueDescriptor, CategoryFacet } from './CategoryFacet';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import { l } from '../../strings/Strings';
 import { without } from 'underscore';
+import { getHeadingTag } from '../../utils/AccessibilityUtils';
+
+export interface ICategoryFacetBreadcrumbOptions {
+  headingLevel?: number;
+}
 
 export class CategoryFacetBreadcrumb {
   constructor(
     private categoryFacet: CategoryFacet,
     private onClickHandler: (e: MouseEvent) => void,
-    private categoryValueDescriptor: CategoryValueDescriptor
+    private categoryValueDescriptor: CategoryValueDescriptor,
+    private readonly options?: ICategoryFacetBreadcrumbOptions
   ) {}
 
   public build(): HTMLElement {
@@ -24,7 +30,11 @@ export class CategoryFacetBreadcrumb {
     const pathToRender = without(this.categoryValueDescriptor.path, ...this.categoryFacet.options.basePath);
     const captionLabel = pathToRender.map(pathPart => this.categoryFacet.getCaption(pathPart)).join('/');
 
-    const breadcrumbTitle = $$('span', { className: 'coveo-category-facet-breadcrumb-title' }, `${this.categoryFacet.options.title}:`);
+    const breadcrumbTitle = $$(
+      getHeadingTag(this.options && this.options.headingLevel, 'span'),
+      { className: 'coveo-category-facet-breadcrumb-title' },
+      `${this.categoryFacet.options.title}:`
+    );
     const valuesContainer = $$('span', { className: 'coveo-category-facet-breadcrumb-values' }, captionLabel, clear);
 
     new AccessibleButton()

--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -306,7 +306,16 @@ export class DynamicFacet extends Component implements IDynamicFacet {
      *
      * @availablesince [March 2020 Release (v2.8521)](https://docs.coveo.com/en/3203/)
      */
-    filterFacetCount: ComponentOptions.buildBooleanOption({ section: 'Filtering' })
+    filterFacetCount: ComponentOptions.buildBooleanOption({ section: 'Filtering' }),
+
+    /**
+     * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading above the facet.
+     *
+     * A value of 0 will render a [`div`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div) element instead.
+     *
+     * **Default:** `2`.
+     */
+    headingLevel: ComponentOptions.buildNumberOption({ defaultValue: 2, min: 0, max: 6 })
   };
 
   private includedAttributeId: string;
@@ -757,7 +766,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
       return;
     }
 
-    const breadcrumbs = new DynamicFacetBreadcrumbs(this);
+    const breadcrumbs = new DynamicFacetBreadcrumbs(this, { headingLevel: args.headingLevel });
     args.breadcrumbs.push({ element: breadcrumbs.element });
   }
 
@@ -786,6 +795,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
       id: this.options.id,
       title: this.options.title,
       enableCollapse: this.options.enableCollapse,
+      headingLevel: this.options.headingLevel,
       clear: () => this.clear(),
       toggleCollapse: () => this.toggleCollapse(),
       collapse: () => this.collapse(),

--- a/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
+++ b/src/ui/DynamicFacet/DynamicFacetBreadcrumbs.ts
@@ -5,11 +5,16 @@ import { SVGIcons } from '../../utils/SVGIcons';
 import { analyticsActionCauseList } from '../Analytics/AnalyticsActionListMeta';
 import { IDynamicFacet, IDynamicFacetValue } from './IDynamicFacet';
 import { escape } from 'underscore';
+import { getHeadingTag } from '../../utils/AccessibilityUtils';
+
+export interface IDynamicFacetBreadcrumbsOptions {
+  headingLevel?: number;
+}
 
 export class DynamicFacetBreadcrumbs {
   public element: HTMLElement;
 
-  constructor(private facet: IDynamicFacet) {
+  constructor(private facet: IDynamicFacet, private readonly options?: IDynamicFacetBreadcrumbsOptions) {
     this.create();
   }
 
@@ -29,8 +34,11 @@ export class DynamicFacetBreadcrumbs {
   }
 
   private createAndAppendTitle() {
-    const titleElement = $$('h3', { className: 'coveo-dynamic-facet-breadcrumb-title', ariaHidden: 'true' }, `${this.facet.options.title}:`)
-      .el;
+    const titleElement = $$(
+      getHeadingTag(this.options && this.options.headingLevel, 'h3'),
+      { className: 'coveo-dynamic-facet-breadcrumb-title', ariaHidden: 'true' },
+      `${this.facet.options.title}:`
+    ).el;
     this.element.appendChild(titleElement);
   }
 

--- a/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeader.ts
+++ b/src/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeader.ts
@@ -5,11 +5,13 @@ import { SVGIcons } from '../../../utils/SVGIcons';
 import { SVGDom } from '../../../utils/SVGDom';
 import { DynamicFacetHeaderButton } from './DynamicFacetHeaderButton';
 import { DynamicFacetHeaderCollapseToggle } from './DynamicFacetHeaderCollapseToggle';
+import { getHeadingTag } from '../../../utils/AccessibilityUtils';
 
 export interface IDynamicFacetHeaderOptions {
   id: string;
   title: string;
   enableCollapse: boolean;
+  headingLevel: number;
   toggleCollapse: () => void;
   collapse: () => void;
   expand: () => void;
@@ -67,7 +69,7 @@ export class DynamicFacetHeader {
 
   private createTitle() {
     return $$(
-      'h2',
+      getHeadingTag(this.options.headingLevel),
       {
         className: 'coveo-dynamic-facet-header-title',
         ariaLabel: `${l('FacetTitle', this.options.title)}`,

--- a/src/ui/DynamicFacet/IDynamicFacet.ts
+++ b/src/ui/DynamicFacet/IDynamicFacet.ts
@@ -32,6 +32,7 @@ export interface IDynamicFacetOptions extends IResponsiveComponentOptions, IDepe
   valueCaption?: Record<string, string>;
   injectionDepth?: number;
   filterFacetCount?: boolean;
+  headingLevel?: number;
 }
 
 export interface IDynamicFacet

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacet.ts
@@ -312,6 +312,16 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
      * @availablesince [April 2020 Release (v2.8864)](https://docs.coveo.com/en/3231/)
      */
     basePath: ComponentOptions.buildListOption<string>({ defaultValue: [] }),
+
+    /**
+     * The [heading level](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Heading_Elements) to use for the heading above the facet.
+     *
+     * A value of 0 will render a [`div`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div) element instead.
+     *
+     * **Default:** `2`.
+     */
+    headingLevel: ComponentOptions.buildNumberOption({ defaultValue: 2, min: 0, max: 6 }),
+
     ...ResponsiveFacetOptions
   };
 
@@ -712,6 +722,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
       id: this.options.id,
       title: this.options.title,
       enableCollapse: this.options.enableCollapse,
+      headingLevel: this.options.headingLevel,
       clear: () => this.clear(),
       toggleCollapse: () => this.toggleCollapse(),
       expand: () => this.expand(),
@@ -782,7 +793,7 @@ export class DynamicHierarchicalFacet extends Component implements IDynamicHiera
       return;
     }
 
-    const breadcrumbs = new DynamicHierarchicalFacetBreadcrumb(this);
+    const breadcrumbs = new DynamicHierarchicalFacetBreadcrumb(this, { headingLevel: args.headingLevel });
     args.breadcrumbs.push({ element: breadcrumbs.element });
   }
 

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetBreadcrumb.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetBreadcrumb.ts
@@ -4,11 +4,16 @@ import { SVGIcons } from '../../utils/SVGIcons';
 import { IDynamicHierarchicalFacet } from './IDynamicHierarchicalFacet';
 import { l } from '../../strings/Strings';
 import { analyticsActionCauseList } from '../Analytics/AnalyticsActionListMeta';
+import { getHeadingTag } from '../../utils/AccessibilityUtils';
+
+export interface IDynamicHierarchicalFacetBreadcrumbsOptions {
+  headingLevel?: number;
+}
 
 export class DynamicHierarchicalFacetBreadcrumb {
   public element: HTMLElement;
 
-  constructor(private facet: IDynamicHierarchicalFacet) {
+  constructor(private facet: IDynamicHierarchicalFacet, private readonly options?: IDynamicHierarchicalFacetBreadcrumbsOptions) {
     this.create();
   }
 
@@ -23,7 +28,11 @@ export class DynamicHierarchicalFacetBreadcrumb {
   }
 
   private createAndAppendTitle() {
-    const titleElement = $$('h3', { className: 'coveo-dynamic-facet-breadcrumb-title' }, `${this.facet.options.title}:`).el;
+    const titleElement = $$(
+      getHeadingTag(this.options && this.options.headingLevel, 'h3'),
+      { className: 'coveo-dynamic-facet-breadcrumb-title' },
+      `${this.facet.options.title}:`
+    ).el;
     this.element.appendChild(titleElement);
   }
 

--- a/src/ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet.ts
+++ b/src/ui/DynamicHierarchicalFacet/IDynamicHierarchicalFacet.ts
@@ -33,6 +33,7 @@ export interface IDynamicHierarchicalFacetOptions extends IResponsiveComponentOp
   filterFacetCount?: boolean;
   clearLabel?: string;
   basePath?: string[];
+  headingLevel?: number;
 }
 
 export interface IDynamicHierarchicalFacet extends Component, IDynamicManagerCompatibleFacet, IAutoLayoutAdjustableInsideFacetColumn {

--- a/src/ui/Facet/BreadcrumbValuesList.ts
+++ b/src/ui/Facet/BreadcrumbValuesList.ts
@@ -7,6 +7,11 @@ import { IBreadcrumbValueElementKlass } from './BreadcrumbValueElement';
 import { Facet } from './Facet';
 import { FacetValue } from './FacetValue';
 import { AccessibleButton } from '../../utils/AccessibleButton';
+import { getHeadingTag } from '../../utils/AccessibilityUtils';
+
+interface IBreadcrumbValueListOptions {
+  headingLevel?: number;
+}
 
 export class BreadcrumbValueList {
   private expanded: FacetValue[];
@@ -14,13 +19,18 @@ export class BreadcrumbValueList {
   protected elem: HTMLElement;
   private valueContainer: HTMLElement;
 
-  constructor(public facet: Facet, public facetValues: FacetValue[], public breadcrumbValueElementKlass: IBreadcrumbValueElementKlass) {
+  constructor(
+    public facet: Facet,
+    public facetValues: FacetValue[],
+    public breadcrumbValueElementKlass: IBreadcrumbValueElementKlass,
+    private readonly options?: IBreadcrumbValueListOptions
+  ) {
     this.setExpandedAndCollapsed();
     this.elem = $$('div', {
       className: 'coveo-facet-breadcrumb'
     }).el;
 
-    const title = $$('span');
+    const title = $$(getHeadingTag(this.options && this.options.headingLevel, 'span'));
     title.addClass('coveo-facet-breadcrumb-title');
     title.text(this.facet.options.title + ':');
     this.elem.appendChild(title.el);

--- a/src/ui/Facet/BreadcrumbValuesList.ts
+++ b/src/ui/Facet/BreadcrumbValuesList.ts
@@ -9,7 +9,7 @@ import { FacetValue } from './FacetValue';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import { getHeadingTag } from '../../utils/AccessibilityUtils';
 
-interface IBreadcrumbValueListOptions {
+export interface IBreadcrumbValueListOptions {
   headingLevel?: number;
 }
 

--- a/src/ui/Facet/Facet.ts
+++ b/src/ui/Facet/Facet.ts
@@ -1304,11 +1304,9 @@ export class Facet extends Component implements IFieldValueCompatibleFacet {
     Assert.exists(args);
 
     if (this.values.hasSelectedOrExcludedValues()) {
-      const element = new BreadcrumbValueList(
-        this,
-        this.values.getSelected().concat(this.values.getExcluded()),
-        BreadcrumbValueElement
-      ).build();
+      const element = new BreadcrumbValueList(this, this.values.getSelected().concat(this.values.getExcluded()), BreadcrumbValueElement, {
+        headingLevel: args.headingLevel
+      }).build();
       args.breadcrumbs.push({ element: element });
     }
   }

--- a/src/ui/FacetSlider/FacetSlider.ts
+++ b/src/ui/FacetSlider/FacetSlider.ts
@@ -16,6 +16,7 @@ import { IAttributeChangedEventArg, Model } from '../../models/Model';
 import { QueryStateModel } from '../../models/QueryStateModel';
 import { IGroupByResult } from '../../rest/GroupByResult';
 import { l } from '../../strings/Strings';
+import { getHeadingTag } from '../../utils/AccessibilityUtils';
 import { $$ } from '../../utils/Dom';
 import { SVGDom } from '../../utils/SVGDom';
 import { SVGIcons } from '../../utils/SVGIcons';
@@ -568,7 +569,7 @@ export class FacetSlider extends Component {
     const populateBreadcrumb = () => {
       if (this.isActive()) {
         args.breadcrumbs.push(<IBreadcrumbItem>{
-          element: this.buildBreadcrumbFacetSlider()
+          element: this.buildBreadcrumbFacetSlider(args.headingLevel)
         });
       }
     };
@@ -588,12 +589,12 @@ export class FacetSlider extends Component {
     }
   }
 
-  private buildBreadcrumbFacetSlider(): HTMLElement {
+  private buildBreadcrumbFacetSlider(headingLevel?: number): HTMLElement {
     const elem = $$('div', {
       className: 'coveo-facet-slider-breadcrumb'
     }).el;
 
-    const title = $$('span', {
+    const title = $$(getHeadingTag(headingLevel, 'span'), {
       className: 'coveo-facet-slider-breadcrumb-title'
     });
     title.text(this.options.title + ': ');

--- a/src/ui/HierarchicalFacet/HierarchicalBreadcrumbValuesList.ts
+++ b/src/ui/HierarchicalFacet/HierarchicalBreadcrumbValuesList.ts
@@ -7,7 +7,7 @@ import { HierarchicalBreadcrumbValueElement } from './HierarchicalBreadcrumbValu
 import { $$ } from '../../utils/Dom';
 import * as _ from 'underscore';
 
-interface IHierarchicalBreadcrumbValuesListOptions {
+export interface IHierarchicalBreadcrumbValuesListOptions {
   headingLevel?: number;
 }
 

--- a/src/ui/HierarchicalFacet/HierarchicalBreadcrumbValuesList.ts
+++ b/src/ui/HierarchicalFacet/HierarchicalBreadcrumbValuesList.ts
@@ -7,13 +7,18 @@ import { HierarchicalBreadcrumbValueElement } from './HierarchicalBreadcrumbValu
 import { $$ } from '../../utils/Dom';
 import * as _ from 'underscore';
 
+interface IHierarchicalBreadcrumbValuesListOptions {
+  headingLevel?: number;
+}
+
 export class HierarchicalBreadcrumbValuesList extends BreadcrumbValueList {
   constructor(
     public facet: HierarchicalFacet,
     public facetValues: FacetValue[],
-    public valueHierarchy: { [facetValue: string]: IValueHierarchy }
+    public valueHierarchy: { [facetValue: string]: IValueHierarchy },
+    options?: IHierarchicalBreadcrumbValuesListOptions
   ) {
-    super(facet, facetValues, HierarchicalBreadcrumbValueElement);
+    super(facet, facetValues, HierarchicalBreadcrumbValueElement, options);
   }
 
   public buildAsString() {

--- a/src/ui/HierarchicalFacet/HierarchicalFacet.ts
+++ b/src/ui/HierarchicalFacet/HierarchicalFacet.ts
@@ -519,7 +519,8 @@ export class HierarchicalFacet extends Facet implements IComponentBindings {
       let element = new HierarchicalBreadcrumbValuesList(
         this,
         this.values.getSelected().concat(this.values.getExcluded()),
-        this.getAllValueHierarchy()
+        this.getAllValueHierarchy(),
+        { headingLevel: args.headingLevel }
       ).build();
       args.breadcrumbs.push({
         element: element

--- a/src/ui/MissingTerm/MissingTermManager.ts
+++ b/src/ui/MissingTerm/MissingTermManager.ts
@@ -11,6 +11,7 @@ import { QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
 import XRegExp = require('xregexp');
 import { Breadcrumb } from '../Breadcrumb/Breadcrumb';
 import { escape } from 'underscore';
+import { getHeadingTag } from '../../utils/AccessibilityUtils';
 
 export class MissingTermManager {
   static ID = 'MissingTermManager';
@@ -56,7 +57,7 @@ export class MissingTermManager {
     }
 
     const missingTerms = this.buildTermForcedToAppear();
-    const BreadcrumbContainer = this.buildBreadcrumbContainer();
+    const BreadcrumbContainer = this.buildBreadcrumbContainer(args.headingLevel);
 
     missingTerms.forEach(term => $$(BreadcrumbContainer).append(term.el));
 
@@ -82,14 +83,14 @@ export class MissingTermManager {
     });
   }
 
-  private buildBreadcrumbContainer() {
+  private buildBreadcrumbContainer(headingLevel?: number) {
     return $$(
       'div',
       {
         className: 'coveo-remove-term-container'
       },
       $$(
-        'span',
+        getHeadingTag(headingLevel, 'span'),
         {
           className: 'coveo-missing-term-breadcrumb-title'
         },

--- a/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
+++ b/src/ui/ResultsFiltersPreferences/ResultsFiltersPreferences.ts
@@ -8,6 +8,7 @@ import { exportGlobally } from '../../GlobalExports';
 import { MODEL_EVENTS } from '../../models/Model';
 import { QueryStateModel, QUERY_STATE_ATTRIBUTES } from '../../models/QueryStateModel';
 import { l } from '../../strings/Strings';
+import { getHeadingTag } from '../../utils/AccessibilityUtils';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import { $$ } from '../../utils/Dom';
 import { LocalStorageUtils } from '../../utils/LocalStorageUtils';
@@ -233,7 +234,7 @@ export class ResultsFiltersPreferences extends Component {
     const actives = this.getActiveFilters();
     if (Utils.isNonEmptyArray(actives)) {
       const container = $$('div', { className: 'coveo-results-filter-preferences-breadcrumb' });
-      const title = $$('span', { className: 'coveo-title' });
+      const title = $$(getHeadingTag(args.headingLevel, 'span'), { className: 'coveo-title' });
       title.text(l('FiltersInYourPreferences') + ':');
       container.el.appendChild(title.el);
 

--- a/src/ui/SimpleFilter/SimpleFilter.ts
+++ b/src/ui/SimpleFilter/SimpleFilter.ts
@@ -6,6 +6,7 @@ import { exportGlobally } from '../../GlobalExports';
 import { Assert } from '../../misc/Assert';
 import { Logger } from '../../misc/Logger';
 import { l } from '../../strings/Strings';
+import { getHeadingTag } from '../../utils/AccessibilityUtils';
 import { AccessibleButton } from '../../utils/AccessibleButton';
 import { $$, Dom } from '../../utils/Dom';
 import { SVGDom } from '../../utils/SVGDom';
@@ -510,7 +511,11 @@ export class SimpleFilter extends Component {
   private handlePopulateBreadcrumb(args: IPopulateBreadcrumbEventArgs) {
     if (this.getSelectedLabeledCheckboxes().length > 0) {
       const elem = $$('div', { className: 'coveo-simplefilter-breadcrumb' });
-      const title = $$('span', { className: 'coveo-simplefilter-breadcrumb-title' }, `${this.options.title}:`);
+      const title = $$(
+        getHeadingTag(args.headingLevel, 'span'),
+        { className: 'coveo-simplefilter-breadcrumb-title' },
+        `${this.options.title}:`
+      );
       elem.append(title.el);
       const values = $$('span', { className: 'coveo-simplefilter-breadcrumb-values' });
       elem.append(values.el);

--- a/src/utils/AccessibilityUtils.ts
+++ b/src/utils/AccessibilityUtils.ts
@@ -1,0 +1,6 @@
+export function getHeadingTag(level?: number, fallbackTag = 'div') {
+  if (level === undefined || level < 1 || level > 6) {
+    return fallbackTag;
+  }
+  return `h${level}`;
+}

--- a/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggleTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderCollapseToggleTest.ts
@@ -15,7 +15,8 @@ export function DynamicFacetHeaderCollapseToggleTest() {
         enableCollapse: true,
         toggleCollapse: jasmine.createSpy('toggleCollapse'),
         collapse: jasmine.createSpy('collapse'),
-        expand: jasmine.createSpy('clear')
+        expand: jasmine.createSpy('clear'),
+        headingLevel: 2
       };
 
       collapseToggle = new DynamicFacetHeaderCollapseToggle(options);

--- a/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetHeader/DynamicFacetHeaderTest.ts
@@ -14,7 +14,8 @@ export function DynamicFacetHeaderTest() {
         enableCollapse: true,
         toggleCollapse: jasmine.createSpy('toggleCollapse'),
         collapse: jasmine.createSpy('collapse'),
-        expand: jasmine.createSpy('clear')
+        expand: jasmine.createSpy('clear'),
+        headingLevel: 2
       };
       initializeComponent();
     });

--- a/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTestUtils.ts
+++ b/unitTests/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetTestUtils.ts
@@ -112,7 +112,8 @@ export class DynamicHierarchicalFacetTestUtils {
       expand: () => {},
       toggleCollapse: () => {},
       enableCollapse: facet.options.enableCollapse,
-      title: facet.options.title
+      title: facet.options.title,
+      headingLevel: 2
     };
 
     return facet;


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3432

Facet headings and breadcrumbs had heading levels, which could break the heading hierarchy in other pages. Since simply replacing them with `span`/`div` could be breaking, I added `heading-level` options to override them.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)