### PR TITLE
JSUI-3478 mimicked visitorId behavior of coveo.analytics

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/fermium

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/fermium
+lts/hydrogen

--- a/gulpTasks/definition.js
+++ b/gulpTasks/definition.js
@@ -40,6 +40,7 @@ function cleanDefs() {
       .pipe(replace(/Partial<[A-z]*>/g, 'any'))
       .pipe(replace(/<\s?([a-z]+)\s?=\s?[a-z]+\s?>/gi, '<$1>'))
       .pipe(replace(/ShadowRootInit/, 'any'))
+      .pipe(replace(/\s*implements any(?=\s)/gs, ''))
       .pipe(gulp.dest('bin/ts/'))
   );
 }
@@ -83,6 +84,7 @@ function externalDefs() {
     .pipe(replace(/undefined/g, 'any'))
     .pipe(replace(/Partial<[A-z]*>/g, 'any'))
     .pipe(replace(/const version: string;/g, ''))
+    .pipe(replace(/\s*implements any(?=\s)/gs, ''))
     .pipe(gulp.dest('./bin/ts'));
 }
 

--- a/lib/jasmine/index.d.ts
+++ b/lib/jasmine/index.d.ts
@@ -448,6 +448,8 @@ declare namespace jasmine {
     object: any;
     /** All arguments passed to the call */
     args: any[];
+    /** The return value of the call */
+    returnValue: any;
   }
 
   interface Matchers {

--- a/pages/AnalyticsHomePage.html
+++ b/pages/AnalyticsHomePage.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Home page - Analytics</title>
+  <meta about="Home page with coveo.analytics." />
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, height=device-height">
+  <script>
+    (function(c,o,v,e,O,u,a){
+    a='coveoua';c[a]=c[a]||function(){(c[a].q=c[a].q|| []).push(arguments)};
+    c[a].t=Date.now();u=o.createElement(v);u.async=1;u.src=e;
+    O=o.getElementsByTagName(v)[0];O.parentNode.insertBefore(u,O)
+    })(window,document,'script','https://static.cloud.coveo.com/coveo.analytics.js/2/coveoua.js')
+  </script>
+  <script>
+    coveoua('send', 'pageview');
+    coveoua('set', 'custom', { 'favorite_color': 'grey' });
+    coveoua('init', 'xx564559b1-0045-48e1-953c-3addd1ee4457', 'https://analytics.cloud.coveo.com/rest/ua');
+  </script>
+</head>
+
+<body>
+  <h2>Analytics website</h2>
+  <div><button onclick="coveoua('send', 'event', { action: 'Clicked button' })">Log some custom analytics</button></div>
+  <div><a href="./AnalyticsSearchPage.html?ua=1">Search page with coveo.analytics</a></div>
+  <div><a href="./AnalyticsSearchPage.html">Search page without coveo.analytics</a></div>
+</body>
+
+</html>

--- a/pages/AnalyticsSearchPage.html
+++ b/pages/AnalyticsSearchPage.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Search page - Analytics</title>
+  <meta about="Search page with coveo.analytics." />
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, height=device-height">
+  <link rel="stylesheet" href="./css/CoveoFullSearch.css" />
+  <script class="coveo-script" src="js/CoveoJsSearch.Lazy.js"></script>
+  <script src="js/templates/templates.js"></script>
+  <script>
+    if (document.location.search.split(/[?&]/g).includes('ua=1')) {
+      (function(c,o,v,e,O,u,a){
+      a='coveoua';c[a]=c[a]||function(){(c[a].q=c[a].q|| []).push(arguments)};
+      c[a].t=Date.now();u=o.createElement(v);u.async=1;u.src=e;
+      O=o.getElementsByTagName(v)[0];O.parentNode.insertBefore(u,O)
+      })(window,document,'script','https://static.cloud.coveo.com/coveo.analytics.js/2/coveoua.js')
+      coveoua('send', 'pageview');
+      coveoua('set', 'custom', { 'favorite_color': 'grey' });
+      coveoua('init', 'xx564559b1-0045-48e1-953c-3addd1ee4457', 'https://analytics.cloud.coveo.com/rest/ua');
+    }
+  </script>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      Coveo.SearchEndpoint.configureSampleEndpointV2();
+      Coveo.init(document.body);
+    })
+  </script>
+</head>
+
+<body id="search" class='CoveoSearchInterface' data-enable-history="true">
+  <div class="coveo-tab-section">
+    <a class="CoveoTab" data-id="All" data-caption="All Content"></a>
+  </div>
+  <div class='coveo-search-section'>
+    <div class="CoveoSearchbox" data-enable-omnibox="true"></div>
+    <div class="CoveoSettings"></div>
+    <div class="CoveoAnalytics"></div>
+  </div>
+  <div class="coveo-main-section">
+    <div class="coveo-facet-column">
+      <div class="CoveoDynamicFacetManager">
+        <div class="CoveoDynamicFacet" data-title="Type" data-field="@objecttype" data-tab="All"></div>
+        <div class="CoveoDynamicFacet" data-title="FileType" data-field="@filetype" data-tab="All"></div>
+        <div class="CoveoDynamicFacet" data-title="Author" data-field="@author" data-tab="All"></div>
+      </div>
+    </div>
+    <div class="coveo-results-column">
+      <div class="CoveoShareQuery"></div>
+      <div class="CoveoExportToExcel"></div>
+      <div class="CoveoPreferencesPanel">
+        <div class="CoveoResultsPreferences"></div>
+        <div class="CoveoResultsFiltersPreferences"></div>
+      </div>
+      <div class="CoveoBreadcrumb"></div>
+      <div class="CoveoDidYouMean"></div>
+      <div class="coveo-results-header">
+        <div class="coveo-summary-section">
+          <span class="CoveoQuerySummary"></span>
+          <span class="CoveoQueryDuration"></span>
+        </div>
+        <div class="coveo-result-layout-section">
+          <span class="CoveoResultLayoutSelector"></span>
+        </div>
+        <div class="coveo-sort-section" role="radiogroup">
+          <span class="CoveoSort" data-sort-criteria="relevancy" data-caption="Relevance"></span>
+          <span class="CoveoSort" data-sort-criteria="date descending,date ascending" data-caption="Date"></span>
+        </div>
+      </div>
+      <div class="CoveoHiddenQuery"></div>
+      <div class="CoveoErrorReport"></div>
+      <div class="CoveoResultList" data-layout="list" data-wait-animation="fade"
+        data-auto-select-fields-to-include="true"></div>
+      <div class="CoveoResultList" data-layout="card" data-wait-animation="fade"
+        data-auto-select-fields-to-include="true"></div>
+      <div class="coveo-results-footer">
+        <div class="coveo-results-footer-left">
+          <div class="CoveoPager"></div>
+        </div>
+        <div class="coveo-results-footer-right">
+          <div class="CoveoResultsPerPage"></div>
+          <div class="CoveoLogo"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>

--- a/src/Eager.ts
+++ b/src/Eager.ts
@@ -8,7 +8,7 @@ export { AnalyticsUtils } from './utils/AnalyticsUtils';
 export { HashUtils } from './utils/HashUtils';
 export { DeviceUtils } from './utils/DeviceUtils';
 export { ColorUtils } from './utils/ColorUtils';
-export { Cookie } from './utils/CookieUtils';
+export { ScopedCookie as Cookie } from './utils/CookieUtils';
 export { CurrencyUtils } from './utils/CurrencyUtils';
 export { DateUtils } from './utils/DateUtils';
 export { analyticsActionCauseList } from './ui/Analytics/AnalyticsActionListMeta';

--- a/src/UtilsModules.ts
+++ b/src/UtilsModules.ts
@@ -1,5 +1,5 @@
 export { ColorUtils } from './utils/ColorUtils';
-export { Cookie } from './utils/CookieUtils';
+export { ScopedCookie as Cookie } from './utils/CookieUtils';
 export { CurrencyUtils } from './utils/CurrencyUtils';
 export { DateUtils } from './utils/DateUtils';
 export { DeviceUtils } from './utils/DeviceUtils';

--- a/src/ui/Analytics/AnalyticsInformation.ts
+++ b/src/ui/Analytics/AnalyticsInformation.ts
@@ -1,14 +1,14 @@
 import { findLastIndex } from 'underscore';
 import { LocalStorageUtils } from '../../Core';
+import { CookieAndLocalStorage } from '../../utils/CookieAndLocalStorageUtils';
 import { Cookie } from '../../utils/CookieUtils';
 import { buildHistoryStore } from '../../utils/HistoryStore';
-import { SafeLocalStorage } from '../../utils/LocalStorageUtils';
 import { PendingSearchEvent } from './PendingSearchEvent';
 
 export class AnalyticsInformation {
   private readonly visitorIdKey = 'visitorId';
   private readonly clientIdKey = 'clientId';
-  private readonly storage = new SafeLocalStorage();
+  private readonly storage = new CookieAndLocalStorage();
 
   public pendingSearchEvent: PendingSearchEvent;
 
@@ -45,17 +45,16 @@ export class AnalyticsInformation {
   }
 
   public clear() {
-    this.clearLocalStorage();
-    this.clearCookies();
+    this.clearVisitorId();
+    this.clearClientId();
   }
 
-  private clearLocalStorage() {
+  private clearVisitorId() {
     this.storage.removeItem(this.visitorIdKey);
-    new LocalStorageUtils(this.clientIdKey).remove();
   }
 
-  private clearCookies() {
-    Cookie.erase(this.visitorIdKey);
+  private clearClientId() {
+    new LocalStorageUtils(this.clientIdKey).remove();
     Cookie.erase(this.clientIdKey);
   }
 }

--- a/src/ui/Analytics/AnalyticsInformation.ts
+++ b/src/ui/Analytics/AnalyticsInformation.ts
@@ -1,7 +1,7 @@
 import { findLastIndex } from 'underscore';
 import { LocalStorageUtils } from '../../Core';
 import { CookieAndLocalStorage } from '../../utils/CookieAndLocalStorageUtils';
-import { Cookie } from '../../utils/CookieUtils';
+import { ScopedCookie } from '../../utils/CookieUtils';
 import { buildHistoryStore } from '../../utils/HistoryStore';
 import { PendingSearchEvent } from './PendingSearchEvent';
 
@@ -55,6 +55,6 @@ export class AnalyticsInformation {
 
   private clearClientId() {
     new LocalStorageUtils(this.clientIdKey).remove();
-    Cookie.erase(this.clientIdKey);
+    ScopedCookie.erase(this.clientIdKey);
   }
 }

--- a/src/utils/CookieAndLocalStorageUtils.ts
+++ b/src/utils/CookieAndLocalStorageUtils.ts
@@ -16,6 +16,6 @@ export class CookieAndLocalStorage implements Partial<Storage> {
 
   setItem(key: string, data: string): void {
     this.safeLocalStorage.setItem(key, data);
-    Cookie.set(key, data);
+    Cookie.set(key, data, 31556926000); // 1 year first party cookie
   }
 }

--- a/src/utils/CookieAndLocalStorageUtils.ts
+++ b/src/utils/CookieAndLocalStorageUtils.ts
@@ -1,0 +1,21 @@
+import { Cookie } from './CookieUtils';
+import { SafeLocalStorage } from './LocalStorageUtils';
+
+// Copied from https://github.com/coveo/coveo.analytics.js/blob/master/src/storage.ts
+export class CookieAndLocalStorage implements Partial<Storage> {
+  private safeLocalStorage = new SafeLocalStorage();
+
+  getItem(key: string): string | null {
+    return this.safeLocalStorage.getItem(key) || Cookie.get(key);
+  }
+
+  removeItem(key: string): void {
+    this.safeLocalStorage.removeItem(key);
+    Cookie.erase(key);
+  }
+
+  setItem(key: string, data: string): void {
+    this.safeLocalStorage.setItem(key, data);
+    Cookie.set(key, data);
+  }
+}

--- a/src/utils/CookieAndLocalStorageUtils.ts
+++ b/src/utils/CookieAndLocalStorageUtils.ts
@@ -1,4 +1,4 @@
-import { Cookie } from './CookieUtils';
+import { ScopedCookie } from './CookieUtils';
 import { SafeLocalStorage } from './LocalStorageUtils';
 
 // Copied from https://github.com/coveo/coveo.analytics.js/blob/master/src/storage.ts
@@ -6,16 +6,16 @@ export class CookieAndLocalStorage implements Partial<Storage> {
   private safeLocalStorage = new SafeLocalStorage();
 
   getItem(key: string): string | null {
-    return this.safeLocalStorage.getItem(key) || Cookie.get(key);
+    return this.safeLocalStorage.getItem(key) || ScopedCookie.get(key);
   }
 
   removeItem(key: string): void {
     this.safeLocalStorage.removeItem(key);
-    Cookie.erase(key);
+    ScopedCookie.erase(key);
   }
 
   setItem(key: string, data: string): void {
     this.safeLocalStorage.setItem(key, data);
-    Cookie.set(key, data, 31556926000); // 1 year first party cookie
+    ScopedCookie.set(key, data, 31556926000); // 1 year first party cookie
   }
 }

--- a/src/utils/CookieUtils.ts
+++ b/src/utils/CookieUtils.ts
@@ -1,69 +1,70 @@
-// Code originally taken from : https://developers.livechatinc.com/blog/setting-cookies-to-subdomains-in-javascript/
-export class Cookie {
-  private static prefix: string = 'coveo_';
-
-  static set(name: string, value: string, expiration?: number) {
-    const host = this.getHostname();
-    if (host.split('.').length === 1) {
-      // no '.' in a domain - it's localhost or something similar
-      document.cookie = this.buildCookie(name, value, expiration);
-    } else {
-      // Remember the cookie on all subdomains.
-      //
-      // Start with trying to set cookie to the top domain.
-      // (example: if user is on foo.com, try to set
-      //  cookie to domain '.com')
-      //
-      // If the cookie will not be set, it means '.com'
-      // is a top level domain and we need to
-      // set the cookie to '.foo.com'
-      const domainParts = host.split('.');
-      domainParts.shift();
-      let domain = '.' + domainParts.join('.');
-
-      document.cookie = this.buildCookie(name, value, expiration, domain);
-
-      // check if cookie was successfuly set to the given domain
-      // (otherwise it was a Top-Level Domain)
-      if (Cookie.get(name) == null || Cookie.get(name) != value) {
-        // append '.' to current domain
-        domain = '.' + host;
-        document.cookie = this.buildCookie(name, value, expiration, domain);
-      }
-    }
-  }
-
-  private static getHostname() {
+// Code originally modified from : https://developers.livechatinc.com/blog/setting-cookies-to-subdomains-in-javascript/
+// Should always match: https://github.com/coveo/coveo.analytics.js/blob/master/src/cookieutils.ts
+export class CoveoAnalyticsCookie {
+  static getHostname() {
     return location.hostname;
   }
 
-  private static buildCookie(name: string, value: string, expiration?: number, domain?: string) {
-    const expires = expiration ? this.buildExpiresValue(expiration) : '';
-    const domainCookie = domain ? `; domain=${domain}` : '';
-    return `${this.prefix}${name}=${value}${expires}${domainCookie}; SameSite=Lax; path=/`;
+  set(name: string, value: string, expire?: number) {
+    var domain: string, expirationDate: Date | undefined, domainParts: string[];
+    if (expire) {
+      expirationDate = new Date();
+      expirationDate.setTime(expirationDate.getTime() + expire);
+    }
+    if (CoveoAnalyticsCookie.getHostname().indexOf('.') === -1) {
+      // no "." in a domain - single domain name, it's localhost or something similar
+      writeCookie(name, value, expirationDate);
+    } else {
+      domainParts = CoveoAnalyticsCookie.getHostname().split('.');
+      // we always have at least 2 domain parts
+      domain = domainParts[domainParts.length - 2] + '.' + domainParts[domainParts.length - 1];
+      writeCookie(name, value, expirationDate, domain);
+    }
   }
 
-  private static buildExpiresValue(expiration: number) {
-    return `; expires=${new Date(Date.now() + expiration).toUTCString()}`;
-  }
-
-  static get(name: string) {
-    const nameEQ = `${this.prefix}${name}=`;
-    const ca = document.cookie.split(';');
-    for (let i = 0; i < ca.length; i++) {
-      let c = ca[i];
-      while (c.charAt(0) === ' ') {
-        c = c.substring(1, c.length);
-      }
-
-      if (c.indexOf(nameEQ) == 0) {
-        return c.substring(nameEQ.length, c.length);
+  get(name: string) {
+    var cookiePrefix = name + '=';
+    var cookieArray = document.cookie.split(';');
+    for (var i = 0; i < cookieArray.length; i++) {
+      var cookie = cookieArray[i];
+      cookie = cookie.replace(/^\s+/, ''); //strip whitespace from front of cookie only
+      if (cookie.lastIndexOf(cookiePrefix, 0) === 0) {
+        return cookie.substring(cookiePrefix.length, cookie.length);
       }
     }
     return null;
   }
 
+  erase(name: string) {
+    this.set(name, '', -1);
+  }
+}
+
+function writeCookie(name: string, value: string, expirationDate?: Date, domain?: string) {
+  document.cookie =
+    `${name}=${value}` +
+    (expirationDate ? `;expires=${expirationDate.toUTCString()}` : '') +
+    (domain ? `;domain=${domain}` : '') +
+    ';SameSite=Lax';
+}
+
+export class Cookie {
+  private static prefix: string = 'coveo_';
+  private static coveoAnalyticsCookie = new CoveoAnalyticsCookie();
+
+  static set(name: string, value: string, expire?: number) {
+    this.coveoAnalyticsCookie.set(this.getRealCookieName(name), value, expire);
+  }
+
+  static get(name: string) {
+    return this.coveoAnalyticsCookie.get(this.getRealCookieName(name));
+  }
+
   static erase(name: string) {
-    Cookie.set(name, '', -1);
+    return this.coveoAnalyticsCookie.erase(this.getRealCookieName(name));
+  }
+
+  private static getRealCookieName(name: string) {
+    return `${this.prefix}${name}`;
   }
 }

--- a/src/utils/CookieUtils.ts
+++ b/src/utils/CookieUtils.ts
@@ -1,21 +1,23 @@
-// Code originally modified from : https://developers.livechatinc.com/blog/setting-cookies-to-subdomains-in-javascript/
-// Should always match: https://github.com/coveo/coveo.analytics.js/blob/master/src/cookieutils.ts
-export class CoveoAnalyticsCookie {
-  private static getHostname() {
+export class CookieContext {
+  public static getHostname() {
     return location.hostname;
   }
+}
 
+// Code originally modified from : https://developers.livechatinc.com/blog/setting-cookies-to-subdomains-in-javascript/
+// Should always match: https://github.com/coveo/coveo.analytics.js/blob/master/src/cookieutils.ts
+class Cookie {
   static set(name: string, value: string, expire?: number) {
     var domain: string, expirationDate: Date | undefined, domainParts: string[];
     if (expire) {
       expirationDate = new Date();
       expirationDate.setTime(expirationDate.getTime() + expire);
     }
-    if (CoveoAnalyticsCookie.getHostname().indexOf('.') === -1) {
+    if (CookieContext.getHostname().indexOf('.') === -1) {
       // no "." in a domain - single domain name, it's localhost or something similar
       writeCookie(name, value, expirationDate);
     } else {
-      domainParts = CoveoAnalyticsCookie.getHostname().split('.');
+      domainParts = CookieContext.getHostname().split('.');
       // we always have at least 2 domain parts
       domain = domainParts[domainParts.length - 2] + '.' + domainParts[domainParts.length - 1];
       writeCookie(name, value, expirationDate, domain);
@@ -48,19 +50,19 @@ function writeCookie(name: string, value: string, expirationDate?: Date, domain?
     ';SameSite=Lax';
 }
 
-export class Cookie {
+export class ScopedCookie {
   private static prefix: string = 'coveo_';
 
   static set(name: string, value: string, expire?: number) {
-    CoveoAnalyticsCookie.set(this.getRealCookieName(name), value, expire);
+    Cookie.set(this.getRealCookieName(name), value, expire);
   }
 
   static get(name: string) {
-    return CoveoAnalyticsCookie.get(this.getRealCookieName(name));
+    return Cookie.get(this.getRealCookieName(name));
   }
 
   static erase(name: string) {
-    return CoveoAnalyticsCookie.erase(this.getRealCookieName(name));
+    return Cookie.erase(this.getRealCookieName(name));
   }
 
   private static getRealCookieName(name: string) {

--- a/src/utils/CookieUtils.ts
+++ b/src/utils/CookieUtils.ts
@@ -3,7 +3,7 @@ export class Cookie {
   private static prefix: string = 'coveo_';
 
   static set(name: string, value: string, expiration?: number) {
-    const host = location.hostname;
+    const host = this.getHostname();
     if (host.split('.').length === 1) {
       // no '.' in a domain - it's localhost or something similar
       document.cookie = this.buildCookie(name, value, expiration);
@@ -31,6 +31,10 @@ export class Cookie {
         document.cookie = this.buildCookie(name, value, expiration, domain);
       }
     }
+  }
+
+  private static getHostname() {
+    return location.hostname;
   }
 
   private static buildCookie(name: string, value: string, expiration?: number, domain?: string) {

--- a/src/utils/CookieUtils.ts
+++ b/src/utils/CookieUtils.ts
@@ -1,11 +1,11 @@
 // Code originally modified from : https://developers.livechatinc.com/blog/setting-cookies-to-subdomains-in-javascript/
 // Should always match: https://github.com/coveo/coveo.analytics.js/blob/master/src/cookieutils.ts
 export class CoveoAnalyticsCookie {
-  static getHostname() {
+  private static getHostname() {
     return location.hostname;
   }
 
-  set(name: string, value: string, expire?: number) {
+  static set(name: string, value: string, expire?: number) {
     var domain: string, expirationDate: Date | undefined, domainParts: string[];
     if (expire) {
       expirationDate = new Date();
@@ -22,7 +22,7 @@ export class CoveoAnalyticsCookie {
     }
   }
 
-  get(name: string) {
+  static get(name: string) {
     var cookiePrefix = name + '=';
     var cookieArray = document.cookie.split(';');
     for (var i = 0; i < cookieArray.length; i++) {
@@ -35,7 +35,7 @@ export class CoveoAnalyticsCookie {
     return null;
   }
 
-  erase(name: string) {
+  static erase(name: string) {
     this.set(name, '', -1);
   }
 }
@@ -50,18 +50,17 @@ function writeCookie(name: string, value: string, expirationDate?: Date, domain?
 
 export class Cookie {
   private static prefix: string = 'coveo_';
-  private static coveoAnalyticsCookie = new CoveoAnalyticsCookie();
 
   static set(name: string, value: string, expire?: number) {
-    this.coveoAnalyticsCookie.set(this.getRealCookieName(name), value, expire);
+    CoveoAnalyticsCookie.set(this.getRealCookieName(name), value, expire);
   }
 
   static get(name: string) {
-    return this.coveoAnalyticsCookie.get(this.getRealCookieName(name));
+    return CoveoAnalyticsCookie.get(this.getRealCookieName(name));
   }
 
   static erase(name: string) {
-    return this.coveoAnalyticsCookie.erase(this.getRealCookieName(name));
+    return CoveoAnalyticsCookie.erase(this.getRealCookieName(name));
   }
 
   private static getRealCookieName(name: string) {

--- a/unitTests/MockCookie.ts
+++ b/unitTests/MockCookie.ts
@@ -69,7 +69,7 @@ export class MockCookie {
 
   public get cookie() {
     return Object.keys(this.cookiesDict)
-      .map(key => `${key}=${this.cookiesDict[key]}`)
+      .map(key => `${key}=${this.cookiesDict[key].value}`)
       .join('; ');
   }
 

--- a/unitTests/MockCookie.ts
+++ b/unitTests/MockCookie.ts
@@ -1,5 +1,3 @@
-import { entries } from 'lodash';
-
 function mapToObject<T = any>(list: string[], predicate: (value: string) => [string, string]): T {
   const obj = {};
   list.forEach(listMember => {
@@ -70,8 +68,8 @@ export class MockCookie {
   }
 
   public get cookie() {
-    return entries(this.cookiesDict)
-      .map(([key, { value }]) => `${key}=${value}`)
+    return Object.keys(this.cookiesDict)
+      .map(key => `${key}=${this.cookiesDict[key]}`)
       .join('; ');
   }
 

--- a/unitTests/ui/AnalyticsInformationTest.ts
+++ b/unitTests/ui/AnalyticsInformationTest.ts
@@ -1,5 +1,5 @@
 import { AnalyticsInformation } from '../../src/ui/Analytics/AnalyticsInformation';
-import { Cookie } from '../../src/utils/CookieUtils';
+import { CoveoAnalyticsCookie } from '../../src/utils/CookieUtils';
 import { buildHistoryStore } from '../../src/utils/HistoryStore';
 import { MockCookie } from '../MockCookie';
 
@@ -117,12 +117,12 @@ export function AnalyticsInformationTest() {
     describe('when setting the clientId', () => {
       const testClientId = 'hello';
       beforeEach(() => {
-        spyOn(Cookie, 'set');
+        spyOn(CoveoAnalyticsCookie.prototype, 'set');
         new AnalyticsInformation().clientId = testClientId;
       });
 
       it('sets the cookie using the same utility as coveo.analytics', () => {
-        expect(Cookie.set).toHaveBeenCalledWith('visitorId', testClientId);
+        expect(CoveoAnalyticsCookie.prototype.set).toHaveBeenCalledWith('coveo_visitorId', testClientId, 31556926000);
       });
 
       it('sets the cookie in the local storage', () => {

--- a/unitTests/ui/AnalyticsInformationTest.ts
+++ b/unitTests/ui/AnalyticsInformationTest.ts
@@ -117,12 +117,12 @@ export function AnalyticsInformationTest() {
     describe('when setting the clientId', () => {
       const testClientId = 'hello';
       beforeEach(() => {
-        spyOn(CoveoAnalyticsCookie.prototype, 'set');
+        spyOn(CoveoAnalyticsCookie, 'set');
         new AnalyticsInformation().clientId = testClientId;
       });
 
       it('sets the cookie using the same utility as coveo.analytics', () => {
-        expect(CoveoAnalyticsCookie.prototype.set).toHaveBeenCalledWith('coveo_visitorId', testClientId, 31556926000);
+        expect(CoveoAnalyticsCookie.set).toHaveBeenCalledWith('coveo_visitorId', testClientId, 31556926000);
       });
 
       it('sets the cookie in the local storage', () => {

--- a/unitTests/ui/AnalyticsInformationTest.ts
+++ b/unitTests/ui/AnalyticsInformationTest.ts
@@ -1,5 +1,5 @@
 import { AnalyticsInformation } from '../../src/ui/Analytics/AnalyticsInformation';
-import { CoveoAnalyticsCookie } from '../../src/utils/CookieUtils';
+import { ScopedCookie } from '../../src/utils/CookieUtils';
 import { buildHistoryStore } from '../../src/utils/HistoryStore';
 import { MockCookie } from '../MockCookie';
 
@@ -117,12 +117,12 @@ export function AnalyticsInformationTest() {
     describe('when setting the clientId', () => {
       const testClientId = 'hello';
       beforeEach(() => {
-        spyOn(CoveoAnalyticsCookie, 'set');
+        spyOn(ScopedCookie, 'set');
         new AnalyticsInformation().clientId = testClientId;
       });
 
       it('sets the cookie using the same utility as coveo.analytics', () => {
-        expect(CoveoAnalyticsCookie.set).toHaveBeenCalledWith('coveo_visitorId', testClientId, 31556926000);
+        expect(ScopedCookie.set).toHaveBeenCalledWith('visitorId', testClientId, 31556926000);
       });
 
       it('sets the cookie in the local storage', () => {

--- a/unitTests/ui/AnalyticsTest.ts
+++ b/unitTests/ui/AnalyticsTest.ts
@@ -407,9 +407,16 @@ export function AnalyticsTest() {
     });
 
     describe('initializes the visitorId correctly', () => {
+      const mockDate = new Date(1680204658699);
       beforeEach(() => {
         MockCookie.clear();
         localStorage.clear();
+        jasmine.clock().install();
+        jasmine.clock().mockDate(mockDate);
+      });
+
+      afterEach(() => {
+        jasmine.clock().uninstall();
       });
 
       describe("when there's no cookie nor local storage", () => {
@@ -429,6 +436,12 @@ export function AnalyticsTest() {
         it('creates a cookie supported by coveo.analytics', () => {
           const cookie = MockCookie.get('coveo_visitorId');
           expect(cookie && cookie.value).toEqual(getLastGeneratedGuid());
+        });
+
+        it('sets the cookie expiration to 1 year', () => {
+          const cookie = MockCookie.get('coveo_visitorId');
+          const expirationDate = new Date(mockDate.getTime() + 31556926000);
+          expect(cookie && cookie.properties.expires).toEqual(expirationDate.toUTCString());
         });
 
         it('creates a localStorage value supported by coveo.analytics', () => {

--- a/unitTests/utils/CookieUtilsTest.ts
+++ b/unitTests/utils/CookieUtilsTest.ts
@@ -1,4 +1,5 @@
 import { Cookie } from '../../src/utils/CookieUtils';
+import { MockCookie, MockSingleCookie } from '../MockCookie';
 import { Simulate } from '../Simulate';
 
 export function CookieUtilsTest() {
@@ -26,6 +27,51 @@ export function CookieUtilsTest() {
         Cookie.erase('patate');
         expect(document.cookie.replace(' ', '').indexOf('coveo_patate=frite')).toBe(-1);
       }
+    });
+
+    describe('includes the correct domain', () => {
+      const scopedCookieName = 'test';
+      const cookieName = `coveo_${scopedCookieName}`;
+      const cookieValue = 'testvalue';
+      function testCookie(options: { simulatedHostname: string }) {
+        spyOn(Cookie as any, 'getHostname').and.returnValue(options.simulatedHostname);
+        Cookie.set(scopedCookieName, cookieValue);
+      }
+
+      function buildMockSingleCookie(domain: string | null): MockSingleCookie {
+        return { value: cookieValue, properties: { SameSite: 'Lax', path: '/', ...(domain !== null ? { domain } : {}) } };
+      }
+
+      beforeEach(() => {
+        MockCookie.clear();
+      });
+
+      it('when the hostname is a website with a subdomain, exclude the subdomain', () => {
+        testCookie({ simulatedHostname: 'hello.example.com' });
+        expect(MockCookie.get(cookieName)).toEqual(buildMockSingleCookie('.example.com'));
+      });
+
+      it('when the hostname is a website without a subdomain, allow subdomains', () => {
+        pending("Doesn't pass, even in coveo.analytics. Not important enough to fix.");
+        testCookie({ simulatedHostname: 'example.com' });
+        expect(MockCookie.get(cookieName)).toEqual(buildMockSingleCookie('.example.com'));
+      });
+
+      it('when the hostname is an IPv4 address, do not include a domain', () => {
+        pending("Doesn't pass, even in coveo.analytics. Not important enough to fix.");
+        testCookie({ simulatedHostname: '192.168.0.1' });
+        expect(MockCookie.get(cookieName)).toEqual(buildMockSingleCookie(null));
+      });
+
+      it('when the hostname is an IPv6 address, do not include a domain', () => {
+        testCookie({ simulatedHostname: '[::1]' });
+        expect(MockCookie.get(cookieName)).toEqual(buildMockSingleCookie(null));
+      });
+
+      it('when the hostname is localhost, do not include a domain', () => {
+        testCookie({ simulatedHostname: 'localhost' });
+        expect(MockCookie.get(cookieName)).toEqual(buildMockSingleCookie(null));
+      });
     });
   });
 }

--- a/unitTests/utils/CookieUtilsTest.ts
+++ b/unitTests/utils/CookieUtilsTest.ts
@@ -1,21 +1,21 @@
-import { Cookie, CoveoAnalyticsCookie } from '../../src/utils/CookieUtils';
+import { ScopedCookie, CookieContext } from '../../src/utils/CookieUtils';
 import { MockCookie, MockSingleCookie } from '../MockCookie';
 import { Simulate } from '../Simulate';
 
 export function CookieUtilsTest() {
   describe('CookieUtils', function () {
     it('sets a cookie accordingly', () => {
-      Cookie.set('foo', 'bar');
+      ScopedCookie.set('foo', 'bar');
       expect(document.cookie.indexOf('foo=bar')).not.toBe(-1);
     });
 
     it('gets the right cookie when cookie exists', () => {
-      Cookie.set('dude', 'dudevalue');
-      expect(Cookie.get('dude')).toBe('dudevalue');
+      ScopedCookie.set('dude', 'dudevalue');
+      expect(ScopedCookie.get('dude')).toBe('dudevalue');
     });
 
     it("returns null if cookie doesn't exist", () => {
-      expect(Cookie.get('foobar2000')).toBe(null);
+      expect(ScopedCookie.get('foobar2000')).toBe(null);
     });
 
     it('erases cookie accordingly', () => {
@@ -24,7 +24,7 @@ export function CookieUtilsTest() {
         expect(true).toBe(true);
       } else {
         document.cookie = 'coveo_patate=frite';
-        Cookie.erase('patate');
+        ScopedCookie.erase('patate');
         expect(document.cookie.replace(' ', '').indexOf('coveo_patate=frite')).toBe(-1);
       }
     });
@@ -34,8 +34,8 @@ export function CookieUtilsTest() {
       const cookieName = `coveo_${scopedCookieName}`;
       const cookieValue = 'testvalue';
       function testCookie(options: { simulatedHostname: string }) {
-        spyOn(CoveoAnalyticsCookie, 'getHostname').and.returnValue(options.simulatedHostname);
-        Cookie.set(scopedCookieName, cookieValue);
+        spyOn(CookieContext, 'getHostname').and.returnValue(options.simulatedHostname);
+        ScopedCookie.set(scopedCookieName, cookieValue);
       }
 
       function buildMockSingleCookie(domain: string | null): MockSingleCookie {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3478

I made JSUI do the same thing as coveo.analytics: store its clientId in a `coveo_visitorId` cookie (with the domain set to the top level domain) and store a copy of it in the local storage.

I also added two sample pages to make it easier to test analytics.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)