### PR TITLE
fix: use last query uuid for custom events

### DIFF
--- a/src/rest/CustomEvent.ts
+++ b/src/rest/CustomEvent.ts
@@ -20,4 +20,11 @@ export interface ICustomEvent extends IAnalyticsEvent {
    * **Example:** `pagerNext`
    */
   eventValue: string;
+
+  /**
+   * The searchQueryUid of the last search event that occurred before this event.
+   *
+   * **Example:** `74682726-0e20-46eb-85ac-f37259346f57`
+   */
+  lastSearchQueryUid: string;
 }

--- a/src/ui/Analytics/LiveAnalyticsClient.ts
+++ b/src/ui/Analytics/LiveAnalyticsClient.ts
@@ -340,7 +340,7 @@ export class LiveAnalyticsClient implements IAnalyticsClient {
     element: HTMLElement
   ): ICustomEvent {
     return this.merge<ICustomEvent>(this.buildAnalyticsEvent(actionCause, metaObject), {
-      searchQueryUid: this.getLastSearchQueryUid(),
+      lastSearchQueryUid: this.getLastSearchQueryUid(),
       eventType: actionCause.type,
       eventValue: actionCause.name,
       originLevel2: this.getOriginLevel2(element),

--- a/unitTests/ui/LiveAnalyticsClientTest.ts
+++ b/unitTests/ui/LiveAnalyticsClientTest.ts
@@ -486,14 +486,14 @@ export function LiveAnalyticsClientTest() {
         expect(analyticsEventReadySpy).toHaveBeenCalled();
       });
 
-      it('should include searchQueryUid', function (done) {
+      it('should include lastSearchQueryUid', function (done) {
         Simulate.query(env, { promise });
         env.queryController.getLastResults = () => results;
         _.defer(function () {
           client.logCustomEvent<IAnalyticsNoMeta>(analyticsActionCauseList.documentOpen, {}, document.createElement('div'));
           expect(endpoint.sendCustomEvent).toHaveBeenCalledWith(
             jasmine.objectContaining({
-              searchQueryUid: results.searchUid
+              lastSearchQueryUid: results.searchUid
             })
           );
           done();


### PR DESCRIPTION
[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

[KIT-2738](https://coveord.atlassian.net/browse/KIT-2738)

There was a mislabelled field for outgoing custom events. It was also suggested that search events may have been sent _**after**_ the custom event (which causes problems since the custom event depends on the last search query UUID), but after doing some digging, I don't see how this could happen unless the implementer themselves were doing thing incorrectly. So for now, I'm just doing the quickest fix to ensure the custom events are properly linked to their respective search events.

TLDR; Custom events were using incorrect field to link to the last query. Should be good to go now.

[KIT-2738]: https://coveord.atlassian.net/browse/KIT-2738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ