### PR TITLE
LENS-5260 add fieldAliases and freeTextSearchFields to QueryBuilder

### DIFF
--- a/src/rest/Query.ts
+++ b/src/rest/Query.ts
@@ -305,6 +305,14 @@ export interface IQuery {
    */
   commerce?: ICommerceRequest;
   /**
+   * Specifies field aliases for the search operation.
+   */
+  fieldAliases?: Record<string, string>;
+  /**
+   * Specifies free text search fields for the search operation.
+   */
+  freeTextSearchFields?: string[];
+  /**
    * The format of a successful response.
    * If not specified, this parameter defaults to 'json'.
    */

--- a/src/ui/Base/QueryBuilder.ts
+++ b/src/ui/Base/QueryBuilder.ts
@@ -526,6 +526,27 @@ export class QueryBuilder {
   }
 
   /**
+   * Adds free text search fields, ensuring unique values.
+   *
+   * @param fields The free text search fields to add. Duplicate values are automatically removed.
+   */
+  public addFreeTextSearchFields(fields: string[]) {
+    this.freeTextSearchFields = _.uniq((this.freeTextSearchFields || []).concat(fields));
+  }
+
+  /**
+   * Merges the specified field aliases into the `fieldAliases` object.
+   *
+   * @param aliases The field aliases to merge into the `fieldAliases` object. If some keys are already present, their values are updated.
+   */
+  public addFieldAliases(aliases: Record<string, string>) {
+    if (this.fieldAliases == null) {
+      this.fieldAliases = {};
+    }
+    _.extend(this.fieldAliases, aliases);
+  }
+
+  /**
    * Returns true if the current query contains any expression that are considered "end user input".
    *
    * This usually means anything entered in the basic (see [q]{@link IQuery.options.q}) or long (see [lq]{@link IQuery.options.lq}) part of the query.

--- a/src/ui/Base/QueryBuilder.ts
+++ b/src/ui/Base/QueryBuilder.ts
@@ -329,6 +329,14 @@ export class QueryBuilder {
    */
   public commerce: ICommerceRequest;
   /**
+   * Specifies field aliases for the search operation.
+   */
+  public fieldAliases: Record<string, string>;
+  /**
+   * Specifies free text search fields for the search operation.
+   */
+  public freeTextSearchFields: string[];
+  /**
    * Build the current content or state of the query builder and return a {@link IQuery}.
    *
    * build can be called multiple times on the same QueryBuilder.
@@ -384,7 +392,9 @@ export class QueryBuilder {
       recommendation: this.recommendation,
       allowQueriesWithoutKeywords: this.allowQueriesWithoutKeywords,
       userActions: this.userActions,
-      commerce: this.commerce
+      commerce: this.commerce,
+      fieldAliases: this.fieldAliases,
+      freeTextSearchFields: this.freeTextSearchFields
     };
     return query;
   }

--- a/unitTests/ui/QueryBuilderTest.ts
+++ b/unitTests/ui/QueryBuilderTest.ts
@@ -173,6 +173,18 @@ export function QueryBuilderTest() {
       });
     });
 
+    it('can set fieldAliases', () => {
+      const fieldAliases = { name: 'name.en', description: 'description.en' };
+      queryBuilder.fieldAliases = fieldAliases;
+      expect(queryBuilder.build().fieldAliases).toEqual(fieldAliases);
+    });
+
+    it('can set freeTextSearchFields', () => {
+      const freeTextSearchFields = ['field1', 'field2', 'field3'];
+      queryBuilder.freeTextSearchFields = freeTextSearchFields;
+      expect(queryBuilder.build().freeTextSearchFields).toEqual(freeTextSearchFields);
+    });
+
     it('should be able to detect end user keywords in the basic expression', () => {
       queryBuilder.expression.add('foo');
       expect(queryBuilder.containsEndUserKeywords()).toBeTruthy();

--- a/unitTests/ui/QueryBuilderTest.ts
+++ b/unitTests/ui/QueryBuilderTest.ts
@@ -179,10 +179,33 @@ export function QueryBuilderTest() {
       expect(queryBuilder.build().fieldAliases).toEqual(fieldAliases);
     });
 
+    it('can addFreeTextSearchFields', () => {
+      queryBuilder.addFreeTextSearchFields(['field1', 'field2']);
+      expect(queryBuilder.build().freeTextSearchFields).toEqual(['field1', 'field2']);
+
+      queryBuilder.addFreeTextSearchFields(['field2', 'field3']);
+      expect(queryBuilder.build().freeTextSearchFields).toEqual(['field1', 'field2', 'field3']);
+    });
+
     it('can set freeTextSearchFields', () => {
       const freeTextSearchFields = ['field1', 'field2', 'field3'];
       queryBuilder.freeTextSearchFields = freeTextSearchFields;
       expect(queryBuilder.build().freeTextSearchFields).toEqual(freeTextSearchFields);
+    });
+
+    it('can addFieldAliases', () => {
+      queryBuilder.addFieldAliases({ name: 'name.en', description: 'description.en' });
+      expect(queryBuilder.build().fieldAliases).toEqual({
+        name: 'name.en',
+        description: 'description.en'
+      });
+
+      queryBuilder.addFieldAliases({ name: 'name.fr', category: 'category.fr' });
+      expect(queryBuilder.build().fieldAliases).toEqual({
+        name: 'name.fr',
+        description: 'description.en',
+        category: 'category.fr'
+      });
     });
 
     it('should be able to detect end user keywords in the basic expression', () => {


### PR DESCRIPTION
Adds to the `QueryBuilder` the `fieldAliases` and `freeTextSearchFields` Search API parameters.


[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/pipelines/a3535101-5bbf-4a5b-a909-47fcf8c9f149)