### PR TITLE
fix issue for classic facet search popup

### DIFF
--- a/src/ui/Facet/FacetSearchElement.ts
+++ b/src/ui/Facet/FacetSearchElement.ts
@@ -49,7 +49,7 @@ export class FacetSearchElement {
     this.clear.style.display = 'none';
     this.search.appendChild(this.clear);
 
-    this.combobox = this.buildCombobox();
+    this.combobox = this.buildSearchInputWrapper();
     this.search.appendChild(this.combobox);
 
     this.input = this.buildInputElement();
@@ -116,11 +116,9 @@ export class FacetSearchElement {
     this.searchDropdownNavigator = SearchDropdownNavigatorFactory(this.facetSearch, config);
   }
 
-  private buildCombobox() {
+  private buildSearchInputWrapper() {
     return $$('div', {
-      className: 'coveo-facet-search-middle',
-      ariaHaspopup: 'listbox',
-      ariaExpanded: 'true'
+      className: 'coveo-facet-search-middle'
     }).el;
   }
 
@@ -315,8 +313,8 @@ export class FacetSearchElement {
       return;
     }
 
-    this.combobox.setAttribute('role', 'combobox');
-    this.combobox.setAttribute('aria-owns', this.facetSearchId);
+    this.input.setAttribute('role', 'combobox');
+    this.input.setAttribute('aria-owns', this.facetSearchId);
     this.input.setAttribute('aria-controls', this.facetSearchId);
     this.input.setAttribute('aria-expanded', 'true');
     this.facetSearch.setExpandedFacetSearchAccessibilityAttributes(this.searchResults);
@@ -327,8 +325,8 @@ export class FacetSearchElement {
       return;
     }
 
-    this.combobox.removeAttribute('role');
-    this.combobox.removeAttribute('aria-owns');
+    this.input.removeAttribute('role');
+    this.input.removeAttribute('aria-owns');
     this.input.removeAttribute('aria-controls');
     this.input.removeAttribute('aria-activedescendant');
     this.input.setAttribute('aria-expanded', 'false');

--- a/src/ui/Facet/FacetSearchValuesList.ts
+++ b/src/ui/Facet/FacetSearchValuesList.ts
@@ -21,8 +21,6 @@ export class FacetSearchValuesList {
     });
     return _.map(valuesToBuildWith, facetValue => {
       const valueElement = new this.facetValueElementKlass(this.facet, facetValue, this.facet.keepDisplayedValuesNextTime).build();
-      valueElement.renderer.excludeIcon.setAttribute('aria-hidden', 'true');
-      valueElement.renderer.label.setAttribute('aria-hidden', 'true');
       return valueElement.renderer.listItem;
     });
   }

--- a/src/ui/Facet/ValueElementRenderer.ts
+++ b/src/ui/Facet/ValueElementRenderer.ts
@@ -184,7 +184,7 @@ export class ValueElementRenderer {
   }
 
   private initAndAppendLabel() {
-    this.label = $$('label', { className: 'coveo-facet-value-label', role: 'group' }).el;
+    this.label = $$('label', { className: 'coveo-facet-value-label' }).el;
     this.tryToInitAndAppendComputedField();
     this.initAndAppendFacetValueLabelWrapper();
     this.listItem.appendChild(this.label);

--- a/unitTests/ui/FacetSearchTest.ts
+++ b/unitTests/ui/FacetSearchTest.ts
@@ -97,12 +97,12 @@ export function FacetSearchTest() {
           expect(setExpandedFacetSearchAccessibilityAttributes).toHaveBeenCalledWith(facetSearch.facetSearchElement['searchResults']);
         });
 
-        it('should give the "combobox" role to the combobox', () => {
-          expect(facetSearch.facetSearchElement.combobox.getAttribute('role')).toEqual('combobox');
+        it('should give the "combobox" role to the input', () => {
+          expect(facetSearch.facetSearchElement.input.getAttribute('role')).toEqual('combobox');
         });
 
-        it('should give the combobox the aria-owns attribute', () => {
-          expect(facetSearch.facetSearchElement.combobox.getAttribute('aria-owns')).toEqual(facetSearchId);
+        it('should give the input the aria-owns attribute', () => {
+          expect(facetSearch.facetSearchElement.input.getAttribute('aria-owns')).toEqual(facetSearchId);
         });
 
         it('should give the input the aria-controls attribute', () => {

--- a/unitTests/ui/ValueElementRendererTest.ts
+++ b/unitTests/ui/ValueElementRendererTest.ts
@@ -29,11 +29,6 @@ export function ValueElementRendererTest() {
       expect(valueRenderer.build().listItem.getAttribute('data-value')).toBe('foo');
     });
 
-    it('should give the label the "group" role to avoid overriding child labels', () => {
-      valueRenderer = new ValueElementRenderer(facet, FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 1234)));
-      expect(valueRenderer.build().label.getAttribute('role')).toEqual('group');
-    });
-
     it('should add a hover class for the list element', () => {
       valueRenderer = new ValueElementRenderer(facet, FacetValue.createFromFieldValue(FakeResults.createFakeFieldValue('foo', 1234)));
       expect($$(valueRenderer.build().listItem).hasClass('coveo-with-hover')).toBe(true);


### PR DESCRIPTION
Mostly move the combobox to the input itself (as opposed to a div before 😕), and cleanup invalid aria attributes when compared to the spec

https://coveord.atlassian.net/browse/JSUI-3519





[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)