### PR TITLE
fix: add version 4 tag to UUID

### DIFF
--- a/src/utils/QueryUtils.ts
+++ b/src/utils/QueryUtils.ts
@@ -47,7 +47,7 @@ export class QueryUtils {
       }
       return ret;
     };
-    let prefix = function (str: string, version: number) {
+    const prefix = function (str: string, version: number) {
       return version + str.slice(1);
     };
     return (

--- a/src/utils/QueryUtils.ts
+++ b/src/utils/QueryUtils.ts
@@ -47,7 +47,23 @@ export class QueryUtils {
       }
       return ret;
     };
-    return S4(buf[0]) + S4(buf[1]) + '-' + S4(buf[2]) + '-' + S4(buf[3]) + '-' + S4(buf[4]) + '-' + S4(buf[5]) + S4(buf[6]) + S4(buf[7]);
+    let prefix = function (str: string, version: number) {
+      return version + str.slice(1);
+    };
+    return (
+      S4(buf[0]) +
+      S4(buf[1]) +
+      '-' +
+      S4(buf[2]) +
+      '-' +
+      prefix(S4(buf[3]), 4) +
+      '-' +
+      S4(buf[4]) +
+      '-' +
+      S4(buf[5]) +
+      S4(buf[6]) +
+      S4(buf[7])
+    );
   }
 
   static setStateObjectOnQueryResults(state: any, results: IQueryResults) {

--- a/unitTests/utils/QueryUtilsTest.ts
+++ b/unitTests/utils/QueryUtilsTest.ts
@@ -103,7 +103,7 @@ export function QueryUtilsTest() {
 
     it('should always return a UUID version 4', () => {
       let uuid = QueryUtils.generateWithCrypto();
-      let versionBit = 13;
+      let versionBit = 14;
       expect(uuid[versionBit]).toBe('4');
     });
 

--- a/unitTests/utils/QueryUtilsTest.ts
+++ b/unitTests/utils/QueryUtilsTest.ts
@@ -96,6 +96,17 @@ export function QueryUtilsTest() {
       expect(QueryUtils.containsAttachment(result)).toBeFalsy();
     });
 
+    it('should return a valid UUID', () => {
+      expect(QueryUtils.generateWithCrypto()).toContain('-');
+      expect(QueryUtils.generateWithCrypto().length).toBe(36);
+    });
+
+    it('should always return a UUID version 4', () => {
+      let uuid = QueryUtils.generateWithCrypto();
+      let versionBit = 13;
+      expect(uuid[versionBit]).toBe('4');
+    });
+
     it('should expose a last resort method to generate UUID for analytics events if everything else fails', () => {
       expect(QueryUtils.generateWithRandom()).toContain('-');
       expect(QueryUtils.generateWithRandom().length).toBe(36);


### PR DESCRIPTION
I added a version 4 tag to the UUID to prevent confusion around UUID versions.

https://coveord.atlassian.net/browse/JSUI-3472





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)