### PR TITLE
Update codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: 'CodeQL'
 
 on:
   push:
-    branches: [master]
+    branches: ["master", "*-*-release"]
   pull_request:
     branches: [master]
   schedule:


### PR DESCRIPTION
GHAS Certifier searches for scans on a deployment package's commit.

Since this repo releases on release branches and not master, add the codeql scan workflow to branches using the \*-\*-release pattern.

J:DEF-1433





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)