### PR TITLE
fix: do not add aria-expanded=true to facet search

### DIFF
--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -318,7 +318,6 @@ export class FacetSearchElement {
     this.combobox.setAttribute('role', 'combobox');
     this.combobox.setAttribute('aria-owns', this.facetSearchId);
     this.input.setAttribute('aria-controls', this.facetSearchId);
-    this.input.setAttribute('aria-expanded', 'true');
     this.facetSearch.setExpandedFacetSearchAccessibilityAttributes(this.searchResults);
   }
 
@@ -331,7 +330,6 @@ export class FacetSearchElement {
     this.combobox.removeAttribute('aria-owns');
     this.input.removeAttribute('aria-controls');
     this.input.removeAttribute('aria-activedescendant');
-    this.input.setAttribute('aria-expanded', 'false');
     this.facetSearch.setCollapsedFacetSearchAccessibilityAttributes();
   }
 }

--- a/unitTests/ui/FacetSearchTest.ts
+++ b/unitTests/ui/FacetSearchTest.ts
@@ -108,10 +108,6 @@ export function FacetSearchTest() {
         it('should give the input the aria-controls attribute', () => {
           expect(facetSearch.facetSearchElement.input.getAttribute('aria-controls')).toEqual(facetSearchId);
         });
-
-        it("should set aria-expanded to true on the input's element", () => {
-          expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual('true');
-        });
       });
 
       describe('when triggering a query', () => {
@@ -161,10 +157,6 @@ export function FacetSearchTest() {
           it("should remove the input's aria-controls attribute", () => {
             expect(facetSearch.facetSearchElement.input.getAttribute('aria-controls')).toBeNull();
           });
-
-          it("should set aria-expanded to false on the input's element", () => {
-            expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual('false');
-          });
         });
       });
 
@@ -179,10 +171,6 @@ export function FacetSearchTest() {
           facetSearch.triggerNewFacetSearch(params);
           await pr;
           done();
-        });
-
-        it("should set aria-expanded to true on the input's element", () => {
-          expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual('true');
         });
 
         it('should contain only a "no values found" element', () => {


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3502

Testing:
- Install [axe-devtools](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd)
- From master:
  - `npm i ; npm run build ; npm run dev`
  - Open http://localhost:8080/index.html
  - Focus the facet search by clicking on it: 
![image](https://github.com/coveo/search-ui/assets/12366410/f25ec028-ff2e-4032-ba41-2d61d9f9ed0d)
  - Run axecore-devtools, see the error about `aria-expanded`
- Checkout fix/JSUI-3502.
- Replace `pages/index.html` by this page:
https://gist.github.com/louis-bompart/94160a8bac286c4fd431b6b6cec4bdfd
- Focus the facet search again
- Rerun axecore-devtools, assert that the error is not there anymore.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)