### PR TITLE
Set webpack public path in eager mode for Relevance inspector

### DIFF
--- a/src/Eager.ts
+++ b/src/Eager.ts
@@ -1,5 +1,8 @@
 export * from './Core';
 
+import { PublicPathUtils } from './utils/PublicPathUtils';
+PublicPathUtils.detectPublicPath();
+
 export { CoreHelpers } from './ui/Templates/CoreHelpers';
 export { SearchInterface, StandaloneSearchInterface } from './ui/SearchInterface/SearchInterface';
 export { jQueryInstance as $ } from './ui/Base/CoveoJQuery';


### PR DESCRIPTION
https://coveord.atlassian.net/browse/JSUI-3508

Even though in Eager mode the "load file on demand" feature is seldom used, it can still be useful for one specific component, (Relevance inspector).

As such, we can just copy the exact same logic we have for `Lazy.ts`, where we detect the public path early in the bootstrapping process.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)