### PR TITLE
fix(slider): should round value when dateField=true

### DIFF
--- a/src/ui/Misc/Slider.ts
+++ b/src/ui/Misc/Slider.ts
@@ -343,6 +343,9 @@ export class SliderButton {
 
   public getValue() {
     const value = this.getPercent() * (this.slider.options.end - this.slider.options.start) + this.slider.options.start;
+    if (this.slider.options.dateField) {
+      return Math.round(value);
+    }
     return value;
   }
 

--- a/unitTests/ui/SliderTest.ts
+++ b/unitTests/ui/SliderTest.ts
@@ -77,6 +77,37 @@ export function SliderTest() {
         expect(slider.getValues()).toEqual([25, 75]);
       });
 
+      it('should return round values when using dateField', () => {
+        slider = new Slider(
+          el,
+          {
+            start: 0,
+            end: 100,
+            rangeSlider: true,
+            dateField: true
+          },
+          root
+        );
+        slider.element.style.width = '100px';
+        slider['sliderRange']['firstButton'].getPercent = () => 1 / 3;
+        expect(slider.getValues()[0]).toEqual(33);
+      });
+
+      it('should not round values when using dateField', () => {
+        slider = new Slider(
+          el,
+          {
+            start: 0,
+            end: 100,
+            rangeSlider: true
+          },
+          root
+        );
+        slider.element.style.width = '100px';
+        slider['sliderRange']['firstButton'].getPercent = () => 1 / 3;
+        expect(slider.getValues()[0]).toBeCloseTo(33.33, 2);
+      });
+
       it('should give position when initializing state with no value', () => {
         expect(() => slider.initializeState()).not.toThrow();
         expect(() => slider.getPosition()).not.toThrow();


### PR DESCRIPTION
When using DATE field, we do not support sub-second precision https://connect.coveo.com/s/article/14754
So let's round it up when dateField=true.

https://coveord.atlassian.net/browse/JSUI-3510





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)