### PR TITLE
JSUI-3433 Apply ARIA17 to facets and improve localization

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueMoreLessButton.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueMoreLessButton.ts
@@ -21,7 +21,7 @@ export class DynamicFacetValueShowMoreLessButton {
       options.label
     );
 
-    this.element = $$('li', null, btn).el;
+    this.element = $$('li', { role: 'none' }, btn).el;
     btn.on('click', () => options.action());
   }
 }

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueRenderer.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValueRenderer.ts
@@ -12,6 +12,7 @@ export class DynamicFacetValueRenderer implements IValueRenderer {
   public render() {
     this.dom = $$('li', {
       className: 'coveo-dynamic-facet-value',
+      role: 'none',
       dataValue: this.facetValue.value
     });
 

--- a/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
+++ b/src/ui/DynamicFacet/DynamicFacetValues/DynamicFacetValues.ts
@@ -16,8 +16,11 @@ export interface IDynamicFacetValueCreatorKlass {
 
 export class DynamicFacetValues implements IDynamicFacetValues {
   private facetValues: IDynamicFacetValue[];
-  private list = $$('ul', { className: 'coveo-dynamic-facet-values', 'aria-labelledby': getDynamicFacetHeaderId(this.facet.options.id) })
-    .el;
+  private list = $$('ul', {
+    className: 'coveo-dynamic-facet-values',
+    'aria-labelledby': getDynamicFacetHeaderId(this.facet.options.id),
+    role: 'group'
+  }).el;
   private valueCreator: IValueCreator;
 
   constructor(private facet: IDynamicFacet, creatorKlass: IDynamicFacetValueCreatorKlass) {

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValueRenderer.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValueRenderer.ts
@@ -20,7 +20,7 @@ export class DynamicHierarchicalFacetValueRenderer {
     this.renderCount();
     this.toggleButtonStates();
 
-    return $$('li', { dataValue: this.facetValue.value }, this.button).el;
+    return $$('li', { role: 'none', dataValue: this.facetValue.value }, this.button).el;
   }
 
   private renderLabel() {

--- a/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValues.ts
+++ b/src/ui/DynamicHierarchicalFacet/DynamicHierarchicalFacetValues/DynamicHierarchicalFacetValues.ts
@@ -18,7 +18,8 @@ export class DynamicHierarchicalFacetValues implements IDynamicHierarchicalFacet
   private _selectedPath: string[] = [];
   private list = $$('ul', {
     className: 'coveo-dynamic-hierarchical-facet-values',
-    'aria-labelledby': getDynamicFacetHeaderId(this.facet.options.id)
+    'aria-labelledby': getDynamicFacetHeaderId(this.facet.options.id),
+    role: 'group'
   }).el;
 
   constructor(private facet: IDynamicHierarchicalFacet) {}
@@ -181,7 +182,7 @@ export class DynamicHierarchicalFacetValues implements IDynamicHierarchicalFacet
     const arrowIcon = $$('div', { className: 'coveo-dynamic-hierarchical-facet-value-arrow-left' }, SVGIcons.icons.arrowDown);
     clearButton.prepend(arrowIcon.el);
 
-    const clear = $$('li', {}, clearButton);
+    const clear = $$('li', { role: 'none' }, clearButton);
     clear.on('click', () => this.facet.header.options.clear());
     $$(this.list).prepend(clear.el);
   }

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -2707,6 +2707,14 @@
     "en": "Show more results for the {0} category",
     "fr": "Afficher plus de résultats pour la catégorie {0}"
   },
+  "ShowLessHierarchicalResults": {
+    "en": "Show fewer results for the {0} facet",
+    "fr": "Afficher moins de résultats pour la catégorie {0}"
+  },
+  "ShowMoreHierarchicalResults": {
+    "en": "Show more results for the {0} facet",
+    "fr": "Afficher plus de résultats pour la catégorie {0}"
+  },
   "SearchFacetResults": {
     "en": "Search for values in {0} facet",
     "fr": "Rechercher des valeurs dans la facette {0}"

--- a/strings/strings.json
+++ b/strings/strings.json
@@ -2709,11 +2709,11 @@
   },
   "ShowLessHierarchicalResults": {
     "en": "Show fewer results for the {0} facet",
-    "fr": "Afficher moins de résultats pour la catégorie {0}"
+    "fr": "Afficher moins de résultats pour la facette {0}"
   },
   "ShowMoreHierarchicalResults": {
     "en": "Show more results for the {0} facet",
-    "fr": "Afficher plus de résultats pour la catégorie {0}"
+    "fr": "Afficher plus de résultats pour la facette {0}"
   },
   "SearchFacetResults": {
     "en": "Search for values in {0} facet",


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3433

I applied [ARIA17](https://www.w3.org/TR/WCAG20-TECHS/ARIA17.html#ARIA17-ex1) by setting the role of the `ul` element which groups facet values to [`group`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/group_role) and removing the [`listitem`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/listitem_role) role from `li` elements.

A localization key was missing so I added it.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)