### PR TITLE
JSUI-3394 added question and answer to smart snippet suggestions analytics

### DIFF
--- a/src/ui/Analytics/AnalyticsActionListMeta.ts
+++ b/src/ui/Analytics/AnalyticsActionListMeta.ts
@@ -274,6 +274,8 @@ export interface IAnalyticsSmartSnippetOpenSnippetInlineLinkMeta extends IAnalyt
 
 export interface IAnalyticsSmartSnippetSuggestionMeta extends IAnalyticsSmartSnippetMeta {
   documentId: { contentIdKey: string; contentIdValue: string };
+  question: string;
+  answerSnippet: string;
 }
 
 export interface IAnalyticsSmartSnippetSuggestionOpenSourceMeta extends IAnalyticsSmartSnippetSuggestionMeta {

--- a/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
+++ b/src/ui/SmartSnippet/SmartSnippetCollapsibleSuggestion.ts
@@ -74,6 +74,16 @@ export class SmartSnippetCollapsibleSuggestion {
     return this.contentLoaded;
   }
 
+  private get analyticsSuggestionMeta(): IAnalyticsSmartSnippetSuggestionMeta {
+    const { documentId, question, answerSnippet } = this.options.questionAnswer;
+    return {
+      searchQueryUid: this.options.searchUid,
+      documentId,
+      question,
+      answerSnippet
+    };
+  }
+
   public build() {
     const collapsibleContainer = this.buildCollapsibleContainer(this.options.questionAnswer, this.buildStyle(this.options.innerCSS));
     const title = this.buildTitle(this.options.questionAnswer.question);
@@ -203,10 +213,7 @@ export class SmartSnippetCollapsibleSuggestion {
   private sendExpandAnalytics() {
     return this.options.bindings.usageAnalytics.logCustomEvent<IAnalyticsSmartSnippetSuggestionMeta>(
       analyticsActionCauseList.expandSmartSnippetSuggestion,
-      {
-        searchQueryUid: this.options.searchUid,
-        documentId: this.options.questionAnswer.documentId
-      },
+      this.analyticsSuggestionMeta,
       this.checkbox.el
     );
   }
@@ -214,10 +221,7 @@ export class SmartSnippetCollapsibleSuggestion {
   private sendCollapseAnalytics() {
     return this.options.bindings.usageAnalytics.logCustomEvent<IAnalyticsSmartSnippetSuggestionMeta>(
       analyticsActionCauseList.collapseSmartSnippetSuggestion,
-      {
-        searchQueryUid: this.options.searchUid,
-        documentId: this.options.questionAnswer.documentId
-      },
+      this.analyticsSuggestionMeta,
       this.checkbox.el
     );
   }
@@ -226,11 +230,10 @@ export class SmartSnippetCollapsibleSuggestion {
     return this.options.bindings.usageAnalytics.logClickEvent<IAnalyticsSmartSnippetSuggestionOpenSourceMeta>(
       analyticsActionCauseList.openSmartSnippetSuggestionSource,
       {
-        searchQueryUid: this.options.searchUid,
+        ...this.analyticsSuggestionMeta,
         documentTitle: this.options.source.title,
         author: Utils.getFieldValue(this.options.source, 'author'),
-        documentURL: href,
-        documentId: this.options.questionAnswer.documentId
+        documentURL: href
       },
       this.options.source,
       element
@@ -241,10 +244,9 @@ export class SmartSnippetCollapsibleSuggestion {
     return this.options.bindings.usageAnalytics.logClickEvent<IAnalyticsSmartSnippetSuggestionOpenSnippetInlineLinkMeta>(
       analyticsActionCauseList.openSmartSnippetSuggestionInlineLink,
       {
-        searchQueryUid: this.options.searchUid,
+        ...this.analyticsSuggestionMeta,
         linkText: link.innerText,
-        linkURL: link.href,
-        documentId: this.options.questionAnswer.documentId
+        linkURL: link.href
       },
       this.options.source,
       link

--- a/unitTests/ui/SmartSnippetSuggestionsTest.ts
+++ b/unitTests/ui/SmartSnippetSuggestionsTest.ts
@@ -210,7 +210,9 @@ export function SmartSnippetSuggestionsTest() {
 
       it('with only a question answer, does not render', async done => {
         await triggerQuerySuccess({
-          results: <IQueryResults>{ questionAnswer: { question: 'abc', answerSnippet: 'def', relatedQuestions: [] } }
+          results: (<Pick<IQueryResults, 'questionAnswer'>>{
+            questionAnswer: { question: 'abc', answerSnippet: 'def', relatedQuestions: [], documentId: sources[0].id, score: 0 }
+          }) as IQueryResults
         });
         expect(test.cmp.element.classList.contains(ClassNames.HAS_QUESTIONS_CLASSNAME)).toBeFalsy();
         done();
@@ -331,7 +333,12 @@ export function SmartSnippetSuggestionsTest() {
           it('sends expand analytics', () => {
             expect(test.cmp.usageAnalytics.logCustomEvent).toHaveBeenCalledWith(
               analyticsActionCauseList.expandSmartSnippetSuggestion,
-              <IAnalyticsSmartSnippetSuggestionMeta>{ documentId: sources[1].id, searchQueryUid: searchUid },
+              <IAnalyticsSmartSnippetSuggestionMeta>{
+                documentId: sources[1].id,
+                searchQueryUid: searchUid,
+                question: questions[1],
+                answerSnippet: mockSnippet(1).innerHTML
+              },
               findClass(ClassNames.QUESTION_TITLE_CHECKBOX_CLASSNAME)[1]
             );
           });
@@ -353,7 +360,12 @@ export function SmartSnippetSuggestionsTest() {
             it('sends collapse analytics', () => {
               expect(test.cmp.usageAnalytics.logCustomEvent).toHaveBeenCalledWith(
                 analyticsActionCauseList.collapseSmartSnippetSuggestion,
-                <IAnalyticsSmartSnippetSuggestionMeta>{ documentId: sources[1].id, searchQueryUid: searchUid },
+                <IAnalyticsSmartSnippetSuggestionMeta>{
+                  documentId: sources[1].id,
+                  searchQueryUid: searchUid,
+                  question: questions[1],
+                  answerSnippet: mockSnippet(1).innerHTML
+                },
                 findClass(ClassNames.QUESTION_TITLE_CHECKBOX_CLASSNAME)[1]
               );
             });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3394

This mimicks the new behavior of coveo.analytics and Headless.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)