### PR TITLE
fix: prevent double  scroll

### DIFF
--- a/src/ui/DynamicFacet/DynamicFacet.ts
+++ b/src/ui/DynamicFacet/DynamicFacet.ts
@@ -712,7 +712,7 @@ export class DynamicFacet extends Component implements IDynamicFacet {
     this.updateQueryStateModel();
     this.values.render();
     this.updateAppearance();
-    if (this.valueToFocusOnRender) {
+    if (this.valueToFocusOnRender && !this.options.enableScrollToTop) {
       const value = this.valueToFocusOnRender;
       this.valueToFocusOnRender = null;
       defer(() => this.values.focus(value));

--- a/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
+++ b/unitTests/ui/DynamicFacet/DynamicFacetTest.ts
@@ -34,6 +34,7 @@ export function DynamicFacetTest() {
       test.cmp.moreValuesAvailable = true;
 
       spyOn(test.cmp.values, 'clearAll').and.callThrough();
+      spyOn(test.cmp.values, 'focus').and.callThrough();
       spyOn(test.cmp.values, 'render').and.callThrough();
       spyOn(test.cmp.values, 'createFromResponse');
       spyOn(test.cmp.values, 'resetValues');
@@ -647,6 +648,15 @@ export function DynamicFacetTest() {
       test.cmp.scrollToTop();
 
       expect(ResultListUtils.scrollToTop).not.toHaveBeenCalledWith(test.cmp.root);
+    });
+
+    it(`when the enableScrollToTop option is "true"
+    should not focus on value`, () => {
+      options.enableScrollToTop = true;
+      initializeComponent();
+      test.cmp.scrollToTop();
+
+      expect(test.cmp.values.focus).not.toHaveBeenCalled();
     });
 
     describe('Testing the header', () => {


### PR DESCRIPTION
Modified the DynamicFacet class to add a condition that checks if the enableScrollToTop option is enabled before focusing on a value during rendering. (src/ui/DynamicFacet/DynamicFacet.ts)

https://coveord.atlassian.net/browse/KIT-4102