### PR TITLE
change facet search input blur logic for keyboard navigation

### DIFF
--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -87,10 +87,10 @@ export class FacetSearchElement {
 
   private onInputBlur(e: FocusEvent) {
     const target = e.relatedTarget as HTMLElement;
-    const isUsingKeyboard = !!target;
     const focusedOnSearchResult = this.searchResults.contains(target);
+    const focusedOnFacet = this.search.parentElement.contains(target);
 
-    if (isUsingKeyboard && !focusedOnSearchResult) {
+    if (focusedOnFacet && !focusedOnSearchResult) {
       this.facetSearch.dismissSearchResults();
     }
   }


### PR DESCRIPTION
The issue reported was due to the fact that there's a global script on the client website that makes the main body of the page the "next target" (`event.relatedTarget`) on facet search input blur. It's a catch all script for all input, not necessarily Coveo related.

The facet search code was assuming that `if relatedTarget is set -> it's keyboard navigation`, which is not always true, as explained above.

Instead, change the logic to verify if the related target is the facet itself and not the results (ie: when the end user shift-tab back to facet values), we should dismiss the results.

That way, even if relatedTarget is set to some random element on the page when "Select all in facet search" gets clicked, like this specific client website, the logic to dismiss or not search results should still be correct.

https://coveord.atlassian.net/browse/JSUI-3505





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)