### PR TITLE
DOC-16560-edited-didyoumean-description

### DIFF
--- a/src/ui/DidYouMean/DidYouMean.ts
+++ b/src/ui/DidYouMean/DidYouMean.ts
@@ -22,7 +22,7 @@ export interface IDidYouMeanOptions {
 /**
  * The DidYouMean component is responsible for displaying query corrections. If this component is in the page and the
  * query returns no results but finds a possible query correction, it automatically triggers a new query with the suggested term.
- * If the query only returns a few results, the results are displayed but a possible query correction is still suggested.
+ * If the query only returns a few results, the results are displayed, but a possible query correction is still suggested.
  */
 export class DidYouMean extends Component {
   static ID = 'DidYouMean';

--- a/src/ui/DidYouMean/DidYouMean.ts
+++ b/src/ui/DidYouMean/DidYouMean.ts
@@ -21,8 +21,8 @@ export interface IDidYouMeanOptions {
 
 /**
  * The DidYouMean component is responsible for displaying query corrections. If this component is in the page and the
- * query returns no result but finds a possible query correction, the component either suggests the correction or
- * automatically triggers a new query with the suggested term.
+ * query returns no results but finds a possible query correction, it automatically triggers a new query with the suggested term.
+ * If the query only returns a few results, the results are displayed but a possible query correction is still suggested.
  */
 export class DidYouMean extends Component {
   static ID = 'DidYouMean';

--- a/src/ui/DidYouMean/DidYouMean.ts
+++ b/src/ui/DidYouMean/DidYouMean.ts
@@ -22,7 +22,7 @@ export interface IDidYouMeanOptions {
 /**
  * The DidYouMean component is responsible for displaying query corrections. If this component is in the page and the
  * query returns no results but finds a possible query correction, it automatically triggers a new query with the suggested term.
- * If the query only returns a few results, the results are displayed, but a possible query correction is still suggested.
+ * If the query only returns a few results, the results are displayed, but an alternate query suggestion is still made.
  */
 export class DidYouMean extends Component {
   static ID = 'DidYouMean';


### PR DESCRIPTION
Jira: **[DOC-16560](https://coveord.atlassian.net/browse/DOC-16560?)**

Purpose: Added a detail to the [DidYouMean description](https://coveo.github.io/search-ui/components/didyoumean.html) so it aligns with the explanation in the Coveo Docs [article](https://docs.coveo.com/en/1810/searching-with-coveo/query-correction-feature#example). 

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

[DOC-16560]: https://coveord.atlassian.net/browse/DOC-16560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ