### PR TITLE
JSUI-3460 fix "not a git directory" jenkins issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,8 @@ node('linux && docker') {
   ]){
     withDockerContainer(image: 'nikolaik/python-nodejs:python3.8-nodejs14', args: '-u=root') {
       stage('Install') {
+        // Prevents "not a git directory" issue.
+        sh "git config --global --add safe.directory '*'"
         sh 'yarn install'
       }
 


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3460

Without this line: https://searchuibuilds.dev.cloud.coveo.com/job/search-ui-github/job/v2.10106.3/12/console
With this line: https://searchuibuilds.dev.cloud.coveo.com/job/search-ui-github/job/v2.10106.3/13/console





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)