### PR TITLE
Add defensive code for PublicPathUtils when no script tag in document

### DIFF
--- a/src/utils/PublicPathUtils.ts
+++ b/src/utils/PublicPathUtils.ts
@@ -38,6 +38,9 @@ export class PublicPathUtils {
       return this.parseScriptDirectoryPath(coveoScript);
     } else {
       const scripts = document.getElementsByTagName('script');
+      if (scripts.length === 0) {
+        return '/';
+      }
       return this.parseScriptDirectoryPath(scripts[scripts.length - 1]);
     }
   }
@@ -63,7 +66,7 @@ export class PublicPathUtils {
     return find(document.querySelectorAll('.coveo-script'), el => this.isScript(el));
   }
 
-  private static parseScriptDirectoryPath(script: HTMLScriptElement) {
+  private static parseScriptDirectoryPath(script?: HTMLScriptElement) {
     return script.src.replace(/\/[\w\.-]*\.js((#|\?)(.*)){0,1}$/, '/');
   }
 

--- a/src/utils/PublicPathUtils.ts
+++ b/src/utils/PublicPathUtils.ts
@@ -66,7 +66,7 @@ export class PublicPathUtils {
     return find(document.querySelectorAll('.coveo-script'), el => this.isScript(el));
   }
 
-  private static parseScriptDirectoryPath(script?: HTMLScriptElement) {
+  private static parseScriptDirectoryPath(script: HTMLScriptElement) {
     return script.src.replace(/\/[\w\.-]*\.js((#|\?)(.*)){0,1}$/, '/');
   }
 


### PR DESCRIPTION
Reported by @mikegron in a test suite for SPS service.

https://coveord.atlassian.net/browse/JSUI-3508

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)