### PR TITLE
test(e2e): fix reference to extra param

### DIFF
--- a/.github/workflows/e2e-certifier.yml
+++ b/.github/workflows/e2e-certifier.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Validate JSUI version
         working-directory: ${{ github.workspace }}/playwright
         env:
-          JSUI_VERSION: ${{ inputs.JSUI_VERSION }}
+          JSUI_VERSION: ${{ fromJSON(inputs.extra).JSUI_VERSION }}
         run: npm run validate-jsui-version
 
       - name: Run tests


### PR DESCRIPTION
## [JSUI-3549](https://coveord.atlassian.net/browse/JSUI-3549)

This is for the action that launches the playwright tests. `JSUI_VERSION` was not being referenced the right way in the the github action. The json needs to be parsed.

Relevant docs: 
https://tools-docs.dep.cloud.coveo.com/deployment-package/_static/schema_doc.html#collapseDescription_certifiers_aud_items_anyOf_i0_github_extra_parameters

https://coveord.atlassian.net/wiki/spaces/CM/pages/3980165140/Team+GitHub+Phase

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

[JSUI-3549]: https://coveord.atlassian.net/browse/JSUI-3549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ