### PR TITLE
doc: decomission search alerts

### DIFF
--- a/src/ui/SearchAlerts/SearchAlerts.ts
+++ b/src/ui/SearchAlerts/SearchAlerts.ts
@@ -44,14 +44,7 @@ export interface ISearchAlertsOptions {
 }
 
 /**
- * The Search Alerts component renders items in the {@link Settings} menu that allow the end user to follow queries
- * and to manage search alerts. A user following a query receives email notifications when the query results change.
- *
- * **Note:**
- * > It is necessary to meet certain requirements to be able to use this component (see
- * > [Deploying Search Alerts on a Coveo JS Search Page](https://docs.coveo.com/en/1932/)).
- *
- * See also the {@link FollowItem} component.
+ * Search alerts have been decommissioned. This component has no functionality and should not be used.
  */
 export class SearchAlerts extends Component {
   static ID = 'SearchAlerts';


### PR DESCRIPTION
https://coveord.atlassian.net/browse/DOC-19069

I suppose you guys could remove the component altogether, but if you don't want to invest more time in this project I think that just adjusting the documentation for the SearchAlerts component would be sufficient.

[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)