### PR TITLE
DOC-17178: sortCriteria combination for JSUI

### DIFF
--- a/src/ui/Sort/Sort.ts
+++ b/src/ui/Sort/Sort.ts
@@ -53,7 +53,7 @@ export class Sort extends Component {
      *
      * You can specify a comma separated list of sort criteria to toggle between when interacting with this component instance (e.g., `data-sort-criteria="date descending,date ascending"`).
      *
-     * You can specify multiple sort criteria to be used in the same request by separating them with a semicolon (e.g., `data-sort-criteria="@size ascending;date ascending"` ).
+     * You can specify multiple sort criteria to be used in the same request by separating them with a semicolon. For example, `data-sort-criteria="@size ascending;date ascending"`.
      * However, this only works when combining:
      * a relevancy criterion followed by one or more field or date criteria (e.g., `data-sort-criteria="relevancy; @length descending"`).
      * a qre criterion followed by one or more field or date criteria (e.g., `data-sort-criteria="qre; @length descending"`).

--- a/src/ui/Sort/Sort.ts
+++ b/src/ui/Sort/Sort.ts
@@ -54,6 +54,11 @@ export class Sort extends Component {
      * You can specify a comma separated list of sort criteria to toggle between when interacting with this component instance (e.g., `data-sort-criteria="date descending,date ascending"`).
      *
      * You can specify multiple sort criteria to be used in the same request by separating them with a semicolon (e.g., `data-sort-criteria="@size ascending;date ascending"` ).
+     * However, this only works when combining:
+     * a relevancy criterion followed by one or more field or date criteria (e.g., `data-sort-criteria="relevancy; @length descending"`).
+     * a qre criterion followed by one or more field or date criteria (e.g., `data-sort-criteria="qre; @length descending"`).
+     * two or more field criteria (e.g., `data-sort-criteria="@size descending; @length ascending"`).
+     * a single date criterion and one or more field criteria in any order (e.g., `data-sort-criteria="@size descending; date ascending"`).
      *
      * Interacting with this component instance will cycle through those criteria in the order they are listed in.
      * Typically, you should only specify a list of sort criteria when you want the end user to be able to to toggle the direction of a `date` or `@field` sort criteria.


### PR DESCRIPTION
[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)


[Jira Ticket](https://coveord.atlassian.net/browse/DOC-17178)

When using a sort component, we can specify a list of criteria to apply. If the first criterion is not enough to sort between two results, we use the second one, and so forth. However, there are some limitations about the combination of criteria we can use. This PR covers the changes for Headless
