### PR TITLE
[KIT-4787] replace jenkins phase with Github Action

### DIFF
--- a/.deployment.config.json
+++ b/.deployment.config.json
@@ -4,23 +4,14 @@
   "team_name": "searchui",
   "general": {
     "aws_regions": {
-      "sequential": [
-        "FIRST_MAIN_REGION"
-      ]
+      "sequential": ["FIRST_MAIN_REGION"]
     },
     "environments_order": {
-      "sequential": [
-        "dev",
-        "stg",
-        "prd"
-      ]
+      "sequential": ["dev", "stg", "prd"]
     },
-    "team_jenkins": "searchuibuilds",
     "start_environment_automatically": false,
     "notifications": {
-      "slack_channels": [
-        "#searchuibuilds"
-      ]
+      "slack_channels": ["#searchuibuilds"]
     }
   },
   "dag_phases": [
@@ -47,18 +38,17 @@
       }
     },
     {
-      "id": "npm-latest-tag-updated",
-      "team_jenkins": {
+      "id": "update-npm-latest-tag",
+      "github": {
         "disabled": true,
-        "job_name": "search_ui/job/update_npm_latest_tag",
+        "workflow_file": "update-npm-latest-tag.yml",
+        "workflow_repository": "coveo-platform/search-ui-cd",
         "extra_parameters": {
           "LATEST_NPM_VERSION": "$[LATEST_NPM_VERSION]"
         },
         "overrides": [
           {
-            "environments": [
-              "prd"
-            ],
+            "environments": ["prd"],
             "content": {
               "disabled": false
             }
@@ -75,10 +65,7 @@
         "auto_approve_in_production": true,
         "run_strategy": "always"
       },
-      "dependencies": [
-        "cdn",
-        "cdn-sri"
-      ]
+      "dependencies": ["cdn", "cdn-sri"]
     }
   ],
   "certifiers": {


### PR DESCRIPTION
## [KIT-4787](https://coveord.atlassian.net/browse/KIT-4787)

- Removes the team jenkins reference from the deployment file
- Replaces the jenkins phase with a new github phase

The new Github phase is in the infra repo in this PR: https://github.com/coveo-platform/search-ui-cd/pull/15
That PR should be merged first.
(It had to be in that private repo so it could be used as a Coveo deployment pipeline phase on a hosted runner)

The linter forced some other formatting changes to the file.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)

[KIT-4787]: https://coveord.atlassian.net/browse/KIT-4787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ