### PR TITLE
fix: use singular only for 1 & -1

### DIFF
--- a/src/misc/L10N.ts
+++ b/src/misc/L10N.ts
@@ -38,7 +38,7 @@ export var L10N = {
     return value;
   },
   formatPlSn: (value: string, count: number | boolean) => {
-    let isPlural = _.isBoolean(count) ? count : count > 1;
+    let isPlural = _.isBoolean(count) ? count : count !== 1 && count !== -1;
     if (isPlural) {
       value = value.replace(pluralRegex, '$1').replace(singularRegex, '');
     } else {

--- a/unitTests/misc/L10NTest.ts
+++ b/unitTests/misc/L10NTest.ts
@@ -46,18 +46,20 @@ export function L10NTest() {
       expect(L10N.format('TwoNumbers', '37', '42')).toBe('37 and 42');
     });
 
-    it('should automatically pluralize values higher than one', () => {
+    it('should automatically pluralize values other than 1 and -1', () => {
       String.locale = 'fr';
-      expect(L10N.format('baby', 0, 0)).toBe('0 bébé');
-      expect(L10N.format('baby', 0.42, 0.42)).toBe('0.42 bébé');
+      expect(L10N.format('baby', 0, 0)).toBe('0 bébés');
+      expect(L10N.format('baby', 0.42, 0.42)).toBe('0.42 bébés');
       expect(L10N.format('baby', 1, 1)).toBe('1 bébé');
+      expect(L10N.format('baby', -1, -1)).toBe('-1 bébé');
       expect(L10N.format('baby', 1.37, 1.37)).toBe('1.37 bébés');
       expect(L10N.format('baby', 42, 42)).toBe('42 bébés');
 
       String.locale = 'en';
-      expect(L10N.format('baby', 0, 0)).toBe('0 baby');
-      expect(L10N.format('baby', 0.42, 0.42)).toBe('0.42 baby');
+      expect(L10N.format('baby', 0, 0)).toBe('0 babies');
+      expect(L10N.format('baby', 0.42, 0.42)).toBe('0.42 babies');
       expect(L10N.format('baby', 1, 1)).toBe('1 baby');
+      expect(L10N.format('baby', -1, -1)).toBe('-1 baby');
       expect(L10N.format('baby', 1.37, 1.37)).toBe('1.37 babies');
       expect(L10N.format('baby', 42, 42)).toBe('42 babies');
     });

--- a/unitTests/ui/CategoryFacet/CategoryValueTest.ts
+++ b/unitTests/ui/CategoryFacet/CategoryValueTest.ts
@@ -151,9 +151,9 @@ export function CategoryValueTest() {
             labelElement = categoryValue.element.find('.coveo-category-facet-value-label');
           });
 
-          it('uses the singular form of resultCount', () => {
+          it('uses the plural form of resultCount', () => {
             const labelAttribute = labelElement.attributes['aria-label'];
-            expect(labelAttribute.value).toMatch(/result$/);
+            expect(labelAttribute.value).toMatch(/results$/);
           });
         });
       });


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3492

0: https://www.bbc.co.uk/worldservice/learningenglish/grammar/learnit/learnitv354.shtml#:~:text=zero%20%3D%20not%20any,same%20as%2032%20degrees%20fahrenheit.

Fractions between 0 and 1 seem to be pluralized too.

In the end, only 1 & -1 seem to be singular


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)