### PR TITLE
release fixes

### DIFF
--- a/build/github-release.deploy.js
+++ b/build/github-release.deploy.js
@@ -37,6 +37,13 @@ async function createRelease() {
   }
 }
 
+async function getReleaseIdByTag() {
+  const res = await github.repos.getReleaseByTag({ owner, repo, tag: tag_name });
+  console.log(`found existing release for tag: ${tag_name}`);
+
+  return res.data.id;
+}
+
 async function getReleaseId() {
   try {
     return await createRelease();

--- a/build/release-version.js
+++ b/build/release-version.js
@@ -10,6 +10,7 @@ async function main() {
     return console.log('please specify a branch name');
   }
 
+  await exec(`git stash`);
   await configureGit();
   const exists = await checkIfBranchExists(branchName);
   exists ? await updateBranch(branchName) : await createBranch(branchName);


### PR DESCRIPTION
## [JSUI-3553](https://coveord.atlassian.net/browse/JSUI-3553)

### Changes:


Made some fixes based on an attempted release here: https://github.com/coveo/search-ui/actions/runs/13817468445/job/38654331831

- Restore the function `getReleaseIdByTag()` (I think we'd removed by accident while making another fix)
- Run `git stash` before committing the release branch (we had gotten the error: "npm error Git working directory not clean". I think this is because we ran unit tests in a previous step, and it left the working dir with some changes.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

[JSUI-3553]: https://coveord.atlassian.net/browse/JSUI-3553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ