### PR TITLE
JSUI-3539 add GitHub certifier

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -71,6 +71,17 @@
       },
       {
         "system_certifier": "snyk-code"
+      },
+      {
+        "github": {
+          "name": "e2e-certifier",
+          "workflow_repository": "coveo/search-ui",
+          "workflow_file": "e2e-certifier.yml",
+          "extra_parameters": {
+            "JSUI_VERSION": "$[MAJOR_MINOR_VERSION].$[PATCH_VERSION]"
+          },
+          "required": false  
+        }
       }
     ]
   },

--- a/.github/workflows/e2e-certifier.yml
+++ b/.github/workflows/e2e-certifier.yml
@@ -13,6 +13,8 @@ on:
         description: The package name
       job:
         description: The name of the job (as defined in the deployment config)
+      JSUI_VERSION:
+        description: The version of JSUI to test
 
 jobs:
   test-job:
@@ -29,7 +31,17 @@ jobs:
         run: |
           npm install
           npx playwright install --with-deps
-      
+
+      - name: Validate JSUI version
+        working-directory: ${{ github.workspace }}/playwright
+        env:
+          JSUI_VERSION: ${{ inputs.JSUI_VERSION }}
+        run: |
+          echo "Expecting deployed JSUI version to be ${{ inputs.JSUI_VERSION }}"
+          npm run validate-jsui-version
+
       - name: Run tests
         working-directory: ${{ github.workspace }}/playwright
-        run: npx playwright test
+        env:
+          JSUI_VERSION: ${{ inputs.JSUI_VERSION }}
+        run: npm test

--- a/.github/workflows/e2e-certifier.yml
+++ b/.github/workflows/e2e-certifier.yml
@@ -17,7 +17,7 @@ on:
         description: The version of JSUI to test
 
 jobs:
-  test-job:
+  e2e-certifier:
     runs-on: ubuntu-24.04
     steps:
       - name: Deploy JSUI beta version on Netlify
@@ -38,6 +38,4 @@ jobs:
 
       - name: Run tests
         working-directory: ${{ github.workspace }}/playwright
-        env:
-          JSUI_VERSION: ${{ inputs.JSUI_VERSION }}
         run: npm test

--- a/.github/workflows/e2e-certifier.yml
+++ b/.github/workflows/e2e-certifier.yml
@@ -28,17 +28,13 @@ jobs:
 
       - name: Install test dependencies
         working-directory: ${{ github.workspace }}/playwright
-        run: |
-          npm install
-          npx playwright install --with-deps
+        run: npm install && npx playwright install --with-deps
 
       - name: Validate JSUI version
         working-directory: ${{ github.workspace }}/playwright
         env:
           JSUI_VERSION: ${{ inputs.JSUI_VERSION }}
-        run: |
-          echo "Expecting deployed JSUI version to be ${{ inputs.JSUI_VERSION }}"
-          npm run validate-jsui-version
+        run: npm run validate-jsui-version
 
       - name: Run tests
         working-directory: ${{ github.workspace }}/playwright

--- a/playwright/e2e/validateJsuiVersion.ts
+++ b/playwright/e2e/validateJsuiVersion.ts
@@ -1,0 +1,19 @@
+// This test is run in CI to validate that the JSUI version is the one expected.
+import {test, expect} from '@playwright/test';
+import {pageURL} from '../utils/utils';
+
+const expectedJsuiVersion = process.env.JSUI_VERSION;
+console.log(`Expected JSUI version: ${expectedJsuiVersion}`);
+
+if (expectedJsuiVersion) {
+    test('validate JSUI version', async ({page}) => {
+        test.setTimeout(180_000);
+        await page.goto(pageURL());
+        const coveoVersion = await page.evaluate(() => (window as any).Coveo.version);
+        // Example value: {lib: '2.10120.0', product: '2.10120.0', supportedApiVersion: 2}
+        expect(coveoVersion.lib).toBe(expectedJsuiVersion);
+        expect(coveoVersion.product).toBe(expectedJsuiVersion);
+    });
+} else {
+    console.log('No JSUI version to validate.');
+}

--- a/playwright/e2e/validateJsuiVersion.ts
+++ b/playwright/e2e/validateJsuiVersion.ts
@@ -3,17 +3,22 @@ import {test, expect} from '@playwright/test';
 import {pageURL} from '../utils/utils';
 
 const expectedJsuiVersion = process.env.JSUI_VERSION;
-console.log(`Expected JSUI version: ${expectedJsuiVersion}`);
+const timeout = 180_000;
 
 if (expectedJsuiVersion) {
+    console.log(`Expected JSUI version: ${expectedJsuiVersion}`);
+
     test('validate JSUI version', async ({page}) => {
-        test.setTimeout(180_000);
-        await page.goto(pageURL());
-        const coveoVersion = await page.evaluate(() => (window as any).Coveo.version);
-        // Example value: {lib: '2.10120.0', product: '2.10120.0', supportedApiVersion: 2}
-        expect(coveoVersion.lib).toBe(expectedJsuiVersion);
-        expect(coveoVersion.product).toBe(expectedJsuiVersion);
+        test.setTimeout(timeout);
+        await expect(async () => {
+            await page.goto(pageURL());
+            const coveoVersion = await page.evaluate(() => (window as any).Coveo.version);
+            // Example value: {lib: '2.10120.0', product: '2.10120.0', supportedApiVersion: 2}
+            expect(coveoVersion.lib).toBe(expectedJsuiVersion);
+            expect(coveoVersion.product).toBe(expectedJsuiVersion);
+        }).toPass({timeout});
     });
+
 } else {
     console.log('No JSUI version to validate.');
 }

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -3,7 +3,10 @@
     "version": "1.0.0",
     "description": "",
     "main": "index.js",
-    "scripts": {},
+    "scripts": {
+        "test": "npx playwright test --project chromium --project firefox --project webkit",
+        "validate-jsui-version": "npx playwright test --project validate-jsui-version"
+    },
     "keywords": [],
     "author": "",
     "license": "ISC",

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -37,7 +37,13 @@ export default defineConfig({
     /* Configure projects for major browsers */
     projects: [
         {
+            name: 'validate-jsui-version',
+            testMatch: 'validateJsuiVersion.ts',
+        },
+
+        {
             name: 'chromium',
+            testIgnore: 'validateJsuiVersion.ts',
             use: {
                 ...devices['Desktop Chrome'],
                 headless: true,
@@ -46,6 +52,7 @@ export default defineConfig({
 
         {
             name: 'firefox',
+            testIgnore: 'validateJsuiVersion.ts',
             use: {
                 ...devices['Desktop Firefox'],
                 headless: true,
@@ -54,6 +61,7 @@ export default defineConfig({
 
         {
             name: 'webkit',
+            testIgnore: 'validateJsuiVersion.ts',
             use: {
                 ...devices['Desktop Safari'],
                 headless: true,


### PR DESCRIPTION
## [JSUI-3539](https://coveord.atlassian.net/browse/JSUI-3539)

NOTE: Let's merge this after the JSUI October release is complete. We can see how it goes for the November release. At very worst, we can remove the new certifier section in the deployment config if something goes wrong.

- Adds the github certifier to the deployment config
    - (It is set as non-required for now)
- Adds a special project in Playwright that only validates the JSUI version that is deployed on Netlify
- Adds this project as a step in the workflow before the main test run

The Netlify JSUI version check will wait for 180 seconds for the deployment and retry twice, giving 9 minutes in total for the deployment to be complete.

Normally the deployment should be ready in about 60 seconds.

Test with correct JSUI version: 
https://github.com/coveo/search-ui/actions/runs/11354821467/job/31582861347

Test with incorrect JSUI verison:
https://github.com/coveo/search-ui/actions/runs/11355020702/job/31583515125

Test where the deployed version on Netlify was upgraded by the webhook:
https://github.com/coveo/search-ui/actions/runs/11355209362/job/31584098923
^ I first deployed an old version (2.10119.0). It was successfully updated to the current beta 2.10120.0.

Once this is merged, we'll have to start a deployment up to staging to see if this works as expected in the context of the deployment pipeline.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

[JSUI-3539]: https://coveord.atlassian.net/browse/JSUI-3539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ