### PR TITLE
JSUI-3458 Count all types of suggestions for Aria Live

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # the repo.
 # see https://help.github.com/articles/about-codeowners/ for more details
 
-* @samisayegh @btaillon @olamothe @ThibodeauJF @kshimCoveo @nrawji
+* @coveo/search
 
 # Prevent PRs that only modify dependencies from notifying everyone
 package.json @ghost

--- a/src/events/OmniboxEvents.ts
+++ b/src/events/OmniboxEvents.ts
@@ -38,6 +38,10 @@ export interface IQuerySuggestSuccessArgs {
   completions: IQuerySuggestCompletion[];
 }
 
+export interface IQuerySuggestRenderedArgs {
+  numberOfSuggestions: number;
+}
+
 /**
  * Describes the object that all [`querySuggestGetFocus`]{@link querySuggestGetFocus} and [`querySuggestSelection`]{@link querySuggestSelection} event handlers receive as an argument.
  */

--- a/src/magicbox/SuggestionsManager.ts
+++ b/src/magicbox/SuggestionsManager.ts
@@ -205,7 +205,8 @@ export class SuggestionsManager {
         this.suggestionsListbox.append(dom.el);
       });
 
-    $$(this.root).trigger(OmniboxEvents.querySuggestRendered);
+    const numberOfSuggestions = this.suggestionsListbox.findAll(`.${this.options.suggestionClass}`).length;
+    $$(this.root).trigger(OmniboxEvents.querySuggestRendered, { numberOfSuggestions });
   }
 
   public get selectedSuggestion(): Suggestion {

--- a/src/ui/AriaLive/AriaLive.ts
+++ b/src/ui/AriaLive/AriaLive.ts
@@ -4,7 +4,7 @@ import { QueryEvents, IQuerySuccessEventArgs, IQueryErrorEventArgs } from '../..
 import { QuerySummaryUtils } from '../../utils/QuerySummaryUtils';
 import { l } from '../../strings/Strings';
 import { OmniboxEvents } from '../../EventsModules';
-import { IQuerySuggestSuccessArgs } from '../../events/OmniboxEvents';
+import { IQuerySuggestRenderedArgs } from '../../events/OmniboxEvents';
 
 export interface IAriaLive {
   updateText: (text: string) => void;
@@ -12,7 +12,6 @@ export interface IAriaLive {
 
 export class AriaLive implements IAriaLive {
   private ariaLiveEl: HTMLElement;
-  private querySuggestions = 0;
 
   constructor(private root: HTMLElement) {
     this.initAriaLiveEl();
@@ -41,10 +40,14 @@ export class AriaLive implements IAriaLive {
     root.on(QueryEvents.duringQuery, () => this.onDuringQuery());
     root.on(QueryEvents.querySuccess, (e, args: IQuerySuccessEventArgs) => this.onQuerySuccess(args));
     root.on(QueryEvents.queryError, (e, args: IQueryErrorEventArgs) => this.onQueryError(args));
-    root.on(OmniboxEvents.querySuggestSuccess, (e, args: IQuerySuggestSuccessArgs) =>
-      args.completions.length ? (this.querySuggestions = args.completions.length) : this.onNoQuerySuggest()
-    );
-    root.on(OmniboxEvents.querySuggestRendered, () => this.onQuerySuggest());
+    root.on(OmniboxEvents.querySuggestRendered, (e, args: IQuerySuggestRenderedArgs) => {
+      if (args.numberOfSuggestions > 0) {
+        this.onQuerySuggest(args.numberOfSuggestions);
+        return;
+      }
+
+      this.onNoQuerySuggest();
+    });
   }
 
   private onDuringQuery() {
@@ -57,8 +60,8 @@ export class AriaLive implements IAriaLive {
     this.updateText(message);
   }
 
-  private onQuerySuggest() {
-    const message = l('QuerySuggestionsAvailable', this.querySuggestions, this.querySuggestions);
+  private onQuerySuggest(numberOfSuggestions: number) {
+    const message = l('QuerySuggestionsAvailable', numberOfSuggestions, numberOfSuggestions);
     this.updateText(message);
   }
 

--- a/unitTests/ui/AriaLiveTest.ts
+++ b/unitTests/ui/AriaLiveTest.ts
@@ -4,6 +4,7 @@ import { $$, OmniboxEvents } from '../../src/Core';
 import { Simulate } from '../Simulate';
 import { MockEnvironmentBuilder, IMockEnvironment } from '../MockEnvironment';
 import { FakeResults } from '../Fake';
+import { IQuerySuggestRenderedArgs } from '../../src/events/OmniboxEvents';
 
 export const AriaLiveTest = () => {
   describe('AriaLive', () => {
@@ -81,7 +82,10 @@ export const AriaLiveTest = () => {
     describe('when fetching query suggestions', () => {
       describe('when there are no suggestions', () => {
         beforeEach(() => {
-          Simulate.querySuggest(env, '', []);
+          const querySuggestRenderedArgs: IQuerySuggestRenderedArgs = {
+            numberOfSuggestions: 0
+          };
+          $$(env.root).trigger(OmniboxEvents.querySuggestRendered, querySuggestRenderedArgs);
         });
 
         it('updates the text', () => {
@@ -91,21 +95,14 @@ export const AriaLiveTest = () => {
 
       describe('when there are 5 suggestions', () => {
         beforeEach(() => {
-          Simulate.querySuggest(env, '', ['', '', '', '', '']);
+          const querySuggestRenderedArgs: IQuerySuggestRenderedArgs = {
+            numberOfSuggestions: 5
+          };
+          $$(env.root).trigger(OmniboxEvents.querySuggestRendered, querySuggestRenderedArgs);
         });
 
-        it('does not update the text', () => {
-          expect(ariaLiveEl().textContent).toEqual('');
-        });
-
-        describe('when the suggestions are rendered', () => {
-          beforeEach(() => {
-            $$(env.root).trigger(OmniboxEvents.querySuggestRendered);
-          });
-
-          it('updates the text', () => {
-            expect(ariaLiveEl().textContent).toContain('5');
-          });
+        it('updates the text', () => {
+          expect(ariaLiveEl().textContent).toContain('5');
         });
       });
     });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3458

HTML structure can be different for field suggestions vs query suggestions... What seems to stay consistent is the presence of the suggestion class

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)