### PR TITLE
SVCINT-1058 update slack result template visual

### DIFF
--- a/src/ui/Templates/CoreHelpers.ts
+++ b/src/ui/Templates/CoreHelpers.ts
@@ -783,10 +783,7 @@ TemplateHelpers.registerTemplateHelper('isMobileDevice', () => {
   return DeviceUtils.isMobileDevice() ? DeviceUtils.getDeviceName() : null;
 });
 
-TemplateHelpers.registerTemplateHelper('pluralReplyHelper', (count: number) => {
-  if (count <= 1) return 'reply';
-  else return 'replies';
-});
+TemplateHelpers.registerTemplateHelper('pluralReplyHelper', (count: number) => (count == 1 ? 'reply' : 'replies'));
 
 function resolveQueryResult(): IQueryResult {
   let found;

--- a/src/ui/Templates/CoreHelpers.ts
+++ b/src/ui/Templates/CoreHelpers.ts
@@ -404,6 +404,11 @@ export interface IHelperStreamHighlightOptions {
   opts?: IStreamHighlightOptions;
 }
 
+export interface IPluralOptions {
+  singular: string;
+  plural: string;
+}
+
 export class CoreHelpers {
   public constructor() {}
 
@@ -783,7 +788,9 @@ TemplateHelpers.registerTemplateHelper('isMobileDevice', () => {
   return DeviceUtils.isMobileDevice() ? DeviceUtils.getDeviceName() : null;
 });
 
-TemplateHelpers.registerTemplateHelper('pluralReplyHelper', (count: number) => (count == 1 ? 'reply' : 'replies'));
+TemplateHelpers.registerTemplateHelper('pluralHelper', (count: number, options: IPluralOptions) =>
+  count > 1 ? options.plural : options.singular
+);
 
 function resolveQueryResult(): IQueryResult {
   let found;

--- a/src/ui/Templates/CoreHelpers.ts
+++ b/src/ui/Templates/CoreHelpers.ts
@@ -783,6 +783,11 @@ TemplateHelpers.registerTemplateHelper('isMobileDevice', () => {
   return DeviceUtils.isMobileDevice() ? DeviceUtils.getDeviceName() : null;
 });
 
+TemplateHelpers.registerTemplateHelper('pluralReplyHelper', (count: number) => {
+  if (count <= 1) return 'reply';
+  else return 'replies';
+});
+
 function resolveQueryResult(): IQueryResult {
   let found;
   let resultList = Component.getComponentRef('ResultList');

--- a/templates/Slack/SlackMessage.html
+++ b/templates/Slack/SlackMessage.html
@@ -28,10 +28,10 @@
       </div>
       <div>
         <span class="CoveoFieldValue" data-field="@date" data-helper="dateTime"
-          data-helper-options-predefined-format="dd / MM / yyyy"></span>
+          data-helper-options-predefined-format="MM/dd/yyyy"></span>
       </div>
     </div>
-    <div style="display: flex; margin-bottom: 4px;">
+    <div style="display: flex; margin-bottom: 16px;">
       <span class="CoveoIcon" data-with-label="false"
         style="height: 32px; width: 32px; background-size: cover; margin-right: 16px; flex-shrink: 0;"></span>
       <div

--- a/templates/Slack/SlackMessage.html
+++ b/templates/Slack/SlackMessage.html
@@ -26,10 +26,6 @@
           <span class="CoveoFieldValue" data-field="@slackchannelname"></span>
         </a>
       </div>
-      <div>
-        <span class="CoveoFieldValue" data-field="@date" data-helper="dateTime"
-          data-helper-options-predefined-format="MM/dd/yyyy"></span>
-      </div>
     </div>
     <div style="display: flex; margin-bottom: 16px;">
       <span class="CoveoIcon" data-with-label="false"
@@ -44,6 +40,9 @@
               style="font-size: 16px; margin-right: 8px; font-weight: bold;"></span>
             <span class="CoveoFieldValue" data-field="@date" data-helper="time"
               style="color: #616061; padding-bottom: 2px;"></span>
+            <span>&nbsp;-&nbsp;</span>
+            <span class="CoveoFieldValue" data-field="@date" data-helper="dateTime"
+              data-helper-options-predefined-format="MM/dd/yyyy" style="color: #616061; padding-bottom: 2px;"></span>              
           </div>
           <span class="CoveoExcerpt"></span>
         </div>

--- a/templates/Slack/SlackMessageReply.html
+++ b/templates/Slack/SlackMessageReply.html
@@ -13,15 +13,9 @@
   }
 </style>
 
-<div class="coveo-result-frame coveo-slack-result-template">
+<div class="coveo-result-frame coveo-slack-result-template" style="margin-bottom: 8px;">
   <div class="coveo-result-row" style="margin-right: 16px;">
-    <div style="font-size: 12px; display: flex; align-items: baseline; margin-bottom: 10px; justify-content: flex-end;">
-      <div>
-        <span class="CoveoFieldValue" data-field="@date" data-helper="dateTime"
-          data-helper-options-predefined-format="dd / MM / yyyy"></span>
-      </div>
-    </div>
-    <div style="display: flex; margin-bottom: 4px; margin-left: 22px; padding-left: 31px; border-left: thin solid #bcc3ca;">
+    <div style="display: flex; margin-bottom: 4px; margin-left: 22px;">
       <div
         style="display: flex; background-color: #F6F7F9; border-radius: 8px; flex-grow: 1; padding: 8px; padding-bottom: 16px;">
         <span class="CoveoImageFieldValue" data-field="@slackmessageauthorprofilepicture" data-width="30"

--- a/templates/Slack/SlackMessageReply.html
+++ b/templates/Slack/SlackMessageReply.html
@@ -26,6 +26,9 @@
               style="font-size: 16px; margin-right: 8px; font-weight: bold;"></span>
             <span class="CoveoFieldValue" data-field="@date" data-helper="time"
               style="color: #616061; padding-bottom: 2px;"></span>
+            <span>&nbsp;-&nbsp;</span>
+            <span class="CoveoFieldValue" data-field="@date" data-helper="dateTime"
+              data-helper-options-predefined-format="MM/dd/yyyy" style="color: #616061; padding-bottom: 2px;"></span>
           </div>
           <span class="CoveoExcerpt"></span>
         </div>

--- a/templates/Slack/SlackMessageThread.html
+++ b/templates/Slack/SlackMessageThread.html
@@ -14,13 +14,19 @@
 
   .coveo-slack-result-template .coveo-folding-footer {
     order: 1;
-    margin: 0;
+    margin-left: 22px;
     font-size: 12px;
+  }
+
+  .coveo-slack-result-template .CoveoResultFolding .coveo-folding-results {
+    margin-left: 22px; 
+    border-left: thin solid #bcc3ca;
   }
 
   .coveo-slack-result-template .coveo-folding-results .coveo-result-folding-child-result, .coveo-slack-result-template .coveo-folding-results .coveo-result-folding-child-result:hover {
     padding-left: 0;
     border-left: none;
+    margin-bottom: 8px;
   }
 
   .coveo-slack-result-template .coveo-folding-oneresult-caption {
@@ -42,10 +48,10 @@
       </div>
       <div>
         <span class="CoveoFieldValue" data-field="@date" data-helper="dateTime"
-          data-helper-options-predefined-format="dd / MM / yyyy"></span>
+          data-helper-options-predefined-format="MM/dd/yyyy"></span>
       </div>
     </div>
-    <div style="display: flex; margin-bottom: 4px;">
+    <div style="display: flex; margin-bottom: 16px;">
       <span class="CoveoIcon" data-with-label="false"
         style="height: 32px; width: 32px; background-size: cover; margin-right: 16px; flex-shrink: 0;"></span>
       <div
@@ -61,9 +67,8 @@
           </div>
           <span class="CoveoExcerpt"></span>
           <div  style="color: #626971; margin-top: 8px; font-weight: 700;">
-            <span class="CoveoText" data-value="Reply count"></span>
-            <span>:&nbsp;</span>
             <span class="CoveoFieldValue" data-field="@slackmessagereplycount"></span>
+            <span class="CoveoFieldValue" data-field="@slackmessagereplycount" data-helper="pluralReplyHelper">
           </div>
         </div>
       </div>

--- a/templates/Slack/SlackMessageThread.html
+++ b/templates/Slack/SlackMessageThread.html
@@ -46,10 +46,6 @@
           <span class="CoveoFieldValue" data-field="@slackchannelname"></span>
         </a>
       </div>
-      <div>
-        <span class="CoveoFieldValue" data-field="@date" data-helper="dateTime"
-          data-helper-options-predefined-format="MM/dd/yyyy"></span>
-      </div>
     </div>
     <div style="display: flex; margin-bottom: 16px;">
       <span class="CoveoIcon" data-with-label="false"
@@ -64,6 +60,9 @@
               style="font-size: 16px; margin-right: 8px; font-weight: bold;"></span>
             <span class="CoveoFieldValue" data-field="@date" data-helper="time"
               style="color: #616061; padding-bottom: 2px;"></span>
+            <span>&nbsp;-&nbsp;</span>
+            <span class="CoveoFieldValue" data-field="@date" data-helper="dateTime"
+              data-helper-options-predefined-format="MM/dd/yyyy" style="color: #616061; padding-bottom: 2px;"></span>              
           </div>
           <span class="CoveoExcerpt"></span>
           <div  style="color: #626971; margin-top: 8px; font-weight: 700;">

--- a/templates/Slack/SlackMessageThread.html
+++ b/templates/Slack/SlackMessageThread.html
@@ -14,7 +14,7 @@
 
   .coveo-slack-result-template .coveo-folding-footer {
     order: 1;
-    margin-left: 22px;
+    margin: 0;
     font-size: 12px;
   }
 
@@ -32,6 +32,10 @@
   .coveo-slack-result-template .coveo-folding-oneresult-caption {
     display: none;
   }
+
+  .coveo-slack-result-template .coveo-folding-show-less {
+    margin: 0 0 0 46px;
+  }  
 </style>
 
 <div class="coveo-result-frame coveo-slack-result-template">

--- a/templates/Slack/SlackMessageThread.html
+++ b/templates/Slack/SlackMessageThread.html
@@ -67,7 +67,8 @@
           <span class="CoveoExcerpt"></span>
           <div  style="color: #626971; margin-top: 8px; font-weight: 700;">
             <span class="CoveoFieldValue" data-field="@slackmessagereplycount"></span>
-            <span class="CoveoFieldValue" data-field="@slackmessagereplycount" data-helper="pluralReplyHelper">
+            <span class="CoveoFieldValue" data-field="@slackmessagereplycount" data-helper="pluralHelper" 
+              data-helper-options="{'singular': 'reply', 'plural': 'replies'}">
           </div>
         </div>
       </div>

--- a/templates/Slack/SlackMessageThread.html
+++ b/templates/Slack/SlackMessageThread.html
@@ -77,7 +77,7 @@
       style="display: grid; grid-template-columns: 1fr auto; grid-template-rows: 1fr min-content; padding-left: 50px;">
       <span class="CoveoResultFolding" style="grid-column: 1 / 3; grid-row: 1;"
         data-result-template-id="SlackMessageReply" data-more-caption="Show thread"
-        data-less-caption="Hide thread"></span>
+        data-less-caption="Hide thread" data-range="0"></span>
       <a class="CoveoResultLink" style="order: 3;" data-field="@clickableuri" data-always-open-in-new-window="true">
         <span class="CoveoText" data-value="Open in Slack" style="font-size: 12px;"></span>
       </a>

--- a/unitTests/ui/CoreHelpersTest.ts
+++ b/unitTests/ui/CoreHelpersTest.ts
@@ -568,5 +568,24 @@ export function CoreHelperTest() {
         expect(TemplateHelpers.getHelper('isMobileDevice')()).toBeNull();
       });
     });
+
+    describe('pluralReplyHelper', () => {
+      const testCases = [
+        {
+          repliesCount: 1,
+          expected: 'reply'
+        },
+        {
+          repliesCount: 5,
+          expected: 'replies'
+        }
+      ];
+
+      testCases.forEach(test => {
+        it(`should return ${test.expected} when number of replies is ${test.repliesCount}`, () => {
+          expect(TemplateHelpers.getHelper('pluralReplyHelper')(test.repliesCount)).toEqual(test.expected);
+        });
+      });
+    });
   });
 }

--- a/unitTests/ui/CoreHelpersTest.ts
+++ b/unitTests/ui/CoreHelpersTest.ts
@@ -8,6 +8,7 @@ import { mockSearchEndpoint, MockEnvironmentBuilder } from '../MockEnvironment';
 import { IQueryResult } from '../../src/rest/QueryResult';
 import { IIconOptions } from '../../src/ui/Icon/Icon';
 import { Component } from '../../src/Core';
+import { IPluralOptions } from '../../src/ui/Templates/CoreHelpers';
 import * as _ from 'underscore';
 
 export function CoreHelperTest() {
@@ -570,6 +571,7 @@ export function CoreHelperTest() {
     });
 
     describe('pluralReplyHelper', () => {
+      const options: IPluralOptions = { singular: 'reply', plural: 'replies' };
       const testCases = [
         {
           repliesCount: 1,
@@ -583,7 +585,7 @@ export function CoreHelperTest() {
 
       testCases.forEach(test => {
         it(`should return ${test.expected} when number of replies is ${test.repliesCount}`, () => {
-          expect(TemplateHelpers.getHelper('pluralReplyHelper')(test.repliesCount)).toEqual(test.expected);
+          expect(TemplateHelpers.getHelper('pluralHelper')(test.repliesCount, options)).toEqual(test.expected);
         });
       });
     });


### PR DESCRIPTION
[SVCINT-1058](https://coveord.atlassian.net/browse/SVCINT-1058)

Some updates in the Slack JSUI result template to match the changes asked in the ticket. 
<img width="1862" alt="Screen Shot 2021-08-18 at 3 58 20 PM" src="https://user-images.githubusercontent.com/67848363/198053478-e1f5e1ef-5009-48b6-aee2-5421ed8ff59c.png">


Final result
![image](https://user-images.githubusercontent.com/67848363/198051213-dda83b41-ef42-43a0-9544-4824ebe83f64.png)


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)