### PR TITLE
fix: enable ordering on specific initial sort

### DIFF
--- a/src/ui/Facet/FacetSettings.ts
+++ b/src/ui/Facet/FacetSettings.ts
@@ -454,7 +454,7 @@ export class FacetSettings extends FacetSort {
 
   private buildAscendingOrDescending(direction: string) {
     const elem = this.buildItem(l(direction));
-    elem.setAttribute('aria-disabled', 'true');
+    elem.setAttribute('aria-disabled', this.activeSort.directionToggle ? 'false' : 'true');
     elem.setAttribute('data-direction', direction.toLowerCase());
     return elem;
   }

--- a/unitTests/ui/FacetSettingsTest.ts
+++ b/unitTests/ui/FacetSettingsTest.ts
@@ -200,12 +200,13 @@ export function FacetSettingsTest() {
     });
 
     it('should show direction section if the initial sort criteria requires changing direction', () => {
+      sorts = ['alphaascending', 'alphadescending'];
       initFacetSettings();
       facetSettings.activeSort = FacetSort.availableSorts.alphaascending;
       facetSettings.open();
 
-      expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-ascending')).not.toBeNull();
-      expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-descending')).not.toBeNull();
+      const ascendingSection = $$(facetSettings.settingsPopup).find('.coveo-facet-settings-item[data-direction="ascending"]');
+      expect($$(ascendingSection).getAttribute('aria-disabled')).toBe('false');
     });
 
     it("should not show direction section if there's a single ascending or descending parameter", () => {

--- a/unitTests/ui/FacetSettingsTest.ts
+++ b/unitTests/ui/FacetSettingsTest.ts
@@ -7,6 +7,7 @@ import { registerCustomMatcher } from '../CustomMatchers';
 import * as Mock from '../MockEnvironment';
 import { Simulate } from '../Simulate';
 import { FacetHeader } from '../../src/ui/Facet/FacetHeader';
+import { FacetSort } from '../../src/ui/Facet/FacetSort';
 
 export function FacetSettingsTest() {
   describe('FacetSettings', () => {
@@ -192,6 +193,15 @@ export function FacetSettingsTest() {
     it("should show direction section if there's two linked parameters that require changing direction", () => {
       sorts = ['alphaascending', 'alphadescending'];
       initFacetSettings();
+      facetSettings.open();
+
+      expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-ascending')).not.toBeNull();
+      expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-descending')).not.toBeNull();
+    });
+
+    it('should show direction section if the initial sort criteria requires changing direction', () => {
+      initFacetSettings();
+      facetSettings.activeSort = FacetSort.availableSorts.alphaascending;
       facetSettings.open();
 
       expect($$(facetSettings.settingsPopup).find('.coveo-facet-settings-section-direction-ascending')).not.toBeNull();


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3494

When the initial sort criteria allows ordering (ascending, descending), enable direction toggle



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)