### PR TITLE
fix: standard facet should behave the same as hierarhical facet for auto selection flag

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -512,11 +512,13 @@ export class DynamicFacet extends Component implements IDynamicFacet {
    */
   public reset() {
     this.ensureDom();
-    if (this.values.hasActiveValues) {
-      this.logger.info('Deselect all values');
-      this.values.clearAll();
-      this.values.render();
+    if (!this.values.hasActiveValues) {
+      return;
     }
+
+    this.logger.info('Deselect all values');
+    this.values.clearAll();
+    this.values.render();
     this.enablePreventAutoSelectionFlag();
     this.updateAppearance();
     this.updateQueryStateModel();

--- a/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
@@ -275,12 +275,30 @@ export function DynamicFacetTest() {
     });
 
     it(`when calling reset
-      when there are no active values
-      should not clear and rerender values`, () => {
+    when there is any active value
+    should set the flag for preventAutoSelect`, () => {
+      mockFacetValues[0].state = FacetValueState.selected;
+      initializeComponent();
+
+      test.cmp.reset();
+
+      expect(test.cmp.dynamicFacetQueryController.buildFacetRequest().preventAutoSelect).toBe(true);
+    });
+
+    it(`when calling reset
+    when there are no active values
+    should not clear and rerender values`, () => {
       test.cmp.reset();
 
       expect(test.cmp.values.clearAll).not.toHaveBeenCalled();
       expect(test.cmp.values.render).toHaveBeenCalledTimes(1);
+    });
+
+    it(`when calling reset
+    when there are no active values
+    should not set the flag for preventAutoSelect`, () => {
+      test.cmp.reset();
+      expect(test.cmp.dynamicFacetQueryController.buildFacetRequest().preventAutoSelect).toBe(false);
     });
 
     it('showMoreValues adds by the numberOfValues option by default', () => {


### PR DESCRIPTION
This is essentially just a small tweak so that DynamicFacet reset() method behave the same way as DynamicHierarchicalFacet() as far as `preventAutoSelect` flag is concerned.

The ticket has a link to the discuss where this originates from (it's a long discussion)

https://coveord.atlassian.net/browse/JSUI-3499





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)