### PR TITLE
fix: revert "fix: do not add aria-expanded=true to facet search (#1954)"

### DIFF
--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -318,6 +318,7 @@ export class FacetSearchElement {
     this.combobox.setAttribute('role', 'combobox');
     this.combobox.setAttribute('aria-owns', this.facetSearchId);
     this.input.setAttribute('aria-controls', this.facetSearchId);
+    this.input.setAttribute('aria-expanded', 'true');
     this.facetSearch.setExpandedFacetSearchAccessibilityAttributes(this.searchResults);
   }
 
@@ -330,6 +331,7 @@ export class FacetSearchElement {
     this.combobox.removeAttribute('aria-owns');
     this.input.removeAttribute('aria-controls');
     this.input.removeAttribute('aria-activedescendant');
+    this.input.setAttribute('aria-expanded', 'false');
     this.facetSearch.setCollapsedFacetSearchAccessibilityAttributes();
   }
 }

--- a/unitTests/ui/FacetSearchTest.ts
+++ b/unitTests/ui/FacetSearchTest.ts
@@ -108,6 +108,10 @@ export function FacetSearchTest() {
         it('should give the input the aria-controls attribute', () => {
           expect(facetSearch.facetSearchElement.input.getAttribute('aria-controls')).toEqual(facetSearchId);
         });
+
+        it("should set aria-expanded to true on the input's element", () => {
+          expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual('true');
+        });
       });
 
       describe('when triggering a query', () => {
@@ -157,6 +161,10 @@ export function FacetSearchTest() {
           it("should remove the input's aria-controls attribute", () => {
             expect(facetSearch.facetSearchElement.input.getAttribute('aria-controls')).toBeNull();
           });
+
+          it("should set aria-expanded to false on the input's element", () => {
+            expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual('false');
+          });
         });
       });
 
@@ -171,6 +179,10 @@ export function FacetSearchTest() {
           facetSearch.triggerNewFacetSearch(params);
           await pr;
           done();
+        });
+
+        it("should set aria-expanded to true on the input's element", () => {
+          expect(facetSearch.facetSearchElement.input.getAttribute('aria-expanded')).toEqual('true');
         });
 
         it('should contain only a "no values found" element', () => {


### PR DESCRIPTION
This reverts commit 6bd7f6cebe83e0d59658a54fd8c34fd25716837c.

It didn't fix the issue reported that we are yet to reproduce, so let's not do it.



[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)